### PR TITLE
Improve merge function.

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -2449,7 +2449,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         left_index_columns = set(left._metadata.index_columns)
         right_index_columns = set(right._metadata.index_columns)
 
-        # TODO: in some case, we can remain indexes.
+        # TODO: in some case, we can keep indexes.
         exprs = []
         for col in left_table.columns:
             if col in left_index_columns:

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -24,7 +24,7 @@ from typing import Any, Optional, List, Tuple, Union
 
 import numpy as np
 import pandas as pd
-from pandas.api.types import is_bool, is_datetime64_dtype, is_datetime64tz_dtype, is_list_like, \
+from pandas.api.types import is_datetime64_dtype, is_datetime64tz_dtype, is_list_like, \
     is_dict_like
 from pyspark import sql as spark
 from pyspark.sql import functions as F, Column


### PR DESCRIPTION
This PR improves `merge` function:

- add `left_on` and `right_on`
- fix index management

but still have some TODOs:

- in some case, indexes can be retained
- when `left_index=True` and `right_index=True` for multi-index, the behavior is not the same as pandas'

I'd leave them to the future work.

Resolves #354.