### PR TITLE
Use "ks" for "koalas".

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ If this fails to install the pyarrow dependency, you may want to try installing 
 
 After installing the package, you can import the package:
 ```py
-from databricks import koalas
+from databricks import koalas as ks
 ```
 
 Now you can turn a pandas DataFrame into a Koalas DataFrame that is API-compliant with the former:
@@ -62,7 +62,7 @@ import pandas as pd
 pdf = pd.DataFrame({'x':range(3), 'y':['a','b','b'], 'z':['a','b','b']})
 
 # Create a Koalas DataFrame from pandas DataFrame
-df = koalas.from_pandas(pdf)
+df = ks.from_pandas(pdf)
 
 # Rename the columns
 df.columns = ['x', 'y', 'z1']

--- a/databricks/koalas/dask/utils.py
+++ b/databricks/koalas/dask/utils.py
@@ -123,7 +123,7 @@ def _skip_doctest(line):
 
 
 def _pandas_to_koalas_in_doctest(line):
-    return line.replace("pd", "koalas")
+    return line.replace("pd", "ks")
 
 
 def skip_doctest(doc):

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -14,7 +14,7 @@ After installing the package, you can import the package:
 
 .. code-block:: python
 
-    from databricks import koalas
+    from databricks import koalas as ks
 
 
 Now you can turn a pandas DataFrame into a Koalas DataFrame that is API-compliant with the former:
@@ -25,7 +25,7 @@ Now you can turn a pandas DataFrame into a Koalas DataFrame that is API-complian
     pdf = pd.DataFrame({'x':range(3), 'y':['a','b','b'], 'z':['a','b','b']})
 
     # Create a Koalas DataFrame from pandas DataFrame
-    df = koalas.from_pandas(pdf)
+    df = ks.from_pandas(pdf)
 
     # Rename the columns
     df.columns = ['x', 'y', 'z1']
@@ -37,7 +37,7 @@ You can also create Koalas DataFrame directly from regular Python data like Pand
 
 .. code-block:: python
 
-    from databricks import koalas
+    from databricks import koalas as ks
 
-    koalas.DataFrame({'x': [1, 2], 'y': [3, 4], 'z': [5, 6]})
+    ks.DataFrame({'x': [1, 2], 'y': [3, 4], 'z': [5, 6]})
 


### PR DESCRIPTION
This partially addresses #158, just uses "ks" instead of "koalas" in `@derived_from` for docs.
The doctests issue mentioned in #158 will be addressed in the separate PR.

Also updated README and quickstart doc to use "ks".