### PR TITLE
Add readthedocs configuration file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,39 @@
+#
+# Copyright (C) 2019 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.5
+  install:
+    - requirements: requirements-dev.txt
+    - method: pip
+      path: .
+      extra_requirements:
+        - spark
+


### PR DESCRIPTION
This PR proposes to add a readthedocs configuration file. (See https://docs.readthedocs.io/en/stable/config-file/v2.html)

I experimentally tested this after creating `stable` branch for testing purpose (and I removed it back).
The documentation will be generated as below:

See https://databricks-koalas.readthedocs.io/en/stable/