### PR TITLE
Run mypy before sphinx test

### DIFF
--- a/dev/lint-python
+++ b/dev/lint-python
@@ -211,6 +211,32 @@ Skipping pydocstyle checks for now."
     fi
 }
 
+function mypy_test {
+    local MYPY_REPORT=
+    local MYPY_STATUS=
+
+    # Check that the documentation builds acceptably, skip check if sphinx is not installed.
+    if ! hash "$MYPY_BUILD" 2> /dev/null; then
+        echo "The $MYPY_BUILD command was not found. Skipping mypy checks for now."
+        echo
+        return
+    fi
+
+    echo "starting mypy test..."
+    MYPY_REPORT=$( ($MYPY_BUILD --package databricks.koalas --show-error-context --ignore-missing-imports) 2>&1)
+    MYPY_STATUS=$?
+
+    if [ "$MYPY_STATUS" -ne 0 ]; then
+        echo "mypy checks failed:"
+        echo "$MYPY_REPORT"
+        echo "$MYPY_STATUS"
+        exit "$MYPY_STATUS"
+    else
+        echo "mypy checks passed."
+        echo
+    fi
+}
+
 function sphinx_test {
     local SPHINX_REPORT=
     local SPHINX_STATUS=
@@ -248,32 +274,6 @@ function sphinx_test {
     popd &> /dev/null
 }
 
-function mypy_test {
-    local MYPY_REPORT=
-    local MYPY_STATUS=
-
-    # Check that the documentation builds acceptably, skip check if sphinx is not installed.
-    if ! hash "$MYPY_BUILD" 2> /dev/null; then
-        echo "The $MYPY_BUILD command was not found. Skipping mypy checks for now."
-        echo
-        return
-    fi
-
-    echo "starting mypy test..."
-    MYPY_REPORT=$( ($MYPY_BUILD --package databricks.koalas --show-error-context --ignore-missing-imports) 2>&1)
-    MYPY_STATUS=$?
-
-    if [ "$MYPY_STATUS" -ne 0 ]; then
-        echo "mypy checks failed:"
-        echo "$MYPY_REPORT"
-        echo "$MYPY_STATUS"
-        exit "$MYPY_STATUS"
-    else
-        echo "mypy checks passed."
-        echo
-    fi
-}
-
 SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
 SPARK_ROOT_DIR="$(dirname "${SCRIPT_DIR}")"
 
@@ -285,8 +285,8 @@ compile_python_test "$PYTHON_SOURCE"
 pycodestyle_test "$PYTHON_SOURCE"
 flake8_test
 pydocstyle_test
-sphinx_test
 mypy_test
+sphinx_test
 
 echo
 echo "all lint-python tests passed!"


### PR DESCRIPTION
This PR simply modifies the *lint-python* script to run mypy before sphinx. My rationale behind this is that the mypy check fails much more often than sphinx, while the latter takes comparably long to run. Running mypy first thus leads to faster feedback and therefore increased development speed.