### PR TITLE
Remove DataFrame.__iter__

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -2663,9 +2663,6 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 return partial(property_or_func, self)
         return Series(self._sdf.__getattr__(key), anchor=self, index=self._metadata.index_map)
 
-    def __iter__(self):
-        return self.toPandas().__iter__()
-
     def __len__(self):
         return self._sdf.count()
 

--- a/docs/source/reference/frame.rst
+++ b/docs/source/reference/frame.rst
@@ -45,7 +45,6 @@ Indexing, iteration
 
    DataFrame.head
    DataFrame.loc
-   DataFrame.__iter__
    DataFrame.iteritems
    DataFrame.get
 


### PR DESCRIPTION
Resolves #319.

The current implementation is going to blow up on large data, and for now we should just remove it. We can add it back when we have a better way to do this. One way to do this is through toLocalIterator, but it's still a bad practice in general.
