### PR TITLE
Add basic describe() function.

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -29,8 +29,8 @@ from pandas.api.types import is_datetime64_dtype, is_datetime64tz_dtype, is_list
 from pyspark import sql as spark
 from pyspark.sql import functions as F, Column
 from pyspark.sql.types import (BooleanType, ByteType, DecimalType, DoubleType, FloatType,
-                               IntegerType, LongType, ShortType, StructField, StructType,
-                               to_arrow_type)
+                               IntegerType, LongType, NumericType, ShortType, StructField,
+                               StructType, to_arrow_type)
 from pyspark.sql.utils import AnalysisException
 
 from databricks import koalas as ks  # For running doctests and reference resolution in PyCharm.
@@ -2539,6 +2539,96 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         sdf = self._sdf.select(
             self._metadata.index_columns + list(map(lambda ser: ser._scol, results)))
         return DataFrame(sdf, self._metadata.copy())
+
+    # TODO: percentiles, include, and exclude should be implemented.
+    def describe(self):
+        """
+        Generate descriptive statistics that summarize the central tendency,
+        dispersion and shape of a dataset's distribution, excluding
+        ``NaN`` values.
+
+        Analyzes both numeric and object series, as well
+        as ``DataFrame`` column sets of mixed data types. The output
+        will vary depending on what is provided. Refer to the notes
+        below for more detail.
+
+        Returns
+        -------
+        Series or DataFrame
+            Summary statistics of the Series or Dataframe provided.
+
+        See Also
+        --------
+        DataFrame.count: Count number of non-NA/null observations.
+        DataFrame.max: Maximum of the values in the object.
+        DataFrame.min: Minimum of the values in the object.
+        DataFrame.mean: Mean of the values.
+        DataFrame.std: Standard deviation of the obersvations.
+
+        Notes
+        -----
+        For numeric data, the result's index will include ``count``,
+        ``mean``, ``stddev``, ``min``, ``max``.
+
+        Currently only numeric data is supported.
+
+        Examples
+        --------
+        Describing a numeric ``Series``.
+
+        >>> s = ks.Series([1, 2, 3])
+        >>> s.describe()
+        count     3.0
+        mean      2.0
+        stddev    1.0
+        min       1.0
+        max       3.0
+        Name: 0, dtype: float64
+
+        Describing a ``DataFrame``. Only numeric fields are returned.
+
+        >>> df = ks.DataFrame({'numeric1': [1, 2, 3],
+        ...                    'numeric2': [4.0, 5.0, 6.0],
+        ...                    'object': ['a', 'b', 'c']
+        ...                   },
+        ...                   columns=['numeric1', 'numeric2', 'object'])
+        >>> df.describe()
+                numeric1  numeric2
+        count        3.0       3.0
+        mean         2.0       5.0
+        stddev       1.0       1.0
+        min          1.0       4.0
+        max          3.0       6.0
+
+        Describing a column from a ``DataFrame`` by accessing it as
+        an attribute.
+
+        >>> df.numeric1.describe()
+        count     3.0
+        mean      2.0
+        stddev    1.0
+        min       1.0
+        max       3.0
+        Name: numeric1, dtype: float64
+        """
+        exprs = []
+        data_columns = []
+        for col in self.columns:
+            kseries = self[col]
+            spark_type = kseries.spark_type
+            if isinstance(spark_type, DoubleType) or isinstance(spark_type, FloatType):
+                exprs.append(F.nanvl(kseries._scol, F.lit(None)).alias(kseries.name))
+                data_columns.append(kseries.name)
+            elif isinstance(spark_type, NumericType):
+                exprs.append(kseries._scol)
+                data_columns.append(kseries.name)
+
+        if len(exprs) == 0:
+            raise ValueError("Cannot describe a DataFrame without columns")
+
+        sdf = self._sdf.select(*exprs).describe()
+        return DataFrame(sdf, index=Metadata(data_columns=data_columns,
+                                             index_map=[('summary', None)])).astype('float64')
 
     def _pd_getitem(self, key):
         from databricks.koalas.series import Series

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -2541,7 +2541,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         return DataFrame(sdf, self._metadata.copy())
 
     # TODO: percentiles, include, and exclude should be implemented.
-    def describe(self):
+    def describe(self) -> 'DataFrame':
         """
         Generate descriptive statistics that summarize the central tendency,
         dispersion and shape of a dataset's distribution, excluding

--- a/databricks/koalas/missing/frame.py
+++ b/databricks/koalas/missing/frame.py
@@ -72,7 +72,6 @@ class _MissingPandasLikeDataFrame(object):
     cummin = unsupported_function('cummin')
     cumprod = unsupported_function('cumprod')
     cumsum = unsupported_function('cumsum')
-    describe = unsupported_function('describe')
     diff = unsupported_function('diff')
     div = unsupported_function('div')
     divide = unsupported_function('divide')

--- a/databricks/koalas/missing/series.py
+++ b/databricks/koalas/missing/series.py
@@ -88,7 +88,6 @@ class _MissingPandasLikeSeries(object):
     cummin = unsupported_function('cummin')
     cumprod = unsupported_function('cumprod')
     cumsum = unsupported_function('cumsum')
-    describe = unsupported_function('describe')
     diff = unsupported_function('diff')
     div = unsupported_function('div')
     divide = unsupported_function('divide')

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -1116,6 +1116,11 @@ class Series(_Frame, IndexOpsMixin):
         wrapped = ks.pandas_wraps(return_col=return_sig)(apply_each)
         return wrapped(self, *args, **kwds)
 
+    def describe(self):
+        return _col(self.to_dataframe().describe())
+
+    describe.__doc__ = DataFrame.describe.__doc__
+
     def _reduce_for_stat_function(self, sfun):
         from inspect import signature
         num_args = len(signature(sfun).parameters)

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -1116,7 +1116,7 @@ class Series(_Frame, IndexOpsMixin):
         wrapped = ks.pandas_wraps(return_col=return_sig)(apply_each)
         return wrapped(self, *args, **kwds)
 
-    def describe(self):
+    def describe(self) -> 'Series':
         return _col(self.to_dataframe().describe())
 
     describe.__doc__ = DataFrame.describe.__doc__

--- a/docs/source/reference/frame.rst
+++ b/docs/source/reference/frame.rst
@@ -70,6 +70,7 @@ Computations / Descriptive Stats
    DataFrame.clip
    DataFrame.corr
    DataFrame.count
+   DataFrame.describe
    DataFrame.kurt
    DataFrame.kurtosis
    DataFrame.max

--- a/docs/source/reference/series.rst
+++ b/docs/source/reference/series.rst
@@ -65,6 +65,7 @@ Computations / Descriptive Stats
    Series.clip
    Series.corr
    Series.count
+   Series.describe
    Series.kurt
    Series.max
    Series.mean


### PR DESCRIPTION
This PR adds `DataFrame.describe()` and `Series.describe()` with basic stats for numeric types.
Resolves #334.