### PR TITLE
Add DataFrame.merge to frame.rst

### DIFF
--- a/docs/source/reference/frame.rst
+++ b/docs/source/reference/frame.rst
@@ -117,6 +117,7 @@ Combining / joining / merging
    :toctree: api/
 
    DataFrame.assign
+   DataFrame.merge
 
 Serialization / IO / Conversion
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
I've just seen that both #264 and #381 missed adding `DataFrame.merge` to the .rst doc files. Therefore, this PR simply adds the missing entry.