### PR TITLE
DataFrame.pivot_table

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -2475,7 +2475,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         indexes) on the index and columns of the result DataFrame.
 
         Parameters
-        ----------%s
+        ----------
         values : column to aggregate.
             They should be either a list of one column or a string. A list of columns
             is not supported yet.
@@ -2524,8 +2524,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         This first example aggregates values by taking the sum.
 
         >>> table = df.pivot_table(values='D', index=['A', 'B'],
-        ...                     columns='C', aggfunc='sum')
-        >>> table # doctest: +SKIP
+        ...                         columns='C', aggfunc='sum')
+        >>> table  # doctest: +NORMALIZE_WHITESPACE
                  large  small
         A   B
         foo one    4.0      1
@@ -2536,8 +2536,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         We can also fill missing values using the `fill_value` parameter.
 
         >>> table = df.pivot_table(values='D', index=['A', 'B'],
-        ...                     columns='C', aggfunc='sum', fill_value=0)
-        >>> table # doctest: +SKIP
+        ...                         columns='C', aggfunc='sum', fill_value=0)
+        >>> table  # doctest: +NORMALIZE_WHITESPACE
                  large  small
         A   B
         foo one      4      1
@@ -2549,8 +2549,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         value column.
 
         >>> table = df.pivot_table(values = ['D'], index =['C'],
-        ...                     columns="A", aggfunc={'D':'mean'})
-        >>> table # doctest: +SKIP
+        ...                         columns="A", aggfunc={'D':'mean'})
+        >>> table  # doctest: +NORMALIZE_WHITESPACE
                bar       foo
         C
         small  5.5  2.333333

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -39,6 +39,7 @@ from databricks.koalas.internal import _InternalFrame
 from databricks.koalas.missing.frame import _MissingPandasLikeDataFrame
 from databricks.koalas.ml import corr
 
+
 # These regular expression patterns are complied and defined here to avoid to compile the same
 # pattern every time it is used in _repr_ and _repr_html_ in DataFrame.
 # Two patterns basically seek the footer string from Pandas'
@@ -224,6 +225,7 @@ class DataFrame(_Frame):
     3  8  7  9  1  0
     4  2  5  4  3  9
     """
+
     def __init__(self, data=None, index=None, columns=None, dtype=None, copy=False):
         if isinstance(data, _InternalFrame):
             assert index is None
@@ -2558,7 +2560,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         if not isinstance(columns, str):
             raise ValueError("columns should be string.")
 
-        if not isinstance(values, str) and not isinstance(values, list) :
+        if not isinstance(values, str) and not isinstance(values, list):
             raise ValueError('values should be string or list of one column.')
 
         if not isinstance(aggfunc, str) and (not isinstance(aggfunc, dict) or not all(
@@ -2570,7 +2572,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             raise NotImplementedError("pivot_table doesn't support aggfuct"
                                       " as dict and without index.")
 
-        if isinstance(values,list) and len(values) > 1:
+        if isinstance(values, list) and len(values) > 1:
             raise NotImplementedError('Values as list of columns is not implemented yet.')
 
         if isinstance(aggfunc, str):
@@ -3448,7 +3450,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 ).withColumnRenamed(
                     'left_table.%s' % left_index_col, left_index_col
                 ).drop(F.col('left_table.%s' % left_index_col))
-        if not(left_index and not right_index):
+        if not (left_index and not right_index):
             selected_columns = selected_columns.drop(*[F.col('right_table.%s' % right_index_col)
                                                        for right_index_col in right_index_columns
                                                        if right_index_col in left_index_columns])

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -2476,7 +2476,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         Parameters
         ----------%s
         values : column to aggregate.
-            They sould be either a list or a string.
+            They should be either a list of one column or a string. A list of columns
+            is not supported yet.
         index : column (string) or list of columns
             If an array is passed, it must be the same length as the data.
             The list should contain string.
@@ -2546,19 +2547,19 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         We can also calculate multiple types of aggregations for any given
         value column.
 
-        >>> table = df.pivot_table(values = ['D','E'], index =['C'],
-        ...                     columns="A", aggfunc={'D':'mean','E':'sum'})
+        >>> table = df.pivot_table(values = ['D'], index =['C'],
+        ...                     columns="A", aggfunc={'D':'mean'})
         >>> table # doctest: +SKIP
-               bar_D  bar_E     foo_D  foo_E
+               bar       foo
         C
-        small    5.5     17  2.333333     13
-        large    5.5     15  2.000000      9
+        small  5.5  2.333333
+        large  5.5  2.000000
         """
         if not isinstance(columns, str):
             raise ValueError("columns should be string.")
 
-        if not isinstance(values, str) and not isinstance(values, list):
-            raise ValueError('values should be string or list of columns.')
+        if not isinstance(values, str) and not isinstance(values, list) :
+            raise ValueError('values should be string or list of one column.')
 
         if not isinstance(aggfunc, str) and (not isinstance(aggfunc, dict) or not all(
                 isinstance(key, str) and isinstance(value, str) for key, value in aggfunc.items())):
@@ -2568,6 +2569,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         if isinstance(aggfunc, dict) and index is None:
             raise NotImplementedError("pivot_table doesn't support aggfuct"
                                       " as dict and without index.")
+
+        if isinstance(values,list) and len(values) > 1:
+            raise NotImplementedError('Values as list of columns is not implemented yet.')
 
         if isinstance(aggfunc, str):
             agg_cols = [F.expr('{1}({0}) as {0}'.format(values, aggfunc))]

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -225,7 +225,6 @@ class DataFrame(_Frame):
     3  8  7  9  1  0
     4  2  5  4  3  9
     """
-
     def __init__(self, data=None, index=None, columns=None, dtype=None, copy=False):
         if isinstance(data, _InternalFrame):
             assert index is None

--- a/databricks/koalas/missing/frame.py
+++ b/databricks/koalas/missing/frame.py
@@ -100,7 +100,6 @@ class _MissingPandasLikeDataFrame(object):
     mode = unsupported_function('mode')
     pct_change = unsupported_function('pct_change')
     pivot = unsupported_function('pivot')
-    pivot_table = unsupported_function('pivot_table')
     pop = unsupported_function('pop')
     pow = unsupported_function('pow')
     prod = unsupported_function('prod')

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -778,3 +778,45 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         with self.assertRaises(NotImplementedError):
             left_kdf.update(right_kdf, join='right')
+
+    def test_pivot_table(self):
+
+        pdf = pd.DataFrame({'a': [4, 2, 3, 4, 8, 6],
+                            'b': [1, 2, 2, 4, 2, 4],
+                            'c': [1, 2, 9, 4, 7, 4]},
+                           index=[10, 20, 30, 40, 50, 60])
+
+        kdf = ks.from_pandas(pdf)
+
+        msg = "values should be string or list of columns."
+        with self.assertRaisesRegex(ValueError, msg):
+            kdf.pivot_table(index=['c'], columns="a", values=5)
+
+        msg = "index should be a None or a list of columns."
+        with self.assertRaisesRegex(ValueError, msg):
+            kdf.pivot_table(index="c", columns="a", values="b")
+
+        pdf = pd.DataFrame({'a': [4, 2, 3, 4, 8, 6],
+                            'b': [1, 2, 2, 4, 2, 4],
+                            'e': [1, 2, 2, 4, 2, 4],
+                            'c': [1, 2, 9, 4, 7, 4]},
+                           index=[10, 20, 30, 40, 50, 60])
+        kdf = ks.from_pandas(pdf)
+
+        msg = "pivot_table doesn't support aggfuct as dict and without index."
+        with self.assertRaisesRegex(NotImplementedError, msg):
+            kdf.pivot_table(columns="a", values=['b', 'e'], aggfunc={'b': 'mean', 'e': 'sum'})
+
+        msg = "columns should be string."
+        with self.assertRaisesRegex(ValueError, msg):
+            kdf.pivot_table(columns=["a"], values=['b'], aggfunc={'b': 'mean', 'e': 'sum'})
+
+        msg = "Columns in aggfunc must be the same as values."
+        with self.assertRaisesRegex(ValueError, msg):
+            kdf.pivot_table(index=['e', 'c'], columns="a", values='b',
+                            aggfunc={'b': 'mean', 'e': 'sum'})
+
+        msg = "Columns in aggfunc must be the same as values."
+        with self.assertRaisesRegex(ValueError, msg):
+            kdf.pivot_table(index=['e', 'c'], columns="a", values='b',
+                            aggfunc={'b': 'mean', 'e': 'sum'})

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -789,11 +789,11 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         kdf = ks.from_pandas(pdf)
 
         # Skip columns comparison by reset_index
-        res_df = kdf.pivot_table(index=['c'], columns="a", values=['b', 'e'],
-                                 aggfunc={'b': 'mean', 'e': 'mean'}) \
+        res_df = kdf.pivot_table(index=['c'], columns="a", values=['b'],
+                                 aggfunc={'b': 'mean'}) \
             .dtypes.reset_index(drop=True)
-        exp_df = pdf.pivot_table(index=['c'], columns="a", values=['b', 'e'],
-                                 aggfunc={'b': 'mean', 'e': 'mean'}) \
+        exp_df = pdf.pivot_table(index=['c'], columns="a", values=['b'],
+                                 aggfunc={'b': 'mean'}) \
             .dtypes.reset_index(drop=True)
         self.assert_eq(res_df, exp_df)
 
@@ -852,7 +852,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         kdf = ks.from_pandas(pdf)
 
-        msg = "values should be string or list of columns."
+        msg = "values should be string or list of one column."
         with self.assertRaisesRegex(ValueError, msg):
             kdf.pivot_table(index=['c'], columns="a", values=5)
 
@@ -873,7 +873,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             kdf.pivot_table(index=['e', 'c'], columns="a", values='b',
                             aggfunc={'b': 'mean', 'e': 'sum'})
 
-        msg = "Columns in aggfunc must be the same as values."
-        with self.assertRaisesRegex(ValueError, msg):
-            kdf.pivot_table(index=['e', 'c'], columns="a", values='b',
+        msg = 'Values as list of columns is not implemented yet.'
+        with self.assertRaisesRegex(NotImplementedError, msg):
+            kdf.pivot_table(index=['c'], columns="a", values=['b','e'],
                             aggfunc={'b': 'mean', 'e': 'sum'})

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -728,7 +728,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
     def test_join(self):
         # check basic function
         pdf1 = pd.DataFrame({'key': ['K0', 'K1', 'K2', 'K3'],
-                            'A': ['A0', 'A1', 'A2', 'A3']}, columns=['key', 'A'])
+                             'A': ['A0', 'A1', 'A2', 'A3']}, columns=['key', 'A'])
         pdf2 = pd.DataFrame({'key': ['K0', 'K1', 'K2'],
                              'B': ['B0', 'B1', 'B2']}, columns=['key', 'B'])
         kdf1 = ks.DataFrame({'key': ['K0', 'K1', 'K2', 'K3'],
@@ -875,5 +875,5 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         msg = 'Values as list of columns is not implemented yet.'
         with self.assertRaisesRegex(NotImplementedError, msg):
-            kdf.pivot_table(index=['c'], columns="a", values=['b','e'],
+            kdf.pivot_table(index=['c'], columns="a", values=['b', 'e'],
                             aggfunc={'b': 'mean', 'e': 'sum'})

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -779,10 +779,74 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         with self.assertRaises(NotImplementedError):
             left_kdf.update(right_kdf, join='right')
 
+    def test_pivot_table_dtypes(self):
+        pdf = pd.DataFrame({'a': [4, 2, 3, 4, 8, 6],
+                            'b': [1, 2, 2, 4, 2, 4],
+                            'e': [1, 2, 2, 4, 2, 4],
+                            'c': [1, 2, 9, 4, 7, 4]},
+                           index=[10, 20, 30, 40, 50, 60])
+
+        kdf = ks.from_pandas(pdf)
+
+        # Skip columns comparison by reset_index
+        res_df = kdf.pivot_table(index=['c'], columns="a", values=['b', 'e'],
+                                 aggfunc={'b': 'mean', 'e': 'mean'}) \
+            .dtypes.reset_index(drop=True)
+        exp_df = pdf.pivot_table(index=['c'], columns="a", values=['b', 'e'],
+                                 aggfunc={'b': 'mean', 'e': 'mean'}) \
+            .dtypes.reset_index(drop=True)
+        self.assert_eq(res_df, exp_df)
+
+        # Results don't have the same column's name
+
+        # Todo: self.assert_eq(kdf.pivot_table(columns="a", values="b").dtypes,
+        #  pdf.pivot_table(columns="a", values="b").dtypes)
+
+        # Todo: self.assert_eq(kdf.pivot_table(index=['c'], columns="a", values="b").dtypes,
+        #  pdf.pivot_table(index=['c'], columns="a", values="b").dtypes)
+
+        # Todo: self.assert_eq(kdf.pivot_table(index=['e', 'c'], columns="a", values="b").dtypes,
+        #  pdf.pivot_table(index=['e', 'c'], columns="a", values="b").dtypes)
+
+        # Todo: self.assert_eq(kdf.pivot_table(index=['e', 'c'],
+        #  columns="a", values="b", fill_value=999).dtypes, pdf.pivot_table(index=['e', 'c'],
+        #  columns="a", values="b", fill_value=999).dtypes)
+
     def test_pivot_table(self):
+        pdf = pd.DataFrame({'a': [4, 2, 3, 4, 8, 6],
+                            'b': [1, 2, 2, 4, 2, 4],
+                            'e': [1, 2, 2, 4, 2, 4],
+                            'c': [1, 2, 9, 4, 7, 4]},
+                           index=[10, 20, 30, 40, 50, 60])
+
+        kdf = ks.from_pandas(pdf)
+
+        # Checking if both DataFrames have the same results (Temporary)
+        np.testing.assert_equal(kdf.pivot_table(columns="a", values="b").to_numpy(),
+                                pdf.pivot_table(columns=["a"], values="b").to_numpy())
+
+        # Todo: self.assert_eq(kdf.pivot_table(columns="a", values="b"),
+        #  pdf.pivot_table(columns=["a"], values="b"))
+
+        # Todo: self.assert_eq(kdf.pivot_table(index=['c'], columns="a", values="b"),
+        #  pdf.pivot_table(index=['c'], columns=["a"], values="b"))
+
+        # Todo: self.assert_eq(kdf.pivot_table(index=['c'], columns="a", values=['b', 'e'],
+        #  aggfunc={'b': 'mean', 'e': 'sum'}), pdf.pivot_table(index=['c'], columns=["a"],
+        #  values=['b', 'e'], aggfunc={'b': 'mean', 'e': 'sum'}))
+
+        # Todo: self.assert_eq(kdf.pivot_table(index=['e', 'c'], columns="a", values="b"),
+        #  pdf.pivot_table(index=['e', 'c'], columns="a", values="b"))
+
+        # Todo: self.assert_eq(kdf.pivot_table(index=['e', 'c'], columns="a", values="b",
+        #  fill_value=999), pdf.pivot_table(index=['e', 'c'], columns="a", values="b",
+        #  fill_value=999))
+
+    def test_pivot_table_erros(self):
 
         pdf = pd.DataFrame({'a': [4, 2, 3, 4, 8, 6],
                             'b': [1, 2, 2, 4, 2, 4],
+                            'e': [1, 2, 2, 4, 2, 4],
                             'c': [1, 2, 9, 4, 7, 4]},
                            index=[10, 20, 30, 40, 50, 60])
 
@@ -795,13 +859,6 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         msg = "index should be a None or a list of columns."
         with self.assertRaisesRegex(ValueError, msg):
             kdf.pivot_table(index="c", columns="a", values="b")
-
-        pdf = pd.DataFrame({'a': [4, 2, 3, 4, 8, 6],
-                            'b': [1, 2, 2, 4, 2, 4],
-                            'e': [1, 2, 2, 4, 2, 4],
-                            'c': [1, 2, 9, 4, 7, 4]},
-                           index=[10, 20, 30, 40, 50, 60])
-        kdf = ks.from_pandas(pdf)
 
         msg = "pivot_table doesn't support aggfuct as dict and without index."
         with self.assertRaisesRegex(NotImplementedError, msg):

--- a/docs/source/reference/frame.rst
+++ b/docs/source/reference/frame.rst
@@ -136,6 +136,7 @@ Reshaping, sorting, transposing
 .. autosummary::
    :toctree: api/
 
+   DataFrame.pivot_table
    DataFrame.sort_index
    DataFrame.sort_values
    DataFrame.nlargest


### PR DESCRIPTION
+ Initial implementation of `DataFrame.pivot_table()`
+ Ignored parameters : `margins`, `dropna` and `margins_name`
+ Resolves #382 