### PR TITLE
Implement .at property for Koalas DataFrames and Series

### DIFF
--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -27,7 +27,7 @@ from pyspark.sql import functions as F
 from pyspark.sql.types import DataType, DoubleType, FloatType
 
 from databricks import koalas as ks  # For running doctests and reference resolution in PyCharm.
-from databricks.koalas.indexing import ILocIndexer, LocIndexer
+from databricks.koalas.indexing import AtIndexer, ILocIndexer, LocIndexer
 from databricks.koalas.utils import validate_arguments_and_invoke_function
 
 max_display_count = 1000
@@ -786,6 +786,12 @@ class _Frame(object):
             return SeriesGroupBy(col, col_by)
         raise TypeError('Constructor expects DataFrame or Series; however, '
                         'got [%s]' % (df_or_s,))
+
+    @property
+    def at(self):
+        return AtIndexer(self)
+
+    at.__doc__ = AtIndexer.__doc__
 
     @property
     def iloc(self):

--- a/databricks/koalas/indexing.py
+++ b/databricks/koalas/indexing.py
@@ -132,6 +132,10 @@ class AtIndexer(object):
         if self._ks is not None and len(key) != 1:
             raise TypeError("Use Series.at like .at[row_index]")
 
+        # TODO Maybe extend to multilevel indices in the future
+        if len(self._kdf._metadata.index_columns) != 1:
+            raise ValueError("'.at' only supports indices with level 1 right now")
+
         column = key[1] if len(key) > 1 else self._ks.name
         if column is not None and column not in self._kdf._metadata.data_columns:
             raise KeyError("'%s" % column)

--- a/databricks/koalas/indexing.py
+++ b/databricks/koalas/indexing.py
@@ -88,7 +88,10 @@ class AtIndexer(object):
     Similar to ``loc``, in that both provide label-based lookups. Use ``at`` if you only need to
     get a single value in a DataFrame or Series.
 
-    Unlike pandas, Koalas only allows using ``at`` to get values but not to set them.
+    .. note:: Unlike pandas, Koalas only allows using ``at`` to get values but not to set them.
+
+    .. note:: Warning: If ``row_index`` matches a lot of rows, large amounts of data will be
+        fetched, potentially causing your machine to run out of memory.
 
     Raises
     ------

--- a/databricks/koalas/indexing.py
+++ b/databricks/koalas/indexing.py
@@ -116,7 +116,7 @@ class AtIndexer(object):
 
     Get array if an index occurs multiple times
 
-    >>> kdf.to_pandas().at[5, 'B']
+    >>> kdf.at[5, 'B']
     array([ 4, 20])
     """
     def __init__(self, df_or_s):

--- a/databricks/koalas/indexing.py
+++ b/databricks/koalas/indexing.py
@@ -130,19 +130,19 @@ class AtIndexer(object):
     def __getitem__(self, key):
         if self._ks is None and (not isinstance(key, tuple) or len(key) != 2):
             raise TypeError("Use DataFrame.at like .at[row_index, column_name]")
-        if self._ks is not None and len(key) != 1:
+        if self._ks is not None and not isinstance(key, str) and len(key) != 1:
             raise TypeError("Use Series.at like .at[row_index]")
 
         # TODO Maybe extend to multilevel indices in the future
         if len(self._kdf._metadata.index_columns) != 1:
             raise ValueError("'.at' only supports indices with level 1 right now")
 
-        column = key[1] if len(key) > 1 else self._ks.name
+        column = key[1] if self._ks is None else self._ks.name
         if column is not None and column not in self._kdf._metadata.data_columns:
             raise KeyError("%s" % column)
         series = self._ks if self._ks is not None else self._kdf[column]
 
-        row = key[0]
+        row = key[0] if self._ks is None else key
         pdf = (series._kdf._sdf
                .where(F.col(self._kdf._metadata.index_columns[0]) == row)
                .select(column)

--- a/databricks/koalas/indexing.py
+++ b/databricks/koalas/indexing.py
@@ -127,7 +127,7 @@ class AtIndexer(object):
     def __getitem__(self, key):
         from databricks.koalas.frame import DataFrame
 
-        if self._ks is None and len(key) != 2:
+        if self._ks is None and (not isinstance(key, tuple) or len(key) != 2):
             raise TypeError("Use DataFrame.at like .at[row_index, column_name]")
         if self._ks is not None and len(key) != 1:
             raise TypeError("Use Series.at like .at[row_index]")

--- a/databricks/koalas/indexing.py
+++ b/databricks/koalas/indexing.py
@@ -128,8 +128,6 @@ class AtIndexer(object):
             self._ks = df_or_s
 
     def __getitem__(self, key):
-        from databricks.koalas.frame import DataFrame
-
         if self._ks is None and (not isinstance(key, tuple) or len(key) != 2):
             raise TypeError("Use DataFrame.at like .at[row_index, column_name]")
         if self._ks is not None and len(key) != 1:

--- a/databricks/koalas/indexing.py
+++ b/databricks/koalas/indexing.py
@@ -138,7 +138,7 @@ class AtIndexer(object):
 
         column = key[1] if len(key) > 1 else self._ks.name
         if column is not None and column not in self._kdf._metadata.data_columns:
-            raise KeyError("'%s" % column)
+            raise KeyError("%s" % column)
         series = self._ks if self._ks is not None else self._kdf[column]
 
         row = key[0]
@@ -147,7 +147,7 @@ class AtIndexer(object):
                .select(column)
                .toPandas())
         if len(pdf) < 1:
-            raise KeyError("'%s" % row)
+            raise KeyError("%s" % row)
 
         values = pdf.iloc[:, 0].values
         return values[0] if len(values) == 1 else values

--- a/databricks/koalas/indexing.py
+++ b/databricks/koalas/indexing.py
@@ -142,13 +142,14 @@ class AtIndexer(object):
         series = self._ks if self._ks is not None else self._kdf[column]
 
         row = key[0]
-        sdf = (series._kdf._sdf
+        pdf = (series._kdf._sdf
                .where(F.col(self._kdf._metadata.index_columns[0]) == row)
-               .select(column))
-        if sdf.count() < 1:
+               .select(column)
+               .toPandas())
+        if len(pdf) < 1:
             raise KeyError("'%s" % row)
 
-        values = DataFrame(sdf).to_pandas().iloc[:, 0].values
+        values = pdf.iloc[:, 0].values
         return values[0] if len(values) == 1 else values
 
 

--- a/databricks/koalas/indexing.py
+++ b/databricks/koalas/indexing.py
@@ -130,7 +130,7 @@ class AtIndexer(object):
         if self._ks is None and len(key) != 2:
             raise TypeError("Use DataFrame.at like .at[row_index, column_name]")
         if self._ks is not None and len(key) != 1:
-            raise TypeError("Use Series.at like .at[column_name]")
+            raise TypeError("Use Series.at like .at[row_index]")
 
         column = key[1] if len(key) > 1 else self._ks.name
         if column is not None and column not in self._kdf._metadata.data_columns:

--- a/databricks/koalas/indexing.py
+++ b/databricks/koalas/indexing.py
@@ -144,7 +144,8 @@ class AtIndexer(object):
         if sdf.count() < 1:
             raise KeyError("'%s" % row)
 
-        return DataFrame(sdf).to_pandas().iloc[:, 0].values
+        values = DataFrame(sdf).to_pandas().iloc[:, 0].values
+        return values[0] if len(values) == 1 else values
 
 
 class LocIndexer(object):

--- a/databricks/koalas/indexing.py
+++ b/databricks/koalas/indexing.py
@@ -101,17 +101,22 @@ class AtIndexer(object):
     Examples
     --------
     >>> kdf = ks.DataFrame([[0, 2, 3], [0, 4, 1], [10, 20, 30]],
-    ...                    index=[4, 5, 6], columns=['A', 'B', 'C'])
+    ...                    index=[4, 5, 5], columns=['A', 'B', 'C'])
     >>> kdf
         A   B   C
     4   0   2   3
     5   0   4   1
-    6  10  20  30
+    5  10  20  30
 
     Get value at specified row/column pair
 
     >>> kdf.at[4, 'B']
     2
+
+    Get array if an index occurs multiple times
+
+    >>> kdf.to_pandas().at[5, 'B']
+    array([ 4, 20])
     """
     def __init__(self, df_or_s):
         from databricks.koalas.frame import DataFrame

--- a/databricks/koalas/indexing.py
+++ b/databricks/koalas/indexing.py
@@ -85,6 +85,7 @@ def _unfold(key, kseries):
 class AtIndexer(object):
     """
     Access a single value for a row/column label pair.
+    If the index is not unique, all matching pairs are returned as an array.
     Similar to ``loc``, in that both provide label-based lookups. Use ``at`` if you only need to
     get a single value in a DataFrame or Series.
 

--- a/databricks/koalas/missing/frame.py
+++ b/databricks/koalas/missing/frame.py
@@ -31,7 +31,6 @@ class _MissingPandasLikeDataFrame(object):
 
     # Properties
     T = unsupported_property('T')
-    at = unsupported_property('at')
     axes = unsupported_property('axes')
     empty = unsupported_property('empty')
     ftypes = unsupported_property('ftypes')

--- a/databricks/koalas/missing/series.py
+++ b/databricks/koalas/missing/series.py
@@ -35,7 +35,6 @@ class _MissingPandasLikeSeries(object):
     argmin = unsupported_function('argmin')
     array = unsupported_property('array')
     asobject = unsupported_property('asobject')
-    at = unsupported_property('at')
     axes = unsupported_property('axes')
     base = unsupported_property('base')
     data = unsupported_property('data')

--- a/databricks/koalas/tests/test_indexing.py
+++ b/databricks/koalas/tests/test_indexing.py
@@ -146,8 +146,8 @@ class IndexingTest(ReusedSQLTestCase):
         np.testing.assert_array_equal(kdf.at[9, 'b'], pdf.at[9, 'b'])
 
         # Assert .at for Series
-        self.assert_eq(test_series.at['b'], 6)
-        self.assert_eq(test_series.at['b'], pdf.loc[3].at['b'])
+        self.assertEqual(test_series.at['b'], 6)
+        self.assertEqual(test_series.at['b'], pdf.loc[3].at['b'])
 
         # Assert invalid column or index names result in a KeyError like with pandas
         with self.assertRaises(KeyError, msg='x'):

--- a/databricks/koalas/tests/test_indexing.py
+++ b/databricks/koalas/tests/test_indexing.py
@@ -151,7 +151,7 @@ class IndexingTest(ReusedSQLTestCase):
         self.assertEqual(test_series.at['b'], 6)
         self.assertEqual(test_series.at['b'], pdf.loc[3].at['b'])
 
-        #
+        # Assert multi-character indices
         self.assertEqual(ks.Series([0, 1], index=['ab', 'cd']).at['ab'],
                          pd.Series([0, 1], index=['ab', 'cd']).at['ab'])
 

--- a/databricks/koalas/tests/test_indexing.py
+++ b/databricks/koalas/tests/test_indexing.py
@@ -136,6 +136,8 @@ class IndexingTest(ReusedSQLTestCase):
         # Assert invalided signatures raise TypeError
         with self.assertRaises(TypeError, msg="Use DataFrame.at like .at[row_index, column_name]"):
             kdf.at[3]
+        with self.assertRaises(TypeError, msg="Use DataFrame.at like .at[row_index, column_name]"):
+            kdf.at['ab']  # 'ab' is of length 2 but str type instead of tuple
         with self.assertRaises(TypeError, msg="Use Series.at like .at[column_name]"):
             test_series.at[3, 'b']
 

--- a/databricks/koalas/tests/test_indexing.py
+++ b/databricks/koalas/tests/test_indexing.py
@@ -151,6 +151,10 @@ class IndexingTest(ReusedSQLTestCase):
         self.assertEqual(test_series.at['b'], 6)
         self.assertEqual(test_series.at['b'], pdf.loc[3].at['b'])
 
+        #
+        self.assertEqual(ks.Series([0, 1], index=['ab', 'cd']).at['ab'],
+                         pd.Series([0, 1], index=['ab', 'cd']).at['ab'])
+
         # Assert invalid column or index names result in a KeyError like with pandas
         with self.assertRaises(KeyError, msg='x'):
             kdf.at[3, 'x']

--- a/docs/source/reference/frame.rst
+++ b/docs/source/reference/frame.rst
@@ -45,6 +45,7 @@ Indexing, iteration
 .. autosummary::
    :toctree: api/
 
+   DataFrame.at
    DataFrame.head
    DataFrame.loc
    DataFrame.iloc

--- a/docs/source/reference/series.rst
+++ b/docs/source/reference/series.rst
@@ -42,6 +42,7 @@ Indexing, iteration
 .. autosummary::
    :toctree: api/
 
+   Series.at
    Series.loc
    Series.iloc
 


### PR DESCRIPTION
As requested in #382, this PR implements pandas' `.at` property for Koalas DataFrames and Series.