### PR TITLE
Cleanup previously generated rst files

### DIFF
--- a/dev/lint-python
+++ b/dev/lint-python
@@ -225,6 +225,8 @@ function sphinx_test {
     echo "starting $SPHINX_BUILD tests..."
     pushd docs &> /dev/null
     make clean &> /dev/null
+    # Remove previously generated rst files
+    rm -fr $DIR/../docs/source/reference/api/*
     # Treat warnings as errors so we stop correctly
     SPHINX_REPORT=$( (SPHINXOPTS="-a -W" make html) 2>&1)
     SPHINX_STATUS=$?


### PR DESCRIPTION
Seems like previously generated rst files (under api) matters in doc generation when new entry is added.

```
reading sources... [100%] reference/series


Warning, treated as error:
autodoc: failed to import method 'DataFrame.__iter__' from module 'databricks.koalas'; the following exception was raised:
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/sphinx/util/inspect.py", line 177, in safe_getattr
    return getattr(obj, name, *defargs)
AttributeError: type object 'DataFrame' has no attribute '__iter__'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/sphinx/ext/autodoc/importer.py", line 271, in import_object
    obj = attrgetter(obj, attrname)
  File "/usr/local/lib/python3.7/site-packages/sphinx/ext/autodoc/__init__.py", line 231, in get_attr
    return autodoc_attrgetter(self.env.app, obj, name, *defargs)
  File "/usr/local/lib/python3.7/site-packages/sphinx/ext/autodoc/__init__.py", line 1446, in autodoc_attrgetter
    return safe_getattr(obj, name, *defargs)
  File "/usr/local/lib/python3.7/site-packages/sphinx/util/inspect.py", line 193, in safe_getattr
    raise AttributeError(name)
AttributeError: __iter__
```

This PR adds a cleanup process in `lint-python`'s document generation sequence.