### PR TITLE
Fix Sphinx version to `2.0.1`.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ numpy>=1.14
 mlflow
 
 # Documentation build
-sphinx
+sphinx==2.0.1
 nbsphinx
 numpydoc
 


### PR DESCRIPTION
Now that Sphinx on PyPI was upgraded to `2.1.0`, but it raises unknown warnings.
I'd fix the Sphinx version to `2.0.1` for now to unblock PRs.