### PR TITLE
Add 'columns' parameter to DataFrame's drop method

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -1168,7 +1168,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         """
         Drop specified labels from columns.
 
-        Remove columns by specifying label names and axis=1.
+        Remove columns by specifying label names and axis=1 or columns.
+        When specifying both labels and columns, only labels will be dropped.
         Removing rows is yet to be implemented.
 
         Parameters

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -18,7 +18,7 @@
 A wrapper class for Spark DataFrame to behave similar to pandas DataFrame.
 """
 from functools import partial, reduce
-from typing import Any
+from typing import Any, List, Union
 
 import numpy as np
 import pandas as pd
@@ -1164,7 +1164,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         sdf = self._sdf
         return DataFrame(spark.DataFrame(sdf._jdf.distinct(), sdf.sql_ctx), self._metadata.copy())
 
-    def drop(self, labels, axis=1):
+    def drop(self, labels=None, axis=1, columns: Union[str, List[str]] = None):
         """
         Drop specified labels from columns.
 
@@ -1178,6 +1178,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         axis : {1 or 'columns'}, default 1
             .. dropna currently only works for axis=1 'columns'
                axis=0 is yet to be implemented.
+        columns : single label or list-like
+            Alternative to specifying axis (``labels, axis=1``
+            is equivalent to ``columns=labels``).
 
         Returns
         -------
@@ -1206,25 +1209,31 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         0  1  7
         1  2  8
 
+        >>> df.drop(columns=['y', 'z'])
+           x  w
+        0  1  7
+        1  2  8
+
         Notes
         -----
         Currently only axis = 1 is supported in this function,
         axis = 0 is yet to be implemented.
         """
-        axis = self._validate_axis(axis)
-        if axis == 1:
-            if isinstance(labels, list):
-                sdf = self._sdf.drop(*labels)
-                metadata = self._metadata.copy(
-                    column_fields=[column for column in self._metadata.column_fields
-                                   if column not in labels])
-            else:
-                sdf = self._sdf.drop(labels)
-                metadata = self._metadata.copy(
-                    column_fields=[column for column in self._metadata.column_fields
-                                   if column != labels])
+        if labels is not None:
+            axis = self._validate_axis(axis)
+            if axis == 1:
+                return self.drop(columns=labels)
+            raise NotImplementedError("Drop currently only works for axis=1")
+        elif columns is not None:
+            if isinstance(columns, str):
+                columns = [columns]
+            sdf = self._sdf.drop(*columns)
+            metadata = self._metadata.copy(
+                column_fields=[column for column in self.columns if column not in columns]
+            )
             return DataFrame(sdf, metadata)
-        raise NotImplementedError("Drop currently only works for axis=1")
+        else:
+            raise ValueError("Need to specify at least one of 'labels' or 'columns'")
 
     def get(self, key, default=None):
         """

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -193,6 +193,28 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(kdf.columns, pd.Index(['x', 'y']))
         self.assert_eq(kdf, pdf)
 
+    def test_drop(self):
+        kdf = koalas.DataFrame({'x': [1, 2], 'y': [3, 4], 'z': [5, 6]})
+
+        # Assert 'labels' or 'columns' parameter is set
+        expected_error_message = "Need to specify at least one of 'labels' or 'columns'"
+        with self.assertRaisesRegex(ValueError, expected_error_message):
+            kdf.drop()
+        # Assert axis cannot be 0
+        with self.assertRaisesRegex(NotImplementedError, "Drop currently only works for axis=1"):
+            kdf.drop('x', axis=0)
+        # Assert using a str for 'labels' works
+        self.assert_eq(kdf.drop('x', axis=1), pd.DataFrame({'y': [3, 4], 'z': [5, 6]}))
+        # Assert axis is 1 by default
+        self.assert_eq(kdf.drop('x'), pd.DataFrame({'y': [3, 4], 'z': [5, 6]}))
+        # Assert using a list for 'labels' works
+        self.assert_eq(kdf.drop(['y', 'z'], axis=1), pd.DataFrame({'x': [1, 2]}))
+        # Assert using 'columns' instead of 'labels' produces the same results
+        self.assert_eq(kdf.drop(columns='x'), pd.DataFrame({'y': [3, 4], 'z': [5, 6]}))
+        self.assert_eq(kdf.drop(columns=['y', 'z']), pd.DataFrame({'x': [1, 2]}))
+        # Assert 'labels' being used when both 'labels' and 'columns' are specified
+        self.assert_eq(kdf.drop(labels=['x'], columns=['y']), pd.DataFrame({'y': [3, 4], 'z': [5, 6]}))
+
     def test_dropna(self):
         pdf = pd.DataFrame({'x': [np.nan, 2, 3, 4, np.nan, 6],
                             'y': [1, 2, np.nan, 4, np.nan, np.nan],

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -213,7 +213,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(kdf.drop(columns='x'), pd.DataFrame({'y': [3, 4], 'z': [5, 6]}))
         self.assert_eq(kdf.drop(columns=['y', 'z']), pd.DataFrame({'x': [1, 2]}))
         # Assert 'labels' being used when both 'labels' and 'columns' are specified
-        expected_output = pd.DataFrame({'y': [3, 4],'z': [5, 6]})
+        expected_output = pd.DataFrame({'y': [3, 4], 'z': [5, 6]})
         self.assert_eq(kdf.drop(labels=['x'], columns=['y']), expected_output)
 
     def test_dropna(self):

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -213,7 +213,8 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(kdf.drop(columns='x'), pd.DataFrame({'y': [3, 4], 'z': [5, 6]}))
         self.assert_eq(kdf.drop(columns=['y', 'z']), pd.DataFrame({'x': [1, 2]}))
         # Assert 'labels' being used when both 'labels' and 'columns' are specified
-        self.assert_eq(kdf.drop(labels=['x'], columns=['y']), pd.DataFrame({'y': [3, 4], 'z': [5, 6]}))
+        expected_output = pd.DataFrame({'y': [3, 4],'z': [5, 6]})
+        self.assert_eq(kdf.drop(labels=['x'], columns=['y']), expected_output)
 
     def test_dropna(self):
         pdf = pd.DataFrame({'x': [np.nan, 2, 3, 4, np.nan, 6],


### PR DESCRIPTION
This PR adds a `columns` parameter to the DataFrame's `drop()` method that behaves exactly like the corresponding parameter in pandas. While it is certainly a matter of taste, I prefer writing `df.drop(columns=['y', 'z'])` over `df.drop(['y', 'z'], axis=1)` and appreciate having compatible APIs between pandas and Koalas. Apart from implementing the described functionality, the PR adds docstests and makes sure no existing tests fail.