### PR TITLE
Keep column name from isna, isnull, notnull, notna

### DIFF
--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -322,12 +322,12 @@ class IndexOpsMixin(object):
         0    False
         1    False
         2     True
-        Name: ((0 IS NULL) OR isnan(0)), dtype: bool
+        Name: 0, dtype: bool
         """
         if isinstance(self.spark_type, (FloatType, DoubleType)):
-            return self._with_new_scol(self._scol.isNull() | F.isnan(self._scol))
+            return self._with_new_scol(self._scol.isNull() | F.isnan(self._scol)).alias(self.name)
         else:
-            return self._with_new_scol(self._scol.isNull())
+            return self._with_new_scol(self._scol.isNull()).alias(self.name)
 
     isna = isnull
 
@@ -360,9 +360,9 @@ class IndexOpsMixin(object):
         0     True
         1     True
         2    False
-        Name: (NOT ((0 IS NULL) OR isnan(0))), dtype: bool
+        Name: 0, dtype: bool
         """
-        return ~self.isnull()
+        return (~self.isnull()).alias(self.name)
 
     notna = notnull
 

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -388,6 +388,9 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
             repr(pser.map(d).rename(0)))
 
     def test_pandas_wraps(self):
+        # This test checks the return column name of `isna()`. Previously it returned the column
+        # name as its internal expression which contains, for instance, '`f(x)`' in the middle of
+        # column name which currently cannot be recognized in PySpark.
         @koalas.pandas_wraps
         def f(x) -> koalas.Col[int]:
             return 2 * x

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -386,3 +386,13 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         self.assertEqual(
             repr(kser.map(d)),
             repr(pser.map(d).rename(0)))
+
+    def test_pandas_wraps(self):
+        @koalas.pandas_wraps
+        def f(x) -> koalas.Col[int]:
+            return 2 * x
+
+        df = koalas.DataFrame({"x": [1, None]})
+        self.assert_eq(
+            f(df["x"]).isna(),
+            pd.Series([False, True]).rename("f(x)"))


### PR DESCRIPTION
This PR keep original names from isna, isnull, notnull, notna. Keeping expression name as is can cause analysis exceptions due to nested `` ` `` in the name for instance.

Resolves #406 