### PR TITLE
Fix minimum numpy version.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 # Dependencies in Koalas
 pandas>=0.23
 pyarrow>=0.10,<0.11
-numpy>=0.14
+numpy>=1.14
 
 # Documentation build
 sphinx

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
     install_requires=[
         'pandas>=0.23',
         'pyarrow>=0.10,<0.11',  # See https://github.com/databricks/koalas/issues/26
-        'numpy>=0.14',
+        'numpy>=1.14',
     ],
     maintainer="Databricks",
     maintainer_email="koalas@databricks.com",


### PR DESCRIPTION
This is a follow-up of #260.
The minimum version should've been `1.14`.