### PR TITLE
Enable more doctests in Series

### DIFF
--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -168,7 +168,7 @@ class Series(_Frame):
         --------
         >>> s = ks.Series([1, 2, 3])
         >>> s.dtype
-        dtype('int64')
+        dtype('int64')a
 
         >>> s = ks.Series(list('abc'))
         >>> s.dtype

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -166,16 +166,16 @@ class Series(_Frame):
 
         Examples
         --------
-        >>> s = ks.Series([1, 2, 3])  # doctest: +SKIP
-        >>> s.dtype  # doctest: +SKIP
+        >>> s = ks.Series([1, 2, 3])
+        >>> s.dtype
         dtype('int64')
 
-        >>> s = ks.Series(list('abc'))  # doctest: +SKIP
-        >>> s.dtype  # doctest: +SKIP
+        >>> s = ks.Series(list('abc'))
+        >>> s.dtype
         dtype('O')
 
-        >>> s = ks.Series(pd.date_range('20130101', periods=3))  # doctest: +SKIP
-        >>> s.dtype  # doctest: +SKIP
+        >>> s = ks.Series(pd.date_range('20130101', periods=3))
+        >>> s.dtype
         dtype('<M8[ns]')
         """
         if type(self.spark_type) == TimestampType:

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -168,7 +168,7 @@ class Series(_Frame):
         --------
         >>> s = ks.Series([1, 2, 3])
         >>> s.dtype
-        dtype('int64')a
+        dtype('int64')
 
         >>> s = ks.Series(list('abc'))
         >>> s.dtype

--- a/databricks/koalas/testing/doctest_main.py
+++ b/databricks/koalas/testing/doctest_main.py
@@ -1,9 +1,26 @@
+#
+# Copyright (C) 2019 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
+import sys
 
 if __name__ == "__main__":
     import doctest
     import databricks.koalas as ks
     from databricks.koalas import frame, series, namespace
     modules = [frame, series, namespace]
-    for m in modules:
-        doctest.testmod(m, extraglobs={"ks": ks})
+    failure_count = sum([doctest.testmod(m, extraglobs={"ks": ks})[0] for m in modules])
+    if failure_count:
+        sys.exit(-1)

--- a/dev/run-tests.sh
+++ b/dev/run-tests.sh
@@ -34,6 +34,4 @@ else
     ARGS="$@"
 fi
 # Runs the main program that finds and runs the docstrings.
-exec python databricks/koalas/testing/doctest_main.py
-# Then run the test suites
-exec nosetests $ARGS --where "$FWDIR"
+python databricks/koalas/testing/doctest_main.py && nosetests $ARGS --where "$FWDIR"


### PR DESCRIPTION
Enable doctests in `series.py` and make `run-tests.sh` handle doctest failures properly.