### PR TITLE
Support statistical functions for Series with boolean values

### DIFF
--- a/databricks/koalas/tests/test_stats.py
+++ b/databricks/koalas/tests/test_stats.py
@@ -99,7 +99,7 @@ class StatsTest(ReusedSQLTestCase, SQLTestUtils):
             # assert ddf.a.cov(ddf.b)._meta.dtype == 'f8'
             # assert ddf.a.corr(ddf.b)._meta.dtype == 'f8'
 
-    def test_stats_on_boolean(self):
+    def test_stats_on_boolean_dataframe(self):
         df = pd.DataFrame({'A': [True, False, True],
                            'B': [False, False, True]})
         ddf = koalas.from_pandas(df)
@@ -112,6 +112,19 @@ class StatsTest(ReusedSQLTestCase, SQLTestUtils):
 
         pd.testing.assert_series_equal(ddf.var(), df.var())
         pd.testing.assert_series_equal(ddf.std(), df.std())
+
+    def test_stats_on_boolean_series(self):
+        s = pd.Series([True, False, True])
+        ds = koalas.from_pandas(s)
+
+        self.assertEqual(ds.min(), s.min())
+        self.assertEqual(ds.max(), s.max())
+
+        self.assertEqual(ds.sum(), s.sum())
+        self.assertEqual(ds.mean(), s.mean())
+
+        self.assertAlmostEqual(ds.var(), s.var())
+        self.assertAlmostEqual(ds.std(), s.std())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
As requested in #218 by @rxin, this PR now also supports statistics for *Series* with boolean values. Like before,  all relevant functionality is covered with unit tests.