### PR TITLE
Use Python 3.6 in readthedocs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -29,7 +29,7 @@ formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.5
+  version: 3.6
   install:
     - requirements: requirements-dev.txt
     - method: pip


### PR DESCRIPTION
Somehow type hint isn't recognized in readthedocs build with Python 3.5. This PR simply bumps up the Python version to 3.6.

https://github.com/databricks/koalas/commit/0470b24b895c7e80fa1dd300837c9d2d234252e4

It was tested in readthedocs.

![Screen Shot 2019-04-30 at 2 30 44 PM](https://user-images.githubusercontent.com/6477701/56942292-d36be800-6b54-11e9-81b1-e4bf4295b320.png)

Resolves #198 