### PR TITLE
Cleanup metadata and add documentations for it

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -691,8 +691,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             for i in idx:
                 info = self._metadata.index_pairs[i]
                 index_column, index_name = info
-                new_index_pairs.append((index_column,
-                                        index_name if index_name is not None else rename(index_name)))
+                new_index_pairs.append(
+                    (index_column,
+                     index_name if index_name is not None else rename(index_name)))
                 index_pairs.remove(info)
 
         if drop:

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -657,7 +657,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         if level is None:
             new_index_map = [(column, name if name is not None else rename(i))
-                               for i, (column, name) in enumerate(self._metadata.index_map)]
+                             for i, (column, name) in enumerate(self._metadata.index_map)]
             index_map = []
         else:
             if isinstance(level, (int, str)):

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -133,7 +133,7 @@ class DataFrame(_Frame):
     def _init_from_pandas(self, pdf):
         metadata = Metadata.from_pandas(pdf)
         reset_index = pdf.reset_index()
-        reset_index.columns = metadata.all_fields
+        reset_index.columns = metadata.columns
         schema = StructType([StructField(name, infer_pd_series_spark_type(col),
                                          nullable=bool(col.isnull().any()))
                              for name, col in reset_index.iteritems()])
@@ -148,14 +148,14 @@ class DataFrame(_Frame):
     def _init_from_spark(self, sdf, metadata=None):
         self._sdf = sdf
         if metadata is None:
-            self._metadata = Metadata(column_fields=self._sdf.schema.fieldNames())
+            self._metadata = Metadata(data_columns=self._sdf.schema.fieldNames())
         else:
             self._metadata = metadata
 
     @property
     def _index_columns(self):
         return [self._sdf.__getitem__(field)
-                for field in self._metadata.index_fields]
+                for field in self._metadata.index_columns]
 
     def _reduce_for_stat_function(self, sfun):
         """
@@ -578,7 +578,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         Currently supported only when the DataFrame has a single index.
         """
         from databricks.koalas.series import Series
-        if len(self._metadata.index_info) != 1:
+        if len(self._metadata.index_pairs) != 1:
             raise KeyError('Currently supported only when the DataFrame has a single index.')
         return Series(self._index_columns[0], anchor=self, index=[])
 
@@ -604,20 +604,26 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 raise KeyError(key)
 
         if drop:
-            columns = [column for column in self._metadata.column_fields if column not in keys]
+            data_columns = [column for column in self._metadata.data_columns if column not in keys]
         else:
-            columns = self._metadata.column_fields
+            data_columns = self._metadata.data_columns
         if append:
-            index_info = self._metadata.index_info + [(column, column) for column in keys]
+            index_pairs = self._metadata.index_pairs + [(column, column) for column in keys]
         else:
-            index_info = [(column, column) for column in keys]
+            index_pairs = [(column, column) for column in keys]
 
-        metadata = self._metadata.copy(column_fields=columns, index_info=index_info)
+        metadata = self._metadata.copy(data_columns=data_columns, index_pairs=index_pairs)
+
+        # Sync Spark's columns as well.
+        sdf = self._sdf.select(['`{}`'.format(name) for name in metadata.columns])
+
         if inplace:
             self._metadata = metadata
+            self._sdf = sdf
         else:
             kdf = self.copy()
             kdf._metadata = metadata
+            kdf._sdf = sdf
             return kdf
 
     def reset_index(self, level=None, drop=False, inplace=False):
@@ -635,63 +641,67 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                         Modify the DataFrame in place (do not create a new object)
         :return: :class:`DataFrame`
         """
-        if len(self._metadata.index_info) == 0:
+        if len(self._metadata.index_pairs) == 0:
             raise NotImplementedError('Can\'t reset index because there is no index.')
 
-        multi_index = len(self._metadata.index_info) > 1
-        if multi_index:
-            rename = lambda i: 'level_{}'.format(i)
-        else:
-            rename = lambda i: \
-                'index' if 'index' not in self._metadata.column_fields else 'level_{}'.fomat(i)
+        multi_index = len(self._metadata.index_pairs) > 1
+
+        def rename(index):
+            if multi_index:
+                return 'level_{}'.format(index)
+            else:
+                if 'index' not in self._metadata.data_columns:
+                    return 'index'
+                else:
+                    return 'level_{}'.format(index)
 
         if level is None:
-            index_columns = [(column, name if name is not None else rename(i))
-                             for i, (column, name) in enumerate(self._metadata.index_info)]
-            index_info = []
+            new_index_pairs = [(column, name if name is not None else rename(i))
+                               for i, (column, name) in enumerate(self._metadata.index_pairs)]
+            index_pairs = []
         else:
             if isinstance(level, (int, str)):
                 level = [level]
             level = list(level)
 
             if all(isinstance(l, int) for l in level):
-                for l in level:
-                    if l >= len(self._metadata.index_info):
+                for lev in level:
+                    if lev >= len(self._metadata.index_pairs):
                         raise IndexError('Too many levels: Index has only {} level, not {}'
-                                         .format(len(self._metadata.index_info), l + 1))
+                                         .format(len(self._metadata.index_pairs), lev + 1))
                 idx = level
-            elif all(isinstance(l, str) for l in level):
+            elif all(isinstance(lev, str) for lev in level):
                 idx = []
                 for l in level:
                     try:
-                        i = self._metadata.index_fields.index(l)
+                        i = self._metadata.index_columns.index(l)
                         idx.append(i)
                     except ValueError:
                         if multi_index:
                             raise KeyError('Level unknown not found')
                         else:
                             raise KeyError('Level unknown must be same as name ({})'
-                                           .format(self._metadata.index_fields[0]))
+                                           .format(self._metadata.index_columns[0]))
             else:
                 raise ValueError('Level should be all int or all string.')
             idx.sort()
 
-            index_columns = []
-            index_info = self._metadata.index_info.copy()
+            new_index_pairs = []
+            index_pairs = self._metadata.index_pairs.copy()
             for i in idx:
-                info = self._metadata.index_info[i]
-                column_field, index_name = info
-                index_columns.append((column_field,
-                                      index_name if index_name is not None else rename(index_name)))
-                index_info.remove(info)
+                info = self._metadata.index_pairs[i]
+                index_column, index_name = info
+                new_index_pairs.append((index_column,
+                                        index_name if index_name is not None else rename(index_name)))
+                index_pairs.remove(info)
 
         if drop:
-            index_columns = []
+            new_index_pairs = []
 
         metadata = self._metadata.copy(
-            column_fields=[column for column, _ in index_columns] + self._metadata.column_fields,
-            index_info=index_info)
-        columns = [name for _, name in index_columns] + self._metadata.column_fields
+            data_columns=[column for column, _ in new_index_pairs] + self._metadata.data_columns,
+            index_pairs=index_pairs)
+        columns = [name for _, name in new_index_pairs] + self._metadata.data_columns
         if inplace:
             self._metadata = metadata
             self.columns = columns
@@ -845,19 +855,22 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         2   0.6   0.0
         3   0.2   0.1
         """
-        sdf = self._sdf.select(['`{}`'.format(name) for name in self._metadata.all_fields])
+        sdf = self._sdf.select(['`{}`'.format(name) for name in self._metadata.columns])
         pdf = sdf.toPandas()
         if len(pdf) == 0 and len(sdf.schema) > 0:
             # TODO: push to OSS
             pdf = pdf.astype({field.name: to_arrow_type(field.dataType).to_pandas_dtype()
                               for field in sdf.schema})
-        if len(self._metadata.index_info) > 0:
+
+        index_columns = self._metadata.index_columns
+        if len(index_columns) > 0:
             append = False
-            for index_field in self._metadata.index_fields:
-                drop = index_field not in self._metadata.column_fields
+            for index_field in index_columns:
+                drop = index_field not in self._metadata.data_columns
                 pdf = pdf.set_index(index_field, drop=drop, append=append)
                 append = True
-            pdf = pdf[self._metadata.column_fields]
+            pdf = pdf[self._metadata.data_columns]
+
         index_names = self._metadata.index_names
         if len(index_names) > 0:
             if isinstance(pdf.index, pd.MultiIndex):
@@ -945,9 +958,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             else:
                 sdf = sdf.withColumn(name, F.lit(c))
 
+        data_columns = self._metadata.data_columns
         metadata = self._metadata.copy(
-            column_fields=(self._metadata.column_fields +
-                           [name for name, _ in pairs if name not in self._metadata.column_fields]))
+            data_columns=(data_columns +
+                          [name for name, _ in pairs if name not in data_columns]))
         return DataFrame(sdf, metadata)
 
     @property
@@ -1047,7 +1061,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 else:
                     columns = list(subset)
                 invalids = [column for column in columns
-                            if column not in self._metadata.column_fields]
+                            if column not in self._metadata.data_columns]
                 if len(invalids) > 0:
                     raise KeyError(invalids)
             else:
@@ -1207,20 +1221,20 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
     @property
     def columns(self):
         """The column labels of the DataFrame."""
-        return pd.Index(self._metadata.column_fields)
+        return pd.Index(self._metadata.data_columns)
 
     @columns.setter
     def columns(self, names):
-        old_names = self._metadata.column_fields
+        old_names = self._metadata.data_columns
         if len(old_names) != len(names):
             raise ValueError(
                 "Length mismatch: Expected axis has %d elements, new values have %d elements"
                 % (len(old_names), len(names)))
-        sdf = self._sdf.select(self._metadata.index_fields +
+        sdf = self._sdf.select(self._metadata.index_columns +
                                [self[old_name]._scol.alias(new_name)
                                 for (old_name, new_name) in zip(old_names, names)])
         self._sdf = sdf
-        self._metadata = self._metadata.copy(column_fields=names)
+        self._metadata = self._metadata.copy(data_columns=names)
 
     @property
     def dtypes(self):
@@ -1249,8 +1263,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         f    datetime64[ns]
         dtype: object
         """
-        return pd.Series([self[col].dtype for col in self._metadata.column_fields],
-                         index=self._metadata.column_fields)
+        return pd.Series([self[col].dtype for col in self._metadata.data_columns],
+                         index=self._metadata.data_columns)
 
     def count(self):
         """
@@ -1363,7 +1377,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 columns = [columns]
             sdf = self._sdf.drop(*columns)
             metadata = self._metadata.copy(
-                column_fields=[column for column in self.columns if column not in columns]
+                data_columns=[column for column in self.columns if column not in columns]
             )
             return DataFrame(sdf, metadata)
         else:
@@ -1558,7 +1572,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 "'DataFrame' object has no attribute %s"
                 % (set(values.keys()).difference(self.columns)))
 
-        _select_columns = self._metadata.index_fields
+        _select_columns = self._metadata.index_columns
         if isinstance(values, dict):
             for col in self.columns:
                 if col in values:
@@ -1802,7 +1816,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         if isinstance(key, str):
             try:
                 return Series(self._sdf.__getitem__(key), anchor=self,
-                              index=self._metadata.index_info)
+                              index=self._metadata.index_pairs)
             except AnalysisException:
                 raise KeyError(key)
         if np.isscalar(key) or isinstance(key, (tuple, str)):
@@ -1816,7 +1830,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             return self.loc[:, key]
         if isinstance(key, DataFrame):
             # TODO Should not implement alignment, too dangerous?
-            return Series(self._sdf.__getitem__(key), anchor=self, index=self._metadata.index_info)
+            return Series(self._sdf.__getitem__(key), anchor=self, index=self._metadata.index_pairs)
         if isinstance(key, Series):
             # TODO Should not implement alignment, too dangerous?
             # It is assumed to be only a filter, otherwise .loc should be used.
@@ -1861,7 +1875,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 return property_or_func.fget(self)  # type: ignore
             else:
                 return partial(property_or_func, self)
-        return Series(self._sdf.__getattr__(key), anchor=self, index=self._metadata.index_info)
+        return Series(self._sdf.__getattr__(key), anchor=self, index=self._metadata.index_pairs)
 
     def __iter__(self):
         return self.toPandas().__iter__()

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -418,7 +418,7 @@ def _spark_col_apply(kdf_or_ks, sfun):
     from databricks.koalas.series import Series
     if isinstance(kdf_or_ks, Series):
         ks = kdf_or_ks
-        return Series(sfun(kdf_or_ks._scol), anchor=ks._kdf, index=ks._index_info)
+        return Series(sfun(kdf_or_ks._scol), anchor=ks._kdf, index=ks._index_pairs)
     assert isinstance(kdf_or_ks, DataFrame)
     kdf = kdf_or_ks
     sdf = kdf._sdf

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -418,7 +418,7 @@ def _spark_col_apply(kdf_or_ks, sfun):
     from databricks.koalas.series import Series
     if isinstance(kdf_or_ks, Series):
         ks = kdf_or_ks
-        return Series(sfun(kdf_or_ks._scol), anchor=ks._kdf, index=ks._index_pairs)
+        return Series(sfun(kdf_or_ks._scol), anchor=ks._kdf, index=ks._index_map)
     assert isinstance(kdf_or_ks, DataFrame)
     kdf = kdf_or_ks
     sdf = kdf._sdf

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -105,7 +105,7 @@ class GroupBy(object):
                      for key, value in func_or_funcs.items()]
         sdf = sdf.groupby(*groupkey_cols).agg(*reordered)
         metadata = Metadata(data_columns=[key for key, _ in func_or_funcs.items()],
-                            index_pairs=[('__index_level_{}__'.format(i), s.name)
+                            index_map=[('__index_level_{}__'.format(i), s.name)
                                          for i, s in enumerate(groupkeys)])
         return DataFrame(sdf, metadata)
 
@@ -256,7 +256,7 @@ class GroupBy(object):
             sdf = sdf.select(*groupkey_cols).distinct()
         sdf = sdf.sort(*groupkey_cols)
         metadata = Metadata(data_columns=data_columns,
-                            index_pairs=[('__index_level_{}__'.format(i), s.name)
+                            index_map=[('__index_level_{}__'.format(i), s.name)
                                          for i, s in enumerate(groupkeys)])
         return DataFrame(sdf, metadata)
 

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -92,8 +92,8 @@ class GroupBy(object):
 
         """
         if not isinstance(func_or_funcs, dict) or \
-            not all(isinstance(key, str) and isinstance(value, str)
-                    for key, value in func_or_funcs.items()):
+                not all(isinstance(key, str) and isinstance(value, str)
+                        for key, value in func_or_funcs.items()):
             raise ValueError("aggs must be a dict mapping from column name (string) to aggregate "
                              "functions (string).")
 
@@ -106,7 +106,7 @@ class GroupBy(object):
         sdf = sdf.groupby(*groupkey_cols).agg(*reordered)
         metadata = Metadata(data_columns=[key for key, _ in func_or_funcs.items()],
                             index_map=[('__index_level_{}__'.format(i), s.name)
-                                         for i, s in enumerate(groupkeys)])
+                                       for i, s in enumerate(groupkeys)])
         return DataFrame(sdf, metadata)
 
     agg = aggregate
@@ -257,7 +257,7 @@ class GroupBy(object):
         sdf = sdf.sort(*groupkey_cols)
         metadata = Metadata(data_columns=data_columns,
                             index_map=[('__index_level_{}__'.format(i), s.name)
-                                         for i, s in enumerate(groupkeys)])
+                                       for i, s in enumerate(groupkeys)])
         return DataFrame(sdf, metadata)
 
 

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -104,8 +104,8 @@ class GroupBy(object):
         reordered = [F.expr('{1}({0}) as {0}'.format(key, value))
                      for key, value in func_or_funcs.items()]
         sdf = sdf.groupby(*groupkey_cols).agg(*reordered)
-        metadata = Metadata(column_fields=[key for key, _ in func_or_funcs.items()],
-                            index_info=[('__index_level_{}__'.format(i), s.name)
+        metadata = Metadata(data_columns=[key for key, _ in func_or_funcs.items()],
+                            index_pairs=[('__index_level_{}__'.format(i), s.name)
                                         for i, s in enumerate(groupkeys)])
         return DataFrame(sdf, metadata)
 
@@ -236,7 +236,7 @@ class GroupBy(object):
                          for i, s in enumerate(groupkeys)]
         sdf = self._kdf._sdf
 
-        column_fields = []
+        data_columns = []
         if len(self._agg_columns) > 0:
             stat_exprs = []
             for ks in self._agg_columns:
@@ -247,16 +247,16 @@ class GroupBy(object):
                 # value, whereas Pandas count doesn't include nan.
                 if isinstance(spark_type, DoubleType) or isinstance(spark_type, FloatType):
                     stat_exprs.append(sfun(F.nanvl(ks._scol, F.lit(None))).alias(ks.name))
-                    column_fields.append(ks.name)
+                    data_columns.append(ks.name)
                 elif isinstance(spark_type, NumericType) or not only_numeric:
                     stat_exprs.append(sfun(ks._scol).alias(ks.name))
-                    column_fields.append(ks.name)
+                    data_columns.append(ks.name)
             sdf = sdf.groupby(*groupkey_cols).agg(*stat_exprs)
         else:
             sdf = sdf.select(*groupkey_cols).distinct()
         sdf = sdf.sort(*groupkey_cols)
-        metadata = Metadata(column_fields=column_fields,
-                            index_info=[('__index_level_{}__'.format(i), s.name)
+        metadata = Metadata(data_columns=data_columns,
+                            index_pairs=[('__index_level_{}__'.format(i), s.name)
                                         for i, s in enumerate(groupkeys)])
         return DataFrame(sdf, metadata)
 
@@ -269,7 +269,7 @@ class DataFrameGroupBy(GroupBy):
 
         if agg_columns is None:
             groupkey_names = set(s.name for s in self._groupkeys)
-            agg_columns = [col for col in self._kdf._metadata.column_fields
+            agg_columns = [col for col in self._kdf._metadata.data_columns
                            if col not in groupkey_names]
         self._agg_columns = [kdf[col] for col in agg_columns]
 

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -106,7 +106,7 @@ class GroupBy(object):
         sdf = sdf.groupby(*groupkey_cols).agg(*reordered)
         metadata = Metadata(data_columns=[key for key, _ in func_or_funcs.items()],
                             index_pairs=[('__index_level_{}__'.format(i), s.name)
-                                        for i, s in enumerate(groupkeys)])
+                                         for i, s in enumerate(groupkeys)])
         return DataFrame(sdf, metadata)
 
     agg = aggregate
@@ -257,7 +257,7 @@ class GroupBy(object):
         sdf = sdf.sort(*groupkey_cols)
         metadata = Metadata(data_columns=data_columns,
                             index_pairs=[('__index_level_{}__'.format(i), s.name)
-                                        for i, s in enumerate(groupkeys)])
+                                         for i, s in enumerate(groupkeys)])
         return DataFrame(sdf, metadata)
 
 

--- a/databricks/koalas/metadata.py
+++ b/databricks/koalas/metadata.py
@@ -25,7 +25,7 @@ import pandas as pd
 from databricks import koalas as ks  # For running doctests and reference resolution in PyCharm.
 
 
-IndexInfo = Tuple[str, Optional[str]]
+IndexMap = Tuple[str, Optional[str]]
 
 
 class Metadata(object):
@@ -161,7 +161,7 @@ class Metadata(object):
     """
 
     def __init__(self, data_columns: List[str],
-                 index_map: Optional[List[IndexInfo]] = None) -> None:
+                 index_map: Optional[List[IndexMap]] = None) -> None:
         """ Create a new metadata to manage column fields and index fields and names.
 
         :param data_columns: list of string
@@ -176,7 +176,7 @@ class Metadata(object):
                    and (index_name is None or isinstance(index_name, str))
                    for index_field, index_name in index_map)
         self._data_columns = data_columns  # type: List[str]
-        self._index_map = index_map or []  # type: List[IndexInfo]
+        self._index_map = index_map or []  # type: List[IndexMap]
 
     @property
     def data_columns(self) -> List[str]:
@@ -196,7 +196,7 @@ class Metadata(object):
                                 if column not in index_columns]
 
     @property
-    def index_map(self) -> List[IndexInfo]:
+    def index_map(self) -> List[IndexMap]:
         """ Return the managed index information. """
         return self._index_map
 
@@ -206,7 +206,7 @@ class Metadata(object):
         return [index_name for _, index_name in self._index_map]
 
     def copy(self, data_columns: Optional[List[str]] = None,
-             index_map: Optional[List[IndexInfo]] = None) -> 'Metadata':
+             index_map: Optional[List[IndexMap]] = None) -> 'Metadata':
         """ Copy the metadata.
 
         :param data_columns: the new column field names. If None, then the original ones are used.
@@ -229,16 +229,16 @@ class Metadata(object):
         data_columns = [str(col) for col in pdf.columns]
         index = pdf.index
 
-        index_map = []  # type: List[IndexInfo]
+        index_map = []  # type: List[IndexMap]
         if isinstance(index, pd.MultiIndex):
             if index.names is None:
                 index_map = [('__index_level_{}__'.format(i), None)
-                               for i in range(len(index.levels))]
+                             for i in range(len(index.levels))]
             else:
                 index_map = [('__index_level_{}__'.format(i) if name is None else name, name)
-                               for i, name in enumerate(index.names)]
+                             for i, name in enumerate(index.names)]
         else:
             index_map = [(index.name
-                            if index.name is not None else '__index_level_0__', index.name)]
+                          if index.name is not None else '__index_level_0__', index.name)]
 
         return Metadata(data_columns=data_columns, index_map=index_map)

--- a/databricks/koalas/metadata.py
+++ b/databricks/koalas/metadata.py
@@ -189,8 +189,8 @@ class Metadata(object):
     def columns(self) -> List[str]:
         """ Return all the field names including index field names. """
         index_columns = self.index_columns
-        return index_columns + [field for field in self._data_columns
-                               if field not in index_columns]
+        return index_columns + [column for column in self._data_columns
+                                if column not in index_columns]
 
     @property
     def index_pairs(self) -> List[IndexInfo]:
@@ -230,12 +230,12 @@ class Metadata(object):
         if isinstance(index, pd.MultiIndex):
             if index.names is None:
                 index_pairs = [('__index_level_{}__'.format(i), None)
-                              for i in range(len(index.levels))]
+                               for i in range(len(index.levels))]
             else:
                 index_pairs = [('__index_level_{}__'.format(i) if name is None else name, name)
-                              for i, name in enumerate(index.names)]
+                               for i, name in enumerate(index.names)]
         else:
             index_pairs = [(index.name
-                          if index.name is not None else '__index_level_0__', index.name)]
+                            if index.name is not None else '__index_level_0__', index.name)]
 
         return Metadata(data_columns=data_columns, index_pairs=index_pairs)

--- a/databricks/koalas/metadata.py
+++ b/databricks/koalas/metadata.py
@@ -36,6 +36,9 @@ class Metadata(object):
     :ivar _index_pairs: list of pair holding the Spark field names for indexes,
                        and the index name to be seen in Koalas DataFrame.
 
+    .. note:: this is an internal class. It is not supposed to be exposed to users and users
+        should not directly access to it.
+
     Metadata represents the index information for a DataFrame it belongs to. For instance,
     if we have a Koalas DataFrame as below, Pandas DataFrame does not store the index as columns.
 

--- a/databricks/koalas/ml.py
+++ b/databricks/koalas/ml.py
@@ -75,7 +75,7 @@ def to_numeric_df(kdf: 'ks.DataFrame') -> Tuple[pyspark.sql.DataFrame, List[str]
     # TODO, it should be more robust.
     accepted_types = {np.dtype(dt) for dt in [np.int8, np.int16, np.int32, np.int64,
                                               np.float32, np.float64, np.bool_]}
-    numeric_fields = [fname for fname in kdf._metadata.column_fields
+    numeric_fields = [fname for fname in kdf._metadata.data_columns
                       if kdf[fname].dtype in accepted_types]
     numeric_df = kdf._sdf.select(*numeric_fields)
     va = VectorAssembler(inputCols=numeric_fields, outputCol=CORRELATION_OUTPUT_COLUMN)

--- a/databricks/koalas/selection.py
+++ b/databricks/koalas/selection.py
@@ -161,18 +161,18 @@ class SparkDataFrameLocator(object):
             else:
                 raiseNotImplemented("Cannot select with MultiIndex with Spark.")
         if cols_sel is None:
-            columns = [_make_col(c) for c in self._kdf._metadata.column_fields]
+            columns = [_make_col(c) for c in self._kdf._metadata.data_columns]
         elif isinstance(cols_sel, spark.Column):
             columns = [cols_sel]
         else:
             columns = [_make_col(c) for c in cols_sel]
         try:
-            kdf = DataFrame(sdf.select(self._kdf._metadata.index_fields + columns))
+            kdf = DataFrame(sdf.select(self._kdf._metadata.index_columns + columns))
         except AnalysisException:
             raise KeyError('[{}] don\'t exist in columns'
                            .format([col._jc.toString() for col in columns]))
         kdf._metadata = self._kdf._metadata.copy(
-            column_fields=kdf._metadata.column_fields[-len(columns):])
+            data_columns=kdf._metadata.data_columns[-len(columns):])
         if cols_sel is not None and isinstance(cols_sel, spark.Column):
             from databricks.koalas.series import _col
             return _col(kdf)

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -60,7 +60,7 @@ def _column_op(f):
         # extract Spark Column. For other arguments, they are used as are.
         args = [arg._scol if isinstance(arg, Series) else arg for arg in args]
         scol = f(self._scol, *args)
-        return Series(scol, anchor=self._kdf, index=self._index_info)
+        return Series(scol, anchor=self._kdf, index=self._index_pairs)
     return wrapper
 
 
@@ -89,7 +89,7 @@ class Series(_Frame):
     :type _scol: pyspark.Column
     :ivar _kdf: Parent's Koalas DataFrame
     :type _kdf: ks.DataFrame
-    :ivar _index_info: Each pair holds the index field name which exists in Spark fields,
+    :ivar _index_pairs: Each pair holds the index field name which exists in Spark fields,
       and the index name.
 
     Parameters
@@ -106,7 +106,7 @@ class Series(_Frame):
         RangeIndex (0, 1, 2, ..., n) if not provided. If both a dict and index
         sequence are used, the index will override the keys found in the
         dict.
-        If `data` is a Spark DataFrame, `index` is expected to be `Metadata`s `index_info`.
+        If `data` is a Spark DataFrame, `index` is expected to be `Metadata`s `index_pairs`.
     dtype : numpy.dtype or None
         If None, dtype will be inferred
     copy : boolean, default False
@@ -142,23 +142,23 @@ class Series(_Frame):
         """
 
         kdf = DataFrame(pd.DataFrame(s))
-        self._init_from_spark(kdf._sdf[kdf._metadata.column_fields[0]],
-                              kdf, kdf._metadata.index_info)
+        self._init_from_spark(kdf._sdf[kdf._metadata.data_columns[0]],
+                              kdf, kdf._metadata.index_pairs)
 
-    def _init_from_spark(self, scol, kdf, index_info):
+    def _init_from_spark(self, scol, kdf, index_pairs):
         """
         Creates Koalas Series from Spark Column.
 
         :param scol: Spark Column
         :param kdf: Koalas DataFrame that should have the `scol`.
-        :param index_info: index information of this Series.
+        :param index_pairs: index information of this Series.
         """
-        assert index_info is not None
+        assert index_pairs is not None
         assert kdf is not None
         assert isinstance(kdf, ks.DataFrame), type(kdf)
         self._scol = scol
         self._kdf = kdf
-        self._index_info = index_info
+        self._index_pairs = index_pairs
 
     # arithmetic operators
     __neg__ = _column_op(spark.Column.__neg__)
@@ -195,7 +195,7 @@ class Series(_Frame):
         # Handle 'literal' + df['col']
         if isinstance(self.spark_type, StringType) and isinstance(other, str):
             return Series(F.concat(F.lit(other), self._scol), anchor=self._kdf,
-                          index=self._index_info)
+                          index=self._index_pairs)
         else:
             return _column_op(spark.Column.__radd__)(self, other)
 
@@ -256,7 +256,7 @@ class Series(_Frame):
         spark_type = as_spark_type(dtype)
         if not spark_type:
             raise ValueError("Type {} not understood".format(dtype))
-        return Series(self._scol.cast(spark_type), anchor=self._kdf, index=self._index_info)
+        return Series(self._scol.cast(spark_type), anchor=self._kdf, index=self._index_pairs)
 
     def getField(self, name):
         if not isinstance(self.schema, StructType):
@@ -266,7 +266,7 @@ class Series(_Frame):
             if name not in fnames:
                 raise AttributeError(
                     "Field {} not found, possible values are {}".format(name, ", ".join(fnames)))
-            return Series(self._scol.getField(name), anchor=self._kdf, index=self._index_info)
+            return Series(self._scol.getField(name), anchor=self._kdf, index=self._index_pairs)
 
     def alias(self, name):
         """An alias for :meth:`Series.rename`."""
@@ -283,7 +283,7 @@ class Series(_Frame):
 
     @property
     def name(self):
-        return self._metadata.column_fields[0]
+        return self._metadata.data_columns[0]
 
     @name.setter
     def name(self, name):
@@ -332,7 +332,7 @@ class Series(_Frame):
             self._scol = scol
             return self
         else:
-            return Series(scol, anchor=self._kdf, index=self._index_info)
+            return Series(scol, anchor=self._kdf, index=self._index_pairs)
 
     @property
     def _metadata(self):
@@ -344,7 +344,7 @@ class Series(_Frame):
 
         Currently supported only when the DataFrame has a single index.
         """
-        if len(self._metadata.index_info) != 1:
+        if len(self._metadata.index_pairs) != 1:
             raise KeyError('Currently supported only when the Column has a single index.')
         return self._kdf.index
 
@@ -434,7 +434,7 @@ class Series(_Frame):
             if inplace:
                 self._kdf = kdf
                 self._scol = s._scol
-                self._index_info = s._index_info
+                self._index_pairs = s._index_pairs
             else:
                 return s
         else:
@@ -445,8 +445,8 @@ class Series(_Frame):
         return SparkDataFrameLocator(self)
 
     def to_dataframe(self):
-        sdf = self._kdf._sdf.select([field for field, _ in self._index_info] + [self._scol])
-        metadata = Metadata(column_fields=[sdf.schema[-1].name], index_info=self._index_info)
+        sdf = self._kdf._sdf.select([field for field, _ in self._index_pairs] + [self._scol])
+        metadata = Metadata(data_columns=[sdf.schema[-1].name], index_pairs=self._index_pairs)
         return DataFrame(sdf, metadata)
 
     def to_string(self, buf=None, na_rep='NaN', float_format=None, header=True,
@@ -597,9 +597,9 @@ class Series(_Frame):
         """
         if isinstance(self.schema[self.name].dataType, (FloatType, DoubleType)):
             return Series(self._scol.isNull() | F.isnan(self._scol), anchor=self._kdf,
-                          index=self._index_info)
+                          index=self._index_pairs)
         else:
-            return Series(self._scol.isNull(), anchor=self._kdf, index=self._index_info)
+            return Series(self._scol.isNull(), anchor=self._kdf, index=self._index_pairs)
 
     isna = isnull
 
@@ -821,7 +821,7 @@ class Series(_Frame):
         index_name = 'index' if self.name != 'index' else 'level_0'
         kdf = DataFrame(sdf)
         kdf.columns = [index_name, self.name]
-        kdf._metadata = Metadata(column_fields=[self.name], index_info=[(index_name, None)])
+        kdf._metadata = Metadata(data_columns=[self.name], index_pairs=[(index_name, None)])
         return _col(kdf)
 
     def isin(self, values):
@@ -871,7 +871,7 @@ class Series(_Frame):
                             .format(values_type=type(values).__name__))
 
         return Series(self._scol.isin(list(values)).alias(self.name), anchor=self._kdf,
-                      index=self._index_info)
+                      index=self._index_pairs)
 
     def corr(self, other, method='pearson'):
         """
@@ -1059,7 +1059,7 @@ class Series(_Frame):
         return len(self.to_dataframe())
 
     def __getitem__(self, key):
-        return Series(self._scol.__getitem__(key), anchor=self._kdf, index=self._index_info)
+        return Series(self._scol.__getitem__(key), anchor=self._kdf, index=self._index_pairs)
 
     def __getattr__(self, item: str) -> Any:
         if item.startswith("__") or item.startswith("_pandas_") or item.startswith("_spark_"):

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -60,7 +60,7 @@ def _column_op(f):
         # extract Spark Column. For other arguments, they are used as are.
         args = [arg._scol if isinstance(arg, Series) else arg for arg in args]
         scol = f(self._scol, *args)
-        return Series(scol, anchor=self._kdf, index=self._index_pairs)
+        return Series(scol, anchor=self._kdf, index=self._index_map)
     return wrapper
 
 
@@ -89,7 +89,7 @@ class Series(_Frame):
     :type _scol: pyspark.Column
     :ivar _kdf: Parent's Koalas DataFrame
     :type _kdf: ks.DataFrame
-    :ivar _index_pairs: Each pair holds the index field name which exists in Spark fields,
+    :ivar _index_map: Each pair holds the index field name which exists in Spark fields,
       and the index name.
 
     Parameters
@@ -106,7 +106,7 @@ class Series(_Frame):
         RangeIndex (0, 1, 2, ..., n) if not provided. If both a dict and index
         sequence are used, the index will override the keys found in the
         dict.
-        If `data` is a Spark DataFrame, `index` is expected to be `Metadata`s `index_pairs`.
+        If `data` is a Spark DataFrame, `index` is expected to be `Metadata`s `index_map`.
     dtype : numpy.dtype or None
         If None, dtype will be inferred
     copy : boolean, default False
@@ -143,22 +143,22 @@ class Series(_Frame):
 
         kdf = DataFrame(pd.DataFrame(s))
         self._init_from_spark(kdf._sdf[kdf._metadata.data_columns[0]],
-                              kdf, kdf._metadata.index_pairs)
+                              kdf, kdf._metadata.index_map)
 
-    def _init_from_spark(self, scol, kdf, index_pairs):
+    def _init_from_spark(self, scol, kdf, index_map):
         """
         Creates Koalas Series from Spark Column.
 
         :param scol: Spark Column
         :param kdf: Koalas DataFrame that should have the `scol`.
-        :param index_pairs: index information of this Series.
+        :param index_map: index information of this Series.
         """
-        assert index_pairs is not None
+        assert index_map is not None
         assert kdf is not None
         assert isinstance(kdf, ks.DataFrame), type(kdf)
         self._scol = scol
         self._kdf = kdf
-        self._index_pairs = index_pairs
+        self._index_map = index_map
 
     # arithmetic operators
     __neg__ = _column_op(spark.Column.__neg__)
@@ -195,7 +195,7 @@ class Series(_Frame):
         # Handle 'literal' + df['col']
         if isinstance(self.spark_type, StringType) and isinstance(other, str):
             return Series(F.concat(F.lit(other), self._scol), anchor=self._kdf,
-                          index=self._index_pairs)
+                          index=self._index_map)
         else:
             return _column_op(spark.Column.__radd__)(self, other)
 
@@ -256,7 +256,7 @@ class Series(_Frame):
         spark_type = as_spark_type(dtype)
         if not spark_type:
             raise ValueError("Type {} not understood".format(dtype))
-        return Series(self._scol.cast(spark_type), anchor=self._kdf, index=self._index_pairs)
+        return Series(self._scol.cast(spark_type), anchor=self._kdf, index=self._index_map)
 
     def getField(self, name):
         if not isinstance(self.schema, StructType):
@@ -266,7 +266,7 @@ class Series(_Frame):
             if name not in fnames:
                 raise AttributeError(
                     "Field {} not found, possible values are {}".format(name, ", ".join(fnames)))
-            return Series(self._scol.getField(name), anchor=self._kdf, index=self._index_pairs)
+            return Series(self._scol.getField(name), anchor=self._kdf, index=self._index_map)
 
     def alias(self, name):
         """An alias for :meth:`Series.rename`."""
@@ -332,7 +332,7 @@ class Series(_Frame):
             self._scol = scol
             return self
         else:
-            return Series(scol, anchor=self._kdf, index=self._index_pairs)
+            return Series(scol, anchor=self._kdf, index=self._index_map)
 
     @property
     def _metadata(self):
@@ -344,7 +344,7 @@ class Series(_Frame):
 
         Currently supported only when the DataFrame has a single index.
         """
-        if len(self._metadata.index_pairs) != 1:
+        if len(self._metadata.index_map) != 1:
             raise KeyError('Currently supported only when the Column has a single index.')
         return self._kdf.index
 
@@ -434,7 +434,7 @@ class Series(_Frame):
             if inplace:
                 self._kdf = kdf
                 self._scol = s._scol
-                self._index_pairs = s._index_pairs
+                self._index_map = s._index_map
             else:
                 return s
         else:
@@ -445,8 +445,8 @@ class Series(_Frame):
         return SparkDataFrameLocator(self)
 
     def to_dataframe(self):
-        sdf = self._kdf._sdf.select([field for field, _ in self._index_pairs] + [self._scol])
-        metadata = Metadata(data_columns=[sdf.schema[-1].name], index_pairs=self._index_pairs)
+        sdf = self._kdf._sdf.select([field for field, _ in self._index_map] + [self._scol])
+        metadata = Metadata(data_columns=[sdf.schema[-1].name], index_map=self._index_map)
         return DataFrame(sdf, metadata)
 
     def to_string(self, buf=None, na_rep='NaN', float_format=None, header=True,
@@ -597,9 +597,9 @@ class Series(_Frame):
         """
         if isinstance(self.schema[self.name].dataType, (FloatType, DoubleType)):
             return Series(self._scol.isNull() | F.isnan(self._scol), anchor=self._kdf,
-                          index=self._index_pairs)
+                          index=self._index_map)
         else:
-            return Series(self._scol.isNull(), anchor=self._kdf, index=self._index_pairs)
+            return Series(self._scol.isNull(), anchor=self._kdf, index=self._index_map)
 
     isna = isnull
 
@@ -821,7 +821,7 @@ class Series(_Frame):
         index_name = 'index' if self.name != 'index' else 'level_0'
         kdf = DataFrame(sdf)
         kdf.columns = [index_name, self.name]
-        kdf._metadata = Metadata(data_columns=[self.name], index_pairs=[(index_name, None)])
+        kdf._metadata = Metadata(data_columns=[self.name], index_map=[(index_name, None)])
         return _col(kdf)
 
     def isin(self, values):
@@ -871,7 +871,7 @@ class Series(_Frame):
                             .format(values_type=type(values).__name__))
 
         return Series(self._scol.isin(list(values)).alias(self.name), anchor=self._kdf,
-                      index=self._index_pairs)
+                      index=self._index_map)
 
     def corr(self, other, method='pearson'):
         """
@@ -1059,7 +1059,7 @@ class Series(_Frame):
         return len(self.to_dataframe())
 
     def __getitem__(self, key):
-        return Series(self._scol.__getitem__(key), anchor=self._kdf, index=self._index_pairs)
+        return Series(self._scol.__getitem__(key), anchor=self._kdf, index=self._index_map)
 
     def __getattr__(self, item: str) -> Any:
         if item.startswith("__") or item.startswith("_pandas_") or item.startswith("_spark_"):

--- a/databricks/koalas/typedef.py
+++ b/databricks/koalas/typedef.py
@@ -221,7 +221,7 @@ def _make_fun(f: typing.Callable, return_type: types.DataType, *args, **kwargs) 
         return f(*args, **kwargs)
 
     # We detected some columns. They need to be wrapped in a UDF to spark.
-    (index_info, kdf) = _get_metadata(args, kwargs)
+    (index_pairs, kdf) = _get_metadata(args, kwargs)
 
     def clean_fun(*args2):
         assert len(args2) == len(all_indexes), \
@@ -248,7 +248,7 @@ def _make_fun(f: typing.Callable, return_type: types.DataType, *args, **kwargs) 
         spark_col_args.append(col._scol)
         kw_name_tokens.append("{}={}".format(key, col.name))
     col = wrapped_udf(*spark_col_args)
-    series = Series(data=col, index=index_info, anchor=kdf)
+    series = Series(data=col, index=index_pairs, anchor=kdf)
     all_name_tokens = name_tokens + sorted(kw_name_tokens)
     name = "{}({})".format(f.__name__, ", ".join(all_name_tokens))
     series = series.astype(return_type).alias(name)
@@ -262,7 +262,7 @@ def _get_metadata(args, kwargs):
     assert all_cols
     # TODO: check all the anchors
     s = all_cols[0]
-    return (s._index_info, s._kdf)
+    return (s._index_pairs, s._kdf)
 
 
 def pandas_wraps(function=None, return_col=None, return_scalar=None):

--- a/databricks/koalas/typedef.py
+++ b/databricks/koalas/typedef.py
@@ -221,7 +221,7 @@ def _make_fun(f: typing.Callable, return_type: types.DataType, *args, **kwargs) 
         return f(*args, **kwargs)
 
     # We detected some columns. They need to be wrapped in a UDF to spark.
-    (index_pairs, kdf) = _get_metadata(args, kwargs)
+    (index_map, kdf) = _get_metadata(args, kwargs)
 
     def clean_fun(*args2):
         assert len(args2) == len(all_indexes), \
@@ -248,7 +248,7 @@ def _make_fun(f: typing.Callable, return_type: types.DataType, *args, **kwargs) 
         spark_col_args.append(col._scol)
         kw_name_tokens.append("{}={}".format(key, col.name))
     col = wrapped_udf(*spark_col_args)
-    series = Series(data=col, index=index_pairs, anchor=kdf)
+    series = Series(data=col, index=index_map, anchor=kdf)
     all_name_tokens = name_tokens + sorted(kw_name_tokens)
     name = "{}({})".format(f.__name__, ", ".join(all_name_tokens))
     series = series.astype(return_type).alias(name)
@@ -262,7 +262,7 @@ def _get_metadata(args, kwargs):
     assert all_cols
     # TODO: check all the anchors
     s = all_cols[0]
-    return (s._index_pairs, s._kdf)
+    return (s._index_map, s._kdf)
 
 
 def pandas_wraps(function=None, return_col=None, return_scalar=None):


### PR DESCRIPTION
This PR:

- adds documentation at `Metadata` with some doctests.
- renames:
  - `all_fields` -> `columns`
  - `index_fields` -> `index_columns`
  - `column_fields` -> `data_columns`
  - `index_names` -> `index_names` (no change)
  - `index_info` -> `index_map`

  I tried to keep the original intention and avoid name conflict between field and column.
Also, `index_info` -> `index_map`, for now (see https://github.com/databricks/koalas/pull/290#issuecomment-491450583)

- fixes a bug (one line fix) at `set_index`:

    ```python
    kdf = ks.DataFrame({
        'A': [1, 2, 3, 4],
        'B': [5, 6, 7, 8],
        'C': [9, 10, 11, 12],
        'D': [13, 14, 15, 16],
        'E': [17, 18, 19, 20]})
    kdf1 = kdf.set_index("A")
    kdf1.to_spark().show()
    ```

   ```
    Failed example:
        kdf1.to_spark().show()  # doctest: +NORMALIZE_WHITESPACE
    Expected:
        +---+---+---+---+---+
        |  A|  B|  C|  D|  E|
        +---+---+---+---+---+
        |  1|  5|  9| 13| 17|
        |  2|  6| 10| 14| 18|
        |  3|  7| 11| 15| 19|
        |  4|  8| 12| 16| 20|
        +---+---+---+---+---+
    Got:
        +-----------------+---+---+---+---+---+
        |__index_level_0__|  A|  B|  C|  D|  E|
        +-----------------+---+---+---+---+---+
        |                0|  1|  5|  9| 13| 17|
        |                1|  2|  6| 10| 14| 18|
        |                2|  3|  7| 11| 15| 19|
        |                3|  4|  8| 12| 16| 20|
        +-----------------+---+---+---+---+---+
   ```

    Note that `__index_level_0__` doesn't exist in metadata anymore. To make it synced, it selects all fields in metadata at `set_index`. 