### PR TITLE
Restores APIs that exists in both Pandas and Spark DataFrame

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -457,16 +457,6 @@ class DataFrame(_Frame, _MissingPandasLikeDataFrame):
         return DataFrame(spark.DataFrame.fillna(self._sdf, value, subset))
 
     @derived_from(spark.DataFrame)
-    def subtract(self, other):
-        return DataFrame(spark.DataFrame.subtract(self._sdf, other))
-
-    sub = subtract
-
-    @derived_from(spark.DataFrame)
-    def subtract(self, other):
-        return DataFrame(spark.DataFrame.subtract(self._sdf, other))
-
-    @derived_from(spark.DataFrame)
     def replace(self, to_replace, value=_NoValue, subset=None):
         return DataFrame(spark.DataFrame.replace(self._sdf, to_replace, value, subset))
 

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -22,7 +22,7 @@ from functools import reduce
 
 import numpy as np
 import pandas as pd
-from pyspark import sql as spark
+from pyspark import sql as spark, _NoValue
 from pyspark.sql import functions as F
 from pyspark.sql.types import StructType, to_arrow_type
 from pyspark.sql.utils import AnalysisException
@@ -271,6 +271,8 @@ class DataFrame(_Frame, _MissingPandasLikeDataFrame):
                 pdf.index.name = index_names[0]
         return pdf
 
+    to_pandas = toPandas
+
     @derived_from(pd.DataFrame)
     def assign(self, **kwargs):
         from databricks.koalas.series import Series
@@ -419,6 +421,62 @@ class DataFrame(_Frame, _MissingPandasLikeDataFrame):
     @property
     def shape(self):
         return len(self), len(self.columns)
+
+    @property
+    def schema(self):
+        return spark.DataFrame.schema.fget(self._sdf)
+
+    @derived_from(spark.DataFrame)
+    def select(self, *cols):
+        return DataFrame(spark.DataFrame.select(self._sdf, *cols))
+
+    @derived_from(spark.DataFrame)
+    def selectExpr(self, *cols):
+        return DataFrame(spark.DataFrame.selectExpr(self._sdf, *cols))
+
+    @derived_from(spark.DataFrame)
+    def describe(self, *cols):
+        return DataFrame(spark.DataFrame.describe(self._sdf, *cols))
+
+    @property
+    def dtypes(self):
+        return spark.DataFrame.dtypes.fget(self._sdf)
+
+    @derived_from(spark.DataFrame)
+    def explain(self, extended=False):
+        return spark.DataFrame.explain(self._sdf, extended)
+
+    @derived_from(spark.DataFrame)
+    def agg(self, *exprs):
+        return DataFrame(spark.DataFrame.agg(self._sdf, *exprs))
+
+    aggregate = agg
+
+    @derived_from(spark.DataFrame)
+    def fillna(self, value, subset=None):
+        return DataFrame(spark.DataFrame.fillna(self._sdf, value, subset))
+
+    @derived_from(spark.DataFrame)
+    def subtract(self, other):
+        return DataFrame(spark.DataFrame.subtract(self._sdf, other))
+
+    sub = subtract
+
+    @derived_from(spark.DataFrame)
+    def subtract(self, other):
+        return DataFrame(spark.DataFrame.subtract(self._sdf, other))
+
+    @derived_from(spark.DataFrame)
+    def replace(self, to_replace, value=_NoValue, subset=None):
+        return DataFrame(spark.DataFrame.replace(self._sdf, to_replace, value, subset))
+
+    @derived_from(spark.DataFrame)
+    def sample(self, withReplacement=None, fraction=None, seed=None):
+        return DataFrame(spark.DataFrame.sample(self._sdf, withReplacement, fraction, seed))
+
+    @derived_from(spark.DataFrame)
+    def join(self, other, on=None, how=None):
+        return DataFrame(spark.DataFrame.join(self, other, on, how))
 
     def _pd_getitem(self, key):
         from databricks.koalas.series import Series

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -15,7 +15,7 @@
 #
 
 """
-A base class to be monkey-patched to DataFrame/Column to behave similar to pandas DataFrame/Series.
+A base class for Koalas DataFrame/Series to behave similar to pandas DataFrame/Series.
 """
 import pandas as pd
 from pyspark.sql import functions as F

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -206,6 +206,8 @@ class Series(_Frame, _MissingPandasLikeSeries):
     def toPandas(self):
         return _col(self.to_dataframe().toPandas())
 
+    to_pandas = toPandas
+
     @derived_from(pd.Series)
     def isnull(self):
         if isinstance(self.schema[self.name].dataType, (FloatType, DoubleType)):

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -38,7 +38,7 @@ class DataFrameTest(ReusedSQLTestCase, TestUtils):
     def df(self):
         return koalas.from_pandas(self.full)
 
-    def test_Dataframe(self):
+    def test_dataframe(self):
         d = self.df
         full = self.full
 
@@ -350,6 +350,12 @@ class DataFrameTest(ReusedSQLTestCase, TestUtils):
 
         with self.assertRaisesRegex(PandasNotImplementedError, "Series.*all.*not implemented"):
             d.a.all()
+
+    def test_spark_api(self):
+        kdf = self.df
+        pdf = self.full
+
+        self.assert_eq(list(kdf.select("a").to_pandas()), list(pdf[['a']]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR partially addresses https://github.com/databricks/koalas/issues/124

This PR restores Spark DataFrame APIs missing by the refactoring:

- `schema`

- `to_pandas`

- `select`

- `selectExpr `

- `describe`

- `dtypes`

- `explain`

- `agg`, `aggregate`

- `fillna`

- `subtract`, `sub`

- `replace`

- `sample`

- `join`

Note that it looks other methods in https://github.com/databricks/koalas/issues/124 should newly be implemented.