### PR TITLE
DataFrame.count()

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -86,6 +86,13 @@ class DataFrame(_Frame):
                 for field in self._metadata.index_fields]
 
     def _reduce_for_stat_function(self, sfun):
+        """
+        Applies sfun to each column and returns a pd.Series where the number of rows equal the
+        number of columns.
+
+        :param sfun: either an 1-arg function that takes a Column and returns a Column, or
+        a 2-arg function that takes a Column and its DataType and returns a Column.
+        """
         from inspect import signature
         exprs = []
         num_args = len(signature(sfun).parameters)

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -662,8 +662,7 @@ class DataFrame(_Frame):
         else:
             kdf = self.assign(**{key: value})
 
-        # Spark DataFrame
-        self._sdf = kdf._sdf
+        self._sdf: spark.DataFrame = kdf._sdf
         self._metadata = kdf._metadata
 
     def __getattr__(self, key):

--- a/databricks/koalas/tests/test_stats.py
+++ b/databricks/koalas/tests/test_stats.py
@@ -47,16 +47,6 @@ class StatsTest(ReusedSQLTestCase, SQLTestUtils):
             getattr(ddf.A, funcname)()
             getattr(ddf, funcname)()
 
-    def test_count(self):
-        df = pd.DataFrame({'A': [1, 2, 3, 4],
-                           'B': [1.0, 2.1, 3, 4]})
-        ddf = koalas.from_pandas(df)
-
-        # NOTE: This does not patch the pandas API, but maintains compat with spark
-        self.assertEqual(ddf.count(), len(df))
-
-        self.assertEqual(ddf.A.count(), df.A.count())
-
     def test_abs(self):
         df = pd.DataFrame({'A': [1, -2, 3, -4, 5],
                            'B': [1., -2, 3, -4, 5],


### PR DESCRIPTION
This patch implements DataFrame.count based on Pandas' syntax. In this PR, DataFrame.count returns a pd.Series, rather than a ks.Series.

In the future, we should look into what we do with Inf and -Inf values, and Series.count.

Resolves #184