### PR TITLE
Allow the direct assignment for scalar value

### DIFF
--- a/databricks/koalas/testing/utils.py
+++ b/databricks/koalas/testing/utils.py
@@ -242,12 +242,12 @@ class TestUtils(object):
 class ComparisonTestBase(ReusedSQLTestCase):
 
     @property
-    def df(self):
+    def kdf(self):
         return koalas.from_pandas(self.pdf)
 
     @property
     def pdf(self):
-        return self.df.toPandas()
+        return self.kdf.toPandas()
 
 
 def compare_both(f=None, almost=True):
@@ -264,7 +264,7 @@ def compare_both(f=None, almost=True):
         else:
             compare = self.assertPandasEqual
 
-        for result_pandas, result_spark in zip(f(self, self.pdf), f(self, self.df)):
+        for result_pandas, result_spark in zip(f(self, self.pdf), f(self, self.kdf)):
             compare(result_pandas, result_spark.toPandas())
 
     return wrapped

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -31,36 +31,36 @@ from databricks.koalas.series import Series
 class DataFrameTest(ReusedSQLTestCase, TestUtils):
 
     @property
-    def full(self):
+    def pdf(self):
         return pd.DataFrame({
             'a': [1, 2, 3, 4, 5, 6, 7, 8, 9],
             'b': [4, 5, 6, 3, 2, 1, 0, 0, 0],
         }, index=[0, 1, 3, 5, 6, 8, 9, 9, 9])
 
     @property
-    def df(self):
-        return koalas.from_pandas(self.full)
+    def kdf(self):
+        return koalas.from_pandas(self.pdf)
 
-    def test_Dataframe(self):
-        d = self.df
-        full = self.full
+    def test_dataframe(self):
+        kdf = self.kdf
+        pdf = self.pdf
 
         expected = pd.Series([2, 3, 4, 5, 6, 7, 8, 9, 10],
                              index=[0, 1, 3, 5, 6, 8, 9, 9, 9],
                              name='(a + 1)')  # TODO: name='a'
 
-        self.assert_eq(d['a'] + 1, expected)
+        self.assert_eq(kdf['a'] + 1, expected)
 
-        self.assert_eq(d.columns, pd.Index(['a', 'b']))
+        self.assert_eq(kdf.columns, pd.Index(['a', 'b']))
 
-        self.assert_eq(d[d['b'] > 2], full[full['b'] > 2])
-        self.assert_eq(d[['a', 'b']], full[['a', 'b']])
-        self.assert_eq(d.a, full.a)
-        # TODO: assert d.b.mean().compute() == full.b.mean()
-        # TODO: assert np.allclose(d.b.var().compute(), full.b.var())
-        # TODO: assert np.allclose(d.b.std().compute(), full.b.std())
+        self.assert_eq(kdf[kdf['b'] > 2], pdf[pdf['b'] > 2])
+        self.assert_eq(kdf[['a', 'b']], pdf[['a', 'b']])
+        self.assert_eq(kdf.a, pdf.a)
+        # TODO: assert d.b.mean().compute() == pdf.b.mean()
+        # TODO: assert np.allclose(d.b.var().compute(), pdf.b.var())
+        # TODO: assert np.allclose(d.b.std().compute(), pdf.b.std())
 
-        assert repr(d)
+        assert repr(kdf)
 
         df = pd.DataFrame({
             'a': [1, 2, 3, 4, 5, 6, 7, 8, 9],
@@ -71,35 +71,49 @@ class DataFrameTest(ReusedSQLTestCase, TestUtils):
 
         self.assertEqual(ddf.a.notnull().alias("x").name, "x")
 
+    def test_assign(self):
+        kdf = self.kdf.copy()
+        pdf = self.pdf.copy()
+
+        kdf['w'] = 1.0
+        pdf['w'] = 1.0
+
+        self.assert_eq(kdf, pdf)
+
+        kdf['a'] = 'abc'
+        pdf['a'] = 'abc'
+
+        self.assert_eq(kdf, pdf)
+
     def test_head_tail(self):
-        d = self.df
-        full = self.full
+        kdf = self.kdf
+        pdf = self.pdf
 
-        self.assert_eq(d.head(2), full.head(2))
-        self.assert_eq(d.head(3), full.head(3))
-        self.assert_eq(d['a'].head(2), full['a'].head(2))
-        self.assert_eq(d['a'].head(3), full['a'].head(3))
+        self.assert_eq(kdf.head(2), pdf.head(2))
+        self.assert_eq(kdf.head(3), pdf.head(3))
+        self.assert_eq(kdf['a'].head(2), pdf['a'].head(2))
+        self.assert_eq(kdf['a'].head(3), pdf['a'].head(3))
 
-        # TODO: self.assert_eq(d.tail(2), full.tail(2))
-        # TODO: self.assert_eq(d.tail(3), full.tail(3))
-        # TODO: self.assert_eq(d['a'].tail(2), full['a'].tail(2))
-        # TODO: self.assert_eq(d['a'].tail(3), full['a'].tail(3))
+        # TODO: self.assert_eq(d.tail(2), pdf.tail(2))
+        # TODO: self.assert_eq(d.tail(3), pdf.tail(3))
+        # TODO: self.assert_eq(d['a'].tail(2), pdf['a'].tail(2))
+        # TODO: self.assert_eq(d['a'].tail(3), pdf['a'].tail(3))
 
     def test_index_head(self):
-        d = self.df
-        full = self.full
+        kdf = self.kdf
+        pdf = self.pdf
 
-        self.assert_eq(list(d.index.head(2).toPandas()), list(full.index[:2]))
-        self.assert_eq(list(d.index.head(3).toPandas()), list(full.index[:3]))
+        self.assert_eq(list(kdf.index.head(2).toPandas()), list(pdf.index[:2]))
+        self.assert_eq(list(kdf.index.head(3).toPandas()), list(pdf.index[:3]))
 
     def test_Series(self):
-        d = self.df
-        full = self.full
+        kdf = self.kdf
+        pdf = self.pdf
 
-        self.assertTrue(isinstance(d.a, Series))
-        self.assertTrue(isinstance(d.a + 1, Series))
-        self.assertTrue(isinstance(1 + d.a, Series))
-        # TODO: self.assert_eq(d + 1, full + 1)
+        self.assertTrue(isinstance(kdf.a, Series))
+        self.assertTrue(isinstance(kdf.a + 1, Series))
+        self.assertTrue(isinstance(1 + kdf.a, Series))
+        # TODO: self.assert_eq(d + 1, pdf + 1)
 
     def test_Index(self):
         for case in [pd.DataFrame(np.random.randn(10, 5), index=list('abcdefghij')),
@@ -110,31 +124,30 @@ class DataFrameTest(ReusedSQLTestCase, TestUtils):
             self.assert_eq(list(ddf.index.toPandas()), list(case.index))
 
     def test_attributes(self):
-        d = self.df
+        kdf = self.kdf
 
-        self.assertIn('a', dir(d))
-        self.assertNotIn('foo', dir(d))
-        self.assertRaises(AttributeError, lambda: d.foo)
+        self.assertIn('a', dir(kdf))
+        self.assertNotIn('foo', dir(kdf))
+        self.assertRaises(AttributeError, lambda: kdf.foo)
 
-        df = koalas.DataFrame({'a b c': [1, 2, 3]})
-        self.assertNotIn('a b c', dir(df))
-        df = koalas.DataFrame({'a': [1, 2], 5: [1, 2]})
-        self.assertIn('a', dir(df))
-        self.assertNotIn(5, dir(df))
+        kdf = koalas.DataFrame({'a b c': [1, 2, 3]})
+        self.assertNotIn('a b c', dir(kdf))
+        kdf = koalas.DataFrame({'a': [1, 2], 5: [1, 2]})
+        self.assertIn('a', dir(kdf))
+        self.assertNotIn(5, dir(kdf))
 
     def test_column_names(self):
-        d = self.df
+        kdf = self.kdf
 
-        self.assert_eq(d.columns, pd.Index(['a', 'b']))
-        self.assert_eq(d[['b', 'a']].columns, pd.Index(['b', 'a']))
-        self.assertEqual(d['a'].name, 'a')
-        self.assertEqual((d['a'] + 1).name, '(a + 1)')  # TODO: 'a'
-        self.assertEqual((d['a'] + d['b']).name, '(a + b)')  # TODO: None
+        self.assert_eq(kdf.columns, pd.Index(['a', 'b']))
+        self.assert_eq(kdf[['b', 'a']].columns, pd.Index(['b', 'a']))
+        self.assertEqual(kdf['a'].name, 'a')
+        self.assertEqual((kdf['a'] + 1).name, '(a + 1)')  # TODO: 'a'
+        self.assertEqual((kdf['a'] + kdf['b']).name, '(a + b)')  # TODO: None
 
     def test_index_names(self):
-        d = self.df
-
-        # TODO?: self.assertIsNone(d.index.name)
+        # kdf = self.kdf
+        # TODO?: self.assertIsNone(kdf.index.name)
 
         idx = pd.Index([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], name='x')
         df = pd.DataFrame(np.random.randn(10, 5), idx)
@@ -142,39 +155,39 @@ class DataFrameTest(ReusedSQLTestCase, TestUtils):
         self.assertEqual(ddf.index.name, 'x')
 
     def test_rename_columns(self):
-        df = pd.DataFrame({'a': [1, 2, 3, 4, 5, 6, 7],
-                           'b': [7, 6, 5, 4, 3, 2, 1]})
-        ddf = koalas.from_pandas(df)
+        pdf = pd.DataFrame({'a': [1, 2, 3, 4, 5, 6, 7],
+                            'b': [7, 6, 5, 4, 3, 2, 1]})
+        kdf = koalas.from_pandas(pdf)
 
-        ddf.columns = ['x', 'y']
-        df.columns = ['x', 'y']
-        self.assert_eq(ddf.columns, pd.Index(['x', 'y']))
-        self.assert_eq(ddf, df)
+        kdf.columns = ['x', 'y']
+        pdf.columns = ['x', 'y']
+        self.assert_eq(kdf.columns, pd.Index(['x', 'y']))
+        self.assert_eq(kdf, pdf)
 
         msg = "Length mismatch: Expected axis has 2 elements, new values have 4 elements"
         with self.assertRaisesRegex(ValueError, msg):
-            ddf.columns = [1, 2, 3, 4]
+            kdf.columns = [1, 2, 3, 4]
 
         # Multi-index columns
-        df = pd.DataFrame({('A', '0'): [1, 2, 2, 3], ('B', 1): [1, 2, 3, 4]})
-        ddf = koalas.from_pandas(df)
+        pdf = pd.DataFrame({('A', '0'): [1, 2, 2, 3], ('B', 1): [1, 2, 3, 4]})
+        kdf = koalas.from_pandas(pdf)
 
-        df.columns = ['x', 'y']
-        ddf.columns = ['x', 'y']
-        self.assert_eq(ddf.columns, pd.Index(['x', 'y']))
-        self.assert_eq(ddf, df)
+        pdf.columns = ['x', 'y']
+        kdf.columns = ['x', 'y']
+        self.assert_eq(kdf.columns, pd.Index(['x', 'y']))
+        self.assert_eq(kdf, pdf)
 
     def test_rename_series(self):
-        s = pd.Series([1, 2, 3, 4, 5, 6, 7], name='x')
-        ds = koalas.from_pandas(s)
+        ps = pd.Series([1, 2, 3, 4, 5, 6, 7], name='x')
+        ks = koalas.from_pandas(ps)
 
-        s.name = 'renamed'
-        ds.name = 'renamed'
-        self.assertEqual(ds.name, 'renamed')
-        self.assert_eq(ds, s)
+        ps.name = 'renamed'
+        ks.name = 'renamed'
+        self.assertEqual(ks.name, 'renamed')
+        self.assert_eq(ks, ps)
 
-        ind = s.index
-        dind = ds.index
+        ind = ps.index
+        dind = ks.index
         ind.name = 'renamed'
         dind.name = 'renamed'
         self.assertEqual(ind.name, 'renamed')
@@ -182,73 +195,73 @@ class DataFrameTest(ReusedSQLTestCase, TestUtils):
 
     def test_rename_series_method(self):
         # Series name
-        s = pd.Series([1, 2, 3, 4, 5, 6, 7], name='x')
-        ds = koalas.from_pandas(s)
+        ps = pd.Series([1, 2, 3, 4, 5, 6, 7], name='x')
+        ks = koalas.from_pandas(ps)
 
-        self.assert_eq(ds.rename('y'), s.rename('y'))
-        self.assertEqual(ds.name, 'x')  # no mutation
-        # self.assert_eq(ds.rename(), s.rename())
+        self.assert_eq(ks.rename('y'), ps.rename('y'))
+        self.assertEqual(ks.name, 'x')  # no mutation
+        # self.assert_eq(ks.rename(), ps.rename())
 
-        ds.rename('z', inplace=True)
-        s.rename('z', inplace=True)
-        self.assertEqual(ds.name, 'z')
-        self.assert_eq(ds, s)
+        ks.rename('z', inplace=True)
+        ps.rename('z', inplace=True)
+        self.assertEqual(ks.name, 'z')
+        self.assert_eq(ks, ps)
 
         # Series index
-        s = pd.Series(['a', 'b', 'c', 'd', 'e', 'f', 'g'], name='x')
-        ds = koalas.from_pandas(s)
+        ps = pd.Series(['a', 'b', 'c', 'd', 'e', 'f', 'g'], name='x')
+        # ks = koalas.from_pandas(s)
 
         # TODO: index
-        # res = ds.rename(lambda x: x ** 2)
-        # self.assert_eq(res, s.rename(lambda x: x ** 2))
+        # res = ks.rename(lambda x: x ** 2)
+        # self.assert_eq(res, ps.rename(lambda x: x ** 2))
 
-        # res = ds.rename(s)
-        # self.assert_eq(res, s.rename(s))
+        # res = ks.rename(ps)
+        # self.assert_eq(res, ps.rename(ps))
 
-        # res = ds.rename(ds)
-        # self.assert_eq(res, s.rename(s))
+        # res = ks.rename(ks)
+        # self.assert_eq(res, ps.rename(ps))
 
-        # res = ds.rename(lambda x: x**2, inplace=True)
-        # self.assertis(res, ds)
+        # res = ks.rename(lambda x: x**2, inplace=True)
+        # self.assertis(res, ks)
         # s.rename(lambda x: x**2, inplace=True)
-        # self.assert_eq(ds, s)
+        # self.assert_eq(ks, ps)
 
     def test_dropna(self):
-        df = pd.DataFrame({'x': [np.nan, 2, 3, 4, np.nan, 6],
-                           'y': [1, 2, np.nan, 4, np.nan, np.nan],
-                           'z': [1, 2, 3, 4, np.nan, np.nan]},
-                          index=[10, 20, 30, 40, 50, 60])
-        ddf = koalas.from_pandas(df)
+        pdf = pd.DataFrame({'x': [np.nan, 2, 3, 4, np.nan, 6],
+                            'y': [1, 2, np.nan, 4, np.nan, np.nan],
+                            'z': [1, 2, 3, 4, np.nan, np.nan]},
+                           index=[10, 20, 30, 40, 50, 60])
+        kdf = koalas.from_pandas(pdf)
 
-        self.assert_eq(ddf.x.dropna(), df.x.dropna())
-        self.assert_eq(ddf.y.dropna(), df.y.dropna())
-        self.assert_eq(ddf.z.dropna(), df.z.dropna())
+        self.assert_eq(kdf.x.dropna(), pdf.x.dropna())
+        self.assert_eq(kdf.y.dropna(), pdf.y.dropna())
+        self.assert_eq(kdf.z.dropna(), pdf.z.dropna())
 
-        self.assert_eq(ddf.dropna(), df.dropna())
-        self.assert_eq(ddf.dropna(how='all'), df.dropna(how='all'))
-        self.assert_eq(ddf.dropna(subset=['x']), df.dropna(subset=['x']))
-        self.assert_eq(ddf.dropna(subset=['y', 'z']), df.dropna(subset=['y', 'z']))
-        self.assert_eq(ddf.dropna(subset=['y', 'z'], how='all'),
-                       df.dropna(subset=['y', 'z'], how='all'))
+        self.assert_eq(kdf.dropna(), pdf.dropna())
+        self.assert_eq(kdf.dropna(how='all'), pdf.dropna(how='all'))
+        self.assert_eq(kdf.dropna(subset=['x']), pdf.dropna(subset=['x']))
+        self.assert_eq(kdf.dropna(subset=['y', 'z']), pdf.dropna(subset=['y', 'z']))
+        self.assert_eq(kdf.dropna(subset=['y', 'z'], how='all'),
+                       pdf.dropna(subset=['y', 'z'], how='all'))
 
-        self.assert_eq(ddf.dropna(thresh=2), df.dropna(thresh=2))
-        self.assert_eq(ddf.dropna(thresh=1, subset=['y', 'z']),
-                       df.dropna(thresh=1, subset=['y', 'z']))
+        self.assert_eq(kdf.dropna(thresh=2), pdf.dropna(thresh=2))
+        self.assert_eq(kdf.dropna(thresh=1, subset=['y', 'z']),
+                       pdf.dropna(thresh=1, subset=['y', 'z']))
 
-        ddf2 = ddf.copy()
+        ddf2 = kdf.copy()
         x = ddf2.x
         x.dropna(inplace=True)
-        self.assert_eq(x, df.x.dropna())
+        self.assert_eq(x, pdf.x.dropna())
         ddf2.dropna(inplace=True)
-        self.assert_eq(ddf2, df.dropna())
+        self.assert_eq(ddf2, pdf.dropna())
 
         msg = "dropna currently only works for axis=0 or axis='index'"
         with self.assertRaisesRegex(NotImplementedError, msg):
-            ddf.dropna(axis=1)
+            kdf.dropna(axis=1)
         with self.assertRaisesRegex(NotImplementedError, msg):
-            ddf.dropna(axis='column')
+            kdf.dropna(axis='column')
         with self.assertRaisesRegex(NotImplementedError, msg):
-            ddf.dropna(axis='foo')
+            kdf.dropna(axis='foo')
 
     def test_dtype(self):
         pdf = pd.DataFrame({'a': list('abc'),
@@ -262,50 +275,50 @@ class DataFrameTest(ReusedSQLTestCase, TestUtils):
         self.assertTrue((kdf.dtypes == pdf.dtypes).all())
 
     def test_value_counts(self):
-        df = pd.DataFrame({'x': [1, 2, 1, 3, 3, np.nan, 1, 4]})
-        ddf = koalas.from_pandas(df)
+        pdf = pd.DataFrame({'x': [1, 2, 1, 3, 3, np.nan, 1, 4]})
+        kdf = koalas.from_pandas(pdf)
 
-        exp = df.x.value_counts()
-        res = ddf.x.value_counts()
+        exp = pdf.x.value_counts()
+        res = kdf.x.value_counts()
         self.assertEqual(res.name, exp.name)
         self.assertPandasAlmostEqual(res.toPandas(), exp)
 
-        self.assertPandasAlmostEqual(ddf.x.value_counts(normalize=True).toPandas(),
-                                     df.x.value_counts(normalize=True))
-        self.assertPandasAlmostEqual(ddf.x.value_counts(ascending=True).toPandas(),
-                                     df.x.value_counts(ascending=True))
-        self.assertPandasAlmostEqual(ddf.x.value_counts(normalize=True, dropna=False).toPandas(),
-                                     df.x.value_counts(normalize=True, dropna=False))
-        self.assertPandasAlmostEqual(ddf.x.value_counts(ascending=True, dropna=False).toPandas(),
-                                     df.x.value_counts(ascending=True, dropna=False))
+        self.assertPandasAlmostEqual(kdf.x.value_counts(normalize=True).toPandas(),
+                                     pdf.x.value_counts(normalize=True))
+        self.assertPandasAlmostEqual(kdf.x.value_counts(ascending=True).toPandas(),
+                                     pdf.x.value_counts(ascending=True))
+        self.assertPandasAlmostEqual(kdf.x.value_counts(normalize=True, dropna=False).toPandas(),
+                                     pdf.x.value_counts(normalize=True, dropna=False))
+        self.assertPandasAlmostEqual(kdf.x.value_counts(ascending=True, dropna=False).toPandas(),
+                                     pdf.x.value_counts(ascending=True, dropna=False))
 
         with self.assertRaisesRegex(NotImplementedError,
                                     "value_counts currently does not support bins"):
-            ddf.x.value_counts(bins=3)
+            kdf.x.value_counts(bins=3)
 
-        s = df.x
+        s = pdf.x
         s.name = 'index'
-        ds = ddf.x
+        ds = kdf.x
         ds.name = 'index'
         self.assertPandasAlmostEqual(ds.value_counts().toPandas(), s.value_counts())
 
     def test_isnull(self):
-        df = pd.DataFrame({'x': [1, 2, 3, 4, None, 6], 'y': list('abdabd')},
-                          index=[10, 20, 30, 40, 50, 60])
-        a = koalas.from_pandas(df)
+        pdf = pd.DataFrame({'x': [1, 2, 3, 4, None, 6], 'y': list('abdabd')},
+                           index=[10, 20, 30, 40, 50, 60])
+        kdf = koalas.from_pandas(pdf)
 
-        self.assert_eq(a.x.notnull(), df.x.notnull())
-        self.assert_eq(a.x.isnull(), df.x.isnull())
-        self.assert_eq(a.notnull(), df.notnull())
-        self.assert_eq(a.isnull(), df.isnull())
+        self.assert_eq(kdf.x.notnull(), pdf.x.notnull())
+        self.assert_eq(kdf.x.isnull(), pdf.x.isnull())
+        self.assert_eq(kdf.notnull(), pdf.notnull())
+        self.assert_eq(kdf.isnull(), pdf.isnull())
 
     def test_to_datetime(self):
-        df = pd.DataFrame({'year': [2015, 2016],
-                           'month': [2, 3],
-                           'day': [4, 5]})
-        ddf = koalas.from_pandas(df)
+        pdf = pd.DataFrame({'year': [2015, 2016],
+                            'month': [2, 3],
+                            'day': [4, 5]})
+        kdf = koalas.from_pandas(pdf)
 
-        self.assert_eq(pd.to_datetime(df), koalas.to_datetime(ddf))
+        self.assert_eq(pd.to_datetime(pdf), koalas.to_datetime(kdf))
 
         s = pd.Series(['3/11/2000', '3/12/2000', '3/13/2000'] * 100)
         ds = koalas.from_pandas(s)
@@ -314,29 +327,29 @@ class DataFrameTest(ReusedSQLTestCase, TestUtils):
                        koalas.to_datetime(ds, infer_datetime_format=True))
 
     def test_missing(self):
-        d = self.df
+        kdf = self.kdf
 
         missing_functions = inspect.getmembers(_MissingPandasLikeDataFrame, inspect.isfunction)
         for name, _ in missing_functions:
             with self.assertRaisesRegex(PandasNotImplementedError,
                                         "DataFrame.*{}.*not implemented".format(name)):
-                getattr(d, name)()
+                getattr(kdf, name)()
 
         missing_functions = inspect.getmembers(_MissingPandasLikeSeries, inspect.isfunction)
         for name, _ in missing_functions:
             with self.assertRaisesRegex(PandasNotImplementedError,
                                         "Series.*{}.*not implemented".format(name)):
-                getattr(d.a, name)()
+                getattr(kdf.a, name)()
 
     def test_to_numpy(self):
-        df = pd.DataFrame({'a': [4, 2, 3, 4, 8, 6],
-                           'b': [1, 2, 9, 4, 2, 4],
-                           'c': ["one", "three", "six", "seven", "one", "5"]},
-                          index=[10, 20, 30, 40, 50, 60])
+        pdf = pd.DataFrame({'a': [4, 2, 3, 4, 8, 6],
+                            'b': [1, 2, 9, 4, 2, 4],
+                            'c': ["one", "three", "six", "seven", "one", "5"]},
+                           index=[10, 20, 30, 40, 50, 60])
 
-        ddf = koalas.from_pandas(df)
+        kdf = koalas.from_pandas(pdf)
 
-        np.testing.assert_equal(ddf.to_numpy(), df.values)
+        np.testing.assert_equal(kdf.to_numpy(), pdf.values)
 
         s = pd.Series([1, 2, 3, 4, 5, 6, 7], name='x')
 

--- a/databricks/koalas/tests/test_indexing.py
+++ b/databricks/koalas/tests/test_indexing.py
@@ -105,7 +105,7 @@ class BasicIndexingTest(ComparisonTestBase):
         self.assertPandasEqual(df2.toPandas(), pdf.set_index(['year', 'month']))
 
     def test_limitations(self):
-        df = self.df.set_index('month')
+        df = self.kdf.set_index('month')
 
         self.assertRaisesRegex(ValueError, 'Level should be all int or all string.',
                                lambda: df.reset_index([1, 'month']))


### PR DESCRIPTION
This PR resolves #192 by falling back to literal when it's not a column

```python
>>> pdf = pd.DataFrame([{'a': 1}, {'a': 1}, {'b': 2}])
>>> pdf
     a    b
0  1.0  NaN
1  1.0  NaN
2  NaN  2.0
>>> pdf['w'] = 1
>>> pdf
     a    b  w
0  1.0  NaN  1
1  1.0  NaN  1
2  NaN  2.0  1
>>> pdf['b'] = 1
>>> pdf
     a  b  w
0  1.0  1  1
1  1.0  1  1
2  NaN  1  1
```

Before:

```python
>>> kdf = ks.DataFrame([{'a': 1}, {'a': 1}, {'b': 2}])
>>> kdf
     a    b
0  1.0  NaN
1  1.0  NaN
2  NaN  2.0
IndentationError: unexpected indent
>>> kdf['w'] = 1
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/.../koalas/databricks/koalas/frame.py", line 656, in __setitem__
    kdf = self.assign(**{key: value})
  File "/.../koalas/databricks/koalas/frame.py", line 335, in assign
    sdf = sdf.withColumn(name, c)
  File "/.../spark/python/lib/pyspark.zip/pyspark/sql/dataframe.py", line 1986, in withColumn
AssertionError: col should be Column
```

After:

```python
>>> kdf = ks.DataFrame([{'a': 1}, {'a': 1}, {'b': 2}])
>>> kdf
     a    b
0  1.0  NaN
1  1.0  NaN
2  NaN  2.0
>>> kdf['w'] = 1
>>> kdf
     a    b  w
0  1.0  NaN  1
1  1.0  NaN  1
2  NaN  2.0  1
>>> kdf['b'] = 1
>>> kdf
     a  b  w
0  1.0  1  1
1  1.0  1  1
2  NaN  1  1
```

While I am here, I also addressed:

1. PEP8 style
2. Koalas DataFrame is named to `kdf` and Pandas DataFrame is named to `pdf` in `test_dataframe.py` to prevent confusion.