### PR TITLE
Preserve group keys as indices when `groupby(...).agg(...)`.

### DIFF
--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -73,6 +73,7 @@ class GroupBy(object):
         >>> df = ks.DataFrame({'A': [1, 1, 2, 2],
         ...                    'B': [1, 2, 3, 4],
         ...                    'C': [0.362, 0.227, 1.267, -0.562]})
+        >>> df = df[['A', 'B', 'C']]
 
         >>> df
            A  B      C
@@ -83,7 +84,8 @@ class GroupBy(object):
 
         Different aggregations per column
 
-        >>> df.groupby('A').agg({'B': 'min', 'C': 'sum'})  # doctest: +NORMALIZE_WHITESPACE
+        >>> aggregated = df.groupby('A').agg({'B': 'min', 'C': 'sum'})
+        >>> aggregated[['B', 'C']]  # doctest: +NORMALIZE_WHITESPACE
            B      C
         A
         1  1  0.589

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -83,10 +83,11 @@ class GroupBy(object):
 
         Different aggregations per column
 
-        >>> df.groupby('A').agg({'B': 'min', 'C': 'sum'})
+        >>> df.groupby('A').agg({'B': 'min', 'C': 'sum'})  # doctest: +NORMALIZE_WHITESPACE
            B      C
-        0  1  0.589
-        1  3  0.705
+        A
+        1  1  0.589
+        2  3  0.705
 
         """
         if not isinstance(func_or_funcs, dict) or \
@@ -99,12 +100,13 @@ class GroupBy(object):
         groupkeys = self._groupkeys
         groupkey_cols = [s._scol.alias('__index_level_{}__'.format(i))
                          for i, s in enumerate(groupkeys)]
-        gdf = sdf.groupby(*groupkey_cols).agg(func_or_funcs)
-        reordered = ['%s(%s)' % (value, key) for key, value in iter(func_or_funcs.items())]
-        kdf = DataFrame(gdf.select(reordered))
-        kdf.columns = [key for key in iter(func_or_funcs.keys())]
-
-        return kdf
+        reordered = [F.expr('{1}({0}) as {0}'.format(key, value))
+                     for key, value in func_or_funcs.items()]
+        sdf = sdf.groupby(*groupkey_cols).agg(*reordered)
+        metadata = Metadata(column_fields=[key for key, _ in func_or_funcs.items()],
+                            index_info=[('__index_level_{}__'.format(i), s.name)
+                                        for i, s in enumerate(groupkeys)])
+        return DataFrame(sdf, metadata)
 
     agg = aggregate
 

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -78,6 +78,15 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
                 self.assert_eq(getattr(kdf.groupby(kdf.b > i), func)(),
                                getattr(pdf.groupby(pdf.b > i), func)(), almost=almost)
 
+    def test_aggregate(self):
+        pdf = pd.DataFrame({'A': [1, 1, 2, 2],
+                            'B': [1, 2, 3, 4],
+                            'C': [0.362, 0.227, 1.267, -0.562]})
+        kdf = koalas.from_pandas(pdf)
+
+        self.assert_eq(kdf.groupby('A').agg({'B': 'min', 'C': 'sum'}),
+                       pdf.groupby('A').agg({'B': 'min', 'C': 'sum'}))
+
     def test_raises(self):
         kdf = koalas.DataFrame({'a': [1, 2, 6, 4, 4, 6, 4, 3, 7],
                                 'b': [4, 2, 7, 3, 3, 1, 1, 1, 2]},


### PR DESCRIPTION
We should preserve group keys as indices of the result `DataFrame` when `groupby(...).agg(...)`.