### PR TITLE
Explicitly specify numpy minimum version.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 # Dependencies in Koalas
 pandas>=0.23
 pyarrow>=0.10,<0.11
+numpy>=0.14
 
 # Documentation build
 sphinx

--- a/setup.py
+++ b/setup.py
@@ -55,8 +55,8 @@ setup(
     python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*',
     install_requires=[
         'pandas>=0.23',
-        'decorator',
         'pyarrow>=0.10,<0.11',  # See https://github.com/databricks/koalas/issues/26
+        'numpy>=0.14',
     ],
     maintainer="Databricks",
     maintainer_email="koalas@databricks.com",


### PR DESCRIPTION
Although `pyarrow==0.10` says numpy minimum version is `1.10.0`, it does not work properly with `numpy<0.14`, so we should explicitly specify the numpy minimum version. This is related to #252.