### PR TITLE
Use pyarrow to infer data type.

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -59,14 +59,14 @@ class DataFrame(_Frame):
         metadata = Metadata.from_pandas(pdf)
         reset_index = pdf.reset_index()
         reset_index.columns = metadata.all_fields
+        schema = StructType([StructField(name, infer_pd_series_spark_type(col),
+                                         nullable=bool(col.isnull().any()))
+                             for name, col in reset_index.iteritems()])
         for name, col in reset_index.iteritems():
             dt = col.dtype
             if is_datetime64_dtype(dt) or is_datetime64tz_dtype(dt):
                 continue
             reset_index[name] = col.replace({np.nan: None})
-        schema = StructType([StructField(name, infer_pd_series_spark_type(col),
-                                         nullable=bool(col.isnull().any()))
-                             for name, col in reset_index.iteritems()])
         self._init_from_spark(default_session().createDataFrame(reset_index, schema=schema),
                               metadata)
 

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -85,6 +85,22 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             self.assertRaises(ValueError, lambda: koalas.from_pandas(b))
             self.assertRaises(ValueError, lambda: koalas.from_pandas(pdf))
 
+    def test_all_null_dataframe(self):
+        a = pd.Series([None, None, None], dtype='float64')
+        b = pd.Series([None, None, None], dtype='str')
+        pdf = pd.DataFrame({'a': a, 'b': b})
+
+        self.assert_eq(koalas.from_pandas(a).dtype, a.dtype)
+        self.assertTrue(koalas.from_pandas(a).toPandas().isnull().all())
+        self.assertRaises(ValueError, lambda: koalas.from_pandas(b))
+        self.assertRaises(ValueError, lambda: koalas.from_pandas(pdf))
+
+        with self.sql_conf({'spark.sql.execution.arrow.enabled': False}):
+            self.assert_eq(koalas.from_pandas(a).dtype, a.dtype)
+            self.assertTrue(koalas.from_pandas(a).toPandas().isnull().all())
+            self.assertRaises(ValueError, lambda: koalas.from_pandas(b))
+            self.assertRaises(ValueError, lambda: koalas.from_pandas(pdf))
+
     def test_nullable_object(self):
         pdf = pd.DataFrame({'a': list('abc') + [np.nan],
                             'b': list(range(1, 4)) + [np.nan],

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -21,14 +21,14 @@ import numpy as np
 import pandas as pd
 
 from databricks import koalas
-from databricks.koalas.testing.utils import ReusedSQLTestCase, TestUtils
+from databricks.koalas.testing.utils import ReusedSQLTestCase, SQLTestUtils
 from databricks.koalas.exceptions import PandasNotImplementedError
 from databricks.koalas.missing.frame import _MissingPandasLikeDataFrame
 from databricks.koalas.missing.series import _MissingPandasLikeSeries
 from databricks.koalas.series import Series
 
 
-class DataFrameTest(ReusedSQLTestCase, TestUtils):
+class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
     @property
     def full(self):
@@ -70,6 +70,35 @@ class DataFrameTest(ReusedSQLTestCase, TestUtils):
         self.assert_eq(df[['a', 'b']], ddf[['a', 'b']])
 
         self.assertEqual(ddf.a.notnull().alias("x").name, "x")
+
+    def test_empty_dataframe(self):
+        a = pd.Series([], dtype='i1')
+        b = pd.Series([], dtype='str')
+        pdf = pd.DataFrame({'a': a, 'b': b})
+
+        self.assert_eq(koalas.from_pandas(a), a)
+        self.assertRaises(ValueError, lambda: koalas.from_pandas(b))
+        self.assertRaises(ValueError, lambda: koalas.from_pandas(pdf))
+
+        with self.sql_conf({'spark.sql.execution.arrow.enabled': False}):
+            self.assert_eq(koalas.from_pandas(a), a)
+            self.assertRaises(ValueError, lambda: koalas.from_pandas(b))
+            self.assertRaises(ValueError, lambda: koalas.from_pandas(pdf))
+
+    def test_nullable_object(self):
+        pdf = pd.DataFrame({'a': list('abc') + [np.nan],
+                            'b': list(range(1, 4)) + [np.nan],
+                            'c': list(np.arange(3, 6).astype('i1')) + [np.nan],
+                            'd': list(np.arange(4.0, 7.0, dtype='float64')) + [np.nan],
+                            'e': [True, False, True, np.nan],
+                            'f': list(pd.date_range('20130101', periods=3)) + [np.nan]})
+
+        kdf = koalas.from_pandas(pdf)
+        self.assert_eq(kdf, pdf)
+
+        with self.sql_conf({'spark.sql.execution.arrow.enabled': False}):
+            kdf = koalas.from_pandas(pdf)
+            self.assert_eq(kdf, pdf)
 
     def test_head_tail(self):
         d = self.df

--- a/databricks/koalas/typedef.py
+++ b/databricks/koalas/typedef.py
@@ -22,6 +22,7 @@ import typing
 from decorator import decorate
 from decorator import getfullargspec
 import numpy as np
+import pandas as pd
 from pandas.api.types import is_datetime64_dtype, is_datetime64tz_dtype
 import pyarrow as pa
 from pyspark.sql import Column
@@ -135,7 +136,7 @@ def as_python_type(spark_tpe):
     return _py_conversions.get(spark_tpe, None)
 
 
-def infer_pd_series_spark_type(s):
+def infer_pd_series_spark_type(s: pd.Series) -> types.DataType:
     """Infer Spark DataType from pandas Series dtype.
 
     :param s: :class:`pandas.Series` to be inferred

--- a/databricks/koalas/typing.py
+++ b/databricks/koalas/typing.py
@@ -143,8 +143,8 @@ def infer_pd_series_spark_type(s):
     """
     dt = s.dtype
     if dt == np.dtype('object'):
-        if len(s) == 0:
-            raise ValueError("can not infer schema from empty dataset")
+        if len(s) == 0 or s.isnull().all():
+            raise ValueError("can not infer schema from empty or null dataset")
         return types.from_arrow_type(pa.Array.from_pandas(s).type)
     elif is_datetime64_dtype(dt) or is_datetime64tz_dtype(dt):
         return types.TimestampType()

--- a/databricks/koalas/typing.py
+++ b/databricks/koalas/typing.py
@@ -22,6 +22,8 @@ from decorator import getfullargspec
 import typing
 
 import numpy as np
+from pandas.api.types import is_datetime64_dtype, is_datetime64tz_dtype
+import pyarrow as pa
 from pyspark.sql import Column
 from pyspark.sql.functions import pandas_udf
 import pyspark.sql.types as types
@@ -131,6 +133,23 @@ def as_spark_type(tpe):
 
 def as_python_type(spark_tpe):
     return _py_conversions.get(spark_tpe, None)
+
+
+def infer_pd_series_spark_type(s):
+    """Infer Spark DataType from pandas Series dtype.
+
+    :param s: :class:`pandas.Series` to be inferred
+    :return: the inferred Spark data type
+    """
+    dt = s.dtype
+    if dt == np.dtype('object'):
+        if len(s) == 0:
+            raise ValueError("can not infer schema from empty dataset")
+        return types.from_arrow_type(pa.Array.from_pandas(s).type)
+    elif is_datetime64_dtype(dt) or is_datetime64tz_dtype(dt):
+        return types.TimestampType()
+    else:
+        return types.from_arrow_type(pa.from_numpy_dtype(dt))
 
 
 def _check_compatible(arg, sig_arg: X):


### PR DESCRIPTION
PySpark without arrow execution sometimes fails to infer data type.
This PR uses pyarrow infer prior to create DataFrame.

Closes #167.