### PR TITLE
validate_arguments_and_invoke_function

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -250,6 +250,7 @@ class DataFrame(_Frame):
         --------
         to_string : Convert DataFrame to a string.
         """
+        # Make sure locals() call is at the top of the function so we don't capture local variables.
         args = locals()
         if max_rows is not None:
             kdf = self.head(max_rows)

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -31,7 +31,7 @@ from pyspark.sql.types import DataType, DoubleType, FloatType, StructField, Stru
 from pyspark.sql.utils import AnalysisException
 
 from databricks import koalas as ks  # For running doctests and reference resolution in PyCharm.
-from databricks.koalas.utils import default_session
+from databricks.koalas.utils import default_session, validate_arguments_and_invoke_function
 from databricks.koalas.dask.compatibility import string_types
 from databricks.koalas.dask.utils import derived_from
 from databricks.koalas.generic import _Frame, max_display_count
@@ -250,24 +250,14 @@ class DataFrame(_Frame):
         --------
         to_string : Convert DataFrame to a string.
         """
+        args = locals()
         if max_rows is not None:
             kdf = self.head(max_rows)
         else:
             kdf = self
 
-        kwargs = {
-            "buf": buf, "columns": columns, "col_space": col_space,
-            "header": header, "index": index, "na_rep": na_rep,
-            "formatters": formatters, "float_format": float_format, "sparsify": sparsify,
-            "index_names": index_names, "justify": justify, "max_rows": max_rows,
-            "max_cols": max_cols, "show_dimensions": show_dimensions, "decimal": decimal,
-            "bold_rows": bold_rows, "classes": classes, "escape": escape,
-            "notebook": notebook, "border": border, "table_id": table_id
-        }
-        if LooseVersion(pd.__version__) >= LooseVersion("0.24"):
-            kwargs["render_links"] = render_links
-
-        return kdf.to_pandas().to_html(**kwargs)
+        return validate_arguments_and_invoke_function(
+            kdf.to_pandas(), self.to_html, pd.DataFrame.to_html, args)
 
     @property
     def index(self):

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -19,15 +19,13 @@ A wrapper class for Spark DataFrame to behave similar to pandas DataFrame.
 """
 from decorator import dispatch_on
 from functools import partial, reduce
-from distutils.version import LooseVersion
 
 import numpy as np
 import pandas as pd
 from pandas.api.types import is_datetime64_dtype, is_datetime64tz_dtype
 from pyspark import sql as spark
 from pyspark.sql import functions as F, Column
-from pyspark.sql.types import DataType, DoubleType, FloatType, StructField, StructType, \
-    to_arrow_type
+from pyspark.sql.types import StructField, StructType, to_arrow_type
 from pyspark.sql.utils import AnalysisException
 
 from databricks import koalas as ks  # For running doctests and reference resolution in PyCharm.

--- a/databricks/koalas/tests/test_utils.py
+++ b/databricks/koalas/tests/test_utils.py
@@ -1,0 +1,45 @@
+#
+# Copyright (C) 2019 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pandas as pd
+
+from databricks.koalas.testing.utils import ReusedSQLTestCase, SQLTestUtils
+from databricks.koalas.utils import validate_arguments_and_invoke_function
+
+
+class UtilsTest(ReusedSQLTestCase, SQLTestUtils):
+
+    # a dummy to_html version with an extra parameter that pandas does not support
+    # used in test_validate_arguments_and_invoke_function
+    def to_html(self, max_rows=None, unsupported_param=None):
+        args = locals()
+
+        pdf = pd.DataFrame({
+            'a': [1, 2, 3],
+            'b': [4, 5, 6],
+        }, index=[0, 1, 3])
+        validate_arguments_and_invoke_function(pdf, self.to_html, pd.DataFrame.to_html, args)
+
+    def test_validate_arguments_and_invoke_function(self):
+        # This should pass and run fine
+        self.to_html()
+        self.to_html(unsupported_param=None)
+        self.to_html(max_rows=5)
+
+        # This should fail because we are explicitly setting an unsupported param
+        # to a non-default value
+        with self.assertRaises(TypeError):
+            self.to_html(unsupported_param=1)

--- a/databricks/koalas/utils.py
+++ b/databricks/koalas/utils.py
@@ -67,8 +67,8 @@ def validate_arguments_and_invoke_function(pdf: pd.DataFrame, koalas_func: Calla
                 del args[param.name]
             else:
                 raise TypeError(
-                    ("The version of pandas available does not support parameter '%s' " +
-                        "for function '%s'.") % (param.name, pandas_func.__name__))
+                    ("The pandas version [%s] available does not support parameter '%s' " +
+                        "for function '%s'.") % (pd.__version__, param.name, pandas_func.__name__))
 
     args['self'] = pdf
     return pandas_func(**args)

--- a/databricks/koalas/utils.py
+++ b/databricks/koalas/utils.py
@@ -22,3 +22,47 @@ from pyspark import sql as spark
 
 def default_session():
     return spark.SparkSession.builder.getOrCreate()
+
+
+def validate_arguments_and_invoke_function(pdf, koalas_func, pandas_func, input_args):
+    """
+    Invokes a pandas function.
+
+    This is created because different versions of pandas support different parameters, and as a
+    result when we code against the latest version, our users might get a confusing
+    "got an unexpected keyword argument" error if they are using an older version of pandas.
+
+    This function validates all the arguments, removes the ones that are not supported if they
+    are simply the default value (i.e. most likely the user didn't explicitly specify it). It
+    throws a TypeError if the user explicitly specify an argument that is not supported by the
+    pandas version available.
+
+    For example usage, look at DataFrame.to_html().
+
+    :param pdf: the pandas DataFrame to operate on
+    :param koalas_func: koalas function, used to get default parameter values
+    :param pandas_func: pandas function, used to check whether pandas supports all the arguments
+    :param input_args: arguments to pass to the pandas function
+    :return: whatever pandas_func returns
+    """
+    import inspect
+
+    # Makes a copy since whatever passed in is likely created by locals(), and we can't delete
+    # 'self' key from that.
+    args = input_args.copy()
+    del args['self']
+
+    koalas_params = inspect.signature(koalas_func).parameters
+    pandas_params = inspect.signature(pandas_func).parameters
+
+    for param in koalas_params.values():
+        if param.name not in pandas_params:
+            if args[param.name] == param.default:
+                del args[param.name]
+            else:
+                raise TypeError(
+                    ("The version of pandas available does not support parameter '%s' " +
+                        "for function '%s'.") % (param.name, pandas_func.__name__))
+
+    args['self'] = pdf
+    return pandas_func(**args)

--- a/databricks/koalas/utils.py
+++ b/databricks/koalas/utils.py
@@ -46,7 +46,9 @@ def validate_arguments_and_invoke_function(pdf: pd.DataFrame, koalas_func: Calla
     :param pdf: the pandas DataFrame to operate on
     :param koalas_func: koalas function, used to get default parameter values
     :param pandas_func: pandas function, used to check whether pandas supports all the arguments
-    :param input_args: arguments to pass to the pandas function
+    :param input_args: arguments to pass to the pandas function, often created by using locals().
+                       Make sure locals() call is at the top of the function so it captures only
+                       input parameters, rather than local variables.
     :return: whatever pandas_func returns
     """
     import inspect

--- a/databricks/koalas/utils.py
+++ b/databricks/koalas/utils.py
@@ -17,14 +17,18 @@
 Commonly used utils in Koalas.
 """
 
+from typing import Callable, Dict
+
 from pyspark import sql as spark
+import pandas as pd
 
 
 def default_session():
     return spark.SparkSession.builder.getOrCreate()
 
 
-def validate_arguments_and_invoke_function(pdf, koalas_func, pandas_func, input_args):
+def validate_arguments_and_invoke_function(pdf: pd.DataFrame, koalas_func: Callable,
+                                           pandas_func: Callable, input_args: Dict):
     """
     Invokes a pandas function.
 


### PR DESCRIPTION
This patch adds validate_arguments_and_invoke_function for compatibility with older pandas versions. It is currently used in to_html, but I think we can apply that to a lot of other functions too.
