### PR TITLE
Inline Series.unique to Pandas'

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -1160,10 +1160,6 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         """
         return self._reduce_for_stat_function(_Frame._count_expr)
 
-    def unique(self):
-        sdf = self._sdf
-        return DataFrame(spark.DataFrame(sdf._jdf.distinct(), sdf.sql_ctx), self._metadata.copy())
-
     def drop(self, labels=None, axis=1, columns: Union[str, List[str]] = None):
         """
         Drop specified labels from columns.

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -492,8 +492,53 @@ class Series(_Frame):
         return _col(self.to_dataframe().head(n))
 
     def unique(self):
-        # Pandas wants a series/array-like object
-        return _col(self.to_dataframe().unique())
+        """
+        Return unique values of Series object.
+
+        Uniques are returned in order of appearance. Hash table-based unique,
+        therefore does NOT sort.
+
+        .. note:: This method should only be used if the resulting Pandas object is expected
+                  to be small, as all the data is loaded into the driver's memory.
+
+        Returns
+        -------
+        ndarray or ExtensionArray
+            The unique values returned as a NumPy array. See Notes.
+
+        See Also
+        --------
+        unique : Top-level unique method for any 1-d array-like object.
+        Index.unique : Return Index with unique values from an Index object.
+
+        Notes
+        -----
+        Returns the unique values as a NumPy array. In case of an
+        extension-array backed Series, a new
+        :class:`~api.extensions.ExtensionArray` of that type with just
+        the unique values is returned. This includes
+
+            * Period
+            * Datetime with Timezone
+            * Interval
+            * Sparse
+            * IntegerNA
+
+        See Examples section.
+
+        Examples
+        --------
+        >>> ks.Series([2, 1, 3, 3], name='A').unique()
+        array([2, 1, 3])
+
+        >>> ks.Series([pd.Timestamp('2016-01-01') for _ in range(3)]).unique()
+        array(['2016-01-01T00:00:00.000000000'], dtype='datetime64[ns]')
+
+        >>> ks.Series([pd.Timestamp('2016-01-01', tz='US/Eastern')
+        ...            for _ in range(3)]).unique()
+        array(['2016-01-01T14:00:00.000000000'], dtype='datetime64[ns]')
+        """
+        return pd.Series.unique(self.to_pandas())
 
     # TODO: Update Documentation for Bins Parameter when its supported
     def value_counts(self, normalize=False, sort=True, ascending=False, bins=None, dropna=True):

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -500,43 +500,29 @@ class Series(_Frame):
         Uniques are returned in order of appearance. Hash table-based unique,
         therefore does NOT sort.
 
-        .. note:: This method should only be used if the resulting Pandas object is expected
-                  to be small, as all the data is loaded into the driver's memory.
+        .. note:: This method returns newly creased Series whereas Pandas returns
+                  the unique values as a NumPy array.
 
         Returns
         -------
-        ndarray or ExtensionArray
-            The unique values returned as a NumPy array. See Notes.
-
-        See Also
-        --------
-        unique : Top-level unique method for any 1-d array-like object.
-        Index.unique : Return Index with unique values from an Index object.
-
-        Notes
-        -----
-        Returns the unique values as a NumPy array. In case of an
-        extension-array backed Series, a new
-        :class:`~api.extensions.ExtensionArray` of that type with just
-        the unique values is returned. This includes
-
-            * Period
-            * Datetime with Timezone
-            * Interval
-            * Sparse
-            * IntegerNA
+        Returns the unique values as a Series.
 
         See Examples section.
 
         Examples
         --------
         >>> ks.Series([2, 1, 3, 3], name='A').unique()
-        array([2, 1, 3])
+        0    1
+        1    3
+        2    2
+        Name: A, dtype: int64
 
         >>> ks.Series([pd.Timestamp('2016-01-01') for _ in range(3)]).unique()
-        array(['2016-01-01T00:00:00.000000000'], dtype='datetime64[ns]')
+        0   2016-01-01
+        Name: 0, dtype: datetime64[ns]
         """
-        return pd.Series.unique(self.to_pandas())
+        sdf = self.to_dataframe()._sdf
+        return _col(DataFrame(sdf.select(self._scol).distinct()))
 
     # TODO: Update Documentation for Bins Parameter when its supported
     def value_counts(self, normalize=False, sort=True, ascending=False, bins=None, dropna=True):

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -491,6 +491,8 @@ class Series(_Frame):
     def head(self, n=5):
         return _col(self.to_dataframe().head(n))
 
+    # TODO: Categorical type isn't supported (due to PySpark's limitation) and
+    # some doctests related with timestamps were not added.
     def unique(self):
         """
         Return unique values of Series object.

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -533,10 +533,6 @@ class Series(_Frame):
 
         >>> ks.Series([pd.Timestamp('2016-01-01') for _ in range(3)]).unique()
         array(['2016-01-01T00:00:00.000000000'], dtype='datetime64[ns]')
-
-        >>> ks.Series([pd.Timestamp('2016-01-01', tz='US/Eastern')
-        ...            for _ in range(3)]).unique()
-        array(['2016-01-01T14:00:00.000000000'], dtype='datetime64[ns]')
         """
         return pd.Series.unique(self.to_pandas())
 


### PR DESCRIPTION
This PR targets to inline Series.unique to Pandas'. After this PR:
**Pandas**

```python
>>> import pandas as pd
>>> pd.DataFrame({"Person": ['a', 'b', 'b', 'c']})
  Person
0      a
1      b
2      b
3      c
>>> df = pd.DataFrame({"Person": ['a', 'b', 'b', 'c']})
>>> df.unique()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.7/site-packages/pandas/core/generic.py", line 4376, in __getattr__
    return object.__getattribute__(self, name)
AttributeError: 'DataFrame' object has no attribute 'unique'
>>> df.Person.unique()
array(['a', 'b', 'c'], dtype=object)
```

**Koalas**

```python
>>> import databricks.koalas as ks
>>> ks.DataFrame({"Person": ['a', 'b', 'b', 'c']})
  Person
0      a
1      b
2      b
3      c
>>> df = ks.DataFrame({"Person": ['a', 'b', 'b', 'c']})
>>> df.unique()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/hyukjin.kwon/workspace/forked/koalas/databricks/koalas/frame.py", line 1528, in __getattr__
    return Series(self._sdf.__getattr__(key), self, self._metadata.index_info)
  File "/Users/hyukjin.kwon/workspace/forked/spark/python/lib/pyspark.zip/pyspark/sql/dataframe.py", line 1296, in __getattr__
AttributeError: 'DataFrame' object has no attribute 'unique'
>>> df.Person.unique()
0    c
1    b
2    a
Name: Person, dtype: object
```

Resolves #233