### PR TITLE
Restructure documentation and exclude stub methods

### DIFF
--- a/databricks/koalas/__init__.py
+++ b/databricks/koalas/__init__.py
@@ -36,7 +36,9 @@ def assert_pyspark_version():
 assert_pyspark_version()
 
 from databricks.koalas.namespace import *
+from databricks.koalas.frame import DataFrame
+from databricks.koalas.series import Series
 from databricks.koalas.typing import Col, pandas_wrap
 
-__all__ = ['read_csv', 'read_parquet', 'to_datetime', 'from_pandas', 'get_dummies',
-           'Col', 'pandas_wrap']
+__all__ = ['read_csv', 'read_parquet', 'to_datetime', 'from_pandas',
+           'get_dummies', 'DataFrame', 'Series']

--- a/databricks/koalas/dask/utils.py
+++ b/databricks/koalas/dask/utils.py
@@ -122,10 +122,15 @@ def _skip_doctest(line):
         return line
 
 
+def _pandas_to_koalas_in_doctest(line):
+    return line.replace("pd", "koalas")
+
+
 def skip_doctest(doc):
     if doc is None:
         return ''
-    return '\n'.join([_skip_doctest(line) for line in doc.split('\n')])
+    return '\n'.join(
+        [_pandas_to_koalas_in_doctest(_skip_doctest(line)) for line in doc.split('\n')])
 
 
 def extra_titles(doc):

--- a/databricks/koalas/missing/__init__.py
+++ b/databricks/koalas/missing/__init__.py
@@ -22,10 +22,4 @@ def _unsupported_function(class_name, method_name):
     def unsupported_function(*args, **kwargs):
         raise PandasNotImplementedError(class_name=class_name, method_name=method_name)
 
-    unsupported_function.__doc__ = \
-        """A stub for the equivalent method to `{0}.{1}()`.
-
-        The method `{0}.{1}()` is not implemented yet.
-        """.format(class_name, method_name)
-
     return unsupported_function

--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -20,7 +20,6 @@ Wrappers around spark that correspond to common pandas functions.
 import numpy as np
 import pandas as pd
 
-from pyspark import sql as spark
 from pyspark.sql import functions as F
 from pyspark.sql.types import *
 
@@ -28,7 +27,7 @@ from databricks.koalas.dask.compatibility import string_types
 from databricks.koalas.dask.utils import derived_from
 from databricks.koalas.frame import DataFrame, default_session, _reduce_spark_multi
 from databricks.koalas.typing import Col, pandas_wrap
-from databricks.koalas.series import Series, _col
+from databricks.koalas.series import Series
 
 
 def from_pandas(pdf):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,6 +55,7 @@ pygments_style = 'sphinx'
 # The master toctree document.
 master_doc = 'index'
 
+numpydoc_show_class_members = False
 
 # -- Options for auto output -------------------------------------------------
 

--- a/docs/databricks.koalas.rst
+++ b/docs/databricks.koalas.rst
@@ -1,50 +1,30 @@
-databricks.koalas package
+Koalas
 ==========================
 
-databricks.koalas.exceptions module
+.. automodule:: databricks.koalas
+    :members:
+    :undoc-members:
+    :inherited-members:
+    :exclude-members: Series, DataFrame
+
+DataFrame
+-----------------------------------
+
+.. autoclass:: databricks.koalas.DataFrame
+    :members:
+    :inherited-members:
+
+Series
+-----------------------------------
+
+.. autoclass:: databricks.koalas.Series
+    :members:
+    :inherited-members:
+
+Exceptions
 -----------------------------------
 
 .. automodule:: databricks.koalas.exceptions
-    :members:
-    :undoc-members:
-    :inherited-members:
-
-databricks.koalas.frame module
------------------------------------
-
-.. automodule:: databricks.koalas.frame
-    :members:
-    :undoc-members:
-    :inherited-members:
-
-databricks.koalas.groups module
------------------------------------
-
-.. automodule:: databricks.koalas.groups
-    :members:
-    :undoc-members:
-    :inherited-members:
-
-databricks.koalas.namespace module
------------------------------------
-
-.. automodule:: databricks.koalas.namespace
-    :members:
-    :undoc-members:
-    :inherited-members:
-
-databricks.koalas.series module
------------------------------------
-
-.. automodule:: databricks.koalas.series
-    :members:
-    :undoc-members:
-    :inherited-members:
-
-databricks.koalas.session module
------------------------------------
-
-.. automodule:: databricks.koalas.session
     :members:
     :undoc-members:
     :inherited-members:


### PR DESCRIPTION
This PR proposes to restructure documentation and exclude stub methods.

1. Clarify what to expose as APIs in `__all__` in Koalas

2. Make the doctest roughly compatible to Koalas.
    For example, see ![Screen Shot 2019-04-23 at 10 58 34 AM](https://user-images.githubusercontent.com/6477701/56546922-c419f700-65b6-11e9-9ab8-5cc8a73911ba.png)

3. Remove all stub methods by only documenting method that has docstring. Namely docstrings in stub were removed.

4. Restructure:

    ```
    Koalas  # koalas.* APIs
    ├── DataFrame
    ├── Exceptions
    └── Series
    ```

Closes #137