### PR TITLE
Add auto-generated ml doc dir into gitignore and lint-python

### DIFF
--- a/dev/lint-python
+++ b/dev/lint-python
@@ -253,6 +253,7 @@ function sphinx_test {
     make clean &> /dev/null
     # Remove previously generated rst files
     rm -fr $DIR/../docs/source/reference/api/*
+    rm -fr $DIR/../docs/source/reference/ml/*
     # Treat warnings as errors so we stop correctly
     SPHINX_REPORT=$( (SPHINXOPTS="-a -W" make html) 2>&1)
     SPHINX_STATUS=$?

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,1 +1,2 @@
 source/reference/api
+source/reference/ml


### PR DESCRIPTION
```
Untracked files:
  (use "git add <file>..." to include in what will be committed)

	docs/source/reference/ml/
```

I realised that we added `ml` directory in API doc. Let's ignore those as well like `api` directory.