### PR TITLE
Use encapsulation instead of monkey patching / inheritance.

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -496,14 +496,14 @@ class DataFrame(_Frame, _MissingPandasLikeDataFrame):
         return {None: 0, 'index': 0, 'columns': 1}.get(axis, axis)
 
 
-def _reduce_spark_multi(df, aggs):
+def _reduce_spark_multi(sdf, aggs):
     """
     Performs a reduction on a dataframe, the functions being known sql aggregate functions.
     """
-    assert isinstance(df, DataFrame)
-    df0 = df._spark_agg(*aggs)
-    l = df0.head(2).collect()
-    assert len(l) == 1, (df, l)
+    assert isinstance(sdf, spark.DataFrame)
+    sdf0 = sdf.agg(*aggs)
+    l = sdf0.head(2)
+    assert len(l) == 1, (sdf, l)
     row = l[0]
     l2 = list(row)
     assert len(l2) == len(aggs), (row, l2)

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -92,22 +92,3 @@ def _spark_col_apply(kdf_or_ks, sfun):
     sdf = kdf._sdf
     sdf = sdf.select([sfun(sdf[col]).alias(col) for col in kdf.columns])
     return DataFrame(sdf)
-
-
-def anchor_wrap(df, col):
-    """
-    Ensures that the column has an anchoring reference to the dataframe.
-
-    This is required to get self-representable columns.
-    :param df: dataframe or column
-    :param col: a column
-    :return: column
-    """
-    if isinstance(col, Column):
-        if isinstance(df, Column):
-            ref = df._pandas_anchor
-        else:
-            assert isinstance(df, DataFrame), type(df)
-            ref = df
-        col._spark_ref_dataframe = ref
-    return col

--- a/databricks/koalas/groups.py
+++ b/databricks/koalas/groups.py
@@ -20,6 +20,7 @@ A wrapper for GroupedData to behave similar to pandas.
 from pyspark.sql.types import StructType
 
 from databricks.koalas.dask.compatibility import string_types
+from databricks.koalas.frame import DataFrame
 
 
 class PandasLikeGroupBy(object):
@@ -27,15 +28,15 @@ class PandasLikeGroupBy(object):
     Extends Spark's group data to do more flexible operations.
     """
 
-    def __init__(self, df, sgd, cols):
+    def __init__(self, kdf, sgd, cols):
         self._groupdata = sgd
-        self._df = df
+        self._kdf = kdf
         # cols can either be:
         # none -> all the dataframe
         # a single element (string) to select a single col (and return a series)
         # a list of cols / strings for all the returns (and return a DF)
         self._cols = cols
-        self._schema = _current_schema(df, cols)  # type: StructType
+        self._schema = _current_schema(kdf, cols)  # type: StructType
 
     def __getitem__(self, key):
         # TODO: handle deeper cases. Right now, it will break with nested columns.
@@ -69,13 +70,13 @@ class PandasLikeGroupBy(object):
                     for key, value in func_or_funcs.items()):
             raise ValueError("aggs must be a dict mapping from column name (string) to aggregate "
                              "functions (string).")
-        df = self._groupdata.agg(func_or_funcs)
+        sdf = self._groupdata.agg(func_or_funcs)
 
         reorder = ['%s(%s)' % (value, key) for key, value in iter(func_or_funcs.items())]
-        df = df._spark_select(reorder)
-        df.columns = [key for key in iter(func_or_funcs.keys())]
+        kdf = DataFrame(sdf.select(reorder))
+        kdf.columns = [key for key in iter(func_or_funcs.keys())]
 
-        return df
+        return kdf
 
     agg = aggregate
 
@@ -98,9 +99,9 @@ class PandasLikeGroupBy(object):
 
 def _current_schema(df, cols):
     if not cols:
-        return df.schema
+        return df._sdf.schema
     if isinstance(cols, list):
-        return df.select(*cols).schema
+        return df._sdf.select(*cols).schema
     else:
         col = cols
-        return df.select(col).schema
+        return df._sdf.select(col).schema

--- a/databricks/koalas/selection.py
+++ b/databricks/koalas/selection.py
@@ -19,7 +19,7 @@ A locator for PandasLikeDataFrame.
 """
 from functools import reduce
 
-from pyspark.sql import Column, DataFrame
+from pyspark.sql import Column
 from pyspark.sql.types import BooleanType
 from pyspark.sql.utils import AnalysisException
 
@@ -28,11 +28,12 @@ from databricks.koalas.exceptions import SparkPandasIndexingError, SparkPandasNo
 
 
 def _make_col(c):
-    if isinstance(c, Column):
-        return c
+    from databricks.koalas.series import Series
+    if isinstance(c, Series):
+        return c._scol
     elif isinstance(c, str):
-        from pyspark.sql.functions import _spark_col
-        return _spark_col(c)
+        from pyspark.sql.functions import col
+        return col(c)
     else:
         raise SparkPandasNotImplementedError(
             description="Can only convert a string to a column type.")
@@ -45,6 +46,7 @@ def _unfold(key, col):
     the col parameter itself. Otherwise check the key contains column selection, and the selection
     is acceptable.
     """
+    from databricks.koalas.series import Series
     if col is not None:
         if isinstance(key, tuple):
             if len(key) > 1:
@@ -58,7 +60,7 @@ def _unfold(key, col):
         rows_sel, cols_sel = key
 
         # make cols_sel a 1-tuple of string if a single string
-        if isinstance(cols_sel, (str, Column)):
+        if isinstance(cols_sel, (str, Series)):
             cols_sel = _make_col(cols_sel)
         elif isinstance(cols_sel, slice) and cols_sel != slice(None):
             raise SparkPandasNotImplementedError(
@@ -82,20 +84,24 @@ class SparkDataFrameLocator(object):
     :class:`Column`(s) for cols.
     """
 
-    def __init__(self, df_or_col):
-        assert isinstance(df_or_col, (DataFrame, Column)), \
-            'unexpected argument type: {}'.format(type(df_or_col))
-        if isinstance(df_or_col, DataFrame):
-            self.df = df_or_col
-            self.col = None
+    def __init__(self, df_or_s):
+        from databricks.koalas.frame import DataFrame
+        from databricks.koalas.series import Series
+        assert isinstance(df_or_s, (DataFrame, Series)), \
+            'unexpected argument type: {}'.format(type(df_or_s))
+        if isinstance(df_or_s, DataFrame):
+            self._kdf = df_or_s
+            self._ks = None
         else:
             # If df_or_col is Column, store both the DataFrame anchored to the Column and
             # the Column itself.
-            self.df = df_or_col._pandas_anchor
-            self.col = df_or_col
+            self._kdf = df_or_s._kdf
+            self._ks = df_or_s
 
     def __getitem__(self, key):
-        from pyspark.sql.functions import _spark_lit
+        from pyspark.sql.functions import lit
+        from databricks.koalas.frame import DataFrame
+        from databricks.koalas.series import Series
 
         def raiseNotImplemented(description):
             raise SparkPandasNotImplementedError(
@@ -103,38 +109,36 @@ class SparkDataFrameLocator(object):
                 pandas_function=".loc[..., ...]",
                 spark_target_function="select, where")
 
-        rows_sel, cols_sel = _unfold(key, self.col)
+        rows_sel, cols_sel = _unfold(key, self._ks)
 
-        df = self.df
-        if isinstance(rows_sel, Column):
-            df_for_check_schema = self.df._spark_select(rows_sel)
-            assert isinstance(df_for_check_schema.schema.fields[0].dataType, BooleanType), \
-                (str(df_for_check_schema), df_for_check_schema.schema.fields[0].dataType)
-            df = df._spark_where(rows_sel)
+        sdf = self._kdf._sdf
+        if isinstance(rows_sel, Series):
+            sdf_for_check_schema = sdf.select(rows_sel)
+            assert isinstance(sdf_for_check_schema.schema.fields[0].dataType, BooleanType), \
+                (str(sdf_for_check_schema), sdf_for_check_schema.schema.fields[0].dataType)
+            sdf = sdf.where(rows_sel)
         elif isinstance(rows_sel, slice):
             if rows_sel.step is not None:
                 raiseNotImplemented("Cannot use step with Spark.")
             if rows_sel == slice(None):
                 # If slice is None - select everything, so nothing to do
                 pass
-            elif len(self.df._index_columns) == 0:
+            elif len(self._kdf._index_columns) == 0:
                 raiseNotImplemented("Cannot use slice for Spark if no index provided.")
-            elif len(self.df._index_columns) == 1:
+            elif len(self._kdf._index_columns) == 1:
                 start = rows_sel.start
                 stop = rows_sel.stop
 
-                index_column = self.df._index_columns[0]
+                index_column = self._kdf.index
                 index_data_type = index_column.schema[0].dataType
                 cond = []
                 if start is not None:
-                    cond.append(index_column >=
-                                _spark_lit(start)._spark_cast(index_data_type))
+                    cond.append(index_column._scol >= lit(start).cast(index_data_type))
                 if stop is not None:
-                    cond.append(index_column <=
-                                _spark_lit(stop)._spark_cast(index_data_type))
+                    cond.append(index_column._scol <= lit(stop).cast(index_data_type))
 
                 if len(cond) > 0:
-                    df = df._spark_where(reduce(lambda x, y: x & y, cond))
+                    sdf = sdf.where(reduce(lambda x, y: x & y, cond))
             else:
                 raiseNotImplemented("Cannot use slice for MultiIndex with Spark.")
         elif isinstance(rows_sel, string_types):
@@ -145,16 +149,16 @@ class SparkDataFrameLocator(object):
             except TypeError:
                 raiseNotImplemented("Cannot use a scalar value for row selection with Spark.")
             if len(rows_sel) == 0:
-                df = df._spark_where(_spark_lit(False))
-            elif len(self.df._index_columns) == 1:
-                index_column = self.df._index_columns[0]
+                sdf = sdf.where(lit(False))
+            elif len(self._kdf._index_columns) == 1:
+                index_column = self._kdf.index
                 index_data_type = index_column.schema[0].dataType
                 if len(rows_sel) == 1:
-                    df = df._spark_where(
-                        index_column == _spark_lit(rows_sel[0])._spark_cast(index_data_type))
+                    sdf = sdf.where(
+                        index_column._scol == lit(rows_sel[0]).cast(index_data_type))
                 else:
-                    df = df._spark_where(index_column._spark_isin(
-                        [_spark_lit(r)._spark_cast(index_data_type) for r in rows_sel]))
+                    sdf = sdf.where(index_column._scol.isin(
+                        [lit(r).cast(index_data_type) for r in rows_sel]))
             else:
                 raiseNotImplemented("Cannot select with MultiIndex with Spark.")
         if cols_sel is None:
@@ -164,11 +168,11 @@ class SparkDataFrameLocator(object):
         else:
             columns = [_make_col(c) for c in cols_sel]
         try:
-            df = df._spark_select(self.df._metadata.index_fields + columns)
+            df = DataFrame(sdf.select(self._kdf._metadata.index_fields + columns))
         except AnalysisException:
             raise KeyError('[{}] don\'t exist in columns'
                            .format([col._jc.toString() for col in columns]))
-        df._metadata = self.df._metadata.copy(
+        df._pandas_metadata = self._kdf._metadata.copy(
             column_fields=df._metadata.column_fields[-len(columns):])
         if cols_sel is not None and isinstance(cols_sel, Column):
             from databricks.koalas.series import _col
@@ -177,6 +181,7 @@ class SparkDataFrameLocator(object):
             return df
 
     def __setitem__(self, key, value):
+        from databricks.koalas.frame import DataFrame
 
         if (not isinstance(key, tuple)) or (len(key) != 2):
             raise NotImplementedError("Only accepts pairs of candidates")

--- a/databricks/koalas/testing/utils.py
+++ b/databricks/koalas/testing/utils.py
@@ -22,10 +22,13 @@ import unittest
 from contextlib import contextmanager
 
 import pandas as pd
+from pyspark import sql as spark
 from pyspark import SparkConf, SparkContext
-from pyspark.sql import Column, DataFrame, SparkSession
+from pyspark.sql import SparkSession
 
 from databricks import koalas
+from databricks.koalas.frame import DataFrame
+from databricks.koalas.series import Series
 
 
 class PySparkTestCase(unittest.TestCase):
@@ -214,7 +217,7 @@ class ReusedSQLTestCase(ReusedPySparkTestCase, SQLTestUtils):
 
     @staticmethod
     def _to_pandas(df):
-        if isinstance(df, (DataFrame, Column)):
+        if isinstance(df, (DataFrame, Series)):
             return df.toPandas()
         else:
             return df

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -63,7 +63,7 @@ class DataFrameTest(ReusedSQLTestCase, TestUtils):
             'a': [1, 2, 3, 4, 5, 6, 7, 8, 9],
             'b': [4, 5, 6, 3, 2, 1, 0, 0, 0],
         })
-        ddf = self.spark.createDataFrame(df)
+        ddf = koalas.from_pandas(df)
         self.assert_eq(df[['a', 'b']], ddf[['a', 'b']])
 
         self.assertEqual(ddf.a.notnull().alias("x").name, "x")

--- a/databricks/koalas/utils.py
+++ b/databricks/koalas/utils.py
@@ -22,8 +22,8 @@ from decorator import decorator
 import types
 import logging
 
-from databricks.koalas.frame import PandasLikeDataFrame
-from databricks.koalas.series import PandasLikeSeries
+#from databricks.koalas.frame import PandasLikeDataFrame
+#from databricks.koalas.series import PandasLikeSeries
 
 logger = logging.getLogger('spark')
 
@@ -46,11 +46,11 @@ def patch_spark():
     # pyspark.sql.DataFrame = PatchedDF
 
     # Just going to update the dictionary
-    _inject(df.DataFrame, PandasLikeDataFrame)
-    _inject(df.Column, PandasLikeSeries)
+    #_inject(df.DataFrame, PandasLikeDataFrame)
+    #_inject(df.Column, PandasLikeSeries)
     # Override in all cases these methods to prevent any dispatching.
-    df.Column.__repr__ = PandasLikeSeries.__repr__
-    df.Column.__str__ = PandasLikeSeries.__str__
+    #df.Column.__repr__ = PandasLikeSeries.__repr__
+    #df.Column.__str__ = PandasLikeSeries.__str__
     # Replace the creation of the operators in columns
     _wrap_operators()
     # Wrap all the functions in the standard libraries

--- a/databricks/koalas/utils.py
+++ b/databricks/koalas/utils.py
@@ -49,12 +49,12 @@ def patch_spark():
     #_inject(df.DataFrame, PandasLikeDataFrame)
     #_inject(df.Column, PandasLikeSeries)
     # Override in all cases these methods to prevent any dispatching.
-    #df.Column.__repr__ = PandasLikeSeries.__repr__
-    #df.Column.__str__ = PandasLikeSeries.__str__
+    # df.Column.__repr__ = PandasLikeSeries.__repr__
+    # df.Column.__str__ = PandasLikeSeries.__str__
     # Replace the creation of the operators in columns
-    _wrap_operators()
+    #_wrap_operators()
     # Wrap all the functions in the standard libraries
-    _wrap_functions()
+    #_wrap_functions()
 
 
 @decorator

--- a/databricks/koalas/utils.py
+++ b/databricks/koalas/utils.py
@@ -22,9 +22,6 @@ from decorator import decorator
 import types
 import logging
 
-#from databricks.koalas.frame import PandasLikeDataFrame
-#from databricks.koalas.series import PandasLikeSeries
-
 logger = logging.getLogger('spark')
 
 _TOUCHED_TEST = "_pandas_updated"
@@ -46,15 +43,15 @@ def patch_spark():
     # pyspark.sql.DataFrame = PatchedDF
 
     # Just going to update the dictionary
-    #_inject(df.DataFrame, PandasLikeDataFrame)
-    #_inject(df.Column, PandasLikeSeries)
+    # inject(df.DataFrame, PandasLikeDataFrame)
+    # inject(df.Column, PandasLikeSeries)
     # Override in all cases these methods to prevent any dispatching.
     # df.Column.__repr__ = PandasLikeSeries.__repr__
     # df.Column.__str__ = PandasLikeSeries.__str__
     # Replace the creation of the operators in columns
-    #_wrap_operators()
+    # wrap_operators()
     # Wrap all the functions in the standard libraries
-    #_wrap_functions()
+    # wrap_functions()
 
 
 @decorator

--- a/dev/_make_missing_functions.py
+++ b/dev/_make_missing_functions.py
@@ -25,10 +25,10 @@ import inspect
 
 import pandas as pd
 
-from databricks.koalas.frame import PandasLikeDataFrame
+from databricks.koalas.frame import DataFrame
 from databricks.koalas.missing.frame import _MissingPandasLikeDataFrame
 from databricks.koalas.missing.series import _MissingPandasLikeSeries
-from databricks.koalas.series import PandasLikeSeries
+from databricks.koalas.series import Series
 
 
 INDENT_LEN = 4
@@ -223,8 +223,8 @@ def make_modified_function_def(original_type, name, original, target):
 
 def _main():
     for original_type, target_type, missing_type in \
-            [(pd.DataFrame, PandasLikeDataFrame, _MissingPandasLikeDataFrame),
-             (pd.Series, PandasLikeSeries, _MissingPandasLikeSeries)]:
+            [(pd.DataFrame, DataFrame, _MissingPandasLikeDataFrame),
+             (pd.Series, Series, _MissingPandasLikeSeries)]:
         missing, modified = inspect_missing_functions(original_type, target_type, missing_type)
 
         print('MISSING functions for {}'.format(original_type.__name__))


### PR DESCRIPTION
Also addressed #23 while implementing `__init__` for wrappers.

Closes #23, #90.