### PR TITLE
repr and repr_html improvements

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -29,8 +29,7 @@ from pyspark.sql.types import BooleanType, StructField, StructType, to_arrow_typ
 from pyspark.sql.utils import AnalysisException
 
 from databricks import koalas as ks  # For running doctests and reference resolution in PyCharm.
-from databricks.koalas.utils import default_session, lazy_property, \
-    validate_arguments_and_invoke_function
+from databricks.koalas.utils import default_session, validate_arguments_and_invoke_function
 from databricks.koalas.dask.compatibility import string_types
 from databricks.koalas.dask.utils import derived_from
 from databricks.koalas.generic import _Frame, max_display_count
@@ -86,11 +85,6 @@ class DataFrame(_Frame):
     def _index_columns(self):
         return [self._sdf.__getitem__(field)
                 for field in self._metadata.index_fields]
-
-    @lazy_property
-    def _pandas_df_with_max_display_count(self) -> pd.DataFrame:
-        """A cached version pandas DataFrame used for repr and repr_html."""
-        return self.head(max_display_count).to_pandas()
 
     def _reduce_for_stat_function(self, sfun):
         """
@@ -739,6 +733,13 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
            __index_level_0__  col1  col2
         0                  0     1     3
         1                  1     2     4
+
+        Calling to_koalas on a Koalas DataFrame simply returns itself.
+
+        >>> df.to_koalas()
+           col1  col2
+        0     1     3
+        1     2     4
         """
         if isinstance(self, DataFrame):
             return self
@@ -1502,10 +1503,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         raise NotImplementedError(key)
 
     def __repr__(self):
-        return repr(self._pandas_df_with_max_display_count)
+        return repr(self.head(max_display_count).to_pandas())
 
     def _repr_html_(self):
-        return self._pandas_df_with_max_display_count._repr_html_()
+        return self.head(max_display_count).to_pandas()._repr_html_()
 
     def __getitem__(self, key):
         return self._pd_getitem(key)

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -1305,33 +1305,45 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         Examples
         --------
         >>> df = ks.DataFrame({
-        ...     'col1': ['A', 'A', 'B', None, 'D', 'C'],
-        ...     'col2': [2, 1, 9, 8, 7, 4],
-        ...     'col3': [0, 1, 9, 4, 2, 3],
+        ...     'col1': ['A', 'B', None, 'D', 'C'],
+        ...     'col2': [2, 9, 8, 7, 4],
+        ...     'col3': [0, 9, 4, 2, 3],
         ... })
         >>> df
            col1  col2  col3
         0     A     2     0
-        1     A     1     1
-        2     B     9     9
-        3  None     8     4
-        4     D     7     2
-        5     C     4     3
+        1     B     9     9
+        2  None     8     4
+        3     D     7     2
+        4     C     4     3
 
         Sort by col1
 
         >>> df.sort_values(by=['col1'])
            col1  col2  col3
         0     A     2     0
-        1     A     1     1
-        2     B     9     9
-        5     C     4     3
-        4     D     7     2
-        3  None     8     4
+        1     B     9     9
+        4     C     4     3
+        3     D     7     2
+        2  None     8     4
 
+        Sort Descending
+
+        >>> df.sort_values(by='col1', ascending=False)
+           col1  col2  col3
+        3     D     7     2
+        4     C     4     3
+        1     B     9     9
+        0     A     2     0
+        2  None     8     4
 
         Sort by multiple columns
 
+        >>> df = ks.DataFrame({
+        ...     'col1': ['A', 'A', 'B', None, 'D', 'C'],
+        ...     'col2': [2, 1, 9, 8, 7, 4],
+        ...     'col3': [0, 1, 9, 4, 2, 3],
+        ... })
         >>> df.sort_values(by=['col1', 'col2'])
            col1  col2  col3
         1     A     1     1
@@ -1339,17 +1351,6 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         2     B     9     9
         5     C     4     3
         4     D     7     2
-        3  None     8     4
-
-        Sort Descending
-
-        >>> df.sort_values(by='col1', ascending=False)
-           col1  col2  col3
-        4     D     7     2
-        5     C     4     3
-        2     B     9     9
-        0     A     2     0
-        1     A     1     1
         3  None     8     4
         """
         if isinstance(by, string_types):

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -164,7 +164,7 @@ class _Frame(object):
                         'got [%s]' % (df_or_s,))
 
     def compute(self):
-        """Alias of `toPandas()` to mimic dask for easily porting tests."""
+        """Alias of `to_pandas()` to mimic dask for easily porting tests."""
         return self.toPandas()
 
     @staticmethod

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -36,7 +36,7 @@ from databricks.koalas.generic import _Frame, max_display_count
 from databricks.koalas.metadata import Metadata
 from databricks.koalas.missing.series import _MissingPandasLikeSeries
 from databricks.koalas.selection import SparkDataFrameLocator
-from databricks.koalas.utils import lazy_property, validate_arguments_and_invoke_function
+from databricks.koalas.utils import validate_arguments_and_invoke_function
 
 
 def _column_op(f):
@@ -127,11 +127,6 @@ class Series(_Frame):
         self._scol = scol
         self._kdf = kdf
         self._index_info = index_info
-
-    @lazy_property
-    def _pandas_series_with_max_display_count(self) -> pd.DataFrame:
-        """A cached version pandas Series used for repr."""
-        return self.head(max_display_count).to_pandas()
 
     # arithmetic operators
     __neg__ = _column_op(spark.Column.__neg__)
@@ -736,7 +731,7 @@ class Series(_Frame):
         return self._pandas_orig_repr()
 
     def __repr__(self):
-        return repr(self._pandas_series_with_max_display_count)
+        return repr(self.head(max_display_count).to_pandas())
 
     def __dir__(self):
         if not isinstance(self.schema, StructType):

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -36,7 +36,7 @@ from databricks.koalas.generic import _Frame, max_display_count
 from databricks.koalas.metadata import Metadata
 from databricks.koalas.missing.series import _MissingPandasLikeSeries
 from databricks.koalas.selection import SparkDataFrameLocator
-from databricks.koalas.utils import validate_arguments_and_invoke_function
+from databricks.koalas.utils import lazy_property, validate_arguments_and_invoke_function
 
 
 def _column_op(f):
@@ -127,6 +127,11 @@ class Series(_Frame):
         self._scol = scol
         self._kdf = kdf
         self._index_info = index_info
+
+    @lazy_property
+    def _pandas_series_with_max_display_count(self) -> pd.DataFrame:
+        """A cached version pandas Series used for repr."""
+        return self.head(max_display_count).to_pandas()
 
     # arithmetic operators
     __neg__ = _column_op(spark.Column.__neg__)
@@ -731,7 +736,7 @@ class Series(_Frame):
         return self._pandas_orig_repr()
 
     def __repr__(self):
-        return repr(self.head(max_display_count).toPandas())
+        return repr(self._pandas_series_with_max_display_count)
 
     def __dir__(self):
         if not isinstance(self.schema, StructType):

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -74,13 +74,26 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assertEqual(koalas.range(1001).__repr__(),
                          koalas.range(max_display_count).__repr__())
 
+    def test_repr_cache_invalidation(self):
+        # If there is any cache, inplace operations should invalidate it.
+        df = koalas.range(10)
+        df.__repr__()
+        df['a'] = df['id']
+        self.assertEqual(df.__repr__(), df.to_pandas().__repr__())
+
     def test_repr_html(self):
         # Make sure we only fetch max_display_count
         self.assertEqual(koalas.range(1001)._repr_html_(),
                          koalas.range(max_display_count)._repr_html_())
 
-    def test_empty_dataframe(self):
+    def test_repr_html_cache_invalidation(self):
+        # If there is any cache, inplace operations should invalidate it.
+        df = koalas.range(10)
+        df._repr_html_()
+        df['a'] = df['id']
+        self.assertEqual(df._repr_html_(), df.to_pandas()._repr_html_())
 
+    def test_empty_dataframe(self):
         pdf = pd.DataFrame({'a': pd.Series([], dtype='i1'),
                             'b': pd.Series([], dtype='str')})
 

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -20,6 +20,7 @@ import numpy as np
 import pandas as pd
 
 from databricks import koalas
+from databricks.koalas.generic import max_display_count
 from databricks.koalas.testing.utils import ReusedSQLTestCase, SQLTestUtils
 from databricks.koalas.exceptions import PandasNotImplementedError
 from databricks.koalas.missing.frame import _MissingPandasLikeDataFrame
@@ -67,6 +68,16 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(df[['a', 'b']], ddf[['a', 'b']])
 
         self.assertEqual(ddf.a.notnull().alias("x").name, "x")
+
+    def test_repr(self):
+        # Make sure we only fetch max_display_count
+        self.assertEqual(koalas.range(1001).__repr__(),
+                         koalas.range(max_display_count).__repr__())
+
+    def test_repr_html(self):
+        # Make sure we only fetch max_display_count
+        self.assertEqual(koalas.range(1001)._repr_html_(),
+                         koalas.range(max_display_count)._repr_html_())
 
     def test_empty_dataframe(self):
 

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -21,6 +21,7 @@ import pandas as pd
 
 from databricks import koalas
 from databricks.koalas import Series
+from databricks.koalas.generic import max_display_count
 from databricks.koalas.testing.utils import ReusedSQLTestCase, SQLTestUtils
 from databricks.koalas.exceptions import PandasNotImplementedError
 from databricks.koalas.missing.series import _MissingPandasLikeSeries
@@ -42,6 +43,11 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         self.assertTrue(isinstance(ks['x'], Series))
 
         # TODO: self.assert_eq(d + 1, pdf + 1)
+
+    def test_repr(self):
+        # Make sure we only fetch max_display_count
+        self.assertEqual(koalas.range(1001)['id'].__repr__(),
+                         koalas.range(max_display_count)['id'].__repr__())
 
     def test_empty_series(self):
         a = pd.Series([], dtype='i1')

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -49,6 +49,13 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         self.assertEqual(koalas.range(1001)['id'].__repr__(),
                          koalas.range(max_display_count)['id'].__repr__())
 
+    def test_repr_cache_invalidation(self):
+        # If there is any cache, inplace operations should invalidate it.
+        s = koalas.range(10)['id']
+        s.__repr__()
+        s.rename('a', inplace=True)
+        self.assertEqual(s.__repr__(), s.rename("a").__repr__())
+
     def test_empty_series(self):
         a = pd.Series([], dtype='i1')
         b = pd.Series([], dtype='str')

--- a/databricks/koalas/tests/test_utils.py
+++ b/databricks/koalas/tests/test_utils.py
@@ -17,7 +17,9 @@
 import pandas as pd
 
 from databricks.koalas.testing.utils import ReusedSQLTestCase, SQLTestUtils
-from databricks.koalas.utils import validate_arguments_and_invoke_function
+from databricks.koalas.utils import lazy_property, validate_arguments_and_invoke_function
+
+some_global_variable = 0
 
 
 class UtilsTest(ReusedSQLTestCase, SQLTestUtils):
@@ -43,3 +45,20 @@ class UtilsTest(ReusedSQLTestCase, SQLTestUtils):
         # to a non-default value
         with self.assertRaises(TypeError):
             self.to_html(unsupported_param=1)
+
+    def test_lazy_property(self):
+        obj = TestClassForLazyProp()
+        # If lazy prop is not working, the second test would fail (because it'd be 2)
+        self.assert_eq(obj.lazy_prop, 1)
+        self.assert_eq(obj.lazy_prop, 1)
+
+
+class TestClassForLazyProp:
+
+    def __init__(self):
+        self.some_variable = 0
+
+    @lazy_property
+    def lazy_prop(self):
+        self.some_variable += 1
+        return self.some_variable

--- a/databricks/koalas/utils.py
+++ b/databricks/koalas/utils.py
@@ -73,3 +73,19 @@ def validate_arguments_and_invoke_function(pobj: Union[pd.DataFrame, pd.Series],
 
     args['self'] = pobj
     return pandas_func(**args)
+
+
+def lazy_property(fn):
+    """
+    Decorator that makes a property lazy-evaluated.
+
+    Copied from https://stevenloria.com/lazy-properties/
+    """
+    attr_name = '_lazy_' + fn.__name__
+
+    @property
+    def _lazy_property(self):
+        if not hasattr(self, attr_name):
+            setattr(self, attr_name, fn(self))
+        return getattr(self, attr_name)
+    return _lazy_property


### PR DESCRIPTION
1. Fixed the bug that `DataFrame. __repr__` was turning the entire DataFrame into pandas DataFrame, rather than simply taking the top 1000 rows.

2. Added a cache so repeated calls of repr and repr_html don't trigger multiple Spark actions. But then I undid that because cache invalidation is difficult. I did leave some of the infrastructure still in place and added test cases to make sure repr and repr_html are correct when it comes to cache invalidation, if we ever implement any form of caching.


