### PR TITLE
Add basic merge functionality to DataFrame

### DIFF
--- a/databricks/koalas/exceptions.py
+++ b/databricks/koalas/exceptions.py
@@ -67,3 +67,7 @@ class PandasNotImplementedError(NotImplementedError):
             msg = "The property `{0}.{1}` is not implemented yet." \
                 .format(class_name, property_name)
         super(NotImplementedError, self).__init__(msg)
+
+
+class SparkPandasMergeError(Exception):
+    pass

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -1474,16 +1474,28 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Parameters
         ----------
-        right: the DataFrame for the right side of the join operation
-        how: a join method out of ['inner', 'left', 'right', 'full', 'outer']
-        on: the column name to be joined on. Defaults to the index if not specified
-        suffixes: suffix to apply to overlapping column names in the left and right side,
-            respectively
+        right: Object to merge with.
+        how: Type of merge to be performed.
+            {‘left’, ‘right’, ‘outer’, ‘inner’}, default ‘inner’
+
+            left: use only keys from left frame, similar to a SQL left outer join; preserve key
+                order.
+            right: use only keys from right frame, similar to a SQL right outer join; preserve key
+                order.
+            outer: use union of keys from both frames, similar to a SQL full outer join; sort keys
+                lexicographically.
+            inner: use intersection of keys from both frames, similar to a SQL inner join;
+                preserve the order of the left keys.
+        on: Column or index level names to join on. These must be found in both DataFrames. If on
+            is None and not merging on indexes then this defaults to the intersection of the
+            columns in both DataFrames.
+        suffixes: Suffix to apply to overlapping column names in the left and right side,
+            respectively.
 
         Returns
         -------
         DataFrame
-            The joined DataFrame
+            A DataFrame of the two merged objects.
 
         Examples
         --------

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -1470,7 +1470,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
     def merge(self, right: 'DataFrame', how: str = 'inner', on: str = None,
               suffixes: Tuple[str, str] = ('_x', '_y')) -> 'DataFrame':
         """
-        Perform a database (SQL) merge operation between two DataFrame objects.
+        Merge DataFrame objects with a database-style join.
 
         Parameters
         ----------

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -1549,7 +1549,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             how = 'full'
         if how not in ('inner', 'left', 'right', 'full'):
             raise ValueError("The 'how' parameter has to be amongst the following values: ",
-                             "['inner', 'left', 'right', 'full', 'outer']")
+                             "['inner', 'left', 'right', 'outer']")
 
         if on is None:
             # FIXME Move index string to constant?

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -1518,7 +1518,6 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         if how == 'full':
             print("Warning: While Koalas will accept 'full', you should use 'outer' instead to",
                   "be compatible with the pandas merge API")
-            pass
         if how == 'outer':
             # 'outer' in pandas equals 'full' in Spark
             how = 'full'

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -17,6 +17,7 @@
 """
 A wrapper class for Spark DataFrame to behave similar to pandas DataFrame.
 """
+import warnings
 from functools import partial, reduce
 from typing import Any, List, Tuple, Union
 
@@ -1541,8 +1542,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             raise SparkPandasMergeError("Only 'on' or 'left_index' and 'right_index' can be set")
 
         if how == 'full':
-            print("Warning: While Koalas will accept 'full', you should use 'outer' instead to",
-                  "be compatible with the pandas merge API")
+            warnings.warn("Warning: While Koalas will accept 'full', you should use 'outer' " +
+                          "instead to be compatible with the pandas merge API", UserWarning)
         if how == 'outer':
             # 'outer' in pandas equals 'full' in Spark
             how = 'full'

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -1509,21 +1509,21 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         >>> left_kdf = ks.DataFrame({'A': [1, 2]})
         >>> right_kdf = ks.DataFrame({'B': ['x', 'y']}, index=[1, 2])
 
-        >>> left_kdf.merge(right_kdf)
+        >>> left_kdf.merge(right_kdf, left_index=True, right_index=True)
            A  B
         0  2  x
 
-        >>> left_kdf.merge(right_kdf, how='left')
+        >>> left_kdf.merge(right_kdf, left_index=True, right_index=True, how='left')
            A     B
         0  1  None
         1  2     x
 
-        >>> left_kdf.merge(right_kdf, how='right')
+        >>> left_kdf.merge(right_kdf, left_index=True, right_index=True, how='right')
              A  B
         0  2.0  x
         1  NaN  y
 
-        >>> left_kdf.merge(right_kdf, how='outer')
+        >>> left_kdf.merge(right_kdf, left_index=True, right_index=True, how='outer')
              A     B
         0  1.0  None
         1  2.0     x

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -1534,7 +1534,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         As described in #263, joining string columns currently returns None for missing values
             instead of NaN.
         """
-        if on is None and not left_index and not right_index :
+        if on is None and not left_index and not right_index:
             raise SparkPandasMergeError("At least 'on' or 'left_index' and 'right_index' have ",
                                         "to be set")
         if on is not None and (left_index or right_index):

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -1499,8 +1499,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> left_kdf = koalas.DataFrame({'A': [1, 2]})
-        >>> right_kdf = koalas.DataFrame({'B': ['x', 'y']}, index=[1, 2])
+        >>> left_kdf = ks.DataFrame({'A': [1, 2]})
+        >>> right_kdf = ks.DataFrame({'B': ['x', 'y']}, index=[1, 2])
 
         >>> left_kdf.merge(right_kdf)
            A  B

--- a/databricks/koalas/missing/frame.py
+++ b/databricks/koalas/missing/frame.py
@@ -122,7 +122,6 @@ class _MissingPandasLikeDataFrame(object):
     median = unsupported_function('median')
     melt = unsupported_function('melt')
     memory_usage = unsupported_function('memory_usage')
-    merge = unsupported_function('merge')
     mod = unsupported_function('mod')
     mode = unsupported_function('mode')
     mul = unsupported_function('mul')

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 
+from collections import OrderedDict
 import inspect
 
 import numpy as np
@@ -398,7 +399,8 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         left_kdf_with_id = koalas.DataFrame({'A': [1, 2], 'id': [0, 1]})
         right_kdf_with_id = koalas.DataFrame({'B': ['x', 'y'], 'id': [0, 1]}, index=[1, 2])
         res = left_kdf_with_id.merge(right_kdf_with_id, on='id')
-        self.assert_eq(res, pd.DataFrame({'A': [1, 2], 'id': [0, 1], 'B': ['x', 'y']}))
+        # Use OrderedDict to also assure column order with Python 3.5
+        self.assert_eq(res, pd.DataFrame(OrderedDict(A=[1, 2], id=[0, 1], B=['x', 'y'])))
 
         # Assert left join
         res = left_kdf.merge(right_kdf, how='left')

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -418,3 +418,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         res = left_kdf.merge(right_kdf, how='full')
         # FIXME Replace None with np.nan once #263 is solved
         self.assert_eq(res, pd.DataFrame({'A': [1, 2, np.nan], 'B': [None, 'x', 'y']}))
+
+        # Assert suffixes create the expected column names
+        res = left_kdf.merge(koalas.DataFrame({'A': [3, 4]}), suffixes=('_left', '_right'))
+        self.assert_eq(res, pd.DataFrame({'A_left': [1, 2], 'A_right': [3, 4]}))

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 
-from collections import OrderedDict
 import inspect
 
 import numpy as np
@@ -408,8 +407,9 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         left_kdf_with_id = koalas.DataFrame({'A': [1, 2], 'id': [0, 1]})
         right_kdf_with_id = koalas.DataFrame({'B': ['x', 'y'], 'id': [0, 1]}, index=[1, 2])
         res = left_kdf_with_id.merge(right_kdf_with_id, on='id')
-        # Use OrderedDict to also assure column order with Python 3.5
-        self.assert_eq(res, pd.DataFrame(OrderedDict(A=[1, 2], id=[0, 1], B=['x', 'y'])))
+        # Explicitly set columns to also assure their correct order with Python 3.5
+        self.assert_eq(res, pd.DataFrame({'A': [1, 2], 'id': [0, 1], 'B': ['x', 'y']},
+                                         columns=['A', 'id', 'B']))
 
         # Assert left join
         res = left_kdf.merge(right_kdf, left_index=True, right_index=True, how='left')


### PR DESCRIPTION
This PR adds the basic [merge](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.merge.html) functionality from pandas to Koalas DataFrames as requested in #232. While the PR does not cover 100% of pandas' functionality, it covers the basic use cases to be useful enough to start with.

Resolves #232