### PR TITLE
Fix python 3.5 build.

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -183,6 +183,7 @@ class DataFrame(_Frame):
         >>> df = ks.DataFrame({'species': ['bear', 'bear', 'marsupial'],
         ...                    'population': [1864, 22000, 80000]},
         ...                     index=['panda', 'polar', 'koala'])
+        >>> df = df[['species', 'population']]
         >>> df
                  species  population
         panda       bear        1864
@@ -448,29 +449,35 @@ class DataFrame(_Frame):
         >>> df = ks.DataFrame({'col1': [1, 2],
         ...                    'col2': [0.5, 0.75]},
         ...                   index=['row1', 'row2'])
+        >>> df = df[['col1', 'col2']]
         >>> df
               col1  col2
         row1     1  0.50
         row2     2  0.75
-        >>> df.to_dict()
-        {'col1': {'row1': 1, 'row2': 2}, 'col2': {'row1': 0.5, 'row2': 0.75}}
+        >>> df_dict = df.to_dict()
+        >>> sorted([(key, sorted(values.items())) for key, values in df_dict.items()])
+        [('col1', [('row1', 1), ('row2', 2)]), ('col2', [('row1', 0.5), ('row2', 0.75)])]
 
         You can specify the return orientation.
 
-        >>> df.to_dict('series')
-        {'col1': row1    1
+        >>> df_dict = df.to_dict('series')
+        >>> sorted(df_dict.items())
+        [('col1', row1    1
         row2    2
-        Name: col1, dtype: int64, 'col2': row1    0.50
+        Name: col1, dtype: int64), ('col2', row1    0.50
         row2    0.75
-        Name: col2, dtype: float64}
-        >>> df.to_dict('split')  # doctest: +ELLIPSIS
-        {'index': ['row1', 'row2'], 'columns': ['col1', 'col2'], 'data': [[1...
+        Name: col2, dtype: float64)]
+        >>> df_dict = df.to_dict('split')
+        >>> sorted(df_dict.items())  # doctest: +ELLIPSIS
+        [('columns', ['col1', 'col2']), ('data', [[1.0, ..., 0.75]]), ('index', ['row1', 'row2'])]
 
-        >>> df.to_dict('records')  # doctest: +ELLIPSIS
-        [{'col1': 1..., 'col2': 0.5}, {'col1': 2..., 'col2': 0.75}]
+        >>> df_dict = df.to_dict('records')
+        >>> [sorted(values.items()) for values in df_dict]  # doctest: +ELLIPSIS
+        [[('col1', 1...), ('col2', 0.5)], [('col1', 2...), ('col2', 0.75)]]
 
-        >>> df.to_dict('index')  # doctest: +ELLIPSIS
-        {'row1': {'col1': 1..., 'col2': 0.5}, 'row2': {'col1': 2..., 'col2': 0.75}}
+        >>> df_dict = df.to_dict('index')
+        >>> sorted([(key, sorted(values.items())) for key, values in df_dict.items()])
+        [('row1', [('col1', 1), ('col2', 0.5)]), ('row2', [('col1', 2), ('col2', 0.75)])]
 
         You can also specify the mapping type.
 
@@ -483,8 +490,8 @@ class DataFrame(_Frame):
 
         >>> dd = defaultdict(list)
         >>> df.to_dict('records', into=dd)  # doctest: +ELLIPSIS
-        [defaultdict(<class 'list'>, {'col1': 1..., 'col2': 0.5}), \
-defaultdict(<class 'list'>, {'col1': 2..., 'col2': 0.75})]
+        [defaultdict(<class 'list'>, {'col..., 'col...}), \
+defaultdict(<class 'list'>, {'col..., 'col...})]
         """
         # Make sure locals() call is at the top of the function so we don't capture local variables.
         args = locals()
@@ -856,6 +863,7 @@ defaultdict(<class 'list'>, {'col1': 2..., 'col2': 0.75})]
         >>> df = ks.DataFrame({"name": ['Alfred', 'Batman', 'Catwoman'],
         ...                    "toy": [None, 'Batmobile', 'Bullwhip'],
         ...                    "born": [None, "1940-04-25", None]})
+        >>> df = df[['name', 'toy', 'born']]
         >>> df
                name        toy        born
         0    Alfred       None        None
@@ -1132,6 +1140,7 @@ defaultdict(<class 'list'>, {'col1': 2..., 'col2': 0.75})]
         ...                    ["John", "Myla", "Lewis", "John", "Myla"],
         ...                    "Age": [24., np.nan, 21., 33, 26],
         ...                    "Single": [False, True, True, True, False]})
+        >>> df = df[["Person", "Age", "Single"]]
         >>> df
           Person   Age  Single
         0   John  24.0   False
@@ -1180,6 +1189,7 @@ defaultdict(<class 'list'>, {'col1': 2..., 'col2': 0.75})]
         Examples
         --------
         >>> df = ks.DataFrame({'x': [1, 2], 'y': [3, 4], 'z': [5, 6], 'w': [7, 8]})
+        >>> df = df[['x', 'y', 'z', 'w']]
         >>> df
            x  y  z  w
         0  1  3  5  7

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -469,7 +469,7 @@ class DataFrame(_Frame):
         Name: col2, dtype: float64)]
         >>> df_dict = df.to_dict('split')
         >>> sorted(df_dict.items())  # doctest: +ELLIPSIS
-        [('columns', ['col1', 'col2']), ('data', [[1.0, ..., 0.75]]), ('index', ['row1', 'row2'])]
+        [('columns', ['col1', 'col2']), ('data', [[1..., 0.75]]), ('index', ['row1', 'row2'])]
 
         >>> df_dict = df.to_dict('records')
         >>> [sorted(values.items()) for values in df_dict]  # doctest: +ELLIPSIS

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -1346,7 +1346,7 @@ defaultdict(<class 'list'>, {'col1': 2..., 'col2': 0.75})]
               for colname, asc in zip(by, ascending)]
         kdf = DataFrame(self._sdf.sort(*by), self._metadata.copy())
         if inplace:
-            self._sdf: spark.DataFrame = kdf._sdf
+            self._sdf = kdf._sdf
             self._metadata = kdf._metadata
         else:
             return kdf
@@ -1498,7 +1498,7 @@ defaultdict(<class 'list'>, {'col1': 2..., 'col2': 0.75})]
         else:
             kdf = self.assign(**{key: value})
 
-        self._sdf: spark.DataFrame = kdf._sdf
+        self._sdf = kdf._sdf
         self._metadata = kdf._metadata
 
     def __getattr__(self, key):

--- a/databricks/koalas/metadata.py
+++ b/databricks/koalas/metadata.py
@@ -36,8 +36,6 @@ class Metadata(object):
     :ivar _index_info: list of pair holding the Spark field names for indexes,
                        and the index name to be seen in Koalas DataFrame.
     """
-    _column_fields: List[str]
-    _index_info: List[IndexInfo]
 
     def __init__(self, column_fields: List[str],
                  index_info: Optional[List[IndexInfo]] = None) -> None:
@@ -54,8 +52,8 @@ class Metadata(object):
             or all(isinstance(index_field, string_types)
                    and (index_name is None or isinstance(index_name, string_types))
                    for index_field, index_name in index_info)
-        self._column_fields = column_fields
-        self._index_info = index_info or []
+        self._column_fields = column_fields  # type: List[str]
+        self._index_info = index_info or []  # type: List[IndexInfo]
 
     @property
     def column_fields(self) -> List[str]:
@@ -108,7 +106,7 @@ class Metadata(object):
         column_fields = [str(col) for col in pdf.columns]
         index = pdf.index
 
-        index_info: List[IndexInfo]
+        index_info = []  # type: List[IndexInfo]
         if isinstance(index, pd.MultiIndex):
             if index.names is None:
                 index_info = [('__index_level_{}__'.format(i), None)

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -119,7 +119,7 @@ class Series(_Frame):
         """
         assert index_info is not None
         self._scol = scol
-        self._kdf: ks.DataFrame = kdf
+        self._kdf = kdf
         self._index_info = index_info
 
     # arithmetic operators

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,14 +4,14 @@ pyarrow>=0.10,<0.11
 decorator
 
 # Documentation build
-sphinx>=2.0.1
-nbsphinx>=0.4.2
-numpydoc>=0.8.0
+sphinx
+nbsphinx
+numpydoc
 
 # Linter
-mypy>=0.701
-flake8>=3.5.0
+mypy
+flake8
 
 # Test
-pytest>=4.4.1
-pytest-cov>=2.6.1
+pytest
+pytest-cov


### PR DESCRIPTION
Currently Python 3.5 build in travis-ci is not working properly since the Python is upgraded while setting up the environment because the dev dependency is strictly versioned but some of them depends only Python 3.6 or upper.

E.g., this (https://travis-ci.com/databricks/koalas/jobs/197751790) is the 3.5 build, but we can see:

![Screen Shot 2019-05-06 at 20 05 04](https://user-images.githubusercontent.com/506656/57221467-594ad000-703a-11e9-9f56-658fb50f97c2.png)
