### PR TITLE
Enable statistics for boolean values

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -98,9 +98,10 @@ class DataFrame(_Frame):
         for col in self.columns:
             col_sdf = self._sdf[col]
             col_type = self._sdf.schema[col].dataType
-            if isinstance(col_type, BooleanType):
+            if isinstance(col_type, BooleanType) and sfun.__name__ not in ('min', 'max'):
                 # Stat functions cannot be used with boolean values by default
                 # Thus, cast to integer (true to 1 and false to 0)
+                # Exclude the min and max methods though since those work with booleans
                 col_sdf = col_sdf.cast('integer')
             if num_args == 1:
                 # Only pass in the column if sfun accepts only one arg

--- a/databricks/koalas/tests/test_stats.py
+++ b/databricks/koalas/tests/test_stats.py
@@ -99,6 +99,19 @@ class StatsTest(ReusedSQLTestCase, SQLTestUtils):
             # assert ddf.a.cov(ddf.b)._meta.dtype == 'f8'
             # assert ddf.a.corr(ddf.b)._meta.dtype == 'f8'
 
+    def test_stats_on_boolean(self):
+        df = pd.DataFrame({'A': [True, False]})
+        ddf = koalas.from_pandas(df)
+
+        self.assert_eq(ddf.min(), df.min())
+        self.assert_eq(ddf.max(), df.max())
+
+        self.assert_eq(ddf.sum(), df.sum())
+        self.assert_eq(ddf.mean(), df.mean())
+
+        self.assert_eq(ddf.var(), df.var())
+        self.assert_eq(ddf.std(), df.std())
+
 
 if __name__ == "__main__":
     try:

--- a/databricks/koalas/tests/test_stats.py
+++ b/databricks/koalas/tests/test_stats.py
@@ -100,17 +100,18 @@ class StatsTest(ReusedSQLTestCase, SQLTestUtils):
             # assert ddf.a.corr(ddf.b)._meta.dtype == 'f8'
 
     def test_stats_on_boolean(self):
-        df = pd.DataFrame({'A': [True, False]})
+        df = pd.DataFrame({'A': [True, False, True],
+                           'B': [False, False, True]})
         ddf = koalas.from_pandas(df)
 
-        self.assert_eq(ddf.min(), df.min())
-        self.assert_eq(ddf.max(), df.max())
+        pd.testing.assert_series_equal(ddf.min(), df.min())
+        pd.testing.assert_series_equal(ddf.max(), df.max())
 
-        self.assert_eq(ddf.sum(), df.sum())
-        self.assert_eq(ddf.mean(), df.mean())
+        pd.testing.assert_series_equal(ddf.sum(), df.sum())
+        pd.testing.assert_series_equal(ddf.mean(), df.mean())
 
-        self.assert_eq(ddf.var(), df.var())
-        self.assert_eq(ddf.std(), df.std())
+        pd.testing.assert_series_equal(ddf.var(), df.var())
+        pd.testing.assert_series_equal(ddf.std(), df.std())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In pandas it is possible to sum over boolean values which are implicitly converted to integers. For example, the following code can be used to compute to number of NA values per column.
```python
>>> df = pd.DataFrame({'A': [0, np.nan, np.nan], 'B': [0, 0, np.nan]})
>>> df.isna().sum()
A    2
B    1
dtype: int64
```

When trying to run the same code with a Koalas DataFrame, the following exception is thrown: `org.apache.spark.sql.AnalysisException: cannot resolve 'sum(`A`)' due to data type mismatch: function sum requires numeric types, not boolean`

To fix this, the PR casts boolean values to integers as required when using statistical functions. Furthermore, the unit tests have been extended to cover the following statistics with boolean values:
- min
- max
- sum
- mean
- var
- std