### PR TITLE
Remove SparkPandasMergeError

### DIFF
--- a/databricks/koalas/exceptions.py
+++ b/databricks/koalas/exceptions.py
@@ -67,7 +67,3 @@ class PandasNotImplementedError(NotImplementedError):
             msg = "The property `{0}.{1}` is not implemented yet." \
                 .format(class_name, property_name)
         super(NotImplementedError, self).__init__(msg)
-
-
-class SparkPandasMergeError(Exception):
-    pass

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -31,7 +31,6 @@ from pyspark.sql.utils import AnalysisException
 
 from databricks import koalas as ks  # For running doctests and reference resolution in PyCharm.
 from databricks.koalas.utils import default_session, validate_arguments_and_invoke_function
-from databricks.koalas.exceptions import SparkPandasMergeError
 from databricks.koalas.generic import _Frame, max_display_count
 from databricks.koalas.metadata import Metadata
 from databricks.koalas.missing.frame import _MissingPandasLikeDataFrame
@@ -2373,10 +2372,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             instead of NaN.
         """
         if on is None and not left_index and not right_index:
-            raise SparkPandasMergeError("At least 'on' or 'left_index' and 'right_index' have ",
-                                        "to be set")
+            raise ValueError("At least 'on' or 'left_index' and 'right_index' have to be set")
         if on is not None and (left_index or right_index):
-            raise SparkPandasMergeError("Only 'on' or 'left_index' and 'right_index' can be set")
+            raise ValueError("Only 'on' or 'left_index' and 'right_index' can be set")
 
         if how == 'full':
             warnings.warn("Warning: While Koalas will accept 'full', you should use 'outer' " +

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -22,7 +22,7 @@ import pandas as pd
 from databricks import koalas
 from databricks.koalas.generic import max_display_count
 from databricks.koalas.testing.utils import ReusedSQLTestCase, SQLTestUtils
-from databricks.koalas.exceptions import PandasNotImplementedError, SparkPandasMergeError
+from databricks.koalas.exceptions import PandasNotImplementedError
 from databricks.koalas.missing.frame import _MissingPandasLikeDataFrame
 
 
@@ -411,10 +411,10 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         # Assert only 'on' or 'left_index' and 'right_index' parameters are set
         msg = "At least 'on' or 'left_index' and 'right_index' have to be set"
-        with self.assertRaises(SparkPandasMergeError, msg=msg):
+        with self.assertRaises(ValueError, msg=msg):
             left_kdf.merge(right_kdf)
         msg = "Only 'on' or 'left_index' and 'right_index' can be set"
-        with self.assertRaises(SparkPandasMergeError, msg=msg):
+        with self.assertRaises(ValueError, msg=msg):
             left_kdf.merge(right_kdf, on='id', left_index=True)
 
         # Assert a valid option for the 'how' parameter is used


### PR DESCRIPTION
As requested in #264, this PR removes the specific `SparkPandasMergeError` and replaces its usage with the more generic `ValueError`.