### PR TITLE
[WIP] Backquote column names to prevent special characters in column names

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -286,7 +286,7 @@ class DataFrame(_Frame):
         exprs = []
         num_args = len(signature(sfun).parameters)
         for col in self.columns:
-            col_sdf = self._sdf[col]
+            col_sdf = self._sdf["`%s`" % col]
             col_type = self._sdf.schema[col].dataType
             if isinstance(col_type, BooleanType) and sfun.__name__ not in ('min', 'max'):
                 # Stat functions cannot be used with boolean values by default

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -3240,7 +3240,11 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             raise KeyError("none key")
         if isinstance(key, str):
             try:
-                return Series(self._sdf.__getitem__(key), anchor=self,
+                # Currently, we don't support nested structure properly in Koalas
+                # as it's not supported in pandas.
+                # If Koalas should support it, we should properly resolve nested
+                # access.
+                return Series(self._sdf.__getitem__("`%s`" % key), anchor=self,
                               index=self._metadata.index_map)
             except AnalysisException:
                 raise KeyError(key)

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -943,5 +943,5 @@ def _spark_col_apply(kdf_or_ks, sfun):
     assert isinstance(kdf_or_ks, DataFrame)
     kdf = kdf_or_ks
     sdf = kdf._sdf
-    sdf = sdf.select([sfun(sdf[col]).alias(col) for col in kdf.columns])
+    sdf = sdf.select([sfun(sdf["`%s`" % col]).alias(col) for col in kdf.columns])
     return DataFrame(sdf)

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -63,7 +63,8 @@ class Index(IndexOpsMixin):
         assert len(kdf._metadata._index_map) == 1
         if scol is None:
             IndexOpsMixin.__init__(
-                self, kdf._internal.copy(scol=kdf._sdf[kdf._internal.index_columns[0]]), kdf)
+                self, kdf._internal.copy(
+                    scol=kdf._sdf["`%s`" % kdf._internal.index_columns[0]]), kdf)
         else:
             IndexOpsMixin.__init__(self, kdf._internal.copy(scol=scol), kdf)
 

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -80,7 +80,7 @@ class Index(IndexOpsMixin):
     def _columns(self) -> List[spark.Column]:
         """ Returns spark Columns corresponding to index columns. """
         kdf = self._kdf
-        return [kdf._sdf[field] for field in kdf._metadata.index_columns]
+        return [kdf._sdf["`%s`" % field] for field in kdf._metadata.index_columns]
 
     def to_pandas(self) -> pd.Index:
         """

--- a/databricks/koalas/mlflow.py
+++ b/databricks/koalas/mlflow.py
@@ -86,7 +86,7 @@ class PythonModelWrapper(object):
         if isinstance(data, pd.DataFrame):
             return self._model.predict(data)
         if isinstance(data, DataFrame):
-            cols = [data._sdf[n] for n in data.columns]
+            cols = [data._sdf["`%s`" % n] for n in data.columns]
             return_col = self._model_udf(*cols)
             # TODO: the columns should be named according to the mlflow spec
             # However, this is only possible with spark >= 3.0

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -1407,8 +1407,9 @@ class Series(_Frame, IndexOpsMixin):
         kdf = self.to_dataframe()
         metadata = kdf._metadata
         sdf = kdf._sdf
-        kdf._sdf = sdf.select([F.concat(F.lit(prefix), sdf[index_column]).alias(index_column)
-                               for index_column in metadata.index_columns] + metadata.data_columns)
+        kdf._sdf = sdf.select(
+            [F.concat(F.lit(prefix), sdf["`%s`" % index_column]).alias(index_column)
+             for index_column in metadata.index_columns] + metadata.data_columns)
         return Series(self._scol, anchor=kdf, index=self._index_map)
 
     def add_suffix(self, suffix):
@@ -1455,8 +1456,9 @@ class Series(_Frame, IndexOpsMixin):
         kdf = self.to_dataframe()
         metadata = kdf._metadata
         sdf = kdf._sdf
-        kdf._sdf = sdf.select([F.concat(sdf[index_column], F.lit(suffix)).alias(index_column)
-                               for index_column in metadata.index_columns] + metadata.data_columns)
+        kdf._sdf = sdf.select(
+            [F.concat(sdf["`%s`" % index_column], F.lit(suffix)).alias(index_column)
+             for index_column in metadata.index_columns] + metadata.data_columns)
         return Series(self._scol, anchor=kdf, index=self._index_map)
 
     def corr(self, other, method='pearson'):

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -222,7 +222,7 @@ class Series(_Frame, IndexOpsMixin):
                     data=data, index=index, dtype=dtype, name=name, copy=copy, fastpath=fastpath)
             kdf = DataFrame(s)
             IndexOpsMixin.__init__(self, kdf._internal.copy(
-                scol=kdf._internal._sdf[kdf._internal.data_columns[0]]), kdf)
+                scol=kdf._internal._sdf["`%s`" % kdf._internal.data_columns[0]]), kdf)
 
     @property
     def _index_map(self) -> List[IndexMap]:

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -183,6 +183,11 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(kdf.columns, pd.Index(['x', 'y']))
         self.assert_eq(kdf, pdf)
 
+    def test_dot_in_column_name(self):
+        self.assert_eq(
+            ks.DataFrame(ks.range(1)._sdf.selectExpr("1 as `a.b`"))['a.b'],
+            ks.Series([1]))
+
     def test_drop(self):
         kdf = ks.DataFrame({'x': [1, 2], 'y': [3, 4], 'z': [5, 6]})
 


### PR DESCRIPTION
This PR proposes to backquote column names to prevent special characters in column names when it's accessed via `__getitem__` (`df[...]`).

Resolves #217