### PR TITLE
Fix requirements-dev.txt to be compatible with both PIP and Conda

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,6 @@ pandas>=0.23
 pyarrow>=0.10,<0.11
 decorator
 sphinx==2.0.1
-nbsphinx=0.4.2
-numpydoc=0.8.0
+nbsphinx==0.4.2
+numpydoc==0.8.0
 


### PR DESCRIPTION
I found this via readthedocs failure. I forgot to add this fix. It was tested against my fork:

https://github.com/HyukjinKwon/spark-pandas/commit/6969d7d87436d96b9039d852c6e4e7ff62965c98

![Screen Shot 2019-04-24 at 7 58 11 AM](https://user-images.githubusercontent.com/6477701/56621271-d9e6f500-6666-11e9-8b38-a671a7e37773.png)


https://databricks-koalas.readthedocs.io/en/latest/
