### PR TITLE
Show "showing only the first ..." at repr and _repr_html_

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -41,6 +41,9 @@ from databricks.koalas.selection import SparkDataFrameLocator
 from databricks.koalas.typedef import infer_pd_series_spark_type
 
 
+# These regular expression patterns are complied and defined here to avoid to compile the same
+# pattern every time it is used in _repr_ and _repr_html_ in DataFrames.
+# Two patterns basically seeks the footer string from Pandas'
 REPR_PATTERN = re.compile(r"\n\n\[(?P<rows>[0-9]+) rows x (?P<columns>[0-9]+) columns\]$")
 REPR_HTML_PATTERN = re.compile(
     r"\n\<p\>(?P<rows>[0-9]+) rows × (?P<columns>[0-9]+) columns\<\/p\>\n\<\/div\>$")
@@ -2361,9 +2364,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         raise NotImplementedError(key)
 
     def __repr__(self):
-        pdf = self.head(max_display_count).to_pandas()
-        repr_string = repr(pdf)
-        if len(pdf) == max_display_count:
+        pdf = self.head(max_display_count + 1).to_pandas()
+        pdf_length = len(pdf)
+        repr_string = repr(pdf[:max_display_count])
+        if pdf_length > max_display_count:
             match = REPR_PATTERN.search(repr_string)
             if match is not None:
                 nrows = match.group("rows")
@@ -2374,9 +2378,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         return repr_string
 
     def _repr_html_(self):
-        pdf = self.head(max_display_count).to_pandas()
-        repr_html = pdf._repr_html_()
-        if len(pdf) == max_display_count:
+        pdf = self.head(max_display_count + 1).to_pandas()
+        pdf_length = len(pdf)
+        repr_html = pdf[:max_display_count]._repr_html_()
+        if pdf_length > max_display_count:
             match = REPR_HTML_PATTERN.search(repr_html)
             if match is not None:
                 nrows = match.group("rows")

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -17,6 +17,7 @@
 """
 A wrapper class for Spark DataFrame to behave similar to pandas DataFrame.
 """
+import re
 import warnings
 from functools import partial, reduce
 from typing import Any, List, Tuple, Union
@@ -38,6 +39,11 @@ from databricks.koalas.missing.frame import _MissingPandasLikeDataFrame
 from databricks.koalas.ml import corr
 from databricks.koalas.selection import SparkDataFrameLocator
 from databricks.koalas.typedef import infer_pd_series_spark_type
+
+
+REPR_PATTERN = re.compile(r"\n\n\[(?P<rows>[0-9]+) rows x (?P<columns>[0-9]+) columns\]$")
+REPR_HTML_PATTERN = re.compile(
+    r"\n\<p\>(?P<rows>[0-9]+) rows × (?P<columns>[0-9]+) columns\<\/p\>\n\<\/div\>$")
 
 
 class DataFrame(_Frame):
@@ -2355,10 +2361,33 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         raise NotImplementedError(key)
 
     def __repr__(self):
-        return repr(self.head(max_display_count).to_pandas())
+        pdf = self.head(max_display_count).to_pandas()
+        repr_string = repr(pdf)
+        if len(pdf) == max_display_count:
+            match = REPR_PATTERN.search(repr_string)
+            if match is not None:
+                nrows = match.group("rows")
+                ncols = match.group("columns")
+                footer = ("\n\n[showing only the first {nrows} rows x {ncols} columns]"
+                          .format(nrows=nrows, ncols=ncols))
+                return REPR_PATTERN.sub(footer, repr_string)
+        return repr_string
 
     def _repr_html_(self):
-        return self.head(max_display_count).to_pandas()._repr_html_()
+        pdf = self.head(max_display_count).to_pandas()
+        repr_html = pdf._repr_html_()
+        if len(pdf) == max_display_count:
+            match = REPR_HTML_PATTERN.search(repr_html)
+            if match is not None:
+                nrows = match.group("rows")
+                ncols = match.group("columns")
+                by = chr(215)
+                footer = ('\n<p>showing only the first {rows} rows {by} {cols} columns</p>\n</div>'
+                          .format(rows=nrows,
+                                  by=by,
+                                  cols=ncols))
+                return REPR_HTML_PATTERN.sub(footer, repr_html)
+        return repr_html
 
     def __getitem__(self, key):
         return self._pd_getitem(key)

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -42,8 +42,8 @@ from databricks.koalas.typedef import infer_pd_series_spark_type
 
 
 # These regular expression patterns are complied and defined here to avoid to compile the same
-# pattern every time it is used in _repr_ and _repr_html_ in DataFrames.
-# Two patterns basically seeks the footer string from Pandas'
+# pattern every time it is used in _repr_ and _repr_html_ in DataFrame.
+# Two patterns basically seek the footer string from Pandas'
 REPR_PATTERN = re.compile(r"\n\n\[(?P<rows>[0-9]+) rows x (?P<columns>[0-9]+) columns\]$")
 REPR_HTML_PATTERN = re.compile(
     r"\n\<p\>(?P<rows>[0-9]+) rows × (?P<columns>[0-9]+) columns\<\/p\>\n\<\/div\>$")
@@ -2372,7 +2372,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             if match is not None:
                 nrows = match.group("rows")
                 ncols = match.group("columns")
-                footer = ("\n\n[showing only the first {nrows} rows x {ncols} columns]"
+                footer = ("\n\n[Showing only the first {nrows} rows x {ncols} columns]"
                           .format(nrows=nrows, ncols=ncols))
                 return REPR_PATTERN.sub(footer, repr_string)
         return repr_string
@@ -2387,7 +2387,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 nrows = match.group("rows")
                 ncols = match.group("columns")
                 by = chr(215)
-                footer = ('\n<p>showing only the first {rows} rows {by} {cols} columns</p>\n</div>'
+                footer = ('\n<p>Showing only the first {rows} rows {by} {cols} columns</p>\n</div>'
                           .format(rows=nrows,
                                   by=by,
                                   cols=ncols))

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -2366,7 +2366,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
     def __repr__(self):
         pdf = self.head(max_display_count + 1).to_pandas()
         pdf_length = len(pdf)
-        repr_string = repr(pdf[:max_display_count])
+        repr_string = repr(pdf.iloc[:max_display_count])
         if pdf_length > max_display_count:
             match = REPR_PATTERN.search(repr_string)
             if match is not None:

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -1093,10 +1093,10 @@ class Series(_Frame):
         return self._pandas_orig_repr()
 
     def __repr__(self):
-        pdf = self.head(max_display_count + 1).to_pandas()
-        pdf_length = len(pdf)
-        repr_string = repr(pdf[:max_display_count])
-        if pdf_length > max_display_count:
+        pser = self.head(max_display_count + 1).to_pandas()
+        pser_length = len(pser)
+        repr_string = repr(pser.iloc[:max_display_count])
+        if pser_length > max_display_count:
             rest, prev_footer = repr_string.rsplit("\n", 1)
             match = REPR_PATTERN.search(prev_footer)
             if match is not None:

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -69,22 +69,12 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         self.assertEqual(ddf.a.notnull().alias("x").name, "x")
 
-    def test_repr(self):
-        # Make sure we only fetch max_display_count
-        self.assertEqual(koalas.range(1001).__repr__(),
-                         koalas.range(max_display_count).__repr__())
-
     def test_repr_cache_invalidation(self):
         # If there is any cache, inplace operations should invalidate it.
         df = koalas.range(10)
         df.__repr__()
         df['a'] = df['id']
         self.assertEqual(df.__repr__(), df.to_pandas().__repr__())
-
-    def test_repr_html(self):
-        # Make sure we only fetch max_display_count
-        self.assertEqual(koalas.range(1001)._repr_html_(),
-                         koalas.range(max_display_count)._repr_html_())
 
     def test_repr_html_cache_invalidation(self):
         # If there is any cache, inplace operations should invalidate it.

--- a/databricks/koalas/tests/test_repr.py
+++ b/databricks/koalas/tests/test_repr.py
@@ -21,23 +21,20 @@ from databricks.koalas.testing.utils import ReusedSQLTestCase
 class ReprTests(ReusedSQLTestCase):
 
     def test_repr(self):
-        kdf = ks.range(max_display_count - 1)
+        kdf = ks.range(max_display_count)
         self.assertTrue("showing only the first" not in repr(kdf))
         self.assert_eq(repr(kdf), repr(kdf.to_pandas()))
 
-        kdf = ks.range(max_display_count)
+        kdf = ks.range(max_display_count + 1)
         self.assertTrue("showing only the first" in repr(kdf))
         self.assertEqual(
             repr(kdf).split("\n")[:10],
             repr(kdf.to_pandas()).split("\n")[:10])
 
     def test_html_repr(self):
-        kdf = ks.range(max_display_count - 1)
+        kdf = ks.range(max_display_count)
         self.assertTrue("showing only the first" not in kdf._repr_html_())
         self.assertEqual(kdf._repr_html_(), kdf.to_pandas()._repr_html_())
 
-        kdf = ks.range(max_display_count)
+        kdf = ks.range(max_display_count + 1)
         self.assertTrue("showing only the first" in kdf._repr_html_())
-        self.assertEqual(
-            repr(kdf).split("\n")[:10],
-            repr(kdf.to_pandas()).split("\n")[:10])

--- a/databricks/koalas/tests/test_repr.py
+++ b/databricks/koalas/tests/test_repr.py
@@ -1,0 +1,43 @@
+#
+# Copyright (C) 2019 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from databricks import koalas as ks
+from databricks.koalas.generic import max_display_count
+from databricks.koalas.testing.utils import ReusedSQLTestCase
+
+
+class ReprTests(ReusedSQLTestCase):
+
+    def test_repr(self):
+        kdf = ks.range(max_display_count - 1)
+        self.assertTrue("showing only the first" not in repr(kdf))
+        self.assert_eq(repr(kdf), repr(kdf.to_pandas()))
+
+        kdf = ks.range(max_display_count)
+        self.assertTrue("showing only the first" in repr(kdf))
+        self.assertEqual(
+            repr(kdf).split("\n")[:10],
+            repr(kdf.to_pandas()).split("\n")[:10])
+
+    def test_html_repr(self):
+        kdf = ks.range(max_display_count - 1)
+        self.assertTrue("showing only the first" not in kdf._repr_html_())
+        self.assertEqual(kdf._repr_html_(), kdf.to_pandas()._repr_html_())
+
+        kdf = ks.range(max_display_count)
+        self.assertTrue("showing only the first" in kdf._repr_html_())
+        self.assertEqual(
+            repr(kdf).split("\n")[:10],
+            repr(kdf.to_pandas()).split("\n")[:10])

--- a/databricks/koalas/tests/test_repr.py
+++ b/databricks/koalas/tests/test_repr.py
@@ -20,21 +20,26 @@ from databricks.koalas.testing.utils import ReusedSQLTestCase
 
 class ReprTests(ReusedSQLTestCase):
 
-    def test_repr(self):
+    def test_repr_dataframe(self):
         kdf = ks.range(max_display_count)
-        self.assertTrue("showing only the first" not in repr(kdf))
+        self.assertTrue("Showing only the first" not in repr(kdf))
         self.assert_eq(repr(kdf), repr(kdf.to_pandas()))
 
         kdf = ks.range(max_display_count + 1)
-        self.assertTrue("showing only the first" in repr(kdf))
-        self.assertEqual(
-            repr(kdf).split("\n")[:10],
-            repr(kdf.to_pandas()).split("\n")[:10])
+        self.assertTrue("Showing only the first" in repr(kdf))
+
+    def test_repr_series(self):
+        kser = ks.range(max_display_count).id
+        self.assertTrue("Showing only the first" not in repr(kser))
+        self.assert_eq(repr(kser), repr(kser.to_pandas()))
+
+        kser = ks.range(max_display_count + 1).id
+        self.assertTrue("Showing only the first" in repr(kser))
 
     def test_html_repr(self):
         kdf = ks.range(max_display_count)
-        self.assertTrue("showing only the first" not in kdf._repr_html_())
+        self.assertTrue("Showing only the first" not in kdf._repr_html_())
         self.assertEqual(kdf._repr_html_(), kdf.to_pandas()._repr_html_())
 
         kdf = ks.range(max_display_count + 1)
-        self.assertTrue("showing only the first" in kdf._repr_html_())
+        self.assertTrue("Showing only the first" in kdf._repr_html_())

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -44,11 +44,6 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
 
         # TODO: self.assert_eq(d + 1, pdf + 1)
 
-    def test_repr(self):
-        # Make sure we only fetch max_display_count
-        self.assertEqual(koalas.range(1001)['id'].__repr__(),
-                         koalas.range(max_display_count)['id'].__repr__())
-
     def test_repr_cache_invalidation(self):
         # If there is any cache, inplace operations should invalidate it.
         s = koalas.range(10)['id']


### PR DESCRIPTION
This PR uses regular expressions at `repr` and `_repr_html_` to show "showing only the first ..."

**`repr`**:

DataFrame:

```python
>>> import databricks.koalas as ks
>>> ks.range(2000)
```

```
      id
0      0
1      1
...
998  998
999  999

[Showing only the first 1000 rows x 1 columns]
```

```python
>>> ks.range(500)
```

```
...
499  499

[500 rows x 1 columns]
```

Series:
```python
>>> ks.DataFrame({'a': [1] * 1000}).a
```

```
998    1
999    1
Name: a, Length: 1000, dtype: int64
```

```python
>>> ks.DataFrame({'a': [1] * 1001}).a
```


```
...
998    1
999    1
Name: a, Length: 1000, dtype: int64
Showing only the first 1000
```

**`_repr_html_`**:

DataFrame

```python
>>> import databricks.koalas as ks
>>> print(ks.range(2000)._repr_html_())
```

```
<div>
<style scoped>
...
</style>
<table border="1" class="dataframe">
  <thead>
...
  <tbody>
    <tr>
      <th>0</td>
...
      <td>999</td>
    </tr>
  </tbody>
</table>
<p>Showing only the first 1000 rows × 1 columns</p>
</div>
```

```python
>>> print(ks.range(500)._repr_html_())
```

```
...
      <th>499</th>
      <td>499</td>
    </tr>
  </tbody>
</table>
<p>500 rows × 1 columns</p>
</div>
```

Closes #307 