### PR TITLE
Use imported Series and DataFrame directly in namespace.py

### DIFF
--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -33,7 +33,7 @@ from databricks.koalas.typedef import Col, pandas_wraps
 from databricks.koalas.series import Series
 
 
-def from_pandas(pobj: Union['pd.DataFrame', 'pd.Series']) -> Union['ks.Series', 'ks.DataFrame']:
+def from_pandas(pobj: Union['pd.DataFrame', 'pd.Series']) -> Union['Series', 'DataFrame']:
     """Create a Koalas DataFrame or Series from a pandas DataFrame or Series.
 
     This is similar to Spark's `SparkSession.createDataFrame()` with pandas DataFrame,


### PR DESCRIPTION
If we use `ks` namespace, it fails for unknown reason. Since the release is close, I am proposing to fix it first.

```
AttributeError: module 'databricks.koalas' has no attribute 'DataFrame'
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<command-3464524554752451> in <module>()
----> 1 import databricks.koalas

/databricks/python/lib/python3.5/site-packages/databricks/koalas/__init__.py in <module>()
     36 assert_pyspark_version()
     37 
---> 38 from databricks.koalas.namespace import *
     39 from databricks.koalas.frame import DataFrame
     40 from databricks.koalas.series import Series

/databricks/python/lib/python3.5/site-packages/databricks/koalas/namespace.py in <module>()
     34 
     35 
---> 36 def from_pandas(pobj: Union['pd.DataFrame', 'pd.Series']) -> Union['ks.Series', 'ks.DataFrame']:
     37     """Create a Koalas DataFrame or Series from a pandas DataFrame or Series.
     38 

/usr/lib/python3.5/typing.py in __getitem__(self, parameters)
    550             parameters = (parameters,)
```