### PR TITLE
Support limit push down in to_html

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -161,13 +161,99 @@ class DataFrame(_Frame):
         cols = list(self.columns)
         return list((col_name, self[col_name]) for col_name in cols)
 
-    @derived_from(pd.DataFrame)
     def to_html(self, buf=None, columns=None, col_space=None, header=True, index=True,
                 na_rep='NaN', formatters=None, float_format=None, sparsify=None, index_names=True,
                 justify=None, max_rows=None, max_cols=None, show_dimensions=False, decimal='.',
                 bold_rows=True, classes=None, escape=True, notebook=False, border=None,
                 table_id=None, render_links=False):
-        return self.toPandas().to_html(
+        """
+        Render a DataFrame as an HTML table.
+
+        .. note:: This method should only be used if the resulting Pandas DataFrame is expected
+            to be small, as all the data is loaded into the driver's memory.
+
+        Parameters
+        ----------
+        buf : StringIO-like, optional
+            Buffer to write to.
+        columns : sequence, optional, default None
+            The subset of columns to write. Writes all columns by default.
+        col_space : int, optional
+            The minimum width of each column.
+        header : bool, optional
+            %(header)s.
+        index : bool, optional, default True
+            Whether to print index (row) labels.
+        na_rep : str, optional, default 'NaN'
+            String representation of NAN to use.
+        formatters : list or dict of one-param. functions, optional
+            Formatter functions to apply to columns' elements by position or
+            name.
+            The result of each function must be a unicode string.
+            List must be of length equal to the number of columns.
+        float_format : one-parameter function, optional, default None
+            Formatter function to apply to columns' elements if they are
+            floats. The result of this function must be a unicode string.
+        sparsify : bool, optional, default True
+            Set to False for a DataFrame with a hierarchical index to print
+            every multiindex key at each row.
+        index_names : bool, optional, default True
+            Prints the names of the indexes.
+        justify : str, default None
+            How to justify the column labels. If None uses the option from
+            the print configuration (controlled by set_option), 'right' out
+            of the box. Valid values are
+
+            * left
+            * right
+            * center
+            * justify
+            * justify-all
+            * start
+            * end
+            * inherit
+            * match-parent
+            * initial
+            * unset.
+        max_rows : int, optional
+            Maximum number of rows to display in the console.
+        max_cols : int, optional
+            Maximum number of columns to display in the console.
+        show_dimensions : bool, default False
+            Display DataFrame dimensions (number of rows by number of columns).
+        decimal : str, default '.'
+            Character recognized as decimal separator, e.g. ',' in Europe.
+        bold_rows : bool, default True
+            Make the row labels bold in the output.
+        classes : str or list or tuple, default None
+            CSS class(es) to apply to the resulting html table.
+        escape : bool, default True
+            Convert the characters <, >, and & to HTML-safe sequences.
+        notebook : {True, False}, default False
+            Whether the generated HTML is for IPython Notebook.
+        border : int
+            A ``border=border`` attribute is included in the opening
+            `<table>` tag. Default ``pd.options.html.border``.
+        table_id : str, optional
+            A css id is included in the opening `<table>` tag if specified.
+        render_links : bool, default False
+            Convert URLs to HTML links.
+
+        Returns
+        -------
+        str (or unicode, depending on data and options)
+            String representation of the dataframe.
+
+        See Also
+        --------
+        to_string : Convert DataFrame to a string.
+        """
+        if max_rows is not None:
+            kdf = self.head(max_rows)
+        else:
+            kdf = self
+
+        return kdf.to_pandas().to_html(
             buf=buf, columns=columns, col_space=col_space, header=header, index=index,
             na_rep=na_rep, formatters=formatters, float_format=float_format, sparsify=sparsify,
             index_names=index_names, justify=justify, max_rows=max_rows, max_cols=max_cols,

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -170,7 +170,8 @@ class DataFrame(_Frame):
         Render a DataFrame as an HTML table.
 
         .. note:: This method should only be used if the resulting Pandas DataFrame is expected
-            to be small, as all the data is loaded into the driver's memory.
+            to be small, as all the data is loaded into the driver's memory. If the input DataFrame
+            is large, set max_rows parameter.
 
         Parameters
         ----------

--- a/databricks/koalas/tests/test_dataframe_conversion.py
+++ b/databricks/koalas/tests/test_dataframe_conversion.py
@@ -1,0 +1,71 @@
+#
+# Copyright (C) 2019 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import string
+
+import pandas as pd
+
+from databricks import koalas
+from databricks.koalas.testing.utils import ReusedSQLTestCase, SQLTestUtils
+
+
+class DataFrameConversionTest(ReusedSQLTestCase, SQLTestUtils):
+
+    @property
+    def pdf(self):
+        return pd.DataFrame({
+            'a': [1, 2, 3],
+            'b': [4, 5, 6],
+        }, index=[0, 1, 3])
+
+    @property
+    def kdf(self):
+        return koalas.from_pandas(self.pdf)
+
+    def strip_all_whitespace(self, str):
+        """A helper function to remove all whitespace from a string."""
+        return str.translate({ord(c): None for c in string.whitespace})
+
+    def test_to_html(self):
+        expected = self.strip_all_whitespace("""
+            <table border="1" class="dataframe">
+              <thead>
+                <tr style="text-align: right;"><th></th><th>a</th><th>b</th></tr>
+              </thead>
+              <tbody>
+                <tr><th>0</th><td>1</td><td>4</td></tr>
+                <tr><th>1</th><td>2</td><td>5</td></tr>
+                <tr><th>3</th><td>3</td><td>6</td></tr>
+              </tbody>
+            </table>
+            """)
+        got = self.strip_all_whitespace(self.kdf.to_html())
+        self.assert_eq(got, expected)
+
+    def test_to_html_max_rows(self):
+        expected = self.strip_all_whitespace("""
+            <table border="1" class="dataframe">
+              <thead>
+                <tr style="text-align: right;"><th></th><th>a</th><th>b</th></tr>
+              </thead>
+              <tbody>
+                <tr><th>0</th><td>1</td><td>4</td></tr>
+                <tr><th>1</th><td>2</td><td>5</td></tr>
+              </tbody>
+            </table>
+            """)
+        got = self.strip_all_whitespace(self.kdf.to_html(max_rows=2))
+        self.assert_eq(got, expected)

--- a/databricks/koalas/tests/test_dataframe_conversion.py
+++ b/databricks/koalas/tests/test_dataframe_conversion.py
@@ -35,7 +35,8 @@ class DataFrameConversionTest(ReusedSQLTestCase, SQLTestUtils):
     def kdf(self):
         return koalas.from_pandas(self.pdf)
 
-    def strip_all_whitespace(self, str):
+    @staticmethod
+    def strip_all_whitespace(str):
         """A helper function to remove all whitespace from a string."""
         return str.translate({ord(c): None for c in string.whitespace})
 


### PR DESCRIPTION
This patch inlines to_html docs from pandas, and supports limit push down when max_rows is specified, so we don't need to pull in all the data. 