### PR TITLE
Add a simple quickstart in Koalas documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ We recommend setting up a Conda environment for development:
 ```bash
 conda create --name koalas-dev-env python=3.6
 conda activate koalas-dev-env
+conda install -c conda-forge pyspark=2.4
 conda install -c conda-forge --yes --file requirements-dev.txt
 pip install -e .  # installs koalas from current checkout
 ```

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,6 +1,4 @@
-.. Koalas' documentation master file, created by
-
-Koalas: pandas APIs on Apache Spark
+API References
 ============================================
 
 .. toctree::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,9 +1,10 @@
-.. Koalas' documentation master file, created by
+.. Koalas' documentation master file
 
-Welcome to Koalas' documentation!
+Koalas: pandas APIs on Apache Spark
 ============================================
 
 .. toctree::
     :maxdepth: 2
 
     api
+    quickstart

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -1,0 +1,43 @@
+Quick Start
+===========
+
+Koalas needs Spark. You can install it via ``pip install pyspark`` or downloading the release.
+
+After that, Koalas can be installed via ``pip`` as below:
+
+.. code-block:: bash
+
+    $ pip install koalas
+
+
+After installing the package, you can import the package:
+
+.. code-block:: python
+
+    from databricks import koalas
+
+
+Now you can turn a pandas DataFrame into a Spark DataFrame that is API-compliant with the former:
+
+.. code-block:: python
+
+    import pandas as pd
+    pdf = pd.DataFrame({'x':range(3), 'y':['a','b','b'], 'z':['a','b','b']})
+
+    # Create a Spark DataFrame from pandas DataFrame
+    df = koalas.from_pandas(pdf)
+
+    # Rename the columns
+    df.columns = ['x', 'y', 'z1']
+
+    # Do some operations in place:
+    df['x2'] = df.x * df.x
+
+You can also create Koakas DataFrame directly from regular Python data like Pandas:
+
+.. code-block:: python
+
+    from databricks import koalas
+
+    koalas.DataFrame({'x': [1, 2], 'y': [3, 4], 'z': [5, 6]})
+

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -33,7 +33,7 @@ Now you can turn a pandas DataFrame into a Spark DataFrame that is API-compliant
     # Do some operations in place:
     df['x2'] = df.x * df.x
 
-You can also create Koakas DataFrame directly from regular Python data like Pandas:
+You can also create Koalas DataFrame directly from regular Python data like Pandas:
 
 .. code-block:: python
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -17,14 +17,14 @@ After installing the package, you can import the package:
     from databricks import koalas
 
 
-Now you can turn a pandas DataFrame into a Spark DataFrame that is API-compliant with the former:
+Now you can turn a pandas DataFrame into a Koalas DataFrame that is API-compliant with the former:
 
 .. code-block:: python
 
     import pandas as pd
     pdf = pd.DataFrame({'x':range(3), 'y':['a','b','b'], 'z':['a','b','b']})
 
-    # Create a Spark DataFrame from pandas DataFrame
+    # Create a Koalas DataFrame from pandas DataFrame
     df = koalas.from_pandas(pdf)
 
     # Rename the columns


### PR DESCRIPTION
This PR add a simple quickstart that's almost copied from `README.md`.
Yes, we should deduplicate them eventually but I would like to propose to put them first.