### PR TITLE
Add a CSS property for breakable words to avoid table text overlapped

### DIFF
--- a/docs/source/themes/nature_with_gtoc/static/nature.css_t
+++ b/docs/source/themes/nature_with_gtoc/static/nature.css_t
@@ -345,6 +345,12 @@ table td.data, table th.row_heading table th.col_heading {
     text-align: right;
 }
 
+/**
+ * Avoid that newlines are injected in the middle of a function name in a table.
+ */
+.longtable.docutils.align-center {
+    word-wrap: break-word;
+}
 
 /**
  * See also


### PR DESCRIPTION
This PR proposes to add a CSS property to allow word breaking when it's overlapped as below:

Before:

![Screen Shot 2019-04-24 at 5 48 48 PM](https://user-images.githubusercontent.com/6477701/56645984-a2556880-66b9-11e9-826d-4c2832ccf6ba.png)

After:

![Screen Shot 2019-04-24 at 5 52 34 PM](https://user-images.githubusercontent.com/6477701/56646071-c9139f00-66b9-11e9-84bd-026979f63745.png)

Partially address #156