### PR TITLE
Add percentiles to describe

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -2555,8 +2555,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         Parameters
         ----------
         percentiles : list of ``float`` in range (0.0, 1.0), default [0.25, 0.5, 0.75]
-            A list of percentiles to be computed. 
-            Use an empty list if no percentiles should be computed. 
+            A list of percentiles to be computed.
+            Use an empty list if no percentiles should be computed.
 
         Returns
         -------
@@ -2657,7 +2657,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         if len(exprs) == 0:
             raise ValueError("Cannot describe a DataFrame without columns")
 
-        formatted_perc =  ["{:.0%}".format(p) for p in percentiles]
+        formatted_perc = ["{:.0%}".format(p) for p in percentiles]
         stats = ["count", "mean", "stddev", "min", *formatted_perc, "max"]
 
         sdf = self._sdf.select(*exprs).summary(stats)

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -2583,14 +2583,14 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         >>> s = ks.Series([1, 2, 3])
         >>> s.describe()
-        count      3.0
-        mean       2.0
-        std        1.0
-        min        1.0
-        25%        1.0
-        50%        2.0
-        75%        3.0
-        max        3.0
+        count    3.0
+        mean     2.0
+        std      1.0
+        min      1.0
+        25%      1.0
+        50%      2.0
+        75%      3.0
+        max      3.0
         Name: 0, dtype: float64
 
         Describing a ``DataFrame``. Only numeric fields are returned.
@@ -2601,15 +2601,15 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         ...                   },
         ...                   columns=['numeric1', 'numeric2', 'object'])
         >>> df.describe()
-                numeric1  numeric2
-        count        3.0       3.0
-        mean         2.0       5.0
-        std          1.0       1.0
-        min          1.0       4.0
-        25%          1.0       4.0
-        50%          2.0       5.0
-        75%          3.0       6.0
-        max          3.0       6.0
+               numeric1  numeric2
+        count       3.0       3.0
+        mean        2.0       5.0
+        std         1.0       1.0
+        min         1.0       4.0
+        25%         1.0       4.0
+        50%         2.0       5.0
+        75%         3.0       6.0
+        max         3.0       6.0
 
         Describing a ``DataFrame`` and selecting custom percentiles.
 
@@ -2618,42 +2618,42 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         ...                   },
         ...                   columns=['numeric1', 'numeric2'])
         >>> df.describe(percentiles = [0.85, 0.15])
-                numeric1  numeric2
-        count        3.0       3.0
-        mean         2.0       5.0
-        std          1.0       1.0
-        min          1.0       4.0
-        15%          1.0       4.0
-        50%          2.0       5.0
-        85%          3.0       6.0
-        max          3.0       6.0
+               numeric1  numeric2
+        count       3.0       3.0
+        mean        2.0       5.0
+        std         1.0       1.0
+        min         1.0       4.0
+        15%         1.0       4.0
+        50%         2.0       5.0
+        85%         3.0       6.0
+        max         3.0       6.0
 
         Describing a column from a ``DataFrame`` by accessing it as
         an attribute.
 
         >>> df.numeric1.describe()
-        count     3.0
-        mean      2.0
-        std       1.0
-        min       1.0
-        25%       1.0
-        50%       2.0
-        75%       3.0
-        max       3.0
+        count    3.0
+        mean     2.0
+        std      1.0
+        min      1.0
+        25%      1.0
+        50%      2.0
+        75%      3.0
+        max      3.0
         Name: numeric1, dtype: float64
 
         Describing a column from a ``DataFrame`` by accessing it as
         an attribute and selecting custom percentiles.
 
         >>> df.numeric1.describe(percentiles = [0.85, 0.15])
-        count     3.0
-        mean      2.0
-        std       1.0
-        min       1.0
-        15%       1.0
-        50%       2.0
-        85%       3.0
-        max       3.0
+        count    3.0
+        mean     2.0
+        std      1.0
+        min      1.0
+        15%      1.0
+        50%      2.0
+        85%      3.0
+        max      3.0
         Name: numeric1, dtype: float64
         """
         exprs = []

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -2573,7 +2573,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         Notes
         -----
         For numeric data, the result's index will include ``count``,
-        ``mean``, ``stddev``, ``min``, ``25%``, ``50%``, ``75%``, ``max``.
+        ``mean``, ``std``, ``min``, ``25%``, ``50%``, ``75%``, ``max``.
 
         Currently only numeric data is supported.
 
@@ -2585,7 +2585,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         >>> s.describe()
         count     3.0
         mean      2.0
-        stddev    1.0
+        std       1.0
         min       1.0
         25%       1.0
         50%       2.0
@@ -2604,7 +2604,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 numeric1  numeric2
         count        3.0       3.0
         mean         2.0       5.0
-        stddev       1.0       1.0
+        std          1.0       1.0
         min          1.0       4.0
         25%          1.0       4.0
         50%          2.0       5.0
@@ -2621,7 +2621,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 numeric1  numeric2
         count        3.0       3.0
         mean         2.0       5.0
-        stddev       1.0       1.0
+        std          1.0       1.0
         min          1.0       4.0
         15%          1.0       4.0
         50%          2.0       5.0
@@ -2634,7 +2634,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         >>> df.numeric1.describe()
         count     3.0
         mean      2.0
-        stddev    1.0
+        std       1.0
         min       1.0
         25%       1.0
         50%       2.0
@@ -2648,7 +2648,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         >>> df.numeric1.describe(percentiles = [0.85, 0.15])
         count     3.0
         mean      2.0
-        stddev    1.0
+        std      1.0
         min       1.0
         15%       1.0
         50%       2.0

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -2541,7 +2541,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         return DataFrame(sdf, self._metadata.copy())
 
     # TODO: percentiles, include, and exclude should be implemented.
-    def describe(self, percentiles=[0.25, 0.5, 0.75]) -> 'DataFrame':
+    def describe(self, percentiles=None) -> 'DataFrame':
         """
         Generate descriptive statistics that summarize the central tendency,
         dispersion and shape of a dataset's distribution, excluding
@@ -2660,7 +2660,13 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         if any((p <= 0.0) or (p >= 1.0) for p in percentiles):
             raise ValueError("Percentiles not in range (0.0, 1.0)")
 
-        formatted_perc = ["{:.0%}".format(p) for p in percentiles]
+        if percentiles:
+            # appending 50% if not in percentiles already
+            perc_list = (percentiles + [0.5]) if 0.5 not in percentiles else percentiles
+        else:
+            perc_list = [0.25, 0.5, 0.75]
+
+        formatted_perc = ["{:.0%}".format(p) for p in sorted(perc_list)]
         stats = ["count", "mean", "stddev", "min", *formatted_perc, "max"]
 
         sdf = self._sdf.select(*exprs).summary(stats)

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -2618,13 +2618,14 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         ...                    'numeric2': [4.0, 5.0, 6.0]
         ...                   },
         ...                   columns=['numeric1', 'numeric2'])
-        >>> df.describe(percentiles = [0.15, 0.85])
+        >>> df.describe(percentiles = [0.85, 0.15])
                 numeric1  numeric2
         count        3.0       3.0
         mean         2.0       5.0
         stddev       1.0       1.0
         min          1.0       4.0
         15%          1.0       4.0
+        50%          2.0       5.0
         85%          3.0       6.0
         max          3.0       6.0
 
@@ -2639,6 +2640,20 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         25%       1.0
         50%       2.0
         75%       3.0
+        max       3.0
+        Name: numeric1, dtype: float64
+
+        Describing a column from a ``DataFrame`` by accessing it as
+        an attribute and selecting custom percentiles.
+
+        >>> df.numeric1.describe(percentiles = [0.85, 0.15])
+        count     3.0
+        mean      2.0
+        stddev    1.0
+        min       1.0
+        15%       1.0
+        50%       2.0
+        85%       3.0
         max       3.0
         Name: numeric1, dtype: float64
         """
@@ -2657,10 +2672,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         if len(exprs) == 0:
             raise ValueError("Cannot describe a DataFrame without columns")
 
-        if any((p <= 0.0) or (p >= 1.0) for p in percentiles):
-            raise ValueError("Percentiles not in range (0.0, 1.0)")
-
         if percentiles:
+            if any((p <= 0.0) or (p >= 1.0) for p in percentiles):
+                raise ValueError("Percentiles not in range (0.0, 1.0)")
             # appending 50% if not in percentiles already
             perc_list = (percentiles + [0.5]) if 0.5 not in percentiles else percentiles
         else:

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -2552,6 +2552,11 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         will vary depending on what is provided. Refer to the notes
         below for more detail.
 
+        Parameters
+        ----------
+        percentiles : a list of percentiles to be computed for the summary.
+            Use an empty list if no percentiles should be computed. 
+
         Returns
         -------
         Series or DataFrame
@@ -2568,7 +2573,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         Notes
         -----
         For numeric data, the result's index will include ``count``,
-        ``mean``, ``stddev``, ``min``, ``max``.
+        ``mean``, ``stddev``, ``min``,``25%``,``50%``,``75%``, ``max``.
 
         Currently only numeric data is supported.
 
@@ -2582,6 +2587,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         mean      2.0
         stddev    1.0
         min       1.0
+        25%       1.0
+        50%       2.0
+        75%       3.0
         max       3.0
         Name: 0, dtype: float64
 
@@ -2598,6 +2606,25 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         mean         2.0       5.0
         stddev       1.0       1.0
         min          1.0       4.0
+        25%          1.0       4.0
+        50%          2.0       5.0
+        75%          3.0       6.0
+        max          3.0       6.0
+
+        Describing a ``DataFrame`` and selecting custom percentiles.
+
+        >>> df = ks.DataFrame({'numeric1': [1, 2, 3],
+        ...                    'numeric2': [4.0, 5.0, 6.0]
+        ...                   },
+        ...                   columns=['numeric1', 'numeric2', 'object'])
+        >>> df.describe(percentiles = [0.15, 0.85])
+                numeric1  numeric2
+        count        3.0       3.0
+        mean         2.0       5.0
+        stddev       1.0       1.0
+        min          1.0       4.0
+        15%          1.0       4.0
+        85%          3.0       6.0
         max          3.0       6.0
 
         Describing a column from a ``DataFrame`` by accessing it as
@@ -2608,6 +2635,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         mean      2.0
         stddev    1.0
         min       1.0
+        25%       1.0
+        50%       2.0
+        75%       3.0
         max       3.0
         Name: numeric1, dtype: float64
         """
@@ -2627,10 +2657,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             raise ValueError("Cannot describe a DataFrame without columns")
 
         formatted_perc =  ["{:.0%}".format(p) for p in percentiles]
-        stats = ["count", "mean", "stddev", "min",*formatted_perc, "max"]
+        stats = ["count", "mean", "stddev", "min", *formatted_perc, "max"]
 
         sdf = self._sdf.select(*exprs).summary(stats)
-        
+
         return DataFrame(sdf, index=Metadata(data_columns=data_columns,
                                              index_map=[('summary', None)])).astype('float64')
 

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -2684,7 +2684,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         sdf = self._sdf.select(*exprs).summary(stats)
 
-        return DataFrame(sdf.replace("stddev", "std", subset='summary'), 
+        return DataFrame(sdf.replace("stddev", "std", subset='summary'),
                          index=Metadata(data_columns=data_columns,
                          index_map=[('summary', None)])).astype('float64')
 

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -2583,14 +2583,14 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         >>> s = ks.Series([1, 2, 3])
         >>> s.describe()
-        count     3.0
-        mean      2.0
-        std       1.0
-        min       1.0
-        25%       1.0
-        50%       2.0
-        75%       3.0
-        max       3.0
+        count      3.0
+        mean       2.0
+        std        1.0
+        min        1.0
+        25%        1.0
+        50%        2.0
+        75%        3.0
+        max        3.0
         Name: 0, dtype: float64
 
         Describing a ``DataFrame``. Only numeric fields are returned.
@@ -2648,7 +2648,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         >>> df.numeric1.describe(percentiles = [0.85, 0.15])
         count     3.0
         mean      2.0
-        std      1.0
+        std       1.0
         min       1.0
         15%       1.0
         50%       2.0

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -2684,7 +2684,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         sdf = self._sdf.select(*exprs).summary(stats)
 
-        return DataFrame(sdf.replace("stddev", "std"), index=Metadata(data_columns=data_columns,
+        return DataFrame(sdf.replace("stddev", "std", subset='summary'), index=Metadata(data_columns=data_columns,
                          index_map=[('summary', None)])).astype('float64')
 
     def _pd_getitem(self, key):

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -2554,9 +2554,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Parameters
         ----------
-        percentiles : list of ``float`` in range (0.0, 1.0), default [0.25, 0.5, 0.75]
+        percentiles : list of ``float`` in range [0.0, 1.0], default None
             A list of percentiles to be computed.
-            Use an empty list if no percentiles should be computed.
 
         Returns
         -------
@@ -2672,15 +2671,15 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         if len(exprs) == 0:
             raise ValueError("Cannot describe a DataFrame without columns")
 
-        if percentiles:
-            if any((p <= 0.0) or (p >= 1.0) for p in percentiles):
-                raise ValueError("Percentiles not in range (0.0, 1.0)")
+        if percentiles is not None:
+            if any((p < 0.0) or (p > 1.0) for p in percentiles):
+                raise ValueError("Percentiles should all be in the interval [0, 1]")
             # appending 50% if not in percentiles already
-            perc_list = (percentiles + [0.5]) if 0.5 not in percentiles else percentiles
+            percentiles = (percentiles + [0.5]) if 0.5 not in percentiles else percentiles
         else:
-            perc_list = [0.25, 0.5, 0.75]
+            percentiles = [0.25, 0.5, 0.75]
 
-        formatted_perc = ["{:.0%}".format(p) for p in sorted(perc_list)]
+        formatted_perc = ["{:.0%}".format(p) for p in sorted(percentiles)]
         stats = ["count", "mean", "stddev", "min", *formatted_perc, "max"]
 
         sdf = self._sdf.select(*exprs).summary(stats)

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -2684,7 +2684,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         sdf = self._sdf.select(*exprs).summary(stats)
 
-        return DataFrame(sdf.replace("stddev", "std", subset='summary'), index=Metadata(data_columns=data_columns,
+        return DataFrame(sdf.replace("stddev", "std", subset='summary'), 
+                         index=Metadata(data_columns=data_columns,
                          index_map=[('summary', None)])).astype('float64')
 
     def _pd_getitem(self, key):

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -2554,7 +2554,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Parameters
         ----------
-        percentiles : a list of percentiles to be computed for the summary.
+        percentiles : list of ``float`` in range (0.0, 1.0), default [0.25, 0.5, 0.75]
+            A list of percentiles to be computed. 
             Use an empty list if no percentiles should be computed. 
 
         Returns
@@ -2573,7 +2574,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         Notes
         -----
         For numeric data, the result's index will include ``count``,
-        ``mean``, ``stddev``, ``min``,``25%``,``50%``,``75%``, ``max``.
+        ``mean``, ``stddev``, ``min``, ``25%``, ``50%``, ``75%``, ``max``.
 
         Currently only numeric data is supported.
 

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -2541,7 +2541,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         return DataFrame(sdf, self._metadata.copy())
 
     # TODO: percentiles, include, and exclude should be implemented.
-    def describe(self) -> 'DataFrame':
+    def describe(self, percentiles=[0.25, 0.5, 0.75]) -> 'DataFrame':
         """
         Generate descriptive statistics that summarize the central tendency,
         dispersion and shape of a dataset's distribution, excluding
@@ -2626,7 +2626,11 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         if len(exprs) == 0:
             raise ValueError("Cannot describe a DataFrame without columns")
 
-        sdf = self._sdf.select(*exprs).describe()
+        formatted_perc =  ["{:.0%}".format(p) for p in percentiles]
+        stats = ["count", "mean", "stddev", "min",*formatted_perc, "max"]
+
+        sdf = self._sdf.select(*exprs).summary(stats)
+        
         return DataFrame(sdf, index=Metadata(data_columns=data_columns,
                                              index_map=[('summary', None)])).astype('float64')
 

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -2617,7 +2617,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         >>> df = ks.DataFrame({'numeric1': [1, 2, 3],
         ...                    'numeric2': [4.0, 5.0, 6.0]
         ...                   },
-        ...                   columns=['numeric1', 'numeric2', 'object'])
+        ...                   columns=['numeric1', 'numeric2'])
         >>> df.describe(percentiles = [0.15, 0.85])
                 numeric1  numeric2
         count        3.0       3.0
@@ -2656,6 +2656,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         if len(exprs) == 0:
             raise ValueError("Cannot describe a DataFrame without columns")
+
+        if any((p <= 0.0)|(p >= 1.0) for p in percentiles):
+            raise ValueError("Percentiles not in range (0.0, 1.0)")
 
         formatted_perc = ["{:.0%}".format(p) for p in percentiles]
         stats = ["count", "mean", "stddev", "min", *formatted_perc, "max"]

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -2657,7 +2657,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         if len(exprs) == 0:
             raise ValueError("Cannot describe a DataFrame without columns")
 
-        if any((p <= 0.0)|(p >= 1.0) for p in percentiles):
+        if any((p <= 0.0) | (p >= 1.0) for p in percentiles):
             raise ValueError("Percentiles not in range (0.0, 1.0)")
 
         formatted_perc = ["{:.0%}".format(p) for p in percentiles]

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -2657,7 +2657,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         if len(exprs) == 0:
             raise ValueError("Cannot describe a DataFrame without columns")
 
-        if any((p <= 0.0) | (p >= 1.0) for p in percentiles):
+        if any((p <= 0.0) or (p >= 1.0) for p in percentiles):
             raise ValueError("Percentiles not in range (0.0, 1.0)")
 
         formatted_perc = ["{:.0%}".format(p) for p in percentiles]

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -2540,8 +2540,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             self._metadata.index_columns + list(map(lambda ser: ser._scol, results)))
         return DataFrame(sdf, self._metadata.copy())
 
-    # TODO: percentiles, include, and exclude should be implemented.
-    def describe(self, percentiles=None) -> 'DataFrame':
+    # TODO: include, and exclude should be implemented.
+    def describe(self, percentiles: Optional[List[float]] = None) -> 'DataFrame':
         """
         Generate descriptive statistics that summarize the central tendency,
         dispersion and shape of a dataset's distribution, excluding
@@ -2554,7 +2554,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Parameters
         ----------
-        percentiles : list of ``float`` in range [0.0, 1.0], default None
+        percentiles : list of ``float`` in range [0.0, 1.0], default [0.25, 0.5, 0.75]
             A list of percentiles to be computed.
 
         Returns
@@ -2684,7 +2684,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         sdf = self._sdf.select(*exprs).summary(stats)
 
-        return DataFrame(sdf, index=Metadata(data_columns=data_columns,
+        return DataFrame(sdf.replace("stddev","std"), index=Metadata(data_columns=data_columns,
                                              index_map=[('summary', None)])).astype('float64')
 
     def _pd_getitem(self, key):

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -2684,8 +2684,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         sdf = self._sdf.select(*exprs).summary(stats)
 
-        return DataFrame(sdf.replace("stddev","std"), index=Metadata(data_columns=data_columns,
-                                             index_map=[('summary', None)])).astype('float64')
+        return DataFrame(sdf.replace("stddev", "std"), index=Metadata(data_columns=data_columns,
+                         index_map=[('summary', None)])).astype('float64')
 
     def _pd_getitem(self, key):
         from databricks.koalas.series import Series

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -1117,7 +1117,7 @@ class Series(_Frame, IndexOpsMixin):
         wrapped = ks.pandas_wraps(return_col=return_sig)(apply_each)
         return wrapped(self, *args, **kwds)
 
-    def describe(self, percentiles=None) -> 'Series':
+    def describe(self, percentiles: Optional[List[float]] = None) -> 'Series':
         return _col(self.to_dataframe().describe(percentiles))
 
     describe.__doc__ = DataFrame.describe.__doc__

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -20,7 +20,7 @@ A wrapper class for Spark Column to behave similar to pandas Series.
 import re
 import inspect
 from functools import partial, wraps
-from typing import Any, Optional, Union
+from typing import Any, Optional, List, Union
 
 import numpy as np
 import pandas as pd

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -1117,8 +1117,8 @@ class Series(_Frame, IndexOpsMixin):
         wrapped = ks.pandas_wraps(return_col=return_sig)(apply_each)
         return wrapped(self, *args, **kwds)
 
-    def describe(self) -> 'Series':
-        return _col(self.to_dataframe().describe())
+    def describe(self, percentiles=None) -> 'Series':
+        return _col(self.to_dataframe().describe(percentiles))
 
     describe.__doc__ = DataFrame.describe.__doc__
 


### PR DESCRIPTION
This PR adds to the existing `Dataframe.describe` method the `percentiles` optional parameter.