### PR TITLE
Inline Datetimelike accessor documentation to Pandas'

### DIFF
--- a/databricks/koalas/datetimes.py
+++ b/databricks/koalas/datetimes.py
@@ -17,12 +17,16 @@
 """
 Date/Time related functions on Koalas Series
 """
+from typing import TYPE_CHECKING
+
 import pandas as pd
 import pyspark.sql.functions as F
 from pyspark.sql.types import DateType, TimestampType, LongType, StringType
 
-import databricks.koalas as ks
 from databricks.koalas.base import _wrap_accessor_pandas, _wrap_accessor_spark
+
+if TYPE_CHECKING:
+    import databricks.koalas as ks
 
 
 class DatetimeMethods(object):

--- a/databricks/koalas/datetimes.py
+++ b/databricks/koalas/datetimes.py
@@ -27,7 +27,7 @@ from databricks.koalas.base import _wrap_accessor_pandas, _wrap_accessor_spark
 
 class DatetimeMethods(object):
     """Date/Time methods for Koalas Series"""
-    def __init__(self, series: ks.Series):
+    def __init__(self, series: 'ks.Series'):
         if not isinstance(series.spark_type, (DateType, TimestampType)):
             raise ValueError(
                 "Cannot call DatetimeMethods on type {}"
@@ -37,7 +37,7 @@ class DatetimeMethods(object):
 
     # Properties
     @property
-    def date(self) -> ks.Series:
+    def date(self) -> 'ks.Series':
         """
         Returns a Series of python datetime.date objects (namely, the date
         part of Timestamps without timezone information).
@@ -48,29 +48,29 @@ class DatetimeMethods(object):
             self, lambda col: F.to_date(col)).alias(self.name)
 
     @property
-    def time(self) -> ks.Series:
+    def time(self) -> 'ks.Series':
         raise NotImplementedError()
 
     @property
-    def timetz(self) -> ks.Series:
+    def timetz(self) -> 'ks.Series':
         raise NotImplementedError()
 
     @property
-    def year(self) -> ks.Series:
+    def year(self) -> 'ks.Series':
         """
         The year of the datetime.
         `"""
         return _wrap_accessor_spark(self, F.year, LongType()).alias(self.name)
 
     @property
-    def month(self) -> ks.Series:
+    def month(self) -> 'ks.Series':
         """
         The month of the timestamp as January = 1 December = 12.
         """
         return _wrap_accessor_spark(self, F.month, LongType()).alias(self.name)
 
     @property
-    def day(self) -> ks.Series:
+    def day(self) -> 'ks.Series':
         """
         The days of the datetime.
         """
@@ -78,28 +78,28 @@ class DatetimeMethods(object):
             self, F.dayofmonth, LongType()).alias(self.name)
 
     @property
-    def hour(self) -> ks.Series:
+    def hour(self) -> 'ks.Series':
         """
         The hours of the datetime.
         """
         return _wrap_accessor_spark(self, F.hour, LongType()).alias(self.name)
 
     @property
-    def minute(self) -> ks.Series:
+    def minute(self) -> 'ks.Series':
         """
         The minutes of the datetime.
         """
         return _wrap_accessor_spark(self, F.minute, LongType()).alias(self.name)
 
     @property
-    def second(self) -> ks.Series:
+    def second(self) -> 'ks.Series':
         """
         The seconds of the datetime.
         """
         return _wrap_accessor_spark(self, F.second, LongType()).alias(self.name)
 
     @property
-    def millisecond(self) -> ks.Series:
+    def millisecond(self) -> 'ks.Series':
         """
         The milliseconds of the datetime.
         """
@@ -107,7 +107,7 @@ class DatetimeMethods(object):
             self, lambda x: x.dt.millisecond, LongType()).alias(self.name)
 
     @property
-    def microsecond(self) -> ks.Series:
+    def microsecond(self) -> 'ks.Series':
         """
         The microseconds of the datetime.
         """
@@ -115,24 +115,24 @@ class DatetimeMethods(object):
             self, lambda x: x.dt.microsecond, LongType()).alias(self.name)
 
     @property
-    def nanosecond(self) -> ks.Series:
+    def nanosecond(self) -> 'ks.Series':
         raise NotImplementedError()
 
     @property
-    def week(self) -> ks.Series:
+    def week(self) -> 'ks.Series':
         """
         The week ordinal of the year.
         """
         return _wrap_accessor_spark(self, F.weekofyear, LongType()).alias(self.name)
 
     @property
-    def weekofyear(self) -> ks.Series:
+    def weekofyear(self) -> 'ks.Series':
         return self.week
 
     weekofyear.__doc__ = week.__doc__
 
     @property
-    def dayofweek(self) -> ks.Series:
+    def dayofweek(self) -> 'ks.Series':
         """
         The day of the week with Monday=0, Sunday=6.
 
@@ -171,13 +171,13 @@ class DatetimeMethods(object):
             self, lambda s: s.dt.dayofweek, LongType()).alias(self._data.name)
 
     @property
-    def weekday(self) -> ks.Series:
+    def weekday(self) -> 'ks.Series':
         return self.dayofweek
 
     weekday.__doc__ = dayofweek.__doc__
 
     @property
-    def dayofyear(self) -> ks.Series:
+    def dayofyear(self) -> 'ks.Series':
         """
         The ordinal day of the year.
         """
@@ -185,7 +185,7 @@ class DatetimeMethods(object):
             self, lambda s: s.dt.dayofyear, LongType()).alias(self._data.name)
 
     # Methods
-    def strftime(self, date_format) -> ks.Series:
+    def strftime(self, date_format) -> 'ks.Series':
         """
         Convert to a String Series using specified date_format.
         """

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -24,6 +24,7 @@ from typing import Any, Optional, List, Union
 
 import numpy as np
 import pandas as pd
+from pandas.core.accessor import CachedAccessor
 
 from pyspark import sql as spark
 from pyspark.sql import functions as F
@@ -36,6 +37,7 @@ from databricks.koalas.generic import _Frame, max_display_count
 from databricks.koalas.metadata import Metadata
 from databricks.koalas.missing.series import _MissingPandasLikeSeries
 from databricks.koalas.utils import validate_arguments_and_invoke_function
+from databricks.koalas.datetimes import DatetimeMethods
 
 
 # This regular expression pattern is complied and defined here to avoid to compile the same
@@ -242,12 +244,6 @@ class Series(_Frame, IndexOpsMixin):
         :return: the copied Series
         """
         return Series(scol, anchor=self._kdf, index=self._index_map)
-
-    @property
-    def dt(self):
-        from databricks.koalas.datetimes import DatetimeMethods
-
-        return DatetimeMethods(self)
 
     @property
     def dtypes(self):
@@ -1616,6 +1612,13 @@ class Series(_Frame, IndexOpsMixin):
         return _col(self.to_dataframe().describe(percentiles))
 
     describe.__doc__ = DataFrame.describe.__doc__
+
+    # ----------------------------------------------------------------------
+    # Accessor Methods
+    # ----------------------------------------------------------------------
+    dt = CachedAccessor("dt", DatetimeMethods)
+
+    # ----------------------------------------------------------------------
 
     def _reduce_for_stat_function(self, sfun):
         from inspect import signature

--- a/docs/source/reference/series.rst
+++ b/docs/source/reference/series.rst
@@ -133,6 +133,52 @@ Reshaping, sorting, transposing
    Series.sort_index
    Series.sort_values
 
+Accessors
+---------
+
+Koalas provides dtype-specific methods under various accessors.
+These are separate namespaces within :class:`Series` that only apply
+to specific data types.
+
+========= =========================
+Data Type                  Accessor
+========= =========================
+Datetime  :ref:`dt <api.series.dt>`
+========= =========================
+
+.. _api.series.dt:
+
+Datetimelike Properties
+~~~~~~~~~~~~~~~~~~~~~~~
+
+``Series.dt`` can be used to access the values of the series as
+datetimelike and return several properties.
+These can be accessed like ``Series.dt.<property>``.
+
+Datetime Properties
+^^^^^^^^^^^^^^^^^^^
+
+.. currentmodule:: databricks.koalas.series
+.. autosummary::
+   :toctree: api/
+
+   Series.dt.date
+   Series.dt.year
+   Series.dt.month
+   Series.dt.week
+   Series.dt.weekofyear
+   Series.dt.day
+   Series.dt.dayofweek
+   Series.dt.weekday
+   Series.dt.dayofyear
+   Series.dt.hour
+   Series.dt.minute
+   Series.dt.second
+   Series.dt.millisecond
+   Series.dt.microsecond
+
+   Series.dt.strftime
+
 Serialization / IO / Conversion
 -------------------------------
 .. autosummary::
@@ -149,27 +195,3 @@ Serialization / IO / Conversion
    Series.to_csv
    Series.to_excel
 
-Datetime Methods
-----------------
-Methods accessible through `Series.dt`
-
-.. currentmodule:: databricks.koalas.datetimes
-.. autosummary::
-   :toctree: api/
-
-   DatetimeMethods.date
-   DatetimeMethods.year
-   DatetimeMethods.month
-   DatetimeMethods.week
-   DatetimeMethods.weekofyear
-   DatetimeMethods.day
-   DatetimeMethods.dayofweek
-   DatetimeMethods.weekday
-   DatetimeMethods.dayofyear
-   DatetimeMethods.hour
-   DatetimeMethods.minute
-   DatetimeMethods.second
-   DatetimeMethods.millisecond
-   DatetimeMethods.microsecond
-
-   DatetimeMethods.strftime

--- a/docs/source/reference/series.rst
+++ b/docs/source/reference/series.rst
@@ -177,6 +177,13 @@ Datetime Properties
    Series.dt.millisecond
    Series.dt.microsecond
 
+Datetime Methods
+^^^^^^^^^^^^^^^^
+
+.. currentmodule:: databricks.koalas.series
+.. autosummary::
+   :toctree: api/
+
    Series.dt.strftime
 
 Serialization / IO / Conversion

--- a/docs/source/themes/nature_with_gtoc/static/nature.css_t
+++ b/docs/source/themes/nature_with_gtoc/static/nature.css_t
@@ -353,6 +353,14 @@ table td.data, table th.row_heading table th.col_heading {
 }
 
 /**
+ * Avoid that tables are located in the middle
+ */
+table.align-center {
+    margin-left: 0;
+    margin-right: auto;
+}
+
+/**
  * See also
  */
 


### PR DESCRIPTION
This PR targets to inline Datetimelike accessor documentation to Pandas'

The problem was that it seems like we can't access property's property (`Series.dt.date` for instance).

I mimicked Pandas' approach (class attribute -> property). Plus, it will cache once it's called. 

Another problem was that the table is located in the center. I don't know why there's difference so I just edited CSS to make the tables alined left like Pandas'. I think it's hacky way to fix.

**Pandas:**

![Screen Shot 2019-05-30 at 1 48 56 PM](https://user-images.githubusercontent.com/6477701/58609307-1f3fb780-82e2-11e9-803d-e1367ec8406e.png)


**After this PR:**

![Screen Shot 2019-05-30 at 3 44 41 PM](https://user-images.githubusercontent.com/6477701/58614045-430af980-82f2-11e9-98a6-05b426913687.png)

