### PR TITLE
Add docs for `.loc` and refine.

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -36,7 +36,6 @@ from databricks.koalas.generic import _Frame, max_display_count
 from databricks.koalas.metadata import Metadata
 from databricks.koalas.missing.frame import _MissingPandasLikeDataFrame
 from databricks.koalas.ml import corr
-from databricks.koalas.selection import SparkDataFrameLocator
 from databricks.koalas.typedef import infer_pd_series_spark_type
 
 
@@ -1462,10 +1461,6 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         return validate_arguments_and_invoke_function(
             kdf.to_pandas(), self.to_excel, pd.DataFrame.to_excel, args)
-
-    @property
-    def loc(self):
-        return SparkDataFrameLocator(self)
 
     def copy(self) -> 'DataFrame':
         """

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -26,6 +26,7 @@ from pyspark.sql import functions as F
 from pyspark.sql.types import DataType, DoubleType, FloatType
 
 from databricks import koalas as ks  # For running doctests and reference resolution in PyCharm.
+from databricks.koalas.indexing import LocIndexer
 
 max_display_count = 1000
 
@@ -384,6 +385,12 @@ class _Frame(object):
             return SeriesGroupBy(col, col_by)
         raise TypeError('Constructor expects DataFrame or Series; however, '
                         'got [%s]' % (df_or_s,))
+
+    @property
+    def loc(self):
+        return LocIndexer(self)
+
+    loc.__doc__ = LocIndexer.__doc__
 
     def compute(self):
         """Alias of `to_pandas()` to mimic dask for easily porting tests."""

--- a/databricks/koalas/indexing.py
+++ b/databricks/koalas/indexing.py
@@ -44,6 +44,19 @@ def _unfold(key, ks):
     If ks parameter is not None, the key should be row selection and the column selection will be
     the Spark Column in the ks parameter. Otherwise check the key contains column selection, and
     the selection is acceptable.
+
+    >>> s = ks.Series([1, 2, 3], name='a')
+    >>> _unfold(slice(1, 2), s)
+    (slice(1, 2, None), Column<b'a'>)
+
+    >>> _unfold((slice(1, 2), slice(None)), None)
+    (slice(1, 2, None), None)
+
+    >>> _unfold((slice(1, 2), s), None)
+    (slice(1, 2, None), Column<b'a'>)
+
+    >>> _unfold((slice(1, 2), 'col'), None)
+    (slice(1, 2, None), Column<b'col'>)
     """
     from databricks.koalas.series import Series
     if ks is not None:

--- a/databricks/koalas/indexing.py
+++ b/databricks/koalas/indexing.py
@@ -38,7 +38,7 @@ def _make_col(c):
             description="Can only convert a string to a column type.")
 
 
-def _unfold(key, ks):
+def _unfold(key, kseries):
     """ Return row selection and column selection pair.
 
     If ks parameter is not None, the key should be row selection and the column selection will be
@@ -59,13 +59,13 @@ def _unfold(key, ks):
     (slice(1, 2, None), Column<b'col'>)
     """
     from databricks.koalas.series import Series
-    if ks is not None:
+    if kseries is not None:
         if isinstance(key, tuple):
             if len(key) > 1:
                 raise SparkPandasIndexingError('Too many indexers')
             key = key[0]
         rows_sel = key
-        cols_sel = ks._scol
+        cols_sel = kseries._scol
     elif isinstance(key, tuple):
         if len(key) != 2:
             raise SparkPandasIndexingError("Only accepts pairs of candidates")

--- a/databricks/koalas/indexing.py
+++ b/databricks/koalas/indexing.py
@@ -106,7 +106,7 @@ class LocIndexer(object):
     - A list or array of labels, e.g. ``['a', 'b', 'c']``.
 
       .. note:: With a list or array of labels for row selection,
-          Koalas does not preserve the given order but preserves the data order.
+          Koalas behaves just a filter without reordering by the labels.
 
     - A slice object with labels, e.g. ``'a':'f'``.
 
@@ -153,7 +153,12 @@ class LocIndexer(object):
     databricks.koalas.exceptions.SparkPandasNotImplementedError: ...
 
     List of labels. Note using ``[[]]`` returns a DataFrame.
-    Also note that Koalas preserves the data order not the given labels order.
+    Also note that Koalas behaves just a filter without reordering by the labels.
+
+    >>> df.loc[['viper', 'sidewinder']]
+                max_speed  shield
+    viper               4       5
+    sidewinder          7       8
 
     >>> df.loc[['sidewinder', 'viper']]
                 max_speed  shield

--- a/databricks/koalas/indexing.py
+++ b/databricks/koalas/indexing.py
@@ -88,21 +88,21 @@ class LocIndexer(object):
       interpreted as a *label* of the index, and **never** as an
       integer position along the index) for column selection.
 
-      .. warning:: A single label for row selection is not allowed
+      .. note:: A single label for row selection is not allowed
 
     - A list or array of labels, e.g. ``['a', 'b', 'c']``.
 
-      .. warning:: With a list or array of labels for row selection,
+      .. note:: With a list or array of labels for row selection,
           Koalas does not preserve the given order but preserves the data order.
 
     - A slice object with labels, e.g. ``'a':'f'``.
 
-      .. warning:: Note that contrary to usual python slices, **both** the
+      .. note:: Note that contrary to usual python slices, **both** the
           start and the stop are included
 
-      .. warning:: The step of the slice is not allowed
+      .. note:: The step of the slice is not allowed
 
-      .. warning:: With a slice, Koalas works as a filter between the range
+      .. note:: With a slice, Koalas works as a filter between the range
 
     - A conditional boolean Series derived from the DataFrame or Series
 
@@ -113,7 +113,7 @@ class LocIndexer(object):
     - A ``callable`` function with one argument (the calling Series, DataFrame
       or Panel) and that returns valid output for indexing (one of the above)
 
-    .. warning:: MultiIndex is not supported yet.
+    .. note:: MultiIndex is not supported yet.
 
     See Also
     --------

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -35,7 +35,6 @@ from databricks.koalas.frame import DataFrame
 from databricks.koalas.generic import _Frame, max_display_count
 from databricks.koalas.metadata import Metadata
 from databricks.koalas.missing.series import _MissingPandasLikeSeries
-from databricks.koalas.selection import SparkDataFrameLocator
 from databricks.koalas.utils import validate_arguments_and_invoke_function
 
 
@@ -439,10 +438,6 @@ class Series(_Frame):
                 return s
         else:
             return kdf
-
-    @property
-    def loc(self):
-        return SparkDataFrameLocator(self)
 
     def to_dataframe(self):
         sdf = self._kdf._sdf.select([field for field, _ in self._index_map] + [self._scol])

--- a/databricks/koalas/tests/test_indexing.py
+++ b/databricks/koalas/tests/test_indexing.py
@@ -116,296 +116,297 @@ class BasicIndexingTest(ComparisonTestBase):
 class IndexingTest(ReusedSQLTestCase):
 
     @property
-    def full(self):
+    def pdf(self):
         return pd.DataFrame({
             'a': [1, 2, 3, 4, 5, 6, 7, 8, 9],
             'b': [4, 5, 6, 3, 2, 1, 0, 0, 0]
         }, index=[0, 1, 3, 5, 6, 8, 9, 9, 9])
 
     @property
-    def df(self):
-        return koalas.from_pandas(self.full)
+    def kdf(self):
+        return koalas.from_pandas(self.pdf)
 
     def test_loc(self):
-        d = self.df
-        full = self.full
+        kdf = self.kdf
+        pdf = self.pdf
 
-        self.assert_eq(d.loc[5:5], full.loc[5:5])
-        self.assert_eq(d.loc[3:8], full.loc[3:8])
-        self.assert_eq(d.loc[:8], full.loc[:8])
-        self.assert_eq(d.loc[3:], full.loc[3:])
-        self.assert_eq(d.loc[[5]], full.loc[[5]])
-        self.assert_eq(d.loc[:], full.loc[:])
+        self.assert_eq(kdf.loc[5:5], pdf.loc[5:5])
+        self.assert_eq(kdf.loc[3:8], pdf.loc[3:8])
+        self.assert_eq(kdf.loc[:8], pdf.loc[:8])
+        self.assert_eq(kdf.loc[3:], pdf.loc[3:])
+        self.assert_eq(kdf.loc[[5]], pdf.loc[[5]])
+        self.assert_eq(kdf.loc[:], pdf.loc[:])
 
-        # TODO?: self.assert_eq(d.loc[[3, 4, 1, 8]], full.loc[[3, 4, 1, 8]])
-        # TODO?: self.assert_eq(d.loc[[3, 4, 1, 9]], full.loc[[3, 4, 1, 9]])
-        # TODO?: self.assert_eq(d.loc[np.array([3, 4, 1, 9])], full.loc[np.array([3, 4, 1, 9])])
+        # TODO?: self.assert_eq(kdf.loc[[3, 4, 1, 8]], pdf.loc[[3, 4, 1, 8]])
+        # TODO?: self.assert_eq(kdf.loc[[3, 4, 1, 9]], pdf.loc[[3, 4, 1, 9]])
+        # TODO?: self.assert_eq(kdf.loc[np.array([3, 4, 1, 9])], pdf.loc[np.array([3, 4, 1, 9])])
 
-        self.assert_eq(d.a.loc[5:5], full.a.loc[5:5])
-        self.assert_eq(d.a.loc[3:8], full.a.loc[3:8])
-        self.assert_eq(d.a.loc[:8], full.a.loc[:8])
-        self.assert_eq(d.a.loc[3:], full.a.loc[3:])
-        self.assert_eq(d.a.loc[[5]], full.a.loc[[5]])
+        self.assert_eq(kdf.a.loc[5:5], pdf.a.loc[5:5])
+        self.assert_eq(kdf.a.loc[3:8], pdf.a.loc[3:8])
+        self.assert_eq(kdf.a.loc[:8], pdf.a.loc[:8])
+        self.assert_eq(kdf.a.loc[3:], pdf.a.loc[3:])
+        self.assert_eq(kdf.a.loc[[5]], pdf.a.loc[[5]])
 
-        # TODO?: self.assert_eq(d.a.loc[[3, 4, 1, 8]], full.a.loc[[3, 4, 1, 8]])
-        # TODO?: self.assert_eq(d.a.loc[[3, 4, 1, 9]], full.a.loc[[3, 4, 1, 9]])
-        # TODO?: self.assert_eq(d.a.loc[np.array([3, 4, 1, 9])], full.a.loc[np.array([3, 4, 1, 9])])
+        # TODO?: self.assert_eq(kdf.a.loc[[3, 4, 1, 8]], pdf.a.loc[[3, 4, 1, 8]])
+        # TODO?: self.assert_eq(kdf.a.loc[[3, 4, 1, 9]], pdf.a.loc[[3, 4, 1, 9]])
+        # TODO?: self.assert_eq(kdf.a.loc[np.array([3, 4, 1, 9])],
+        #                       pdf.a.loc[np.array([3, 4, 1, 9])])
 
-        self.assert_eq(d.a.loc[[]], full.a.loc[[]])
-        self.assert_eq(d.a.loc[np.array([])], full.a.loc[np.array([])])
+        self.assert_eq(kdf.a.loc[[]], pdf.a.loc[[]])
+        self.assert_eq(kdf.a.loc[np.array([])], pdf.a.loc[np.array([])])
 
-        self.assert_eq(d.loc[1000:], full.loc[1000:])
-        self.assert_eq(d.loc[-2000:-1000], full.loc[-2000:-1000])
+        self.assert_eq(kdf.loc[1000:], pdf.loc[1000:])
+        self.assert_eq(kdf.loc[-2000:-1000], pdf.loc[-2000:-1000])
 
     def test_loc_non_informative_index(self):
-        df = pd.DataFrame({'x': [1, 2, 3, 4]}, index=[10, 20, 30, 40])
-        ddf = koalas.from_pandas(df)
+        pdf = pd.DataFrame({'x': [1, 2, 3, 4]}, index=[10, 20, 30, 40])
+        kdf = koalas.from_pandas(pdf)
 
-        self.assert_eq(ddf.loc[20:30], df.loc[20:30])
+        self.assert_eq(kdf.loc[20:30], pdf.loc[20:30])
 
-        df = pd.DataFrame({'x': [1, 2, 3, 4]}, index=[10, 20, 20, 40])
-        ddf = koalas.from_pandas(df)
-        self.assert_eq(ddf.loc[20:20], df.loc[20:20])
+        pdf = pd.DataFrame({'x': [1, 2, 3, 4]}, index=[10, 20, 20, 40])
+        kdf = koalas.from_pandas(pdf)
+        self.assert_eq(kdf.loc[20:20], pdf.loc[20:20])
 
     def test_loc_with_series(self):
-        d = self.df
-        full = self.full
+        kdf = self.kdf
+        pdf = self.pdf
 
-        self.assert_eq(d.loc[d.a % 2 == 0], full.loc[full.a % 2 == 0])
+        self.assert_eq(kdf.loc[kdf.a % 2 == 0], pdf.loc[pdf.a % 2 == 0])
 
     def test_loc_noindex(self):
-        d = self.df
-        d = d.reset_index()
-        full = self.full
-        full = full.reset_index()
+        kdf = self.kdf
+        kdf = kdf.reset_index()
+        pdf = self.pdf
+        pdf = pdf.reset_index()
 
-        self.assert_eq(d[['a']], full[['a']])
+        self.assert_eq(kdf[['a']], pdf[['a']])
 
-        self.assert_eq(d.loc[:], full.loc[:])
-        self.assertRaises(NotImplementedError, lambda: d.loc[5:5])
+        self.assert_eq(kdf.loc[:], pdf.loc[:])
+        self.assertRaises(NotImplementedError, lambda: kdf.loc[5:5])
 
     def test_loc_multiindex(self):
-        d = self.df
-        d = d.set_index('b', append=True)
-        full = self.full
-        full = full.set_index('b', append=True)
+        kdf = self.kdf
+        kdf = kdf.set_index('b', append=True)
+        pdf = self.pdf
+        pdf = pdf.set_index('b', append=True)
 
-        self.assert_eq(d[['a']], full[['a']])
+        self.assert_eq(kdf[['a']], pdf[['a']])
 
-        self.assert_eq(d.loc[:], full.loc[:])
-        self.assertRaises(NotImplementedError, lambda: d.loc[5:5])
+        self.assert_eq(kdf.loc[:], pdf.loc[:])
+        self.assertRaises(NotImplementedError, lambda: kdf.loc[5:5])
 
     def test_loc2d_multiindex(self):
-        d = self.df
-        d = d.set_index('b', append=True)
-        full = self.full
-        full = full.set_index('b', append=True)
+        kdf = self.kdf
+        kdf = kdf.set_index('b', append=True)
+        pdf = self.pdf
+        pdf = pdf.set_index('b', append=True)
 
-        self.assert_eq(d.loc[:, :], full.loc[:, :])
-        self.assert_eq(d.loc[:, 'a'], full.loc[:, 'a'])
-        self.assertRaises(NotImplementedError, lambda: d.loc[5:5, 'a'])
+        self.assert_eq(kdf.loc[:, :], pdf.loc[:, :])
+        self.assert_eq(kdf.loc[:, 'a'], pdf.loc[:, 'a'])
+        self.assertRaises(NotImplementedError, lambda: kdf.loc[5:5, 'a'])
 
     def test_loc2d(self):
-        d = self.df
-        full = self.full
+        kdf = self.kdf
+        pdf = self.pdf
 
         # index indexer is always regarded as slice for duplicated values
-        self.assert_eq(d.loc[5:5, 'a'], full.loc[5:5, 'a'])
-        self.assert_eq(d.loc[[5], 'a'], full.loc[[5], 'a'])
-        self.assert_eq(d.loc[5:5, ['a']], full.loc[5:5, ['a']])
-        self.assert_eq(d.loc[[5], ['a']], full.loc[[5], ['a']])
-        self.assert_eq(d.loc[:, :], full.loc[:, :])
+        self.assert_eq(kdf.loc[5:5, 'a'], pdf.loc[5:5, 'a'])
+        self.assert_eq(kdf.loc[[5], 'a'], pdf.loc[[5], 'a'])
+        self.assert_eq(kdf.loc[5:5, ['a']], pdf.loc[5:5, ['a']])
+        self.assert_eq(kdf.loc[[5], ['a']], pdf.loc[[5], ['a']])
+        self.assert_eq(kdf.loc[:, :], pdf.loc[:, :])
 
-        self.assert_eq(d.loc[3:8, 'a'], full.loc[3:8, 'a'])
-        self.assert_eq(d.loc[:8, 'a'], full.loc[:8, 'a'])
-        self.assert_eq(d.loc[3:, 'a'], full.loc[3:, 'a'])
-        self.assert_eq(d.loc[[8], 'a'], full.loc[[8], 'a'])
+        self.assert_eq(kdf.loc[3:8, 'a'], pdf.loc[3:8, 'a'])
+        self.assert_eq(kdf.loc[:8, 'a'], pdf.loc[:8, 'a'])
+        self.assert_eq(kdf.loc[3:, 'a'], pdf.loc[3:, 'a'])
+        self.assert_eq(kdf.loc[[8], 'a'], pdf.loc[[8], 'a'])
 
-        self.assert_eq(d.loc[3:8, ['a']], full.loc[3:8, ['a']])
-        self.assert_eq(d.loc[:8, ['a']], full.loc[:8, ['a']])
-        self.assert_eq(d.loc[3:, ['a']], full.loc[3:, ['a']])
-        # TODO?: self.assert_eq(d.loc[[3, 4, 3], ['a']], full.loc[[3, 4, 3], ['a']])
+        self.assert_eq(kdf.loc[3:8, ['a']], pdf.loc[3:8, ['a']])
+        self.assert_eq(kdf.loc[:8, ['a']], pdf.loc[:8, ['a']])
+        self.assert_eq(kdf.loc[3:, ['a']], pdf.loc[3:, ['a']])
+        # TODO?: self.assert_eq(kdf.loc[[3, 4, 3], ['a']], pdf.loc[[3, 4, 3], ['a']])
 
-        self.assertRaises(SparkPandasIndexingError, lambda: d.loc[3, 3, 3])
-        self.assertRaises(SparkPandasIndexingError, lambda: d.a.loc[3, 3])
-        self.assertRaises(SparkPandasIndexingError, lambda: d.a.loc[3:, 3])
-        self.assertRaises(SparkPandasIndexingError, lambda: d.a.loc[d.a % 2 == 0, 3])
+        self.assertRaises(SparkPandasIndexingError, lambda: kdf.loc[3, 3, 3])
+        self.assertRaises(SparkPandasIndexingError, lambda: kdf.a.loc[3, 3])
+        self.assertRaises(SparkPandasIndexingError, lambda: kdf.a.loc[3:, 3])
+        self.assertRaises(SparkPandasIndexingError, lambda: kdf.a.loc[kdf.a % 2 == 0, 3])
 
     def test_loc2d_with_known_divisions(self):
-        df = pd.DataFrame(np.random.randn(20, 5),
-                          index=list('abcdefghijklmnopqrst'),
-                          columns=list('ABCDE'))
-        ddf = koalas.from_pandas(df)
+        pdf = pd.DataFrame(np.random.randn(20, 5),
+                           index=list('abcdefghijklmnopqrst'),
+                           columns=list('ABCDE'))
+        kdf = koalas.from_pandas(pdf)
 
-        self.assert_eq(ddf.loc[['a'], 'A'], df.loc[['a'], 'A'])
-        self.assert_eq(ddf.loc[['a'], ['A']], df.loc[['a'], ['A']])
-        self.assert_eq(ddf.loc['a':'o', 'A'], df.loc['a':'o', 'A'])
-        self.assert_eq(ddf.loc['a':'o', ['A']], df.loc['a':'o', ['A']])
-        self.assert_eq(ddf.loc[['n'], ['A']], df.loc[['n'], ['A']])
-        self.assert_eq(ddf.loc[['a', 'c', 'n'], ['A']], df.loc[['a', 'c', 'n'], ['A']])
-        # TODO?: self.assert_eq(ddf.loc[['t', 'b'], ['A']], df.loc[['t', 'b'], ['A']])
-        # TODO?: self.assert_eq(ddf.loc[['r', 'r', 'c', 'g', 'h'], ['A']],
-        # TODO?:                df.loc[['r', 'r', 'c', 'g', 'h'], ['A']])
+        self.assert_eq(kdf.loc[['a'], 'A'], pdf.loc[['a'], 'A'])
+        self.assert_eq(kdf.loc[['a'], ['A']], pdf.loc[['a'], ['A']])
+        self.assert_eq(kdf.loc['a':'o', 'A'], pdf.loc['a':'o', 'A'])
+        self.assert_eq(kdf.loc['a':'o', ['A']], pdf.loc['a':'o', ['A']])
+        self.assert_eq(kdf.loc[['n'], ['A']], pdf.loc[['n'], ['A']])
+        self.assert_eq(kdf.loc[['a', 'c', 'n'], ['A']], pdf.loc[['a', 'c', 'n'], ['A']])
+        # TODO?: self.assert_eq(kdf.loc[['t', 'b'], ['A']], pdf.loc[['t', 'b'], ['A']])
+        # TODO?: self.assert_eq(kdf.loc[['r', 'r', 'c', 'g', 'h'], ['A']],
+        # TODO?:                pdf.loc[['r', 'r', 'c', 'g', 'h'], ['A']])
 
     def test_loc2d_duplicated_columns(self):
-        df = pd.DataFrame(np.random.randn(20, 5),
-                          index=list('abcdefghijklmnopqrst'),
-                          columns=list('AABCD'))
-        ddf = koalas.from_pandas(df)
+        pdf = pd.DataFrame(np.random.randn(20, 5),
+                           index=list('abcdefghijklmnopqrst'),
+                           columns=list('AABCD'))
+        pdf = koalas.from_pandas(pdf)
 
-        # TODO?: self.assert_eq(ddf.loc[['a'], 'A'], df.loc[['a'], 'A'])
-        # TODO?: self.assert_eq(ddf.loc[['a'], ['A']], df.loc[['a'], ['A']])
-        self.assert_eq(ddf.loc[['j'], 'B'], df.loc[['j'], 'B'])
-        self.assert_eq(ddf.loc[['j'], ['B']], df.loc[['j'], ['B']])
+        # TODO?: self.assert_eq(pdf.loc[['a'], 'A'], pdf.loc[['a'], 'A'])
+        # TODO?: self.assert_eq(pdf.loc[['a'], ['A']], pdf.loc[['a'], ['A']])
+        self.assert_eq(pdf.loc[['j'], 'B'], pdf.loc[['j'], 'B'])
+        self.assert_eq(pdf.loc[['j'], ['B']], pdf.loc[['j'], ['B']])
 
-        # TODO?: self.assert_eq(ddf.loc['a':'o', 'A'], df.loc['a':'o', 'A'])
-        # TODO?: self.assert_eq(ddf.loc['a':'o', ['A']], df.loc['a':'o', ['A']])
-        self.assert_eq(ddf.loc['j':'q', 'B'], df.loc['j':'q', 'B'])
-        self.assert_eq(ddf.loc['j':'q', ['B']], df.loc['j':'q', ['B']])
+        # TODO?: self.assert_eq(pdf.loc['a':'o', 'A'], pdf.loc['a':'o', 'A'])
+        # TODO?: self.assert_eq(pdf.loc['a':'o', ['A']], pdf.loc['a':'o', ['A']])
+        self.assert_eq(pdf.loc['j':'q', 'B'], pdf.loc['j':'q', 'B'])
+        self.assert_eq(pdf.loc['j':'q', ['B']], pdf.loc['j':'q', ['B']])
 
-        # TODO?: self.assert_eq(ddf.loc['a':'o', 'B':'D'], df.loc['a':'o', 'B':'D'])
-        # TODO?: self.assert_eq(ddf.loc['a':'o', 'B':'D'], df.loc['a':'o', 'B':'D'])
-        # TODO?: self.assert_eq(ddf.loc['j':'q', 'B':'A'], df.loc['j':'q', 'B':'A'])
-        # TODO?: self.assert_eq(ddf.loc['j':'q', 'B':'A'], df.loc['j':'q', 'B':'A'])
+        # TODO?: self.assert_eq(pdf.loc['a':'o', 'B':'D'], pdf.loc['a':'o', 'B':'D'])
+        # TODO?: self.assert_eq(pdf.loc['a':'o', 'B':'D'], pdf.loc['a':'o', 'B':'D'])
+        # TODO?: self.assert_eq(pdf.loc['j':'q', 'B':'A'], pdf.loc['j':'q', 'B':'A'])
+        # TODO?: self.assert_eq(pdf.loc['j':'q', 'B':'A'], pdf.loc['j':'q', 'B':'A'])
 
-        self.assert_eq(ddf.loc[ddf.B > 0, 'B'], df.loc[df.B > 0, 'B'])
-        # TODO?: self.assert_eq(ddf.loc[ddf.B > 0, ['A', 'C']], df.loc[df.B > 0, ['A', 'C']])
+        self.assert_eq(pdf.loc[pdf.B > 0, 'B'], pdf.loc[pdf.B > 0, 'B'])
+        # TODO?: self.assert_eq(pdf.loc[pdf.B > 0, ['A', 'C']], pdf.loc[pdf.B > 0, ['A', 'C']])
 
     def test_getitem(self):
-        df = pd.DataFrame({'A': [1, 2, 3, 4, 5, 6, 7, 8, 9],
-                           'B': [9, 8, 7, 6, 5, 4, 3, 2, 1],
-                           'C': [True, False, True] * 3},
-                          columns=list('ABC'))
-        ddf = koalas.from_pandas(df)
-        self.assert_eq(ddf['A'], df['A'])
+        pdf = pd.DataFrame({'A': [1, 2, 3, 4, 5, 6, 7, 8, 9],
+                            'B': [9, 8, 7, 6, 5, 4, 3, 2, 1],
+                            'C': [True, False, True] * 3},
+                           columns=list('ABC'))
+        kdf = koalas.from_pandas(pdf)
+        self.assert_eq(kdf['A'], pdf['A'])
 
-        self.assert_eq(ddf[['A', 'B']], df[['A', 'B']])
+        self.assert_eq(kdf[['A', 'B']], pdf[['A', 'B']])
 
-        self.assert_eq(ddf[ddf.C], df[df.C])
+        self.assert_eq(kdf[kdf.C], pdf[pdf.C])
 
-        self.assertRaises(KeyError, lambda: ddf['X'])
-        self.assertRaises(KeyError, lambda: ddf[['A', 'X']])
-        self.assertRaises(AttributeError, lambda: ddf.X)
+        self.assertRaises(KeyError, lambda: kdf['X'])
+        self.assertRaises(KeyError, lambda: kdf[['A', 'X']])
+        self.assertRaises(AttributeError, lambda: kdf.X)
 
         # not str/unicode
-        # TODO?: df = pd.DataFrame(np.random.randn(10, 5))
-        # TODO?: ddf = koalas.from_pandas(df)
-        # TODO?: self.assert_eq(ddf[0], df[0])
-        # TODO?: self.assert_eq(ddf[[1, 2]], df[[1, 2]])
+        # TODO?: pdf = pd.DataFrame(np.random.randn(10, 5))
+        # TODO?: kdf = koalas.from_pandas(pdf)
+        # TODO?: self.assert_eq(kdf[0], pdf[0])
+        # TODO?: self.assert_eq(kdf[[1, 2]], pdf[[1, 2]])
 
-        # TODO?: self.assertRaises(KeyError, lambda: df[8])
-        # TODO?: self.assertRaises(KeyError, lambda: df[[1, 8]])
+        # TODO?: self.assertRaises(KeyError, lambda: pdf[8])
+        # TODO?: self.assertRaises(KeyError, lambda: pdf[[1, 8]])
 
     def test_getitem_slice(self):
-        df = pd.DataFrame({'A': [1, 2, 3, 4, 5, 6, 7, 8, 9],
-                           'B': [9, 8, 7, 6, 5, 4, 3, 2, 1],
-                           'C': [True, False, True] * 3},
-                          index=list('abcdefghi'))
-        ddf = koalas.from_pandas(df)
-        self.assert_eq(ddf['a':'e'], df['a':'e'])
-        self.assert_eq(ddf['a':'b'], df['a':'b'])
-        self.assert_eq(ddf['f':], df['f':])
+        pdf = pd.DataFrame({'A': [1, 2, 3, 4, 5, 6, 7, 8, 9],
+                            'B': [9, 8, 7, 6, 5, 4, 3, 2, 1],
+                            'C': [True, False, True] * 3},
+                           index=list('abcdefghi'))
+        kdf = koalas.from_pandas(pdf)
+        self.assert_eq(kdf['a':'e'], pdf['a':'e'])
+        self.assert_eq(kdf['a':'b'], pdf['a':'b'])
+        self.assert_eq(kdf['f':], pdf['f':])
 
     def test_loc_on_numpy_datetimes(self):
-        df = pd.DataFrame({'x': [1, 2, 3]},
-                          index=list(map(np.datetime64, ['2014', '2015', '2016'])))
-        a = koalas.from_pandas(df)
+        pdf = pd.DataFrame({'x': [1, 2, 3]},
+                           index=list(map(np.datetime64, ['2014', '2015', '2016'])))
+        kdf = koalas.from_pandas(pdf)
 
-        self.assert_eq(a.loc['2014':'2015'], df.loc['2014':'2015'])
+        self.assert_eq(kdf.loc['2014':'2015'], pdf.loc['2014':'2015'])
 
     def test_loc_on_pandas_datetimes(self):
-        df = pd.DataFrame({'x': [1, 2, 3]},
-                          index=list(map(pd.Timestamp, ['2014', '2015', '2016'])))
-        a = koalas.from_pandas(df)
+        pdf = pd.DataFrame({'x': [1, 2, 3]},
+                           index=list(map(pd.Timestamp, ['2014', '2015', '2016'])))
+        kdf = koalas.from_pandas(pdf)
 
-        self.assert_eq(a.loc['2014':'2015'], df.loc['2014':'2015'])
+        self.assert_eq(kdf.loc['2014':'2015'], pdf.loc['2014':'2015'])
 
     @unittest.skip('TODO?: the behavior of slice for datetime')
     def test_loc_datetime_no_freq(self):
         datetime_index = pd.date_range('2016-01-01', '2016-01-31', freq='12h')
         datetime_index.freq = None  # FORGET FREQUENCY
-        df = pd.DataFrame({'num': range(len(datetime_index))}, index=datetime_index)
-        ddf = koalas.from_pandas(df)
+        pdf = pd.DataFrame({'num': range(len(datetime_index))}, index=datetime_index)
+        kdf = koalas.from_pandas(pdf)
 
         slice_ = slice('2016-01-03', '2016-01-05')
-        result = ddf.loc[slice_, :]
-        expected = df.loc[slice_, :]
+        result = kdf.loc[slice_, :]
+        expected = pdf.loc[slice_, :]
         self.assert_eq(result, expected)
 
     @unittest.skip('TODO?: the behavior of slice for datetime')
     def test_loc_timestamp_str(self):
-        df = pd.DataFrame({'A': np.random.randn(100), 'B': np.random.randn(100)},
-                          index=pd.date_range('2011-01-01', freq='H', periods=100))
-        ddf = koalas.from_pandas(df)
+        pdf = pd.DataFrame({'A': np.random.randn(100), 'B': np.random.randn(100)},
+                           index=pd.date_range('2011-01-01', freq='H', periods=100))
+        kdf = koalas.from_pandas(pdf)
 
         # partial string slice
-        # TODO?: self.assert_eq(df.loc['2011-01-02'],
-        # TODO?:                ddf.loc['2011-01-02'])
-        self.assert_eq(df.loc['2011-01-02':'2011-01-05'],
-                       ddf.loc['2011-01-02':'2011-01-05'])
+        # TODO?: self.assert_eq(pdf.loc['2011-01-02'],
+        # TODO?:                kdf.loc['2011-01-02'])
+        self.assert_eq(pdf.loc['2011-01-02':'2011-01-05'],
+                       kdf.loc['2011-01-02':'2011-01-05'])
 
         # series
-        # TODO?: self.assert_eq(df.A.loc['2011-01-02'],
-        # TODO?:                ddf.A.loc['2011-01-02'])
-        self.assert_eq(df.A.loc['2011-01-02':'2011-01-05'],
-                       ddf.A.loc['2011-01-02':'2011-01-05'])
+        # TODO?: self.assert_eq(pdf.A.loc['2011-01-02'],
+        # TODO?:                kdf.A.loc['2011-01-02'])
+        self.assert_eq(pdf.A.loc['2011-01-02':'2011-01-05'],
+                       kdf.A.loc['2011-01-02':'2011-01-05'])
 
-        df = pd.DataFrame({'A': np.random.randn(100), 'B': np.random.randn(100)},
-                          index=pd.date_range('2011-01-01', freq='M', periods=100))
-        ddf = koalas.from_pandas(df)
-        # TODO?: self.assert_eq(df.loc['2011-01'], ddf.loc['2011-01'])
-        # TODO?: self.assert_eq(df.loc['2011'], ddf.loc['2011'])
+        pdf = pd.DataFrame({'A': np.random.randn(100), 'B': np.random.randn(100)},
+                           index=pd.date_range('2011-01-01', freq='M', periods=100))
+        kdf = koalas.from_pandas(pdf)
+        # TODO?: self.assert_eq(pdf.loc['2011-01'], kdf.loc['2011-01'])
+        # TODO?: self.assert_eq(pdf.loc['2011'], kdf.loc['2011'])
 
-        self.assert_eq(df.loc['2011-01':'2012-05'], ddf.loc['2011-01':'2012-05'])
-        self.assert_eq(df.loc['2011':'2015'], ddf.loc['2011':'2015'])
+        self.assert_eq(pdf.loc['2011-01':'2012-05'], kdf.loc['2011-01':'2012-05'])
+        self.assert_eq(pdf.loc['2011':'2015'], kdf.loc['2011':'2015'])
 
         # series
-        # TODO?: self.assert_eq(df.B.loc['2011-01'], ddf.B.loc['2011-01'])
-        # TODO?: self.assert_eq(df.B.loc['2011'], ddf.B.loc['2011'])
+        # TODO?: self.assert_eq(pdf.B.loc['2011-01'], kdf.B.loc['2011-01'])
+        # TODO?: self.assert_eq(pdf.B.loc['2011'], kdf.B.loc['2011'])
 
-        self.assert_eq(df.B.loc['2011-01':'2012-05'], ddf.B.loc['2011-01':'2012-05'])
-        self.assert_eq(df.B.loc['2011':'2015'], ddf.B.loc['2011':'2015'])
+        self.assert_eq(pdf.B.loc['2011-01':'2012-05'], kdf.B.loc['2011-01':'2012-05'])
+        self.assert_eq(pdf.B.loc['2011':'2015'], kdf.B.loc['2011':'2015'])
 
     @unittest.skip('TODO?: the behavior of slice for datetime')
     def test_getitem_timestamp_str(self):
-        df = pd.DataFrame({'A': np.random.randn(100), 'B': np.random.randn(100)},
-                          index=pd.date_range('2011-01-01', freq='H', periods=100))
-        ddf = koalas.from_pandas(df)
+        pdf = pd.DataFrame({'A': np.random.randn(100), 'B': np.random.randn(100)},
+                           index=pd.date_range('2011-01-01', freq='H', periods=100))
+        kdf = koalas.from_pandas(pdf)
 
         # partial string slice
-        # TODO?: self.assert_eq(df['2011-01-02'],
-        # TODO?:                ddf['2011-01-02'])
-        self.assert_eq(df['2011-01-02':'2011-01-05'],
-                       ddf['2011-01-02':'2011-01-05'])
+        # TODO?: self.assert_eq(pdf['2011-01-02'],
+        # TODO?:                kdf['2011-01-02'])
+        self.assert_eq(pdf['2011-01-02':'2011-01-05'],
+                       kdf['2011-01-02':'2011-01-05'])
 
-        df = pd.DataFrame({'A': np.random.randn(100), 'B': np.random.randn(100)},
-                          index=pd.date_range('2011-01-01', freq='M', periods=100))
-        ddf = koalas.from_pandas(df)
+        pdf = pd.DataFrame({'A': np.random.randn(100), 'B': np.random.randn(100)},
+                           index=pd.date_range('2011-01-01', freq='M', periods=100))
+        kdf = koalas.from_pandas(pdf)
 
-        # TODO?: self.assert_eq(df['2011-01'], ddf['2011-01'])
-        # TODO?: self.assert_eq(df['2011'], ddf['2011'])
+        # TODO?: self.assert_eq(pdf['2011-01'], kdf['2011-01'])
+        # TODO?: self.assert_eq(pdf['2011'], kdf['2011'])
 
-        self.assert_eq(df['2011-01':'2012-05'], ddf['2011-01':'2012-05'])
-        self.assert_eq(df['2011':'2015'], ddf['2011':'2015'])
+        self.assert_eq(pdf['2011-01':'2012-05'], kdf['2011-01':'2012-05'])
+        self.assert_eq(pdf['2011':'2015'], kdf['2011':'2015'])
 
     @unittest.skip('TODO?: period index can\'t convert to DataFrame correctly')
     def test_getitem_period_str(self):
-        df = pd.DataFrame({'A': np.random.randn(100), 'B': np.random.randn(100)},
-                          index=pd.period_range('2011-01-01', freq='H', periods=100))
-        ddf = koalas.from_pandas(df)
+        pdf = pd.DataFrame({'A': np.random.randn(100), 'B': np.random.randn(100)},
+                           index=pd.period_range('2011-01-01', freq='H', periods=100))
+        kdf = koalas.from_pandas(pdf)
 
         # partial string slice
-        # TODO?: self.assert_eq(df['2011-01-02'],
-        # TODO?:                ddf['2011-01-02'])
-        self.assert_eq(df['2011-01-02':'2011-01-05'],
-                       ddf['2011-01-02':'2011-01-05'])
+        # TODO?: self.assert_eq(pdf['2011-01-02'],
+        # TODO?:                kdf['2011-01-02'])
+        self.assert_eq(pdf['2011-01-02':'2011-01-05'],
+                       kdf['2011-01-02':'2011-01-05'])
 
-        df = pd.DataFrame({'A': np.random.randn(100), 'B': np.random.randn(100)},
-                          index=pd.period_range('2011-01-01', freq='M', periods=100))
-        ddf = koalas.from_pandas(df)
+        pdf = pd.DataFrame({'A': np.random.randn(100), 'B': np.random.randn(100)},
+                           index=pd.period_range('2011-01-01', freq='M', periods=100))
+        kdf = koalas.from_pandas(pdf)
 
-        # TODO?: self.assert_eq(df['2011-01'], ddf['2011-01'])
-        # TODO?: self.assert_eq(df['2011'], ddf['2011'])
+        # TODO?: self.assert_eq(pdf['2011-01'], kdf['2011-01'])
+        # TODO?: self.assert_eq(pdf['2011'], kdf['2011'])
 
-        self.assert_eq(df['2011-01':'2012-05'], ddf['2011-01':'2012-05'])
-        self.assert_eq(df['2011':'2015'], ddf['2011':'2015'])
+        self.assert_eq(pdf['2011-01':'2012-05'], kdf['2011-01':'2012-05'])
+        self.assert_eq(pdf['2011':'2015'], kdf['2011':'2015'])

--- a/docs/source/reference/series.rst
+++ b/docs/source/reference/series.rst
@@ -32,6 +32,13 @@ Conversion
 
    Series.astype
 
+Indexing, iteration
+-------------------
+.. autosummary::
+   :toctree: api/
+
+   Series.loc
+
 Function application, GroupBy & Window
 --------------------------------------
 .. autosummary::


### PR DESCRIPTION
Basic things in this PR is to add docstring, but additionally some refinement around `.loc`:

- move `selection.SparkDataFrameLocator` to `indexing.LogIndexer` to follow pandas style.
- refactor variable names.

Resolves #320.