### PR TITLE
Revamp the UDF wrapper to make it more usable

### DIFF
--- a/databricks/koalas/__init__.py
+++ b/databricks/koalas/__init__.py
@@ -41,7 +41,7 @@ from databricks.koalas.series import Series
 from databricks.koalas.typedef import Col, pandas_wrap
 
 __all__ = ['read_csv', 'read_parquet', 'to_datetime', 'from_pandas',
-           'get_dummies', 'DataFrame', 'Series']
+           'get_dummies', 'DataFrame', 'Series', 'Col', 'pandas_wrap']
 
 
 def _auto_patch():

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -509,7 +509,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         from databricks.koalas.series import Series
         if len(self._metadata.index_info) != 1:
             raise KeyError('Currently supported only when the DataFrame has a single index.')
-        return Series(self._index_columns[0], self, [])
+        return Series(self._index_columns[0], anchor=self, index=[])
 
     def set_index(self, keys, drop=True, append=False, inplace=False):
         """Set the DataFrame index (row labels) using one or more existing columns. By default
@@ -1481,7 +1481,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             raise KeyError("none key")
         if isinstance(key, string_types):
             try:
-                return Series(self._sdf.__getitem__(key), self, self._metadata.index_info)
+                return Series(self._sdf.__getitem__(key), anchor=self, index=self._metadata.index_info)
             except AnalysisException:
                 raise KeyError(key)
         if np.isscalar(key) or isinstance(key, (tuple, string_types)):
@@ -1495,7 +1495,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             return self.loc[:, key]
         if isinstance(key, DataFrame):
             # TODO Should not implement alignment, too dangerous?
-            return Series(self._sdf.__getitem__(key), self, self._metadata.index_info)
+            return Series(self._sdf.__getitem__(key), anchor=self, index=self._metadata.index_info)
         if isinstance(key, Series):
             # TODO Should not implement alignment, too dangerous?
             # It is assumed to be only a filter, otherwise .loc should be used.
@@ -1540,7 +1540,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 return property_or_func.fget(self)  # type: ignore
             else:
                 return partial(property_or_func, self)
-        return Series(self._sdf.__getattr__(key), self, self._metadata.index_info)
+        return Series(self._sdf.__getattr__(key), anchor=self, index=self._metadata.index_info)
 
     def __iter__(self):
         return self.toPandas().__iter__()

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -1481,7 +1481,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             raise KeyError("none key")
         if isinstance(key, string_types):
             try:
-                return Series(self._sdf.__getitem__(key), anchor=self, index=self._metadata.index_info)
+                return Series(self._sdf.__getitem__(key), anchor=self,
+                              index=self._metadata.index_info)
             except AnalysisException:
                 raise KeyError(key)
         if np.isscalar(key) or isinstance(key, (tuple, string_types)):

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -196,7 +196,7 @@ def _spark_col_apply(kdf_or_ks, sfun):
     from databricks.koalas.series import Series
     if isinstance(kdf_or_ks, Series):
         ks = kdf_or_ks
-        return Series(sfun(kdf_or_ks._scol), ks._kdf, ks._index_info)
+        return Series(sfun(kdf_or_ks._scol), anchor=ks._kdf, index=ks._index_info)
     assert isinstance(kdf_or_ks, DataFrame)
     kdf = kdf_or_ks
     sdf = kdf._sdf

--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -239,19 +239,19 @@ def read_parquet(path, columns=None):
 
 def to_datetime(arg, errors='raise', format=None, infer_datetime_format=False):
     if isinstance(arg, Series):
-        return Series(_to_datetime1(
-            arg._scol,
+        return _to_datetime1(
+            arg,
             errors=errors,
             format=format,
-            infer_datetime_format=infer_datetime_format), arg._kdf, arg._index_info)
+            infer_datetime_format=infer_datetime_format)
     if isinstance(arg, DataFrame):
-        return Series(_to_datetime2(
-            arg_year=arg['year']._scol,
-            arg_month=arg['month']._scol,
-            arg_day=arg['day']._scol,
+        return _to_datetime2(
+            arg_year=arg['year'],
+            arg_month=arg['month'],
+            arg_day=arg['day'],
             errors=errors,
             format=format,
-            infer_datetime_format=infer_datetime_format), arg, arg._metadata.index_info)
+            infer_datetime_format=infer_datetime_format)
     if isinstance(arg, dict):
         return _to_datetime2(
             arg_year=arg['year'],

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -94,7 +94,8 @@ class Series(_Frame):
     """
 
     @derived_from(pd.Series)
-    def __init__(self, data=None, index=None, dtype=None, name=None, copy=False, fastpath=False, anchor=None):
+    def __init__(self, data=None, index=None, dtype=None, name=None, copy=False, fastpath=False,
+                 anchor=None):
         if isinstance(data, pd.Series):
             self._init_from_pandas(data)
         elif isinstance(data, spark.Column):
@@ -162,7 +163,8 @@ class Series(_Frame):
     def __radd__(self, other):
         # Handle 'literal' + df['col']
         if isinstance(self.spark_type, StringType) and isinstance(other, str):
-            return Series(F.concat(F.lit(other), self._scol), anchor=self._kdf, index=self._index_info)
+            return Series(F.concat(F.lit(other), self._scol), anchor=self._kdf,
+                          index=self._index_info)
         else:
             return _column_op(spark.Column.__radd__)(self, other)
 
@@ -466,7 +468,8 @@ class Series(_Frame):
     @derived_from(pd.Series)
     def isnull(self):
         if isinstance(self.schema[self.name].dataType, (FloatType, DoubleType)):
-            return Series(self._scol.isNull() | F.isnan(self._scol), anchor=self._kdf, index=self._index_info)
+            return Series(self._scol.isNull() | F.isnan(self._scol), anchor=self._kdf,
+                          index=self._index_info)
         else:
             return Series(self._scol.isNull(), anchor=self._kdf, index=self._index_info)
 

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -125,6 +125,8 @@ class Series(_Frame):
         :param index_info: index information of this Series.
         """
         assert index_info is not None
+        assert kdf is not None
+        assert isinstance(kdf, ks.DataFrame), type(kdf)
         self._scol = scol
         self._kdf = kdf
         self._index_info = index_info

--- a/databricks/koalas/tests/test_stats.py
+++ b/databricks/koalas/tests/test_stats.py
@@ -53,9 +53,9 @@ class StatsTest(ReusedSQLTestCase, SQLTestUtils):
                            'C': [-6., -7, -8, -9, 10],
                            'D': ['a', 'b', 'c', 'd', 'e']})
         ddf = koalas.from_pandas(df)
-        self.assertPandasAlmostEqual(ddf.A.abs(), df.A.abs())
-        self.assertPandasAlmostEqual(ddf.B.abs(), df.B.abs())
-        self.assertPandasAlmostEqual(ddf[['B', 'C']].abs(), df[['B', 'C']].abs())
+        self.assert_eq(ddf.A.abs(), df.A.abs())
+        self.assert_eq(ddf.B.abs(), df.B.abs())
+        self.assert_eq(ddf[['B', 'C']].abs(), df[['B', 'C']].abs())
         # self.assert_eq(ddf.select('A', 'B').abs(), df[['A', 'B']].abs())
 
     def test_corr(self):

--- a/databricks/koalas/tests/test_stats.py
+++ b/databricks/koalas/tests/test_stats.py
@@ -53,9 +53,9 @@ class StatsTest(ReusedSQLTestCase, SQLTestUtils):
                            'C': [-6., -7, -8, -9, 10],
                            'D': ['a', 'b', 'c', 'd', 'e']})
         ddf = koalas.from_pandas(df)
-        self.assert_eq(ddf.A.abs(), df.A.abs())
-        self.assert_eq(ddf.B.abs(), df.B.abs())
-        self.assert_eq(ddf[['B', 'C']].abs(), df[['B', 'C']].abs())
+        self.assertPandasAlmostEqual(ddf.A.abs(), df.A.abs())
+        self.assertPandasAlmostEqual(ddf.B.abs(), df.B.abs())
+        self.assertPandasAlmostEqual(ddf[['B', 'C']].abs(), df[['B', 'C']].abs())
         # self.assert_eq(ddf.select('A', 'B').abs(), df[['A', 'B']].abs())
 
     def test_corr(self):

--- a/databricks/koalas/typedef.py
+++ b/databricks/koalas/typedef.py
@@ -185,8 +185,10 @@ def _make_fun(f: typing.Callable, return_type: types.DataType, *args, **kwargs) 
     """
     from databricks.koalas.series import Series
     # All the arguments.
-    frozen_args = []  # None for columns or the value for non-columns
-    col_args = []  # ks.Series for columns or None for the non-columns
+    # None for columns or the value for non-columns
+    frozen_args = []  # type: typing.List[typing.Any]
+    # ks.Series for columns or None for the non-columns
+    col_args = []  # type: typing.List[typing.Optional[Series]]
     for arg in args:
         if isinstance(arg, Series):
             frozen_args.append(None)
@@ -198,8 +200,10 @@ def _make_fun(f: typing.Callable, return_type: types.DataType, *args, **kwargs) 
             frozen_args.append(arg)
             col_args.append(None)
 
-    frozen_kwargs = []  # Value is none for kwargs that are columns, and the value otherwise
-    col_kwargs = []  # Value is a spark col for kwarg that is column, and None otherwise
+    # Value is none for kwargs that are columns, and the value otherwise
+    frozen_kwargs = []  # type: typing.List[typing.Tuple[str, typing.Any]]
+    # Value is a spark col for kwarg that is column, and None otherwise
+    col_kwargs = []  # type: typing.List[typing.Tuple[str, Series]]
     for (key, arg) in kwargs.items():
         if isinstance(arg, Series):
             col_kwargs.append((key, arg))
@@ -210,8 +214,7 @@ def _make_fun(f: typing.Callable, return_type: types.DataType, *args, **kwargs) 
             frozen_kwargs.append((key, arg))
 
     col_args_idxs = [idx for (idx, c) in enumerate(col_args) if c is not None]
-    all_indexes = (col_args_idxs
-                   + [key for (key, _) in col_kwargs])  # type: typing.List[typing.Union[int, str]]
+    all_indexes = (col_args_idxs + [key for (key, _) in col_kwargs])  # type: ignore
     if not all_indexes:
         # No argument is related to spark
         # The function is just called through without other considerations.
@@ -388,3 +391,4 @@ def _get_return_type(return_sig, return_col, return_scalar) -> X:
         return _Scalar(inner)
     if return_sig is not None:
         return _to_stype(return_sig)
+    assert False

--- a/databricks/koalas/typedef.py
+++ b/databricks/koalas/typedef.py
@@ -243,12 +243,14 @@ def _make_fun(f: typing.Callable, return_type: types.DataType, *args, **kwargs) 
         if col is not None:
             spark_col_args.append(col._scol)
             name_tokens.append(col.name)
+    kw_name_tokens = []
     for (key, col) in col_kwargs:
         spark_col_args.append(col._scol)
-        name_tokens.append("{}={}".format(key, col.name))
+        kw_name_tokens.append("{}={}".format(key, col.name))
     col = wrapped_udf(*spark_col_args)
     series = Series(data=col, index=index_info, anchor=kdf)
-    name = "{}({})".format(f.__name__, ", ".join(name_tokens))
+    all_name_tokens = name_tokens + sorted(kw_name_tokens)
+    name = "{}({})".format(f.__name__, ", ".join(all_name_tokens))
     series = series.astype(return_type).alias(name)
     return series
 

--- a/databricks/koalas/typedef.py
+++ b/databricks/koalas/typedef.py
@@ -18,7 +18,6 @@
 Utilities to deal with types. This is mostly focused on python3.
 """
 import typing
-import types as python_types
 from inspect import getfullargspec
 from functools import wraps
 
@@ -353,9 +352,7 @@ def pandas_wrap(_function=None, return_col=None, return_scalar=None):
     The arguments provided to the function must be picklable, or an error will be raised by Spark:
 
     >>> import sys
-    >>> fun(df.col1, arg1=sys.stdout)
-    Traceback (most recent call last):
-      ...
+    >>> # fun(df.col1, arg1=sys.stdout)  # Will fail!
 
     """
     def function_wrapper(f):

--- a/databricks/koalas/typedef.py
+++ b/databricks/koalas/typedef.py
@@ -280,6 +280,7 @@ def pandas_wrap(_function=None, return_col=None, return_scalar=None):
     >>> df = ks.DataFrame(pdf)
 
     Consider a simple function that operates on pandas series of integers
+
     >>> def fun(col1):
     ...     return col1.apply(lambda x: x * 2) # Arbitrary pandas code.
     >>> fun(pdf.col1)

--- a/docs/source/reference/general_functions.rst
+++ b/docs/source/reference/general_functions.rst
@@ -19,3 +19,11 @@ Top-level dealing with datetimelike
    :toctree: api/
 
    to_datetime
+
+
+Integration with Spark and pandas
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. autosummary::
+   :toctree: api/
+
+   pandas_wrap


### PR DESCRIPTION
This revamps and significantly improves / simplifies the pandas wrapper (which is a much more flexible pandas udf wrapper). The exact naming of some of the content like `pandas_wrap` or `Col` can be debated. See the docstring examples for usage and motivation.