### PR TITLE
DataFrame/Series.to_pandas

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -364,7 +364,7 @@ class DataFrame(_Frame):
                 pdf.index.name = index_names[0]
         return pdf
 
-    # toPandas alias to match Spark's version
+    # Alias to maintain backward compatibility with Spark
     toPandas = to_pandas
 
     @derived_from(pd.DataFrame)

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -327,13 +327,11 @@ class DataFrame(_Frame):
         """
         Return a Pandas DataFrame.
 
-        This method should only be used if the resulting Pandas's DataFrame is
-        expected to be small, as all the data is loaded into the driver's memory.
+        .. note:: This method should only be used if the resulting Pandas DataFrame is expected
+            to be small, as all the data is loaded into the driver's memory.
 
         Examples
         --------
-        Constructing DataFrame from a dictionary:
-
         >>> df = ks.DataFrame([(.2, .3), (.0, .6), (.6, .0), (.2, .1)],
         ...                   columns=['dogs', 'cats'])
         >>> df.to_pandas()

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -323,8 +323,26 @@ class DataFrame(_Frame):
 
     notna = notnull
 
-    @derived_from(spark.DataFrame)
-    def toPandas(self):
+    def to_pandas(self):
+        """
+        Return a Pandas DataFrame.
+
+        This method should only be used if the resulting Pandas's DataFrame is
+        expected to be small, as all the data is loaded into the driver's memory.
+
+        Examples
+        --------
+        Constructing DataFrame from a dictionary:
+
+        >>> df = ks.DataFrame([(.2, .3), (.0, .6), (.6, .0), (.2, .1)],
+        ...                   columns=['dogs', 'cats'])
+        >>> df.to_pandas()
+           dogs  cats
+        0   0.2   0.3
+        1   0.0   0.6
+        2   0.6   0.0
+        3   0.2   0.1
+        """
         sdf = self._sdf.select(['`{}`'.format(name) for name in self._metadata.all_fields])
         pdf = sdf.toPandas()
         if len(pdf) == 0 and len(sdf.schema) > 0:
@@ -345,6 +363,9 @@ class DataFrame(_Frame):
             else:
                 pdf.index.name = index_names[0]
         return pdf
+
+    # toPandas alias to match Spark's version
+    toPandas = to_pandas
 
     @derived_from(pd.DataFrame)
     def assign(self, **kwargs):

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -298,6 +298,7 @@ class Series(_Frame):
         1    0.0
         2    0.6
         3    0.2
+        Name: dogs, dtype: float64
         """
         return _col(self.to_dataframe().toPandas())
 

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -286,9 +286,11 @@ class Series(_Frame):
         """
         Return a pandas DataFrame.
 
-        This method should only be used if the resulting Pandas's DataFrame is
-        expected to be small, as all the data is loaded into the driver's memory.
+        .. note:: This method should only be used if the resulting Pandas DataFrame is expected
+            to be small, as all the data is loaded into the driver's memory.
 
+        Examples
+        --------
         >>> df = ks.DataFrame([(.2, .3), (.0, .6), (.6, .0), (.2, .1)],
         ...                   columns=['dogs', 'cats'])
         >>> df['dogs'].to_pandas()

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -282,8 +282,25 @@ class Series(_Frame):
         metadata = Metadata(column_fields=[sdf.schema[-1].name], index_info=self._index_info)
         return DataFrame(sdf, metadata)
 
-    def toPandas(self):
+    def to_pandas(self):
+        """
+        Return a pandas DataFrame.
+
+        This method should only be used if the resulting Pandas's DataFrame is
+        expected to be small, as all the data is loaded into the driver's memory.
+
+        >>> df = ks.DataFrame([(.2, .3), (.0, .6), (.6, .0), (.2, .1)],
+        ...                   columns=['dogs', 'cats'])
+        >>> df['dogs'].to_pandas()
+        0    0.2
+        1    0.0
+        2    0.6
+        3    0.2
+        """
         return _col(self.to_dataframe().toPandas())
+
+    # Alias to maintain backward compatibility with Spark
+    toPandas = to_pandas
 
     @derived_from(pd.Series)
     def isnull(self):

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -399,3 +399,9 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         ddf = koalas.from_pandas(s)
         np.testing.assert_equal(ddf.to_numpy(), s.values)
+
+    def test_to_pandas(self):
+        kdf = self.kdf
+        pdf = self.pdf
+        self.assert_eq(kdf.toPandas(), pdf)
+        self.assert_eq(kdf.to_pandas(), pdf)

--- a/docs/source/reference/frame.rst
+++ b/docs/source/reference/frame.rst
@@ -113,5 +113,6 @@ Serialization / IO / Conversion
 .. autosummary::
    :toctree: api/
 
+   DataFrame.to_pandas
    DataFrame.to_html
    DataFrame.to_numpy

--- a/docs/source/reference/series.rst
+++ b/docs/source/reference/series.rst
@@ -73,8 +73,9 @@ Missing data handling
    Series.dropna
 
 Serialization / IO / Conversion
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------
 .. autosummary::
    :toctree: api/
 
+   Series.to_pandas
    Series.to_numpy


### PR DESCRIPTION
Rename existing toPandas methods to_pandas, add docs, and alias toPandas to to_pandas for backward compatibility with Spark.
