### PR TITLE
DataFrame.to_clipboard & Series.to_clipboard

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,7 @@ install:
   - conda list
   -
   # Useful for to_clipboard test
+  - export DISPLAY=:0.0
   - sudo apt-get install xclip
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,9 @@ install:
 
   # Show installed packages
   - conda list
+  -
+  # Useful for to_clipboard test
+  - sudo apt-get install xclip
 
 before_script:
   - export SPARK_HOME="$HOME/.cache/spark-versions/spark-$SPARK_VERSION-bin-hadoop2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ install:
 
   # Show installed packages
   - conda list
-  -
+
   # Useful for to_clipboard test
   - export DISPLAY=:0.0
   - sudo apt-get install xclip

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -285,7 +285,7 @@ class DataFrame(_Frame):
         Write a text representation of object to the system clipboard.
         This can be pasted into Excel, for example.
 
-            .. note:: This method should only be used if the resulting Excel is expected
+            .. note:: This method should only be used if the resulting DataFrame is expected
                 to be small, as all the data is loaded into the driver's memory.
 
         Parameters
@@ -296,16 +296,10 @@ class DataFrame(_Frame):
             - False, write a string representation of the object to the
               clipboard.
 
-        sep : str, default ``'\t'``
+        sep : str, default ``'\\t'``
             Field delimiter.
         **kwargs
             These parameters will be passed to DataFrame.to_csv.
-
-        See Also
-        --------
-        DataFrame.to_csv : Write a DataFrame to a comma-separated values
-            (csv) file.
-        read_clipboard : Read text from clipboard and pass to read_table.
 
         Notes
         -----

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -278,6 +278,65 @@ class DataFrame(_Frame):
         cols = list(self.columns)
         return list((col_name, self[col_name]) for col_name in cols)
 
+    def to_clipboard(self, excel=True, sep=None, **kwargs):
+        r"""
+         Copy object to the system clipboard.
+         Write a text representation of object to the system clipboard.
+         This can be pasted into Excel, for example.
+         Parameters
+         ----------
+         excel : bool, default True
+             - True, use the provided separator, writing in a csv format for
+               allowing easy pasting into excel.
+             - False, write a string representation of the object to the
+               clipboard.
+         sep : str, default ``'\t'``
+             Field delimiter.
+         **kwargs./
+             These parameters will be passed to DataFrame.to_csv.
+         See Also
+         --------
+         DataFrame.to_csv : Write a DataFrame to a comma-separated values
+             (csv) file.
+         read_clipboard : Read text from clipboard and pass to read_table.
+         Notes
+         -----
+         Requirements for your platform.
+           - Linux : `xclip`, or `xsel` (with `gtk` or `PyQt4` modules)
+           - Windows : none
+           - OS X : none
+         Examples
+         --------
+         Copy the contents of a DataFrame to the clipboard.
+         >>> df = ks.DataFrame([[1, 2, 3], [4, 5, 6]], columns=['A', 'B', 'C'])
+         >>> df.to_clipboard(sep=',')
+
+         ... # Wrote the following to the system clipboard:
+         ... # ,A,B,C
+         ... # 0,1,2,3
+         ... # 1,4,5,6
+         We can omit the the index by passing the keyword `index` and setting
+         it to false.
+         >>> df.to_clipboard(sep=',', index=False)
+
+         ... # Wrote the following to the system clipboard:
+         ... # A,B,C
+         ... # 1,2,3
+         ... # 4,5,6
+         """
+
+        args = locals()
+        kdf = self
+
+        if len(args['kwargs']) > 1:
+            # explode kwargs
+            kwargs_copy = args['kwargs']
+            args = {**args, **kwargs_copy}
+        del args['kwargs']
+
+        return validate_arguments_and_invoke_function(
+            kdf.to_pandas(), self.to_clipboard, pd.DataFrame.to_clipboard, args)
+
     def to_html(self, buf=None, columns=None, col_space=None, header=True, index=True,
                 na_rep='NaN', formatters=None, float_format=None, sparsify=None, index_names=True,
                 justify=None, max_rows=None, max_cols=None, show_dimensions=False, decimal='.',

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -279,51 +279,62 @@ class DataFrame(_Frame):
         return list((col_name, self[col_name]) for col_name in cols)
 
     def to_clipboard(self, excel=True, sep=None, **kwargs):
-        r"""
-         Copy object to the system clipboard.
-         Write a text representation of object to the system clipboard.
-         This can be pasted into Excel, for example.
-         Parameters
-         ----------
-         excel : bool, default True
-             - True, use the provided separator, writing in a csv format for
-               allowing easy pasting into excel.
-             - False, write a string representation of the object to the
-               clipboard.
-         sep : str, default ``'\t'``
-             Field delimiter.
-         **kwargs./
-             These parameters will be passed to DataFrame.to_csv.
-         See Also
-         --------
-         DataFrame.to_csv : Write a DataFrame to a comma-separated values
-             (csv) file.
-         read_clipboard : Read text from clipboard and pass to read_table.
-         Notes
-         -----
-         Requirements for your platform.
-           - Linux : `xclip`, or `xsel` (with `gtk` or `PyQt4` modules)
-           - Windows : none
-           - OS X : none
-         Examples
-         --------
-         Copy the contents of a DataFrame to the clipboard.
-         >>> df = ks.DataFrame([[1, 2, 3], [4, 5, 6]], columns=['A', 'B', 'C'])
-         >>> df.to_clipboard(sep=',')
+        """
+        Copy object to the system clipboard.
 
-         ... # Wrote the following to the system clipboard:
-         ... # ,A,B,C
-         ... # 0,1,2,3
-         ... # 1,4,5,6
-         We can omit the the index by passing the keyword `index` and setting
-         it to false.
-         >>> df.to_clipboard(sep=',', index=False)
+        Write a text representation of object to the system clipboard.
+        This can be pasted into Excel, for example.
 
-         ... # Wrote the following to the system clipboard:
-         ... # A,B,C
-         ... # 1,2,3
-         ... # 4,5,6
-         """
+            .. note:: This method should only be used if the resulting Excel is expected
+                to be small, as all the data is loaded into the driver's memory.
+
+        Parameters
+        ----------
+        excel : bool, default True
+            - True, use the provided separator, writing in a csv format for
+              allowing easy pasting into excel.
+            - False, write a string representation of the object to the
+              clipboard.
+
+        sep : str, default ``'\t'``
+            Field delimiter.
+        **kwargs
+            These parameters will be passed to DataFrame.to_csv.
+
+        See Also
+        --------
+        DataFrame.to_csv : Write a DataFrame to a comma-separated values
+            (csv) file.
+        read_clipboard : Read text from clipboard and pass to read_table.
+
+        Notes
+        -----
+        Requirements for your platform.
+
+          - Linux : `xclip`, or `xsel` (with `gtk` or `PyQt4` modules)
+          - Windows : none
+          - OS X : none
+
+        Examples
+        --------
+        Copy the contents of a DataFrame to the clipboard.
+
+        >>> df = ks.DataFrame([[1, 2, 3], [4, 5, 6]], columns=['A', 'B', 'C'])
+        >>> df.to_clipboard(sep=',')
+        ... # Wrote the following to the system clipboard:
+        ... # ,A,B,C
+        ... # 0,1,2,3
+        ... # 1,4,5,6
+
+        We can omit the the index by passing the keyword `index` and setting
+        it to false.
+
+        >>> df.to_clipboard(sep=',', index=False)
+        ... # Wrote the following to the system clipboard:
+        ... # A,B,C
+        ... # 1,2,3
+        ... # 4,5,6
+        """
 
         args = locals()
         kdf = self

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -285,8 +285,8 @@ class DataFrame(_Frame):
         Write a text representation of object to the system clipboard.
         This can be pasted into Excel, for example.
 
-            .. note:: This method should only be used if the resulting DataFrame is expected
-                to be small, as all the data is loaded into the driver's memory.
+        .. note:: This method should only be used if the resulting DataFrame is expected
+            to be small, as all the data is loaded into the driver's memory.
 
         Parameters
         ----------

--- a/databricks/koalas/missing/frame.py
+++ b/databricks/koalas/missing/frame.py
@@ -175,7 +175,6 @@ class _MissingPandasLikeDataFrame(object):
     swaplevel = unsupported_function('swaplevel')
     tail = unsupported_function('tail')
     take = unsupported_function('take')
-    to_clipboard = unsupported_function('to_clipboard')
     to_dense = unsupported_function('to_dense')
     to_feather = unsupported_function('to_feather')
     to_gbq = unsupported_function('to_gbq')

--- a/databricks/koalas/missing/series.py
+++ b/databricks/koalas/missing/series.py
@@ -198,7 +198,6 @@ class _MissingPandasLikeSeries(object):
     swaplevel = unsupported_function('swaplevel')
     tail = unsupported_function('tail')
     take = unsupported_function('take')
-    to_clipboard = unsupported_function('to_clipboard')
     to_csv = unsupported_function('to_csv')
     to_dense = unsupported_function('to_dense')
     to_excel = unsupported_function('to_excel')

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -516,8 +516,8 @@ class Series(_Frame):
         Write a text representation of object to the system clipboard.
         This can be pasted into Excel, for example.
 
-            .. note:: This method should only be used if the resulting DataFrame is expected
-                to be small, as all the data is loaded into the driver's memory.
+        .. note:: This method should only be used if the resulting DataFrame is expected
+            to be small, as all the data is loaded into the driver's memory.
 
         Parameters
         ----------

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -509,6 +509,71 @@ class Series(_Frame):
         return validate_arguments_and_invoke_function(
             kseries.to_pandas(), self.to_string, pd.Series.to_string, args)
 
+    def to_clipboard(self, excel=True, sep=None, **kwargs):
+        """
+        Copy object to the system clipboard.
+
+        Write a text representation of object to the system clipboard.
+        This can be pasted into Excel, for example.
+
+            .. note:: This method should only be used if the resulting DataFrame is expected
+                to be small, as all the data is loaded into the driver's memory.
+
+        Parameters
+        ----------
+        excel : bool, default True
+            - True, use the provided separator, writing in a csv format for
+              allowing easy pasting into excel.
+            - False, write a string representation of the object to the
+              clipboard.
+
+        sep : str, default ``'\\t'``
+            Field delimiter.
+        **kwargs
+            These parameters will be passed to DataFrame.to_csv.
+
+        Notes
+        -----
+        Requirements for your platform.
+
+          - Linux : `xclip`, or `xsel` (with `gtk` or `PyQt4` modules)
+          - Windows : none
+          - OS X : none
+
+        Examples
+        --------
+        Copy the contents of a DataFrame to the clipboard.
+
+        >>> df = ks.Series([1, 2, 3, 4, 5, 6, 7], name='x')
+        >>> df.to_clipboard(sep=',')
+        ... # Wrote the following to the system clipboard:
+        ... # 0, 1
+        ... # 1, 2
+        ... # 2, 3
+        ... # 3, 4
+        ... # 4, 5
+        ... # 5, 6
+        ... # 6, 7
+
+        We can omit the the index by passing the keyword `index` and setting
+        it to false.
+
+        >>> df.to_clipboard(sep=',', index=False)
+        ... # Wrote the following to the system clipboard:
+        ... # 1
+        ... # 2
+        ... # 3
+        ... # 4
+        ... # 5
+        ... # 6
+        ... # 7
+        """
+        args = locals()
+        kseries = self
+
+        return validate_arguments_and_invoke_function(
+            kseries.to_pandas(), self.to_clipboard, pd.Series.to_clipboard, args)
+
     def to_dict(self, into=dict):
         """
         Convert Series to {label -> value} dict or dict-like object.

--- a/databricks/koalas/tests/test_dataframe_conversion.py
+++ b/databricks/koalas/tests/test_dataframe_conversion.py
@@ -165,3 +165,14 @@ class DataFrameConversionTest(ReusedSQLTestCase, SQLTestUtils, TestUtils):
                        pdf.to_json(orient='records', lines=True))
         self.assert_eq(kdf.to_json(orient='split', index=False),
                        pdf.to_json(orient='split', index=False))
+
+    def test_to_clipboard(self):
+        pdf = self.pdf
+        kdf = self.kdf
+
+        self.assert_eq(kdf.to_clipboard(), pdf.to_clipboard())
+        self.assert_eq(kdf.to_clipboard(excel=False, sep=";"),
+                       pdf.to_clipboard(excel=False, sep=";"))
+        self.assert_eq(kdf.to_clipboard(index=False),
+                       pdf.to_clipboard(index=False))
+

--- a/databricks/koalas/tests/test_dataframe_conversion.py
+++ b/databricks/koalas/tests/test_dataframe_conversion.py
@@ -171,8 +171,7 @@ class DataFrameConversionTest(ReusedSQLTestCase, SQLTestUtils, TestUtils):
         kdf = self.kdf
 
         self.assert_eq(kdf.to_clipboard(), pdf.to_clipboard())
-        self.assert_eq(kdf.to_clipboard(excel=False, sep=";"),
-                       pdf.to_clipboard(excel=False, sep=";"))
-        self.assert_eq(kdf.to_clipboard(index=False),
-                       pdf.to_clipboard(index=False))
-
+        self.assert_eq(kdf.to_clipboard(excel=False),
+                       pdf.to_clipboard(excel=False))
+        self.assert_eq(kdf.to_clipboard(sep=";", index=False),
+                       pdf.to_clipboard(sep=";", index=False))

--- a/databricks/koalas/tests/test_series_conversion.py
+++ b/databricks/koalas/tests/test_series_conversion.py
@@ -1,0 +1,42 @@
+#
+# Copyright (C) 2019 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import pandas as pd
+
+from databricks import koalas
+from databricks.koalas.testing.utils import ReusedSQLTestCase, SQLTestUtils
+
+
+class SeriesConversionTest(ReusedSQLTestCase, SQLTestUtils):
+
+    @property
+    def ps(self):
+        return pd.Series([1, 2, 3, 4, 5, 6, 7], name='x')
+
+    @property
+    def ks(self):
+        return koalas.from_pandas(self.ps)
+
+    def test_to_clipboard(self):
+        ps = self.ps
+        ks = self.ks
+
+        self.assert_eq(ks.to_clipboard(), ps.to_clipboard())
+        self.assert_eq(ks.to_clipboard(excel=False),
+                       ps.to_clipboard(excel=False))
+        self.assert_eq(ks.to_clipboard(sep=',', index=False),
+                       ps.to_clipboard(sep=',', index=False))

--- a/databricks/koalas/tests/test_utils.py
+++ b/databricks/koalas/tests/test_utils.py
@@ -35,6 +35,16 @@ class UtilsTest(ReusedSQLTestCase, SQLTestUtils):
         }, index=[0, 1, 3])
         validate_arguments_and_invoke_function(pdf, self.to_html, pd.DataFrame.to_html, args)
 
+    def to_clipboard(self, sep=',', **kwargs):
+        args = locals()
+
+        pdf = pd.DataFrame({
+            'a': [1, 2, 3],
+            'b': [4, 5, 6],
+        }, index=[0, 1, 3])
+        validate_arguments_and_invoke_function(pdf, self.to_clipboard,
+                                               pd.DataFrame.to_clipboard, args)
+
     def test_validate_arguments_and_invoke_function(self):
         # This should pass and run fine
         self.to_html()
@@ -45,6 +55,9 @@ class UtilsTest(ReusedSQLTestCase, SQLTestUtils):
         # to a non-default value
         with self.assertRaises(TypeError):
             self.to_html(unsupported_param=1)
+
+        # Support for **kwargs
+        self.to_clipboard(sep=',', index=False)
 
     def test_lazy_property(self):
         obj = TestClassForLazyProp()

--- a/databricks/koalas/utils.py
+++ b/databricks/koalas/utils.py
@@ -59,6 +59,12 @@ def validate_arguments_and_invoke_function(pobj: Union[pd.DataFrame, pd.Series],
     args = input_args.copy()
     del args['self']
 
+    if 'kwargs' in args:
+        # explode kwargs
+        kwargs = args['kwargs']
+        del args['kwargs']
+        args = {**args, **kwargs}
+
     koalas_params = inspect.signature(koalas_func).parameters
     pandas_params = inspect.signature(pandas_func).parameters
 
@@ -69,7 +75,7 @@ def validate_arguments_and_invoke_function(pobj: Union[pd.DataFrame, pd.Series],
             else:
                 raise TypeError(
                     ("The pandas version [%s] available does not support parameter '%s' " +
-                        "for function '%s'.") % (pd.__version__, param.name, pandas_func.__name__))
+                     "for function '%s'.") % (pd.__version__, param.name, pandas_func.__name__))
 
     args['self'] = pobj
     return pandas_func(**args)
@@ -88,4 +94,5 @@ def lazy_property(fn):
         if not hasattr(self, attr_name):
             setattr(self, attr_name, fn(self))
         return getattr(self, attr_name)
+
     return _lazy_property

--- a/docs/source/reference/frame.rst
+++ b/docs/source/reference/frame.rst
@@ -127,3 +127,4 @@ Serialization / IO / Conversion
    DataFrame.to_json
    DataFrame.to_dict
    DataFrame.to_excel
+   DataFrame.to_clipboard

--- a/docs/source/reference/series.rst
+++ b/docs/source/reference/series.rst
@@ -91,3 +91,4 @@ Serialization / IO / Conversion
    Series.to_numpy
    Series.to_string
    Series.to_dict
+   Series.to_clipboard


### PR DESCRIPTION
Add `DataFrame.to_clipboard` and `Series.to_clipboard`. Part of #169.

Improve `validate_arguments_and_invoke_function()`  when receiving argument `**kwargs`
+ actual args : `{'kwargs': {'index': False}, 'sep': ',', 'excel': True}`
+ expected args : `{'sep': ',', 'excel': True, 'index': False}`


