### PR TITLE
Cleanup and inline documentation of dt functions to Pandas'

### DIFF
--- a/databricks/koalas/datetimes.py
+++ b/databricks/koalas/datetimes.py
@@ -155,7 +155,7 @@ class DatetimeMethods(object):
         Examples
         --------
         >>> s = ks.from_pandas(pd.date_range('2016-12-31', '2017-01-08', freq='D').to_series())
-        >>> s.dt.dayofweek()
+        >>> s.dt.dayofweek
         2016-12-31    5
         2017-01-01    6
         2017-01-02    0

--- a/databricks/koalas/datetimes.py
+++ b/databricks/koalas/datetimes.py
@@ -17,137 +17,172 @@
 """
 Date/Time related functions on Koalas Series
 """
+import pandas as pd
 import pyspark.sql.functions as F
-
 from pyspark.sql.types import DateType, TimestampType, LongType, StringType
-from databricks.koalas.base import (
-    _wrap_accessor_pandas,
-    _wrap_accessor_spark
-)
 
 import databricks.koalas as ks
-
-from databricks.koalas.utils import lazy_property
+from databricks.koalas.base import _wrap_accessor_pandas, _wrap_accessor_spark
 
 
 class DatetimeMethods(object):
     """Date/Time methods for Koalas Series"""
-    def __init__(self, series):
+    def __init__(self, series: ks.Series):
         if not isinstance(series.spark_type, (DateType, TimestampType)):
             raise ValueError(
                 "Cannot call DatetimeMethods on type {}"
                 .format(series.spark_type))
         self._data = series
+        self.name = self._data.name
 
     # Properties
-    @lazy_property
+    @property
     def date(self) -> ks.Series:
         """
-        The date part of the datetime.
+        Returns a Series of python datetime.date objects (namely, the date
+        part of Timestamps without timezone information).
         """
         # TODO: Hit a weird exception
         # syntax error in attribute name: `to_date(`start_date`)` with alias
         return _wrap_accessor_spark(
-            self, lambda col: F.to_date(col).alias('date')
-        )
+            self, lambda col: F.to_date(col)).alias(self.name)
 
-    @lazy_property
+    @property
     def time(self) -> ks.Series:
         raise NotImplementedError()
 
-    @lazy_property
+    @property
     def timetz(self) -> ks.Series:
         raise NotImplementedError()
 
-    @lazy_property
+    @property
     def year(self) -> ks.Series:
         """
         The year of the datetime.
         `"""
-        return _wrap_accessor_spark(self, F.year, LongType())
+        return _wrap_accessor_spark(self, F.year, LongType()).alias(self.name)
 
-    @lazy_property
+    @property
     def month(self) -> ks.Series:
         """
         The month of the timestamp as January = 1 December = 12.
         """
-        return _wrap_accessor_spark(self, F.month, LongType())
+        return _wrap_accessor_spark(self, F.month, LongType()).alias(self.name)
 
-    @lazy_property
+    @property
     def day(self) -> ks.Series:
         """
         The days of the datetime.
         """
-        return _wrap_accessor_spark(self, F.dayofmonth, LongType())
+        return _wrap_accessor_spark(
+            self, F.dayofmonth, LongType()).alias(self.name)
 
-    @lazy_property
+    @property
     def hour(self) -> ks.Series:
         """
         The hours of the datetime.
         """
-        return _wrap_accessor_spark(self, F.hour, LongType())
+        return _wrap_accessor_spark(self, F.hour, LongType()).alias(self.name)
 
-    @lazy_property
+    @property
     def minute(self) -> ks.Series:
         """
         The minutes of the datetime.
         """
-        return _wrap_accessor_spark(self, F.minute, LongType())
+        return _wrap_accessor_spark(self, F.minute, LongType()).alias(self.name)
 
-    @lazy_property
+    @property
     def second(self) -> ks.Series:
         """
         The seconds of the datetime.
         """
-        return _wrap_accessor_spark(self, F.second, LongType())
+        return _wrap_accessor_spark(self, F.second, LongType()).alias(self.name)
 
-    @lazy_property
+    @property
     def millisecond(self) -> ks.Series:
         """
         The milliseconds of the datetime.
         """
         return _wrap_accessor_pandas(
-            self, lambda x: x.dt.millisecond, LongType())
+            self, lambda x: x.dt.millisecond, LongType()).alias(self.name)
 
-    @lazy_property
+    @property
     def microsecond(self) -> ks.Series:
         """
         The microseconds of the datetime.
         """
         return _wrap_accessor_pandas(
-            self, lambda x: x.dt.microsecond, LongType())
+            self, lambda x: x.dt.microsecond, LongType()).alias(self.name)
 
-    @lazy_property
+    @property
     def nanosecond(self) -> ks.Series:
         raise NotImplementedError()
 
-    @lazy_property
+    @property
     def week(self) -> ks.Series:
         """
         The week ordinal of the year.
         """
-        return _wrap_accessor_spark(self, F.weekofyear, LongType())
+        return _wrap_accessor_spark(self, F.weekofyear, LongType()).alias(self.name)
 
-    @lazy_property
+    @property
     def weekofyear(self) -> ks.Series:
-        """
-        The week ordinal of the year.
-        """
-        return _wrap_accessor_spark(self, F.weekofyear, LongType())
+        return self.week
 
-    @lazy_property
+    weekofyear.__doc__ = week.__doc__
+
+    @property
     def dayofweek(self) -> ks.Series:
         """
         The day of the week with Monday=0, Sunday=6.
-        """
-        return _wrap_accessor_pandas(self, lambda s: s.dt.dayofweek, LongType())
 
-    @lazy_property
+        Return the day of the week. It is assumed the week starts on
+        Monday, which is denoted by 0 and ends on Sunday which is denoted
+        by 6. This method is available on both Series with datetime
+        values (using the `dt` accessor) or DatetimeIndex.
+
+        Returns
+        -------
+        Series or Index
+            Containing integers indicating the day number.
+
+        See Also
+        --------
+        Series.dt.dayofweek : Alias.
+        Series.dt.weekday : Alias.
+        Series.dt.day_name : Returns the name of the day of the week.
+
+        Examples
+        --------
+        >>> s = ks.from_pandas(pd.date_range('2016-12-31', '2017-01-08', freq='D').to_series())
+        >>> s.dt.dayofweek()
+        2016-12-31    5
+        2017-01-01    6
+        2017-01-02    0
+        2017-01-03    1
+        2017-01-04    2
+        2017-01-05    3
+        2017-01-06    4
+        2017-01-07    5
+        2017-01-08    6
+        Name: 0, dtype: int64
+        """
+        return _wrap_accessor_pandas(
+            self, lambda s: s.dt.dayofweek, LongType()).alias(self._data.name)
+
+    @property
+    def weekday(self) -> ks.Series:
+        return self.dayofweek
+
+    weekday.__doc__ = dayofweek.__doc__
+
+    @property
     def dayofyear(self) -> ks.Series:
         """
-        The day ordinal of the year.
+        The ordinal day of the year.
         """
-        return _wrap_accessor_pandas(self, lambda s: s.dt.dayofyear, LongType())
+        return _wrap_accessor_pandas(
+            self, lambda s: s.dt.dayofyear, LongType()).alias(self._data.name)
 
     # Methods
     def strftime(self, date_format) -> ks.Series:
@@ -158,4 +193,4 @@ class DatetimeMethods(object):
             self,
             lambda x: x.dt.strftime(date_format),
             StringType()
-        )
+        ).alias(self.name)

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -27,7 +27,6 @@ from pyspark.sql import functions as F
 from pyspark.sql.types import DataType, DoubleType, FloatType
 
 from databricks import koalas as ks  # For running doctests and reference resolution in PyCharm.
-from databricks.koalas.exceptions import PandasNotImplementedError
 from databricks.koalas.indexing import ILocIndexer, LocIndexer
 from databricks.koalas.utils import validate_arguments_and_invoke_function
 

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -135,7 +135,8 @@ class Series(_Frame, IndexOpsMixin):
 
     @property
     def dt(self):
-        from databricks.koalas.datetime import DatetimeMethods
+        from databricks.koalas.datetimes import DatetimeMethods
+
         return DatetimeMethods(self)
 
     @property

--- a/databricks/koalas/tests/test_series_datetime.py
+++ b/databricks/koalas/tests/test_series_datetime.py
@@ -20,7 +20,7 @@ import numpy as np
 import pandas as pd
 import pandas.testing as mt
 
-from databricks import koalas
+from databricks import koalas as ks
 from databricks.koalas.testing.utils import ReusedSQLTestCase, SQLTestUtils
 
 
@@ -38,7 +38,7 @@ class SeriesDateTimeTest(ReusedSQLTestCase, SQLTestUtils):
 
     @property
     def ks_start_date(self):
-        return koalas.from_pandas(self.pd_start_date)
+        return ks.from_pandas(self.pd_start_date)
 
     def check_func(self, func):
         # import pdb; pdb.set_trace()
@@ -54,14 +54,14 @@ class SeriesDateTimeTest(ReusedSQLTestCase, SQLTestUtils):
         "timezone behaviours inherited from C library.")
     def test_subtraction(self):
         pdf = self.pdf1
-        kdf = koalas.from_pandas(pdf)
+        kdf = ks.from_pandas(pdf)
         kdf['diff_seconds'] = kdf['end_date'] - kdf['start_date'] - 1
 
         self.assertEqual(list(kdf['diff_seconds'].toPandas()), [35545499, 33644699, 31571099])
 
     def test_div(self):
         pdf = self.pdf1
-        kdf = koalas.from_pandas(pdf)
+        kdf = ks.from_pandas(pdf)
         for u in 'D', 's', 'ms':
             duration = np.timedelta64(1, u)
             self.assert_eq(
@@ -116,3 +116,8 @@ class SeriesDateTimeTest(ReusedSQLTestCase, SQLTestUtils):
 
     def test_strftime(self):
         self.check_func(lambda x: x.dt.strftime('%Y-%m-%d'))
+
+    def test_unsupported_type(self):
+        self.assertRaisesRegex(ValueError,
+                               'Cannot call DatetimeMethods on type LongType',
+                               lambda: ks.Series([0]).dt)

--- a/databricks/koalas/typedef.py
+++ b/databricks/koalas/typedef.py
@@ -346,11 +346,11 @@ def pandas_wraps(function=None, return_col=None, return_scalar=None):
 
     Notes
     -----
-    The arguments provided to the function must be picklable, or an error will be raised by Spark:
+    The arguments provided to the function must be picklable, or an error will be raised by Spark.
+    The example below fails.
 
     >>> import sys
-    >>> # fun(df.col1, arg1=sys.stdout)  # Will fail!
-
+    >>> fun(df.col1, arg1=sys.stdout)  # doctest: +SKIP
     """
     def function_wrapper(f):
         @wraps(f)

--- a/docs/source/reference/series.rst
+++ b/docs/source/reference/series.rst
@@ -119,7 +119,7 @@ Datetime Methods
 ----------------
 Methods accessible through `Series.dt`
 
-.. currentmodule:: databricks.koalas.datetime
+.. currentmodule:: databricks.koalas.datetimes
 .. autosummary::
    :toctree: api/
 
@@ -130,6 +130,7 @@ Methods accessible through `Series.dt`
    DatetimeMethods.weekofyear
    DatetimeMethods.day
    DatetimeMethods.dayofweek
+   DatetimeMethods.weekday
    DatetimeMethods.dayofyear
    DatetimeMethods.hour
    DatetimeMethods.minute


### PR DESCRIPTION
1. rename `datetime.py` to `datetimes.py` to match with Pandas'
2. Add some missing docstrings that has some examples
3. `lazy_property` -> `property`. I don't feel strongly but let's use `lazy_property` when it's really needed .. :-)..
4. Add the original name of the returned series.
5. Add a couple of minor tests and type hints.