### PR TITLE
Loosen DataFrame.corr test assertion for floats

### DIFF
--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -364,11 +364,11 @@ class Series(_Frame):
         ...                    's2': [.3, .6, .0, .1]})
         >>> s1 = df.s1
         >>> s2 = df.s2
-        >>> s1.corr(s2, method='pearson')
-        -0.8510644963469898
+        >>> s1.corr(s2, method='pearson')  # doctest: +ELLIPSIS
+        -0.851064...
 
-        >>> s1.corr(s2, method='spearman')
-        -0.9486832980505125
+        >>> s1.corr(s2, method='spearman')  # doctest: +ELLIPSIS
+        -0.948683...
 
         Notes
         -----


### PR DESCRIPTION
This PR fixes a test failure in my local. I didn't investigate closely but I just suspect it's basically Python's float limitation https://docs.python.org/3/tutorial/floatingpoint.html _or_ some changes from Spark upstream (I was testing it with Apache Spark master)

```
**********************************************************************
File "/.../koalas/databricks/koalas/series.py", line 367, in series.Series.corr
Failed example:
    s1.corr(s2, method='pearson')
Expected:
    -0.8510644963469898
Got:
    -0.8510644963469901


Failure
<Click to see difference>

**********************************************************************
File "/.../koalas/databricks/koalas/series.py", line 370, in series.Series.corr
Failed example:
    s1.corr(s2, method='spearman')
Expected:
    -0.9486832980505125
Got:
    -0.9486832980505139
```