### PR TITLE
Modify ml module doc.

### DIFF
--- a/docs/source/reference/ml.rst
+++ b/docs/source/reference/ml.rst
@@ -22,7 +22,7 @@ tensorflow, ...). See comprehensive examples in
    **pip install koalas[mlflow]**
 
 .. autosummary::
-   :toctree: ml/
+   :toctree: api/
 
-   databricks.koalas.mlflow.PythonModelWrapper
-   databricks.koalas.mlflow.load_model
+   PythonModelWrapper
+   load_model


### PR DESCRIPTION
I think we can put the api doc for mlflow related APIs in the same api directory, otherwise we need to add the directory to `.gitignore`.
Also we can remove the package prefix because `currentmodule` is specified.

I checked the generated docs in my local.
