### PR TITLE
Add Series.apply

### DIFF
--- a/databricks/koalas/__init__.py
+++ b/databricks/koalas/__init__.py
@@ -38,10 +38,10 @@ assert_pyspark_version()
 from databricks.koalas.namespace import *
 from databricks.koalas.frame import DataFrame
 from databricks.koalas.series import Series
-from databricks.koalas.typedef import Col, pandas_wrap
+from databricks.koalas.typedef import Col, pandas_wraps
 
 __all__ = ['read_csv', 'read_parquet', 'to_datetime', 'from_pandas',
-           'get_dummies', 'DataFrame', 'Series', 'Col', 'pandas_wrap']
+           'get_dummies', 'DataFrame', 'Series', 'Col', 'pandas_wraps']
 
 
 def _auto_patch():

--- a/databricks/koalas/missing/series.py
+++ b/databricks/koalas/missing/series.py
@@ -69,7 +69,6 @@ class _MissingPandasLikeSeries(object):
     all = unsupported_function('all')
     any = unsupported_function('any')
     append = unsupported_function('append')
-    apply = unsupported_function('apply')
     argmax = unsupported_function('argmax')
     argmin = unsupported_function('argmin')
     argsort = unsupported_function('argsort')

--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -30,7 +30,7 @@ from databricks import koalas as ks  # For running doctests and reference resolu
 from databricks.koalas.dask.compatibility import string_types
 from databricks.koalas.utils import default_session
 from databricks.koalas.frame import DataFrame, _reduce_spark_multi
-from databricks.koalas.typedef import Col, pandas_wrap
+from databricks.koalas.typedef import Col, pandas_wraps
 from databricks.koalas.series import Series
 
 
@@ -410,8 +410,8 @@ def get_dummies(data, prefix=None, prefix_sep='_', dummy_na=False, columns=None,
     return kdf[remaining_columns]
 
 
-# @pandas_wrap(return_col=np.datetime64)
-@pandas_wrap
+# @pandas_wraps(return_col=np.datetime64)
+@pandas_wraps
 def _to_datetime1(arg, errors, format, infer_datetime_format) -> Col[np.datetime64]:
     return pd.to_datetime(
         arg,
@@ -420,8 +420,8 @@ def _to_datetime1(arg, errors, format, infer_datetime_format) -> Col[np.datetime
         infer_datetime_format=infer_datetime_format)
 
 
-# @pandas_wrap(return_col=np.datetime64)
-@pandas_wrap
+# @pandas_wraps(return_col=np.datetime64)
+@pandas_wraps
 def _to_datetime2(arg_year, arg_month, arg_day,
                   errors, format, infer_datetime_format) -> Col[np.datetime64]:
     arg = dict(year=arg_year, month=arg_month, day=arg_day)

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -731,9 +731,9 @@ class Series(_Frame):
         """
         Invoke function on values of Series.
 
-        Can be a Python function that only works on the series.
+        Can be a Python function that only works on the Series.
 
-        .. note:: unlike Pandas, it is required for `func` to specify return type hint.
+        .. note:: unlike pandas, it is required for `func` to specify return type hint.
 
         Parameters
         ----------
@@ -750,7 +750,7 @@ class Series(_Frame):
 
         Examples
         --------
-        Create a series with typical summer temperatures for each city.
+        Create a Series with typical summer temperatures for each city.
 
         >>> s = ks.Series([20, 21, 12],
         ...               index=['London', 'New York', 'Helsinki'])
@@ -775,7 +775,7 @@ class Series(_Frame):
 
         Define a custom function that needs additional positional
         arguments and pass these additional arguments using the
-        ``args`` keyword by using `pandas_wraps`.
+        ``args`` keyword
 
         >>> def subtract_custom_value(x, custom_value) -> np.int64:
         ...     return x - custom_value
@@ -788,7 +788,7 @@ class Series(_Frame):
 
 
         Define a custom function that takes keyword arguments
-        and pass these arguments to ``apply``  by using `pandas_wraps`.
+        and pass these arguments to ``apply``
 
         >>> def add_custom_values(x, **kwargs) -> np.int64:
         ...     for month in kwargs:
@@ -802,7 +802,7 @@ class Series(_Frame):
         Name: add_custom_values(0), dtype: int64
 
 
-        Use a function from the Numpy library by using `pandas_wraps`.
+        Use a function from the Numpy library
 
         >>> def numpy_log(col) -> np.float64:
         ...     return np.log(col)

--- a/databricks/koalas/typedef.py
+++ b/databricks/koalas/typedef.py
@@ -32,7 +32,7 @@ import pyspark.sql.types as types
 from databricks import koalas as ks  # For running doctests and reference resolution in PyCharm.
 
 
-__all__ = ['Col', '_make_fun', 'pandas_wrap', 'as_spark_type',
+__all__ = ['Col', 'pandas_wraps', 'as_spark_type',
            'as_python_type', 'infer_pd_series_spark_type']
 
 
@@ -265,7 +265,7 @@ def _get_metadata(args, kwargs):
     return (s._index_info, s._kdf)
 
 
-def pandas_wrap(_function=None, return_col=None, return_scalar=None):
+def pandas_wraps(function=None, return_col=None, return_scalar=None):
     """ This annotation makes a function available for Koalas.
 
     Spark requires more information about the return types than pandas, and sometimes more
@@ -277,14 +277,14 @@ def pandas_wrap(_function=None, return_col=None, return_scalar=None):
 
     Wrapping a function with python 3's type annotations:
 
-    >>> from databricks.koalas import pandas_wrap, Col
+    >>> from databricks.koalas import pandas_wraps, Col
     >>> pdf = pd.DataFrame({"col1": [1, 2], "col2": [10, 20]}, dtype=np.int64)
     >>> df = ks.DataFrame(pdf)
 
     Consider a simple function that operates on pandas series of integers
 
     >>> def fun(col1):
-    ...     return col1.apply(lambda x: x * 2) # Arbitrary pandas code.
+    ...     return col1.apply(lambda x: x * 2)  # Arbitrary pandas code.
     >>> fun(pdf.col1)
     0    2
     1    4
@@ -294,9 +294,9 @@ def pandas_wrap(_function=None, return_col=None, return_scalar=None):
     The following function uses python built-in typing hint system to hint that this function
     returns a Series of integers:
 
-    >>> @pandas_wrap
+    >>> @pandas_wraps
     ... def fun(col1) -> Col[np.int64]:
-    ...     return col1.apply(lambda x: x * 2) # Arbitrary pandas code.
+    ...     return col1.apply(lambda x: x * 2)  # Arbitrary pandas code.
 
     This function works as before on pandas Series:
 
@@ -312,11 +312,11 @@ def pandas_wrap(_function=None, return_col=None, return_scalar=None):
     1    4
     Name: fun(col1), dtype: int64
 
-    Alternatively, the type hint can be provided as an argument to the pandas_wrap decorator:
+    Alternatively, the type hint can be provided as an argument to the `pandas_wraps` decorator:
 
-    >>> @pandas_wrap(return_col=np.int64)
+    >>> @pandas_wraps(return_col=np.int64)
     ... def fun(col1):
-    ...     return col1.apply(lambda x: x * 2) # Arbitrary pandas code.
+    ...     return col1.apply(lambda x: x * 2)  # Arbitrary pandas code.
 
     >>> fun(df.col1)
     0    2
@@ -328,7 +328,7 @@ def pandas_wrap(_function=None, return_col=None, return_scalar=None):
     It will automatically distribute argument values that are not Koalas series. Here is an
     example of function with optional series arguments and non-series arguments:
 
-    >>> @pandas_wrap(return_col=float)
+    >>> @pandas_wraps(return_col=float)
     ... def fun(col1, col2 = None, arg1="x", **kwargs):
     ...    return 2.0 * col1 if arg1 == "x" else 3.0 * col1 * col2 * kwargs['col3']
 
@@ -363,7 +363,7 @@ def pandas_wrap(_function=None, return_col=None, return_scalar=None):
         return wrapper
     if return_col is not None or return_scalar is not None:
         return function_wrapper
-    return function_wrapper(_function)
+    return function_wrapper(function)
 
 
 def _infer_return_type(f, return_col_hint=None, return_scalar_hint=None) -> X:
@@ -380,7 +380,7 @@ def _get_return_type(return_sig, return_col, return_scalar) -> X:
     if not (return_col or return_sig or return_scalar):
         raise ValueError(
             "Missing type information. It should either be provided as an argument to "
-            "pandas_wrap, or as a python typing hint")
+            "pandas_wraps, or as a python typing hint")
     if return_col is not None:
         if isinstance(return_col, Col):
             return _to_stype(return_col)

--- a/docs/source/reference/general_functions.rst
+++ b/docs/source/reference/general_functions.rst
@@ -26,4 +26,4 @@ Integration with Spark and pandas
 .. autosummary::
    :toctree: api/
 
-   pandas_wrap
+   pandas_wraps


### PR DESCRIPTION
This PR adds `apply` to Series. It works identically with Pandas except that Koalas requires to add a type hint to the input `func`'s return type.

```python
>>> import pandas as pd
>>> import numpy as np
>>> import databricks.koalas as ks
>>>
>>> pser = pd.Series([20, 21, 12], index=['London', 'New York', 'Helsinki'])
>>> kser = ks.Series(pser)
>>> def square(x) -> np.int64:
...     return x ** 2
...
```

```
>>> kser.apply(square)
London      400
New York    441
Helsinki    144
Name: square(0), dtype: int64
```

```
>>> pser.apply(square)
London      400
New York    441
Helsinki    144
dtype: int64
```

While I am here,
 - I renamed `pandas_wrap` -> `pandas_wraps` just to match with `functools.wraps`.
 - Addressed few nits.