### PR TITLE
Test requirement-dev.txt against pip as well in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,11 +58,18 @@ install:
   - conda config --env --add pinned_packages pandas==$PANDAS_VERSION
   - conda config --env --add pinned_packages pyarrow==$PYARROW_VERSION
   - conda install -c conda-forge --yes codecov
-  - conda install -c conda-forge --yes --file requirements-dev.txt
-  - pip install mlflow
 
-  # Show installed packages
-  - conda list
+  # Test PyPI installation at Python 3.5. This is also because
+  # one of the dependency requires Python 3.6 Conda specifically.
+  - if [[ $TRAVIS_PYTHON_VERSION == "3.5" ]]; then
+      pip install -r requirements-dev.txt;
+      # Show installed packages
+      pip list;
+    else
+      conda install -c conda-forge --yes --file requirements-dev.txt;
+      # Show installed packages
+      conda list;
+    fi
 
   # Useful for to_clipboard test
   - export DISPLAY=:0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,8 +46,11 @@ That's it. Your contribution, once merged, will be available in the next release
 
 ## Environment Setup
 
+**Conda**
+
 We recommend setting up a Conda environment for development:
 ```bash
+# Python 3.6+ is required
 conda create --name koalas-dev-env python=3.6
 conda activate koalas-dev-env
 conda install -c conda-forge pyspark=2.4
@@ -60,6 +63,14 @@ Once setup, make sure you switch to `koalas-dev-env` before development:
 conda activate koalas-dev-env
 ```
 
+**pip**
+
+You can use `pip` alternatively if your Python is 3.5+.
+```bash
+pip install pyspark=2.4
+pip install -r requirements-dev.txt
+pip install -e .  # installs koalas from current checkout
+```
 
 ## Running Tests
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@
 pandas>=0.23
 pyarrow>=0.10
 numpy>=1.14
+mlflow
 
 # Documentation build
 sphinx


### PR DESCRIPTION
This PR proposes to test `pip` at Python 3.5. We provide a `requirement-dev.txt` file that can be used at both `pip` and `conda`.

This is because:

**1. We should test `pip` compatibility of `requirement-dev.txt` file:**

We met the compatibility issue before at https://github.com/databricks/koalas/pull/154. We can prevent this via running it in Travis CI.


**2. One of the dependency in Koalas, `mlflow` requires Python 3.6 specifically in Conda:**


mlflow requires Python 3.6+ if we use conda

```
conda install -c conda-forge --yes mlflow
Collecting package metadata: done
Solving environment: failed

SpecsConfigurationConflictError: Requested specs conflict with configured specs.
  requested specs:
    - mlflow
  pinned specs:
    - python=3.5
Use 'conda config --show-sources' to look for 'pinned_specs' and 'track_features'
configuration parameters.  Pinned specs may also be defined in the file
```

although mlflow doesn't specify the Python versions to force.

One or one of the culprits seems to be `docker-py` - it seems requiring Python 3.6+ for docker-py 3.6.0+. However, mlflow specifies it 3.6.0+ (https://github.com/conda-forge/mlflow-feedstock/blob/master/recipe/meta.yaml#L29)

```bash
$ conda search docker-py --channel conda-forge
```

```
Loading channels: done
# Name                       Version           Build  Channel
...
docker-py                      3.5.0          py27_0  conda-forge
docker-py                      3.5.0       py27_1000  conda-forge
docker-py                      3.5.0          py35_0  conda-forge
docker-py                      3.5.0          py36_0  conda-forge
docker-py                      3.5.0       py36_1000  conda-forge
docker-py                      3.5.0       py37_1000  conda-forge
...
docker-py                      3.6.0       py27_1000  conda-forge
docker-py                      3.6.0       py36_1000  conda-forge
docker-py                      3.6.0       py37_1000  conda-forge
...
docker-py                      3.7.1          py27_0  conda-forge
docker-py                      3.7.1          py36_0  conda-forge
docker-py                      3.7.1          py37_0  conda-forge
...
language: python
```

Note that this looks a difference between PIP and conda at docker-py side. BTW, it's `docker` at pypi and `docker-py` in conda.

See `https://github.com/conda-forge/docker-py-feedstock/issues/25`
https://github.com/mlflow/mlflow/blob/master/setup.py#L46
https://github.com/conda-forge/mlflow-feedstock/blob/master/recipe/meta.yaml#L29
