### PR TITLE
Refine metadata management.

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -107,9 +107,7 @@ class DataFrame(_Frame, _MissingPandasLikeDataFrame):
         from databricks.koalas.series import Series
         if len(self._metadata.index_info) != 1:
             raise KeyError('Currently supported only when the DataFrame has a single index.')
-        index = Series(self._index_columns[0], self)
-        index._pandas_metadata = index._metadata.copy(index_info=[])
-        return index
+        return Series(self._index_columns[0], self, [])
 
     def set_index(self, keys, drop=True, append=False, inplace=False):
         """Set the DataFrame index (row labels) using one or more existing columns. By default
@@ -426,7 +424,7 @@ class DataFrame(_Frame, _MissingPandasLikeDataFrame):
             raise KeyError("none key")
         if isinstance(key, string_types):
             try:
-                return Series(self._sdf.__getitem__(key), self)
+                return Series(self._sdf.__getitem__(key), self, self._metadata.index_info)
             except AnalysisException:
                 raise KeyError(key)
         if np.isscalar(key) or isinstance(key, (tuple, string_types)):
@@ -440,7 +438,7 @@ class DataFrame(_Frame, _MissingPandasLikeDataFrame):
             return self.loc[:, key]
         if isinstance(key, DataFrame):
             # TODO Should not implement alignment, too dangerous?
-            return Series(self._sdf.__getitem__(key), self)
+            return Series(self._sdf.__getitem__(key), self, self._metadata.index_info)
         if isinstance(key, Series):
             # TODO Should not implement alignment, too dangerous?
             # It is assumed to be only a filter, otherwise .loc should be used.
@@ -474,7 +472,7 @@ class DataFrame(_Frame, _MissingPandasLikeDataFrame):
         from databricks.koalas.series import Series
         if key.startswith("__") or key.startswith("_pandas_") or key.startswith("_spark_"):
             raise AttributeError(key)
-        return Series(self._sdf.__getattr__(key), self)
+        return Series(self._sdf.__getattr__(key), self, self._metadata.index_info)
 
     def __iter__(self):
         return self.toPandas().__iter__()

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -58,13 +58,9 @@ class DataFrame(_Frame, _MissingPandasLikeDataFrame):
     def _init_from_spark(self, sdf, metadata=None, *args):
         self._sdf = sdf
         if metadata is None:
-            self._pandas_metadata = Metadata(column_fields=self._sdf.schema.fieldNames())
+            self._metadata = Metadata(column_fields=self._sdf.schema.fieldNames())
         else:
-            self._pandas_metadata = metadata
-
-    @property
-    def _metadata(self):
-        return self._pandas_metadata
+            self._metadata = metadata
 
     @property
     def _index_columns(self):
@@ -141,10 +137,10 @@ class DataFrame(_Frame, _MissingPandasLikeDataFrame):
 
         metadata = self._metadata.copy(column_fields=columns, index_info=index_info)
         if inplace:
-            self._pandas_metadata = metadata
+            self._metadata = metadata
         else:
             kdf = self.copy()
-            kdf._pandas_metadata = metadata
+            kdf._metadata = metadata
             return kdf
 
     def reset_index(self, level=None, drop=False, inplace=False):
@@ -220,11 +216,11 @@ class DataFrame(_Frame, _MissingPandasLikeDataFrame):
             index_info=index_info)
         columns = [name for _, name in index_columns] + self._metadata.column_fields
         if inplace:
-            self._pandas_metadata = metadata
+            self._metadata = metadata
             self.columns = columns
         else:
             kdf = self.copy()
-            kdf._pandas_metadata = metadata
+            kdf._metadata = metadata
             kdf.columns = columns
             return kdf
 
@@ -358,7 +354,7 @@ class DataFrame(_Frame, _MissingPandasLikeDataFrame):
                                [self[old_name]._scol.alias(new_name)
                                 for (old_name, new_name) in zip(old_names, names)])
         self._sdf = sdf
-        self._pandas_metadata = self._metadata.copy(column_fields=names)
+        self._metadata = self._metadata.copy(column_fields=names)
 
     @derived_from(pd.DataFrame, ua_args=['axis', 'level', 'numeric_only'])
     def count(self):
@@ -466,7 +462,7 @@ class DataFrame(_Frame, _MissingPandasLikeDataFrame):
             kdf = self.assign(**{key: value})
 
         self._sdf = kdf._sdf
-        self._pandas_metadata = kdf._metadata
+        self._metadata = kdf._metadata
 
     def __getattr__(self, key):
         from databricks.koalas.series import Series

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -86,7 +86,7 @@ def _spark_col_apply(kdf_or_ks, sfun):
     from databricks.koalas.series import Series
     if isinstance(kdf_or_ks, Series):
         ks = kdf_or_ks
-        return Series(sfun(kdf_or_ks._scol), ks._kdf)
+        return Series(sfun(kdf_or_ks._scol), ks._kdf, ks._index_info)
     assert isinstance(kdf_or_ks, DataFrame)
     kdf = kdf_or_ks
     sdf = kdf._sdf

--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -170,7 +170,7 @@ def to_datetime(arg, errors='raise', format=None, infer_datetime_format=False):
             arg._scol,
             errors=errors,
             format=format,
-            infer_datetime_format=infer_datetime_format), arg._kdf)
+            infer_datetime_format=infer_datetime_format), arg._kdf, arg._index_info)
     if isinstance(arg, DataFrame):
         return Series(_to_datetime2(
             arg_year=arg['year']._scol,
@@ -178,7 +178,7 @@ def to_datetime(arg, errors='raise', format=None, infer_datetime_format=False):
             arg_day=arg['day']._scol,
             errors=errors,
             format=format,
-            infer_datetime_format=infer_datetime_format), arg)
+            infer_datetime_format=infer_datetime_format), arg, arg._metadata.index_info)
     if isinstance(arg, dict):
         return _to_datetime2(
             arg_year=arg['year'],

--- a/databricks/koalas/selection.py
+++ b/databricks/koalas/selection.py
@@ -172,7 +172,7 @@ class SparkDataFrameLocator(object):
         except AnalysisException:
             raise KeyError('[{}] don\'t exist in columns'
                            .format([col._jc.toString() for col in columns]))
-        kdf._pandas_metadata = self._kdf._metadata.copy(
+        kdf._metadata = self._kdf._metadata.copy(
             column_fields=kdf._metadata.column_fields[-len(columns):])
         if cols_sel is not None and isinstance(cols_sel, spark.Column):
             from databricks.koalas.series import _col

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -292,7 +292,7 @@ class Series(_Frame, _MissingPandasLikeSeries):
         index_name = 'index' if self.name != 'index' else 'level_0'
         kdf = DataFrame(sdf)
         kdf.columns = [index_name, self.name]
-        kdf._pandas_metadata = Metadata(column_fields=[self.name], index_info=[(index_name, None)])
+        kdf._metadata = Metadata(column_fields=[self.name], index_info=[(index_name, None)])
         return _col(kdf)
 
     @derived_from(pd.Series, ua_args=['level'])

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -54,7 +54,7 @@ def _column_op(f, self, *args):
     # extract Spark Column. For other arguments, they are used as are.
     args = [arg._scol if isinstance(arg, Series) else arg for arg in args]
     scol = f(self._scol, *args)
-    return Series(scol, self._kdf)
+    return Series(scol, self._kdf, self._index_info)
 
 
 class Series(_Frame, _MissingPandasLikeSeries):
@@ -74,22 +74,22 @@ class Series(_Frame, _MissingPandasLikeSeries):
         """
 
         kdf = DataFrame(pd.DataFrame(s))
-        self._init_from_spark(kdf._sdf[kdf._metadata.column_fields[0]], kdf)
+        self._init_from_spark(kdf._sdf[kdf._metadata.column_fields[0]],
+                              kdf, kdf._metadata.index_info)
 
     @__init__.register(spark.Column)
-    def _init_from_spark(self, scol, kdf, metadata=None, *args):
+    def _init_from_spark(self, scol, kdf, index_info, *args):
         """
         Creates Koalas Series from Spark Column.
 
         :param scol: Spark Column
         :param kdf: Koalas DataFrame that should have the `scol`.
-        :param metadata: Metadata that contains column names and index information of `kdf`.
+        :param index_info: index information of this Series.
         """
-
+        assert index_info is not None
         self._scol = scol
         self._kdf = kdf
-        self._pandas_metadata = metadata
-        self._pandas_schema = None
+        self._index_info = index_info
 
     # arithmetic operators
     __neg__ = _column_op(spark.Column.__neg__)
@@ -148,7 +148,7 @@ class Series(_Frame, _MissingPandasLikeSeries):
         spark_type = as_spark_type(dtype)
         if not spark_type:
             raise ValueError("Type {} not understood".format(dtype))
-        return Series(self._scol.cast(spark_type), self._kdf)
+        return Series(self._scol.cast(spark_type), self._kdf, self._index_info)
 
     def getField(self, name):
         if not isinstance(self.schema, StructType):
@@ -158,7 +158,7 @@ class Series(_Frame, _MissingPandasLikeSeries):
             if name not in fnames:
                 raise AttributeError(
                     "Field {} not found, possible values are {}".format(name, ", ".join(fnames)))
-            return Series(self._scol.getField(name), self._kdf)
+            return Series(self._scol.getField(name), self._kdf, self._index_info)
 
     # TODO: automate the process here
     def alias(self, name):
@@ -166,9 +166,7 @@ class Series(_Frame, _MissingPandasLikeSeries):
 
     @property
     def schema(self):
-        if self._pandas_schema is None:
-            self._pandas_schema = self.to_dataframe()._sdf.schema
-        return self._pandas_schema
+        return self.to_dataframe()._sdf.schema
 
     @property
     def shape(self):
@@ -189,17 +187,13 @@ class Series(_Frame, _MissingPandasLikeSeries):
         scol = self._scol.alias(index)
         if kwargs.get('inplace', False):
             self._scol = scol
-            self._pandas_schema = None
-            self._pandas_metadata = self._metadata.copy(column_fields=[index])
             return self
         else:
-            return Series(scol, self._kdf, self._metadata.copy(column_fields=[index]))
+            return Series(scol, self._kdf, self._index_info)
 
     @property
     def _metadata(self):
-        if self._pandas_metadata is None:
-            self._pandas_metadata = self.to_dataframe()._metadata
-        return self._pandas_metadata
+        return self.to_dataframe()._metadata
 
     @property
     def index(self):
@@ -222,13 +216,13 @@ class Series(_Frame, _MissingPandasLikeSeries):
             kdf = self.to_dataframe()
         kdf = kdf.reset_index(level=level, drop=drop)
         if drop:
-            col = _col(kdf)
+            s = _col(kdf)
             if inplace:
                 self._kdf = kdf
-                self._scol = col._scol
-                self._pandas_metadata = None
+                self._scol = s._scol
+                self._index_info = s._index_info
             else:
-                return col
+                return s
         else:
             return kdf
 
@@ -237,13 +231,8 @@ class Series(_Frame, _MissingPandasLikeSeries):
         return SparkDataFrameLocator(self)
 
     def to_dataframe(self):
-        kdf = self._kdf
-        if self._pandas_metadata is not None:
-            metadata = self._pandas_metadata
-        else:
-            metadata = kdf._metadata
-        sdf = kdf._sdf.select(metadata.index_fields + [self._scol])
-        metadata = metadata.copy(column_fields=[sdf.schema[-1].name])
+        sdf = self._kdf._sdf.select([field for field, _ in self._index_info] + [self._scol])
+        metadata = Metadata(column_fields=[sdf.schema[-1].name], index_info=self._index_info)
         return DataFrame(sdf, metadata)
 
     def toPandas(self):
@@ -252,9 +241,9 @@ class Series(_Frame, _MissingPandasLikeSeries):
     @derived_from(pd.Series)
     def isnull(self):
         if isinstance(self.schema[self.name].dataType, (FloatType, DoubleType)):
-            return Series(self._scol.isNull() | F.isnan(self._scol), self._kdf)
+            return Series(self._scol.isNull() | F.isnan(self._scol), self._kdf, self._index_info)
         else:
-            return Series(self._scol.isNull(), self._kdf)
+            return Series(self._scol.isNull(), self._kdf, self._index_info)
 
     isna = isnull
 
@@ -317,7 +306,7 @@ class Series(_Frame, _MissingPandasLikeSeries):
         return len(self.to_dataframe())
 
     def __getitem__(self, key):
-        return Series(self._scol.__getitem__(key), self._kdf)
+        return Series(self._scol.__getitem__(key), self._kdf, self._index_info)
 
     def __getattr__(self, item):
         if item.startswith("__") or item.startswith("_pandas_") or item.startswith("_spark_"):
@@ -335,7 +324,7 @@ class Series(_Frame, _MissingPandasLikeSeries):
             fields = []
         else:
             fields = [f for f in self.schema.fieldNames() if ' ' not in f]
-        return super(spark.Column, self).__dir__() + fields
+        return super(Series, self).__dir__() + fields
 
     def _pandas_orig_repr(self):
         # TODO: figure out how to reuse the original one.


### PR DESCRIPTION
- Make `Series` not forget to take `index_info` over.
  - currently `DataFrame.index` will remove the index info, but they are not taken over.
- Remove `_pandas_metadata` from `DataFrame`.