### PR TITLE
Add clip method to Koalas Series and DataFrames

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -26,7 +26,9 @@ import pandas as pd
 from pandas.api.types import is_datetime64_dtype, is_datetime64tz_dtype, is_list_like
 from pyspark import sql as spark
 from pyspark.sql import functions as F, Column
-from pyspark.sql.types import BooleanType, StructField, StructType, to_arrow_type
+from pyspark.sql.types import (BooleanType, ByteType, DecimalType, DoubleType, FloatType,
+                               IntegerType, LongType, ShortType, StructField, StructType,
+                               to_arrow_type)
 from pyspark.sql.utils import AnalysisException
 
 from databricks import koalas as ks  # For running doctests and reference resolution in PyCharm.
@@ -1674,6 +1676,68 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             self._sdf = sdf
         else:
             return DataFrame(sdf, self._metadata.copy())
+
+    def clip(self, lower: Union[float, int] = None, upper: Union[float, int] = None) \
+            -> 'DataFrame':
+        """
+        Trim values at input threshold(s).
+
+        Assigns values outside boundary to boundary values.
+
+        Parameters
+        ----------
+        lower : float or int, default None
+            Minimum threshold value. All values below this threshold will be set to it.
+        upper : float or int, default None
+            Maximum threshold value. All values above this threshold will be set to it.
+
+        Returns
+        -------
+        DataFrame
+            DataFrame with the values outside the clip boundaries replaced.
+
+        Examples
+        --------
+        >>> ks.DataFrame({'A': [0, 2, 4]}).clip(1, 3)
+           A
+        0  1
+        1  2
+        2  3
+
+        Notes
+        -----
+        One difference between this implementation and pandas is that running
+        pd.DataFrame({'A': ['a', 'b']}).clip(0, 1) will crash with "TypeError: '<=' not supported
+        between instances of 'str' and 'int'" while ks.DataFrame({'A': ['a', 'b']}).clip(0, 1)
+        will output the original DataFrame, simply ignoring the incompatible types.
+        """
+        if is_list_like(lower) or is_list_like(upper):
+            raise ValueError("List-like value are not supported for 'lower' and 'upper' at the " +
+                             "moment")
+
+        if lower is None and upper is None:
+            return self
+
+        sdf = self._sdf
+
+        numeric_types = (DecimalType, DoubleType, FloatType, ByteType, IntegerType, LongType,
+                         ShortType)
+        numeric_columns = [c for c in self.columns
+                           if isinstance(sdf.schema[c].dataType, numeric_types)]
+        nonnumeric_columns = [c for c in self.columns
+                              if not isinstance(sdf.schema[c].dataType, numeric_types)]
+
+        if lower is not None:
+            sdf = sdf.select(*[F.when(F.col(c) < lower, lower).otherwise(F.col(c)).alias(c)
+                               for c in numeric_columns] + nonnumeric_columns)
+        if upper is not None:
+            sdf = sdf.select(*[F.when(F.col(c) > upper, upper).otherwise(F.col(c)).alias(c)
+                               for c in numeric_columns] + nonnumeric_columns)
+
+        # Restore initial column order
+        sdf = sdf.select(list(self.columns))
+
+        return ks.DataFrame(sdf)
 
     def head(self, n=5):
         """

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -312,7 +312,8 @@ class _Frame(object):
         # TODO: The first example above should not have "Name: abs(0)".
         return _spark_col_apply(self, F.abs)
 
-    def clip(self, lower: Union[float, int] = None, upper: Union[float, int] = None) \
+    def clip(self: Union['ks.Series', 'ks.DataFrame'],  # Use type hint on to avoid mypy issues
+             lower: Union[float, int] = None, upper: Union[float, int] = None) \
             -> Union['ks.Series', 'ks.DataFrame']:
         """
         Trim values at input threshold(s).

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -312,8 +312,7 @@ class _Frame(object):
         # TODO: The first example above should not have "Name: abs(0)".
         return _spark_col_apply(self, F.abs)
 
-    def clip(self: Union['ks.Series', 'ks.DataFrame'],  # Use type hint to avoid mypy issues
-             lower: Union[float, int] = None, upper: Union[float, int] = None) \
+    def clip(self, lower: Union[float, int] = None, upper: Union[float, int] = None) \
             -> Union['ks.Series', 'ks.DataFrame']:
         """
         Trim values at input threshold(s).
@@ -353,7 +352,7 @@ class _Frame(object):
 
         is_df = isinstance(self, ks.DataFrame)
 
-        df = self if is_df else self.to_dataframe()
+        df = self if is_df else self.to_dataframe()  # type: ignore
         sdf = df._sdf
 
         if lower is not None:

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -312,7 +312,7 @@ class _Frame(object):
         # TODO: The first example above should not have "Name: abs(0)".
         return _spark_col_apply(self, F.abs)
 
-    def clip(self: Union['ks.Series', 'ks.DataFrame'],  # Use type hint on to avoid mypy issues
+    def clip(self: Union['ks.Series', 'ks.DataFrame'],  # Use type hint to avoid mypy issues
              lower: Union[float, int] = None, upper: Union[float, int] = None) \
             -> Union['ks.Series', 'ks.DataFrame']:
         """

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -21,6 +21,7 @@ from collections.abc import Iterable
 from typing import Union
 
 import numpy as np
+from pandas.api.types import is_list_like
 
 from pyspark import sql as spark
 from pyspark.sql import functions as F
@@ -354,6 +355,10 @@ class _Frame(object):
         between instances of 'str' and 'int'" while ks.DataFrame({'A': ['a', 'b']}).clip(0, 1)
         will output the original DataFrame, simply ignoring the incompatible types.
         """
+        if is_list_like(lower) or is_list_like(upper):
+            raise ValueError("List-like value are not supported for 'lower' and 'upper' at the " +
+                             "moment")
+
         if lower is None and upper is None:
             return self  # type: ignore
 

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -346,6 +346,13 @@ class _Frame(object):
         0  1
         1  2
         2  3
+
+        Notes
+        -----
+        One difference between this implementation and pandas is that running
+        pd.DataFrame({'A': ['a', 'b']}).clip(0, 1) will crash with "TypeError: '<=' not supported
+        between instances of 'str' and 'int'" while ks.DataFrame({'A': ['a', 'b']}).clip(0, 1)
+        will output the original DataFrame, simply ignoring the incompatible types.
         """
         if lower is None and upper is None:
             return self  # type: ignore

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -348,7 +348,7 @@ class _Frame(object):
         2  3
         """
         if lower is None and upper is None:
-            return self
+            return self  # type: ignore
 
         is_df = isinstance(self, ks.DataFrame)
 

--- a/databricks/koalas/missing/frame.py
+++ b/databricks/koalas/missing/frame.py
@@ -63,7 +63,6 @@ class _MissingPandasLikeDataFrame(object):
     bfill = unsupported_function('bfill')
     bool = unsupported_function('bool')
     boxplot = unsupported_function('boxplot')
-    clip = unsupported_function('clip')
     clip_lower = unsupported_function('clip_lower')
     clip_upper = unsupported_function('clip_upper')
     combine = unsupported_function('combine')

--- a/databricks/koalas/missing/series.py
+++ b/databricks/koalas/missing/series.py
@@ -82,7 +82,6 @@ class _MissingPandasLikeSeries(object):
     between_time = unsupported_function('between_time')
     bfill = unsupported_function('bfill')
     bool = unsupported_function('bool')
-    clip = unsupported_function('clip')
     clip_lower = unsupported_function('clip_lower')
     clip_upper = unsupported_function('clip_upper')
     combine = unsupported_function('combine')

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -19,7 +19,7 @@ A wrapper class for Spark Column to behave similar to pandas Series.
 """
 import inspect
 from functools import partial, wraps
-from typing import Any
+from typing import Any, Union
 
 import numpy as np
 import pandas as pd
@@ -697,6 +697,41 @@ class Series(_Frame):
             self._scol = ks._scol
         else:
             return ks
+
+    def clip(self, lower: Union[float, int] = None, upper: Union[float, int] = None) -> 'Series':
+        """
+        Trim values at input threshold(s).
+
+        Assigns values outside boundary to boundary values.
+
+        Parameters
+        ----------
+        lower : float or int, default None
+            Minimum threshold value. All values below this threshold will be set to it.
+        upper : float or int, default None
+            Maximum threshold value. All values above this threshold will be set to it.
+
+        Returns
+        -------
+        Series
+            Series with the values outside the clip boundaries replaced
+
+        Examples
+        --------
+        >>> ks.Series([0, 2, 4]).clip(1, 3)
+        0    1
+        1    2
+        2    3
+        Name: 0, dtype: int64
+
+        Notes
+        -----
+        One difference between this implementation and pandas is that running
+        pd.Series(['a', 'b']).clip(0, 1) will crash with "TypeError: '<=' not supported between
+        instances of 'str' and 'int'" while ks.Series(['a', 'b']).clip(0, 1) will output the
+        original Series, simply ignoring the incompatible types.
+        """
+        return _col(self.to_dataframe().clip(lower, upper))
 
     def head(self, n=5):
         """

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -458,3 +458,16 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         res = left_kdf.merge(koalas.DataFrame({'A': [3, 4]}), left_index=True, right_index=True,
                              suffixes=('_left', '_right'))
         self.assert_eq(res, pd.DataFrame({'A_left': [1, 2], 'A_right': [3, 4]}))
+
+    def test_clip(self):
+        pdf = pd.DataFrame({'A': [0, 2, 4]})
+        kdf = koalas.from_pandas(pdf)
+
+        # Assert no lower or upper
+        self.assert_eq(kdf.clip(), pdf.clip())
+        # Assert lower only
+        self.assert_eq(kdf.clip(1), pdf.clip(1))
+        # Assert upper only
+        self.assert_eq(kdf.clip(upper=3), pdf.clip(upper=3))
+        # Assert lower and upper
+        self.assert_eq(kdf.clip(1, 3), pdf.clip(1, 3))

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -463,6 +463,13 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         pdf = pd.DataFrame({'A': [0, 2, 4]})
         kdf = koalas.from_pandas(pdf)
 
+        # Assert list-like values are not accepted for 'lower' and 'upper'
+        msg = "List-like value are not supported for 'lower' and 'upper' at the moment"
+        with self.assertRaises(ValueError, msg=msg):
+            kdf.clip(lower=[1])
+        with self.assertRaises(ValueError, msg=msg):
+            kdf.clip(upper=[1])
+
         # Assert no lower or upper
         self.assert_eq(kdf.clip(), pdf.clip())
         # Assert lower only

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -471,3 +471,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(kdf.clip(upper=3), pdf.clip(upper=3))
         # Assert lower and upper
         self.assert_eq(kdf.clip(1, 3), pdf.clip(1, 3))
+
+        # Assert behavior on string values
+        str_kdf = koalas.DataFrame({'A': ['a', 'b', 'c']})
+        self.assert_eq(str_kdf.clip(1, 3), str_kdf)

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -239,3 +239,7 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(ks.clip(upper=3), ps.clip(upper=3))
         # Assert lower and upper
         self.assert_eq(ks.clip(1, 3), ps.clip(1, 3))
+
+        # Assert behavior on string values
+        str_ks = koalas.Series(['a', 'b', 'c'])
+        self.assert_eq(str_ks.clip(1, 3), str_ks)

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -231,6 +231,13 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         ps = pd.Series([0, 2, 4])
         ks = koalas.from_pandas(ps)
 
+        # Assert list-like values are not accepted for 'lower' and 'upper'
+        msg = "List-like value are not supported for 'lower' and 'upper' at the moment"
+        with self.assertRaises(ValueError, msg=msg):
+            ks.clip(lower=[1])
+        with self.assertRaises(ValueError, msg=msg):
+            ks.clip(upper=[1])
+
         # Assert no lower or upper
         self.assert_eq(ks.clip(), ps.clip())
         # Assert lower only

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -226,3 +226,16 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
             with self.assertRaisesRegex(PandasNotImplementedError,
                                         "property.*Series.*{}.*not implemented".format(name)):
                 getattr(ks, name)
+
+    def test_clip(self):
+        ps = pd.Series([0, 2, 4])
+        ks = koalas.from_pandas(ps)
+
+        # Assert no lower or upper
+        self.assert_eq(ks.clip(), ps.clip())
+        # Assert lower only
+        self.assert_eq(ks.clip(1), ps.clip(1))
+        # Assert upper only
+        self.assert_eq(ks.clip(upper=3), ps.clip(upper=3))
+        # Assert lower and upper
+        self.assert_eq(ks.clip(1, 3), ps.clip(1, 3))


### PR DESCRIPTION
This PR adds pandas' `clip()` method to Koalas Series and DataFrames.

For reference:
https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.clip.html
https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.clip.html