### PR TITLE
Add to_dict in DataFrame and Series

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -442,9 +442,9 @@ class DataFrame(_Frame):
         If you want a `defaultdict`, you need to initialize it:
 
         >>> dd = defaultdict(list)
-        >>> df.to_dict('records', into=dd)
-        [defaultdict(<class 'list'>, {'col1': 1.0, 'col2': 0.5}), \
-defaultdict(<class 'list'>, {'col1': 2.0, 'col2': 0.75})]
+        >>> df.to_dict('records', into=dd)  # doctest: +ELLIPSIS
+        [defaultdict(<class 'list'>, {'col1': 1..., 'col2': 0.5}), \
+defaultdict(<class 'list'>, {'col1': 2..., 'col2': 0.75})]
         """
         # Make sure locals() call is at the top of the function so we don't capture local variables.
         args = locals()

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -429,8 +429,8 @@ class DataFrame(_Frame):
         >>> df.to_dict('records')  # doctest: +ELLIPSIS
         [{'col1': 1..., 'col2': 0.5}, {'col1': 2..., 'col2': 0.75}]
 
-        >>> df.to_dict('index')
-        {'row1': {'col1': 1, 'col2': 0.5}, 'row2': {'col1': 2, 'col2': 0.75}}
+        >>> df.to_dict('index')  # doctest: +ELLIPSIS
+        {'row1': {'col1': 1..., 'col2': 0.5}, 'row2': {'col1': 2..., 'col2': 0.75}}
 
         You can also specify the mapping type.
 

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -374,6 +374,9 @@ class DataFrame(_Frame):
         The type of the key-value pairs can be customized with the parameters
         (see below).
 
+        .. note:: This method should only be used if the resulting Pandas DataFrame is expected
+            to be small, as all the data is loaded into the driver's memory.
+
         Parameters
         ----------
         orient : str {'dict', 'list', 'series', 'split', 'records', 'index'}

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -367,6 +367,91 @@ class DataFrame(_Frame):
         return validate_arguments_and_invoke_function(
             kdf.to_pandas(), self.to_string, pd.DataFrame.to_string, args)
 
+    def to_dict(self, orient='dict', into=dict):
+        """
+        Convert the DataFrame to a dictionary.
+
+        The type of the key-value pairs can be customized with the parameters
+        (see below).
+
+        Parameters
+        ----------
+        orient : str {'dict', 'list', 'series', 'split', 'records', 'index'}
+            Determines the type of the values of the dictionary.
+
+            - 'dict' (default) : dict like {column -> {index -> value}}
+            - 'list' : dict like {column -> [values]}
+            - 'series' : dict like {column -> Series(values)}
+            - 'split' : dict like
+              {'index' -> [index], 'columns' -> [columns], 'data' -> [values]}
+            - 'records' : list like
+              [{column -> value}, ... , {column -> value}]
+            - 'index' : dict like {index -> {column -> value}}
+
+            Abbreviations are allowed. `s` indicates `series` and `sp`
+            indicates `split`.
+
+        into : class, default dict
+            The collections.abc.Mapping subclass used for all Mappings
+            in the return value.  Can be the actual class or an empty
+            instance of the mapping type you want.  If you want a
+            collections.defaultdict, you must pass it initialized.
+
+        Returns
+        -------
+        dict, list or collections.abc.Mapping
+            Return a collections.abc.Mapping object representing the DataFrame.
+            The resulting transformation depends on the `orient` parameter.
+
+        Examples
+        --------
+        >>> df = ks.DataFrame({'col1': [1, 2],
+        ...                    'col2': [0.5, 0.75]},
+        ...                   index=['row1', 'row2'])
+        >>> df
+              col1  col2
+        row1     1  0.50
+        row2     2  0.75
+        >>> df.to_dict()
+        {'col1': {'row1': 1, 'row2': 2}, 'col2': {'row1': 0.5, 'row2': 0.75}}
+
+        You can specify the return orientation.
+
+        >>> df.to_dict('series')
+        {'col1': row1    1
+        row2    2
+        Name: col1, dtype: int64, 'col2': row1    0.50
+        row2    0.75
+        Name: col2, dtype: float64}
+        >>> df.to_dict('split')  # doctest: +ELLIPSIS
+        {'index': ['row1', 'row2'], 'columns': ['col1', 'col2'], 'data': [[1...
+
+        >>> df.to_dict('records')  # doctest: +ELLIPSIS
+        [{'col1': 1..., 'col2': 0.5}, {'col1': 2..., 'col2': 0.75}]
+
+        >>> df.to_dict('index')
+        {'row1': {'col1': 1, 'col2': 0.5}, 'row2': {'col1': 2, 'col2': 0.75}}
+
+        You can also specify the mapping type.
+
+        >>> from collections import OrderedDict, defaultdict
+        >>> df.to_dict(into=OrderedDict)
+        OrderedDict([('col1', OrderedDict([('row1', 1), ('row2', 2)])), \
+('col2', OrderedDict([('row1', 0.5), ('row2', 0.75)]))])
+
+        If you want a `defaultdict`, you need to initialize it:
+
+        >>> dd = defaultdict(list)
+        >>> df.to_dict('records', into=dd)
+        [defaultdict(<class 'list'>, {'col1': 1.0, 'col2': 0.5}), \
+defaultdict(<class 'list'>, {'col1': 2.0, 'col2': 0.75})]
+        """
+        # Make sure locals() call is at the top of the function so we don't capture local variables.
+        args = locals()
+        kdf = self
+        return validate_arguments_and_invoke_function(
+            kdf.to_pandas(), self.to_dict, pd.DataFrame.to_dict, args)
+
     @property
     def index(self):
         """The index (row labels) Column of the DataFrame.

--- a/databricks/koalas/missing/frame.py
+++ b/databricks/koalas/missing/frame.py
@@ -159,7 +159,6 @@ class _MissingPandasLikeDataFrame(object):
     to_clipboard = unsupported_function('to_clipboard')
     to_csv = unsupported_function('to_csv')
     to_dense = unsupported_function('to_dense')
-    to_dict = unsupported_function('to_dict')
     to_excel = unsupported_function('to_excel')
     to_feather = unsupported_function('to_feather')
     to_gbq = unsupported_function('to_gbq')

--- a/databricks/koalas/missing/series.py
+++ b/databricks/koalas/missing/series.py
@@ -166,7 +166,6 @@ class _MissingPandasLikeSeries(object):
     to_clipboard = unsupported_function('to_clipboard')
     to_csv = unsupported_function('to_csv')
     to_dense = unsupported_function('to_dense')
-    to_dict = unsupported_function('to_dict')
     to_excel = unsupported_function('to_excel')
     to_frame = unsupported_function('to_frame')
     to_hdf = unsupported_function('to_hdf')

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -378,6 +378,9 @@ class Series(_Frame):
         """
         Convert Series to {label -> value} dict or dict-like object.
 
+        .. note:: This method should only be used if the resulting Pandas DataFrame is expected
+            to be small, as all the data is loaded into the driver's memory.
+
         Parameters
         ----------
         into : class, default dict

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -374,6 +374,41 @@ class Series(_Frame):
         return validate_arguments_and_invoke_function(
             kseries.to_pandas(), self.to_string, pd.Series.to_string, args)
 
+    def to_dict(self, into=dict):
+        """
+        Convert Series to {label -> value} dict or dict-like object.
+
+        Parameters
+        ----------
+        into : class, default dict
+            The collections.abc.Mapping subclass to use as the return
+            object. Can be the actual class or an empty
+            instance of the mapping type you want.  If you want a
+            collections.defaultdict, you must pass it initialized.
+
+        Returns
+        -------
+        collections.abc.Mapping
+            Key-value representation of Series.
+
+        Examples
+        --------
+        >>> s = ks.Series([1, 2, 3, 4])
+        >>> s.to_dict()
+        {0: 1, 1: 2, 2: 3, 3: 4}
+        >>> from collections import OrderedDict, defaultdict
+        >>> s.to_dict(OrderedDict)
+        OrderedDict([(0, 1), (1, 2), (2, 3), (3, 4)])
+        >>> dd = defaultdict(list)
+        >>> s.to_dict(dd)
+        defaultdict(<class 'list'>, {0: 1, 1: 2, 2: 3, 3: 4})
+        """
+        # Make sure locals() call is at the top of the function so we don't capture local variables.
+        args = locals()
+        kseries = self
+        return validate_arguments_and_invoke_function(
+            kseries.to_pandas(), self.to_dict, pd.Series.to_dict, args)
+
     def to_pandas(self):
         """
         Return a pandas Series.

--- a/docs/source/reference/frame.rst
+++ b/docs/source/reference/frame.rst
@@ -120,3 +120,4 @@ Serialization / IO / Conversion
    DataFrame.to_koalas
    DataFrame.to_spark
    DataFrame.to_string
+   DataFrame.to_dict

--- a/docs/source/reference/series.rst
+++ b/docs/source/reference/series.rst
@@ -87,3 +87,4 @@ Serialization / IO / Conversion
    Series.to_pandas
    Series.to_numpy
    Series.to_string
+   Series.to_dict


### PR DESCRIPTION
This PR adds to_dict in DataFrame and Series.

https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_dict.html#pandas.DataFrame.to_dict

https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.to_dict.html#pandas.Series.to_dict