### PR TITLE
spark.DataFrame.to_koalas()

### DIFF
--- a/databricks/koalas/__init__.py
+++ b/databricks/koalas/__init__.py
@@ -43,6 +43,7 @@ from databricks.koalas.typedef import Col, pandas_wrap
 __all__ = ['read_csv', 'read_parquet', 'to_datetime', 'from_pandas',
            'get_dummies', 'DataFrame', 'Series']
 
+
 def _auto_patch():
     import os
     import logging
@@ -55,5 +56,6 @@ def _auto_patch():
 
     from pyspark.sql import dataframe as df
     df.DataFrame.to_koalas = DataFrame.to_koalas
+
 
 _auto_patch()

--- a/databricks/koalas/__init__.py
+++ b/databricks/koalas/__init__.py
@@ -42,3 +42,18 @@ from databricks.koalas.typedef import Col, pandas_wrap
 
 __all__ = ['read_csv', 'read_parquet', 'to_datetime', 'from_pandas',
            'get_dummies', 'DataFrame', 'Series']
+
+def _auto_patch():
+    import os
+    import logging
+    # Autopatching is on by default.
+    x = os.getenv("SPARK_KOALAS_AUTOPATCH", "true")
+    if x.lower() in ("true", "1", "enabled"):
+        logger = logging.getLogger('spark')
+        logger.info("Patching spark automatically. You can disable it by setting "
+                    "SPARK_KOALAS_AUTOPATCH=false in your environment")
+
+    from pyspark.sql import dataframe as df
+    df.DataFrame.to_koalas = DataFrame.to_koalas
+
+_auto_patch()

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -303,6 +303,47 @@ class DataFrame(_Frame):
 
     notna = notnull
 
+    def to_koalas(self):
+        """
+        Converts the existing DataFrame into a Koalas DataFrame.
+
+        This method is monkey-patched into Spark's DataFrame and can be used
+        to convert a Spark DataFrame into a Koalas DataFrame. If running on
+        an existing Koalas DataFrame, the method returns itself.
+
+        If a Koalas DataFrame is converted to a Spark DataFrame and then back
+        to Koalas, it will lose the index information and the original index
+        will be turned into a normal column.
+
+        Examples
+        --------
+        >>> df = ks.DataFrame({'col1': [1, 2], 'col2': [3, 4]})
+        >>> df
+           col1  col2
+        0     1     3
+        1     2     4
+
+        >>> spark_df = df.to_spark()
+        >>> spark_df
+        DataFrame[__index_level_0__: bigint, col1: bigint, col2: bigint]
+
+        >>> kdf = spark_df.to_koalas()
+        >>> kdf
+           __index_level_0__  col1  col2
+        0                  0     1     3
+        1                  1     2     4
+        """
+        if isinstance(self, DataFrame):
+            return self
+        else:
+            return DataFrame(self)
+
+    def to_spark(self):
+        """
+        Return the current DataFrame as a Spark DataFrame.
+        """
+        return self._sdf
+
     @derived_from(spark.DataFrame)
     def toPandas(self):
         sdf = self._sdf.select(['`{}`'.format(name) for name in self._metadata.all_fields])

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -315,6 +315,10 @@ class DataFrame(_Frame):
         to Koalas, it will lose the index information and the original index
         will be turned into a normal column.
 
+        See Also
+        --------
+        DataFrame.to_spark
+
         Examples
         --------
         >>> df = ks.DataFrame({'col1': [1, 2], 'col2': [3, 4]})
@@ -341,6 +345,10 @@ class DataFrame(_Frame):
     def to_spark(self):
         """
         Return the current DataFrame as a Spark DataFrame.
+
+        See Also
+        --------
+        DataFrame.to_koalas
         """
         return self._sdf
 

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -19,8 +19,6 @@ import inspect
 import numpy as np
 import pandas as pd
 
-from pyspark import sql as spark
-
 from databricks import koalas
 from databricks.koalas.testing.utils import ReusedSQLTestCase, SQLTestUtils
 from databricks.koalas.exceptions import PandasNotImplementedError

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -19,6 +19,8 @@ import inspect
 import numpy as np
 import pandas as pd
 
+from pyspark import sql as spark
+
 from databricks import koalas
 from databricks.koalas.testing.utils import ReusedSQLTestCase, SQLTestUtils
 from databricks.koalas.exceptions import PandasNotImplementedError

--- a/docs/source/reference/frame.rst
+++ b/docs/source/reference/frame.rst
@@ -115,3 +115,5 @@ Serialization / IO / Conversion
 
    DataFrame.to_html
    DataFrame.to_numpy
+   DataFrame.to_koalas
+   DataFrame.to_spark


### PR DESCRIPTION
Introduces a new method to_koalas that can be used to convert a Spark DataFrame into a Koalas DataFrame. This method is monkey patched into Spark dynamically when the koalas package is imported.

Resolves #175