### PR TITLE
Add a new env for travis-ci.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
         - SPARK_VERSION=2.4.3
         - PANDAS_VERSION=0.24.2
         - PYARROW_VERSION=0.10.0
-    - python: "3.7"
+    - python: "3.6"
       env:
         - SPARK_VERSION=2.4.3
         - PANDAS_VERSION=0.24.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,14 @@ matrix:
         - PYARROW_VERSION=0.10.0
     - python: "3.6"
       env:
-        - SPARK_VERSION=2.4.1
+        - SPARK_VERSION=2.4.3
         - PANDAS_VERSION=0.24.2
         - PYARROW_VERSION=0.10.0
+    - python: "3.7"
+      env:
+        - SPARK_VERSION=2.4.3
+        - PANDAS_VERSION=0.24.2
+        - PYARROW_VERSION=0.13.0
 
 before_install:
  - ./dev/download_travis_dependencies.sh

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 # Dependencies in Koalas
 pandas>=0.23
-pyarrow>=0.10,<0.11
+pyarrow>=0.10
 numpy>=1.14
 
 # Documentation build

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*',
     install_requires=[
         'pandas>=0.23',
-        'pyarrow>=0.10,<0.11',  # See https://github.com/databricks/koalas/issues/26
+        'pyarrow>=0.10',
         'numpy>=1.14',
     ],
     maintainer="Databricks",


### PR DESCRIPTION
After new version of Spark 2.4 was released, we might be able to remove maximum pyarrow version boundary.
This PR is to add a new env for travis-ci to see whether it works or not.