### PR TITLE
Add Series.map

### DIFF
--- a/databricks/koalas/missing/series.py
+++ b/databricks/koalas/missing/series.py
@@ -126,7 +126,6 @@ class _MissingPandasLikeSeries(object):
     le = unsupported_function('le')
     lt = unsupported_function('lt')
     mad = unsupported_function('mad')
-    map = unsupported_function('map')
     mask = unsupported_function('mask')
     median = unsupported_function('median')
     memory_usage = unsupported_function('memory_usage')

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -155,6 +155,7 @@ class Series(_Frame, IndexOpsMixin):
         return self.schema.fields[-1].dataType
 
     # TODO: arg should support Series
+    # TODO: NaN and None
     def map(self, arg):
         """
         Map values of Series according to input correspondence.
@@ -196,7 +197,7 @@ class Series(_Frame, IndexOpsMixin):
         Name: 0, dtype: object
 
         ``map`` accepts a ``dict``. Values that are not found
-        in the ``dict`` are converted to ``NaN``, unless the dict has a default
+        in the ``dict`` are converted to ``None``, unless the dict has a default
         value (e.g. ``defaultdict``):
 
         >>> s.map({'cat': 'kitten', 'dog': 'puppy'})

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -15,6 +15,7 @@
 #
 
 import inspect
+from collections import defaultdict
 
 import numpy as np
 import pandas as pd
@@ -353,3 +354,17 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
     def test_to_list(self):
         if LooseVersion(pd.__version__) >= LooseVersion("0.24.0"):
             self.assertEqual(self.ks.to_list(), self.ps.to_list())
+
+    def test_map(self):
+        pser = pd.Series(['cat', 'dog', None, 'rabbit'])
+        kser = koalas.from_pandas(pser)
+        # Currently Koalas doesn't return NaN as Pandas does.
+        self.assertEqual(
+            repr(kser.map({})),
+            repr(pser.map({}).replace({pd.np.nan: None}).rename(0)))
+
+        d = defaultdict(lambda: "abc")
+        self.assertTrue("abc" in repr(kser.map(d)))
+        self.assertEqual(
+            repr(kser.map(d)),
+            repr(pser.map(d).rename(0)))

--- a/docs/source/reference/series.rst
+++ b/docs/source/reference/series.rst
@@ -50,6 +50,8 @@ Function application, GroupBy & Window
 .. autosummary::
    :toctree: api/
 
+   Series.apply
+   Series.map
    Series.groupby
 
 .. _api.series.stats:


### PR DESCRIPTION
This PR adds `Series.map`.  If the function is given as an argument, seems we can just reuse `apply`.

```python
>>> import pandas as pd
>>> pdf = pd.DataFrame({'a': [1,2,3,4,5,6]})
>>> pdf.a.apply(lambda x: x+  1)
0    2
1    3
2    4
3    5
4    6
5    7
Name: a, dtype: int64
>>> pdf.a.map(lambda x: x+  1)
0    2
1    3
2    4
3    5
4    6
5    7
Name: a, dtype: int64
```