### PR TITLE
Add DataFrame.applymap

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -210,7 +210,7 @@ class DataFrame(_Frame):
             See https://docs.python.org/3/library/typing.html. For instance, as below:
 
             >>> def function() -> int:
-            ...    1
+            ...     return 1
 
         Parameters
         ----------

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -199,6 +199,59 @@ class DataFrame(_Frame):
         row.name = None
         return row  # Return first row as a Series
 
+    def applymap(self, func):
+        """
+        Apply a function to a Dataframe elementwise.
+
+        This method applies a function that accepts and returns a scalar
+        to every element of a DataFrame.
+
+        .. note:: unlike pandas, it is required for `func` to specify return type hint.
+
+        Parameters
+        ----------
+        func : callable
+            Python function, returns a single value from a single value.
+
+        Returns
+        -------
+        DataFrame
+            Transformed DataFrame.
+
+        Examples
+        --------
+        >>> df = ks.DataFrame([[1, 2.12], [3.356, 4.567]])
+        >>> df
+               0      1
+        0  1.000  2.120
+        1  3.356  4.567
+
+        >>> def str_len(x) -> int:
+        ...     return len(str(x))
+        >>> df.applymap(str_len)
+           0  1
+        0  3  4
+        1  5  5
+
+        >>> def power(x) -> float:
+        ...     return x ** 2
+        >>> df.applymap(power)
+                   0          1
+        0   1.000000   4.494400
+        1  11.262736  20.857489
+        """
+
+        applied = []
+        for column in self._metadata.data_columns:
+            applied.append(self[column].apply(func))
+
+        sdf = self._sdf.select(
+            self._metadata.index_columns + [c._scol for c in applied])
+
+        metadata = self._metadata.copy(data_columns=[c.name for c in applied])
+
+        return DataFrame(sdf, metadata)
+
     def corr(self, method='pearson'):
         """
         Compute pairwise correlation of columns, excluding NA/null values.

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -207,6 +207,10 @@ class DataFrame(_Frame):
         to every element of a DataFrame.
 
         .. note:: unlike pandas, it is required for `func` to specify return type hint.
+            See https://docs.python.org/3/library/typing.html. For instance, as below:
+
+            >>> def function() -> int:
+            ...    1
 
         Parameters
         ----------

--- a/databricks/koalas/missing/frame.py
+++ b/databricks/koalas/missing/frame.py
@@ -55,7 +55,6 @@ class _MissingPandasLikeDataFrame(object):
     any = unsupported_function('any')
     append = unsupported_function('append')
     apply = unsupported_function('apply')
-    applymap = unsupported_function('applymap')
     asfreq = unsupported_function('asfreq')
     asof = unsupported_function('asof')
     at_time = unsupported_function('at_time')

--- a/docs/source/reference/frame.rst
+++ b/docs/source/reference/frame.rst
@@ -56,6 +56,7 @@ Function application, GroupBy & Window
 .. autosummary::
    :toctree: api/
 
+   DataFrame.applymap
    DataFrame.pipe
    DataFrame.groupby
 


### PR DESCRIPTION
This PR adds DataFrame.`applymap`.

We can reuse `Series.apply`:

```python
>>> import pandas as pd
>>> pd.DataFrame({'a': [1,2,3], 'b': [1.0, 2.0, 3.0]})
   a    b
0  1  1.0
1  2  2.0
2  3  3.0
>>> pdf = pd.DataFrame({'a': [1,2,3], 'b': [1.0, 2.0, 3.0]})
>>> pdf.applymap(lambda x: x + 1)
   a    b
0  2  2.0
1  3  3.0
2  4  4.0
```
