### PR TITLE
Stats on numeric columns

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -180,8 +180,9 @@ class DataFrame(_Frame):
             col_type = self._sdf.schema[col].dataType
 
             numeric_only = numeric_only if numeric_only is not None else True
+            is_numeric_or_boolean = isinstance(col_type, (NumericType, BooleanType))
             min_or_max = sfun.__name__ in ('min', 'max')
-            keep_column = not numeric_only or min_or_max or isinstance(col_type, (NumericType, BooleanType))
+            keep_column = not numeric_only or is_numeric_or_boolean or min_or_max
 
             if keep_column:
                 if isinstance(col_type, BooleanType) and not min_or_max:

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -178,19 +178,20 @@ class DataFrame(_Frame):
         for col in self.columns:
             col_sdf = self._sdf[col]
             col_type = self._sdf.schema[col].dataType
-            if isinstance(col_type, BooleanType) and sfun.__name__ not in ('min', 'max'):
-                # Stat functions cannot be used with boolean values by default
-                # Thus, cast to integer (true to 1 and false to 0)
-                # Exclude the min and max methods though since those work with booleans
-                col_sdf = col_sdf.cast('integer')
-            if num_args == 1:
-                # Only pass in the column if sfun accepts only one arg
-                col_sdf = sfun(col_sdf)
-            else:  # must be 2
-                assert num_args == 2
-                # Pass in both the column and its data type if sfun accepts two args
-                col_sdf = sfun(col_sdf, col_type)
-            exprs.append(col_sdf.alias(col))
+            if isinstance(col_type, NumericType):
+                if isinstance(col_type, BooleanType) and sfun.__name__ not in ('min', 'max'):
+                    # Stat functions cannot be used with boolean values by default
+                    # Thus, cast to integer (true to 1 and false to 0)
+                    # Exclude the min and max methods though since those work with booleans
+                    col_sdf = col_sdf.cast('integer')
+                if num_args == 1:
+                    # Only pass in the column if sfun accepts only one arg
+                    col_sdf = sfun(col_sdf)
+                else:  # must be 2
+                    assert num_args == 2
+                    # Pass in both the column and its data type if sfun accepts two args
+                    col_sdf = sfun(col_sdf, col_type)
+                exprs.append(col_sdf.alias(col))
 
         sdf = self._sdf.select(*exprs)
         pdf = sdf.toPandas()

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -169,8 +169,12 @@ class DataFrame(_Frame):
         Applies sfun to each column and returns a pd.Series where the number of rows equal the
         number of columns.
 
-        :param sfun: either an 1-arg function that takes a Column and returns a Column, or
+        Parameters
+        ----------
+        sfun : either an 1-arg function that takes a Column and returns a Column, or
         a 2-arg function that takes a Column and its DataType and returns a Column.
+        numeric_only : boolean, default False
+            If True, sfun is applied on numeric columns (including booleans) only.
         """
         from inspect import signature
         exprs = []

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -1899,7 +1899,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         Single    5
         dtype: int64
         """
-        return self._reduce_for_stat_function(_Frame._count_expr)
+        return self._reduce_for_stat_function(_Frame._count_expr, numeric_only=False)
 
     def drop(self, labels=None, axis=1, columns: Union[str, List[str]] = None):
         """

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -164,7 +164,7 @@ class DataFrame(_Frame):
         else:
             self._metadata = metadata
 
-    def _reduce_for_stat_function(self, sfun, numeric_only=None):
+    def _reduce_for_stat_function(self, sfun, numeric_only=False):
         """
         Applies sfun to each column and returns a pd.Series where the number of rows equal the
         number of columns.
@@ -179,7 +179,6 @@ class DataFrame(_Frame):
             col_sdf = self._sdf[col]
             col_type = self._sdf.schema[col].dataType
 
-            numeric_only = numeric_only if numeric_only is not None else True
             is_numeric_or_boolean = isinstance(col_type, (NumericType, BooleanType))
             min_or_max = sfun.__name__ in ('min', 'max')
             keep_column = not numeric_only or is_numeric_or_boolean or min_or_max

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -524,9 +524,15 @@ class _Frame(object):
         return validate_arguments_and_invoke_function(
             kdf.to_pandas(), self.to_excel, f, args)
 
-    def mean(self):
+    def mean(self, numeric_only=None):
         """
         Return the mean of the values.
+
+        Parameters
+        ----------
+        numeric_only : bool, default None
+            Include only float, int, boolean columns. If None, will attempt to use
+            everything, then use only numeric data. Not implemented for Series.
 
         Returns
         -------
@@ -550,11 +556,17 @@ class _Frame(object):
         >>> df['a'].mean()
         2.0
         """
-        return self._reduce_for_stat_function(F.mean)
+        return self._reduce_for_stat_function(F.mean, numeric_only=numeric_only)
 
-    def sum(self):
+    def sum(self, numeric_only=None):
         """
         Return the sum of the values.
+
+        Parameters
+        ----------
+        numeric_only : bool, default None
+            Include only float, int, boolean columns. If None, will attempt to use
+            everything, then use only numeric data. Not implemented for Series.
 
         Returns
         -------
@@ -578,11 +590,17 @@ class _Frame(object):
         >>> df['a'].sum()
         6.0
         """
-        return self._reduce_for_stat_function(F.sum)
+        return self._reduce_for_stat_function(F.sum, numeric_only=numeric_only)
 
-    def skew(self):
+    def skew(self, numeric_only=None):
         """
         Return unbiased skew normalized by N-1.
+
+        Parameters
+        ----------
+        numeric_only : bool, default None
+            Include only float, int, boolean columns. If None, will attempt to use
+            everything, then use only numeric data. Not implemented for Series.
 
         Returns
         -------
@@ -606,12 +624,18 @@ class _Frame(object):
         >>> df['a'].skew()
         0.0
         """
-        return self._reduce_for_stat_function(F.skewness)
+        return self._reduce_for_stat_function(F.skewness, numeric_only=numeric_only)
 
-    def kurtosis(self):
+    def kurtosis(self, numeric_only=None):
         """
         Return unbiased kurtosis using Fisher’s definition of kurtosis (kurtosis of normal == 0.0).
         Normalized by N-1.
+
+        Parameters
+        ----------
+        numeric_only : bool, default None
+            Include only float, int, boolean columns. If None, will attempt to use
+            everything, then use only numeric data. Not implemented for Series.
 
         Returns
         -------
@@ -635,13 +659,19 @@ class _Frame(object):
         >>> df['a'].kurtosis()
         -1.5
         """
-        return self._reduce_for_stat_function(F.kurtosis)
+        return self._reduce_for_stat_function(F.kurtosis, numeric_only=numeric_only)
 
     kurt = kurtosis
 
-    def min(self):
+    def min(self, numeric_only=None):
         """
         Return the minimum of the values.
+
+        Parameters
+        ----------
+        numeric_only : bool, default None
+            Include only float, int, boolean columns. If None, will attempt to use
+            everything, then use only numeric data. Not implemented for Series.
 
         Returns
         -------
@@ -665,11 +695,17 @@ class _Frame(object):
         >>> df['a'].min()
         1.0
         """
-        return self._reduce_for_stat_function(F.min)
+        return self._reduce_for_stat_function(F.min, numeric_only=numeric_only)
 
-    def max(self):
+    def max(self, numeric_only=None):
         """
         Return the maximum of the values.
+
+        Parameters
+        ----------
+        numeric_only : bool, default None
+            Include only float, int, boolean columns. If None, will attempt to use
+            everything, then use only numeric data. Not implemented for Series.
 
         Returns
         -------
@@ -693,11 +729,17 @@ class _Frame(object):
         >>> df['a'].max()
         3.0
         """
-        return self._reduce_for_stat_function(F.max)
+        return self._reduce_for_stat_function(F.max, numeric_only=numeric_only)
 
-    def std(self):
+    def std(self, numeric_only=None):
         """
         Return sample standard deviation.
+
+        Parameters
+        ----------
+        numeric_only : bool, default None
+            Include only float, int, boolean columns. If None, will attempt to use
+            everything, then use only numeric data. Not implemented for Series.
 
         Returns
         -------
@@ -721,11 +763,17 @@ class _Frame(object):
         >>> df['a'].std()
         1.0
         """
-        return self._reduce_for_stat_function(F.stddev)
+        return self._reduce_for_stat_function(F.stddev, numeric_only=numeric_only)
 
-    def var(self):
+    def var(self, numeric_only=None):
         """
         Return unbiased variance.
+
+        Parameters
+        ----------
+        numeric_only : bool, default None
+            Include only float, int, boolean columns. If None, will attempt to use
+            everything, then use only numeric data. Not implemented for Series.
 
         Returns
         -------
@@ -749,7 +797,7 @@ class _Frame(object):
         >>> df['a'].var()
         1.0
         """
-        return self._reduce_for_stat_function(F.variance)
+        return self._reduce_for_stat_function(F.variance, numeric_only=numeric_only)
 
     @property
     def size(self) -> int:

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -524,7 +524,7 @@ class _Frame(object):
         return validate_arguments_and_invoke_function(
             kdf.to_pandas(), self.to_excel, f, args)
 
-    def mean(self, numeric_only=None):
+    def mean(self, numeric_only=True):
         """
         Return the mean of the values.
 
@@ -558,7 +558,7 @@ class _Frame(object):
         """
         return self._reduce_for_stat_function(F.mean, numeric_only=numeric_only)
 
-    def sum(self, numeric_only=None):
+    def sum(self, numeric_only=True):
         """
         Return the sum of the values.
 
@@ -592,7 +592,7 @@ class _Frame(object):
         """
         return self._reduce_for_stat_function(F.sum, numeric_only=numeric_only)
 
-    def skew(self, numeric_only=None):
+    def skew(self, numeric_only=True):
         """
         Return unbiased skew normalized by N-1.
 
@@ -626,7 +626,7 @@ class _Frame(object):
         """
         return self._reduce_for_stat_function(F.skewness, numeric_only=numeric_only)
 
-    def kurtosis(self, numeric_only=None):
+    def kurtosis(self, numeric_only=True):
         """
         Return unbiased kurtosis using Fisher’s definition of kurtosis (kurtosis of normal == 0.0).
         Normalized by N-1.
@@ -663,7 +663,7 @@ class _Frame(object):
 
     kurt = kurtosis
 
-    def min(self, numeric_only=None):
+    def min(self, numeric_only=False):
         """
         Return the minimum of the values.
 
@@ -697,7 +697,7 @@ class _Frame(object):
         """
         return self._reduce_for_stat_function(F.min, numeric_only=numeric_only)
 
-    def max(self, numeric_only=None):
+    def max(self, numeric_only=False):
         """
         Return the maximum of the values.
 
@@ -731,7 +731,7 @@ class _Frame(object):
         """
         return self._reduce_for_stat_function(F.max, numeric_only=numeric_only)
 
-    def std(self, numeric_only=None):
+    def std(self, numeric_only=True):
         """
         Return sample standard deviation.
 
@@ -765,7 +765,7 @@ class _Frame(object):
         """
         return self._reduce_for_stat_function(F.stddev, numeric_only=numeric_only)
 
-    def var(self, numeric_only=None):
+    def var(self, numeric_only=True):
         """
         Return unbiased variance.
 

--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -137,7 +137,7 @@ def range(start: int,
     return DataFrame(sdf)
 
 
-def read_csv(path, header='infer', names=None, usecols=None,
+def read_csv(path, sep=None, header='infer', names=None, usecols=None,
              mangle_dupe_cols=True, parse_dates=False, comment=None):
     """Read CSV (comma-separated) file into DataFrame.
 
@@ -204,7 +204,7 @@ def read_csv(path, header='infer', names=None, usecols=None,
                 raise ValueError("Only length-1 comment characters supported")
             reader.option("comment", comment)
 
-        sdf = reader.csv(path)
+        sdf = reader.csv(path, sep=sep)
 
         if header is None:
             sdf = sdf.selectExpr(*["`%s` as `%s`" % (field.name, i)

--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -137,7 +137,7 @@ def range(start: int,
     return DataFrame(sdf)
 
 
-def read_csv(path, sep=None, header='infer', names=None, usecols=None,
+def read_csv(path, header='infer', names=None, usecols=None,
              mangle_dupe_cols=True, parse_dates=False, comment=None):
     """Read CSV (comma-separated) file into DataFrame.
 
@@ -204,7 +204,7 @@ def read_csv(path, sep=None, header='infer', names=None, usecols=None,
                 raise ValueError("Only length-1 comment characters supported")
             reader.option("comment", comment)
 
-        sdf = reader.csv(path, sep=sep)
+        sdf = reader.csv(path)
 
         if header is None:
             sdf = sdf.selectExpr(*["`%s` as `%s`" % (field.name, i)

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -1772,7 +1772,11 @@ class Series(_Frame, IndexOpsMixin):
 
     # ----------------------------------------------------------------------
 
-    def _reduce_for_stat_function(self, sfun):
+    def _reduce_for_stat_function(self, sfun, numeric_only=None):
+        """
+        :param sfun: the stats function to be used for aggregation
+        :param numeric_only: not used by this implementation, but passed down by stats functions
+        """
         from inspect import signature
         num_args = len(signature(sfun).parameters)
         col_sdf = self._scol

--- a/databricks/koalas/tests/test_stats.py
+++ b/databricks/koalas/tests/test_stats.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-import unittest
-
 import numpy as np
 import pandas as pd
 
@@ -26,149 +24,150 @@ from databricks.koalas.testing.utils import ReusedSQLTestCase, SQLTestUtils
 class StatsTest(ReusedSQLTestCase, SQLTestUtils):
 
     def test_stat_functions(self):
-        df = pd.DataFrame({'A': [1, 2, 3, 4],
-                           'B': [1.0, 2.1, 3, 4]})
-        ddf = koalas.from_pandas(df)
+        pdf = pd.DataFrame({'A': [1, 2, 3, 4],
+                            'B': [1.0, 2.1, 3, 4]})
+        kdf = koalas.from_pandas(pdf)
 
         functions = ['max', 'min', 'mean', 'sum']
         for funcname in functions:
-            self.assertEqual(getattr(ddf.A, funcname)(), getattr(df.A, funcname)())
-            self.assert_eq(getattr(ddf, funcname)(), getattr(df, funcname)())
+            self.assertEqual(getattr(kdf.A, funcname)(), getattr(pdf.A, funcname)())
+            self.assert_eq(getattr(kdf, funcname)(), getattr(pdf, funcname)())
 
         functions = ['std', 'var']
         for funcname in functions:
-            self.assertAlmostEqual(getattr(ddf.A, funcname)(), getattr(df.A, funcname)())
-            self.assertPandasAlmostEqual(getattr(ddf, funcname)(), getattr(df, funcname)())
+            self.assertAlmostEqual(getattr(kdf.A, funcname)(), getattr(pdf.A, funcname)())
+            self.assertPandasAlmostEqual(getattr(kdf, funcname)(), getattr(pdf, funcname)())
 
         # NOTE: To test skew and kurt, just make sure they run.
         #       The numbers are different in spark and pandas.
         functions = ['skew', 'kurt']
         for funcname in functions:
-            getattr(ddf.A, funcname)()
-            getattr(ddf, funcname)()
+            getattr(kdf.A, funcname)()
+            getattr(kdf, funcname)()
 
     def test_abs(self):
-        df = pd.DataFrame({'A': [1, -2, 3, -4, 5],
-                           'B': [1., -2, 3, -4, 5],
-                           'C': [-6., -7, -8, -9, 10],
-                           'D': ['a', 'b', 'c', 'd', 'e']})
-        ddf = koalas.from_pandas(df)
-        self.assert_eq(ddf.A.abs(), df.A.abs())
-        self.assert_eq(ddf.B.abs(), df.B.abs())
-        self.assert_eq(ddf[['B', 'C']].abs(), df[['B', 'C']].abs())
-        # self.assert_eq(ddf.select('A', 'B').abs(), df[['A', 'B']].abs())
+        pdf = pd.DataFrame({'A': [1, -2, 3, -4, 5],
+                            'B': [1., -2, 3, -4, 5],
+                            'C': [-6., -7, -8, -9, 10],
+                            'D': ['a', 'b', 'c', 'd', 'e']})
+        kdf = koalas.from_pandas(pdf)
+        self.assert_eq(kdf.A.abs(), pdf.A.abs())
+        self.assert_eq(kdf.B.abs(), pdf.B.abs())
+        self.assert_eq(kdf[['B', 'C']].abs(), pdf[['B', 'C']].abs())
+        # self.assert_eq(kdf.select('A', 'B').abs(), pdf[['A', 'B']].abs())
 
     def test_corr(self):
         # Disable arrow execution since corr() is using UDT internally which is not supported.
         with self.sql_conf({'spark.sql.execution.arrow.enabled': False}):
             # DataFrame
             # we do not handle NaNs for now
-            df = pd.util.testing.makeMissingDataframe(0.3, 42).fillna(0)
-            ddf = koalas.from_pandas(df)
+            pdf = pd.util.testing.makeMissingDataframe(0.3, 42).fillna(0)
+            kdf = koalas.from_pandas(pdf)
 
-            res = ddf.corr()
-            sol = df.corr()
+            res = kdf.corr()
+            sol = pdf.corr()
             self.assertPandasAlmostEqual(res, sol)
 
             # Series
-            a = df.A
-            b = df.B
-            da = ddf.A
-            db = ddf.B
+            a = pdf.A
+            b = pdf.B
+            da = kdf.A
+            db = kdf.B
 
             res = da.corr(db)
             sol = a.corr(b)
             self.assertAlmostEqual(res, sol)
-            self.assertRaises(TypeError, lambda: da.corr(ddf))
+            self.assertRaises(TypeError, lambda: da.corr(kdf))
 
     def test_cov_corr_meta(self):
         # Disable arrow execution since corr() is using UDT internally which is not supported.
         with self.sql_conf({'spark.sql.execution.arrow.enabled': False}):
-            df = pd.DataFrame({'a': np.array([1, 2, 3], dtype='i1'),
-                               'b': np.array([1, 2, 3], dtype='i2'),
-                               'c': np.array([1, 2, 3], dtype='i4'),
-                               'd': np.array([1, 2, 3]),
-                               'e': np.array([1.0, 2.0, 3.0], dtype='f4'),
-                               'f': np.array([1.0, 2.0, 3.0]),
-                               'g': np.array([True, False, True]),
-                               'h': np.array(list('abc'))},
-                              index=pd.Index([1, 2, 3], name='myindex'))
-            ddf = koalas.from_pandas(df)
-            self.assert_eq(ddf.corr(), df.corr())
+            pdf = pd.DataFrame({'a': np.array([1, 2, 3], dtype='i1'),
+                                'b': np.array([1, 2, 3], dtype='i2'),
+                                'c': np.array([1, 2, 3], dtype='i4'),
+                                'd': np.array([1, 2, 3]),
+                                'e': np.array([1.0, 2.0, 3.0], dtype='f4'),
+                                'f': np.array([1.0, 2.0, 3.0]),
+                                'g': np.array([True, False, True]),
+                                'h': np.array(list('abc'))},
+                               index=pd.Index([1, 2, 3], name='myindex'))
+            kdf = koalas.from_pandas(pdf)
+            self.assert_eq(kdf.corr(), pdf.corr())
 
     def test_stats_on_boolean_dataframe(self):
-        df = pd.DataFrame({'A': [True, False, True],
-                           'B': [False, False, True]})
-        ddf = koalas.from_pandas(df)
+        pdf = pd.DataFrame({'A': [True, False, True],
+                            'B': [False, False, True]})
+        kdf = koalas.from_pandas(pdf)
 
-        pd.testing.assert_series_equal(ddf.min(), df.min())
-        pd.testing.assert_series_equal(ddf.max(), df.max())
+        pd.testing.assert_series_equal(kdf.min(), pdf.min())
+        pd.testing.assert_series_equal(kdf.max(), pdf.max())
 
-        pd.testing.assert_series_equal(ddf.sum(), df.sum())
-        pd.testing.assert_series_equal(ddf.mean(), df.mean())
+        pd.testing.assert_series_equal(kdf.sum(), pdf.sum())
+        pd.testing.assert_series_equal(kdf.mean(), pdf.mean())
 
-        pd.testing.assert_series_equal(ddf.var(), df.var())
-        pd.testing.assert_series_equal(ddf.std(), df.std())
+        pd.testing.assert_series_equal(kdf.var(), pdf.var())
+        pd.testing.assert_series_equal(kdf.std(), pdf.std())
 
     def test_stats_on_boolean_series(self):
-        s = pd.Series([True, False, True])
-        ds = koalas.from_pandas(s)
+        ps = pd.Series([True, False, True])
+        ks = koalas.from_pandas(ps)
 
-        self.assertEqual(ds.min(), s.min())
-        self.assertEqual(ds.max(), s.max())
+        self.assertEqual(ks.min(), ps.min())
+        self.assertEqual(ks.max(), ps.max())
 
-        self.assertEqual(ds.sum(), s.sum())
-        self.assertEqual(ds.mean(), s.mean())
+        self.assertEqual(ks.sum(), ps.sum())
+        self.assertEqual(ks.mean(), ps.mean())
 
-        self.assertAlmostEqual(ds.var(), s.var())
-        self.assertAlmostEqual(ds.std(), s.std())
+        self.assertAlmostEqual(ks.var(), ps.var())
+        self.assertAlmostEqual(ks.std(), ps.std())
 
     def test_some_stats_functions_should_discard_non_numeric_columns_by_default(self):
-        df = pd.DataFrame({'i': [0, 1, 2],
-                           'b': [False, False, True],
-                           's': ['x', 'y', 'z']})
-        ddf = koalas.from_pandas(df)
+        pdf = pd.DataFrame({'i': [0, 1, 2],
+                            'b': [False, False, True],
+                            's': ['x', 'y', 'z']})
+        kdf = koalas.from_pandas(pdf)
 
         # min and max do not discard non-numeric columns by default
-        self.assertEqual(len(ddf.min()), 3)
-        self.assertEqual(len(ddf.max()), 3)
+        self.assertEqual(len(kdf.min()), len(kdf.min()))
+        self.assertEqual(len(kdf.max()), len(kdf.max()))
 
         # all the others do
-        self.assertEqual(len(ddf.sum()), 2)
-        self.assertEqual(len(ddf.mean()), 2)
+        self.assertEqual(len(kdf.sum()), len(kdf.sum()))
+        self.assertEqual(len(kdf.mean()), len(kdf.mean()))
 
-        self.assertEqual(len(ddf.var()), 2)
-        self.assertEqual(len(ddf.std()), 2)
+        self.assertEqual(len(kdf.var()), len(kdf.var()))
+        self.assertEqual(len(kdf.std()), len(kdf.std()))
 
-        self.assertEqual(len(ddf.kurtosis()), 2)
-        self.assertEqual(len(ddf.skew()), 2)
+        self.assertEqual(len(kdf.kurtosis()), len(kdf.kurtosis()))
+        self.assertEqual(len(kdf.skew()), len(kdf.skew()))
 
     def test_stats_on_non_numeric_columns_should_be_discarded_if_numeric_only_is_true(self):
-        df = pd.DataFrame({'i': [0, 1, 2],
-                           'b': [False, False, True],
-                           's': ['x', 'y', 'z']})
-        ddf = koalas.from_pandas(df)
+        pdf = pd.DataFrame({'i': [0, 1, 2],
+                            'b': [False, False, True],
+                            's': ['x', 'y', 'z']})
+        kdf = koalas.from_pandas(pdf)
 
-        self.assertEqual(len(ddf.sum(numeric_only=True)), 2)
-        self.assertEqual(len(ddf.mean(numeric_only=True)), 2)
+        self.assertEqual(len(kdf.sum(numeric_only=True)), len(kdf.sum(numeric_only=True)))
+        self.assertEqual(len(kdf.mean(numeric_only=True)), len(kdf.mean(numeric_only=True)))
 
-        self.assertEqual(len(ddf.var(numeric_only=True)), 2)
-        self.assertEqual(len(ddf.std(numeric_only=True)), 2)
+        self.assertEqual(len(kdf.var(numeric_only=True)), len(kdf.var(numeric_only=True)))
+        self.assertEqual(len(kdf.std(numeric_only=True)), len(kdf.std(numeric_only=True)))
 
-        self.assertEqual(len(ddf.kurtosis(numeric_only=True)), 2)
-        self.assertEqual(len(ddf.skew(numeric_only=True)), 2)
+        self.assertEqual(len(kdf.kurtosis(numeric_only=True)), len(kdf.kurtosis(numeric_only=True)))
+        self.assertEqual(len(kdf.skew(numeric_only=True)), len(kdf.skew(numeric_only=True)))
 
     def test_stats_on_non_numeric_columns_should_not_be_discarded_if_numeric_only_is_false(self):
-        df = pd.DataFrame({'i': [0, 1, 2],
-                           'b': [False, False, True],
-                           's': ['x', 'y', 'z']})
-        ddf = koalas.from_pandas(df)
+        pdf = pd.DataFrame({'i': [0, 1, 2],
+                            'b': [False, False, True],
+                            's': ['x', 'y', 'z']})
+        kdf = koalas.from_pandas(pdf)
 
-        self.assertEqual(len(ddf.sum(numeric_only=False)), 3)
-        self.assertEqual(len(ddf.mean(numeric_only=False)), 3)
+        self.assertEqual(len(kdf.sum(numeric_only=False)), len(kdf.sum(numeric_only=False)))
+        self.assertEqual(len(kdf.mean(numeric_only=False)), len(kdf.mean(numeric_only=False)))
 
-        self.assertEqual(len(ddf.var(numeric_only=False)), 3)
-        self.assertEqual(len(ddf.std(numeric_only=False)), 3)
+        self.assertEqual(len(kdf.var(numeric_only=False)), len(kdf.var(numeric_only=False)))
+        self.assertEqual(len(kdf.std(numeric_only=False)), len(kdf.std(numeric_only=False)))
 
-        self.assertEqual(len(ddf.kurtosis(numeric_only=False)), 3)
-        self.assertEqual(len(ddf.skew(numeric_only=False)), 3)
+        self.assertEqual(len(kdf.kurtosis(numeric_only=False)),
+                         len(kdf.kurtosis(numeric_only=False)))
+        self.assertEqual(len(kdf.skew(numeric_only=False)), len(kdf.skew(numeric_only=False)))

--- a/databricks/koalas/tests/test_stats.py
+++ b/databricks/koalas/tests/test_stats.py
@@ -123,17 +123,17 @@ class StatsTest(ReusedSQLTestCase, SQLTestUtils):
         self.assertAlmostEqual(ds.var(), s.var())
         self.assertAlmostEqual(ds.std(), s.std())
 
-    def test_stats_on_non_numeric_columns_should_be_discarded_by_default(self):
+    def test_some_stats_functions_should_discard_non_numeric_columns_by_default(self):
         df = pd.DataFrame({'i': [0, 1, 2],
                            'b': [False, False, True],
                            's': ['x', 'y', 'z']})
         ddf = koalas.from_pandas(df)
 
-        # min and max are not affected by this restriction
+        # min and max do not discard non-numeric columns by default
         self.assertEqual(len(ddf.min()), 3)
         self.assertEqual(len(ddf.max()), 3)
 
-        # all the others are
+        # all the others do
         self.assertEqual(len(ddf.sum()), 2)
         self.assertEqual(len(ddf.mean()), 2)
 
@@ -142,6 +142,21 @@ class StatsTest(ReusedSQLTestCase, SQLTestUtils):
 
         self.assertEqual(len(ddf.kurtosis()), 2)
         self.assertEqual(len(ddf.skew()), 2)
+
+    def test_stats_on_non_numeric_columns_should_be_discarded_if_numeric_only_is_true(self):
+        df = pd.DataFrame({'i': [0, 1, 2],
+                           'b': [False, False, True],
+                           's': ['x', 'y', 'z']})
+        ddf = koalas.from_pandas(df)
+
+        self.assertEqual(len(ddf.sum(numeric_only=True)), 2)
+        self.assertEqual(len(ddf.mean(numeric_only=True)), 2)
+
+        self.assertEqual(len(ddf.var(numeric_only=True)), 2)
+        self.assertEqual(len(ddf.std(numeric_only=True)), 2)
+
+        self.assertEqual(len(ddf.kurtosis(numeric_only=True)), 2)
+        self.assertEqual(len(ddf.skew(numeric_only=True)), 2)
 
     def test_stats_on_non_numeric_columns_should_not_be_discarded_if_numeric_only_is_false(self):
         df = pd.DataFrame({'i': [0, 1, 2],

--- a/databricks/koalas/tests/test_stats.py
+++ b/databricks/koalas/tests/test_stats.py
@@ -122,3 +122,38 @@ class StatsTest(ReusedSQLTestCase, SQLTestUtils):
 
         self.assertAlmostEqual(ds.var(), s.var())
         self.assertAlmostEqual(ds.std(), s.std())
+
+    def test_stats_on_non_numeric_columns_should_be_discarded_by_default(self):
+        df = pd.DataFrame({'i': [0, 1, 2],
+                           'b': [False, False, True],
+                           's': ['x', 'y', 'z']})
+        ddf = koalas.from_pandas(df)
+
+        # min and max are not affected by this restriction
+        self.assertEqual(len(ddf.min()), 3)
+        self.assertEqual(len(ddf.max()), 3)
+
+        # all the others are
+        self.assertEqual(len(ddf.sum()), 2)
+        self.assertEqual(len(ddf.mean()), 2)
+
+        self.assertEqual(len(ddf.var()), 2)
+        self.assertEqual(len(ddf.std()), 2)
+
+        self.assertEqual(len(ddf.kurtosis()), 2)
+        self.assertEqual(len(ddf.skew()), 2)
+
+    def test_stats_on_non_numeric_columns_should_not_be_discarded_if_numeric_only_is_false(self):
+        df = pd.DataFrame({'i': [0, 1, 2],
+                           'b': [False, False, True],
+                           's': ['x', 'y', 'z']})
+        ddf = koalas.from_pandas(df)
+
+        self.assertEqual(len(ddf.sum(numeric_only=False)), 3)
+        self.assertEqual(len(ddf.mean(numeric_only=False)), 3)
+
+        self.assertEqual(len(ddf.var(numeric_only=False)), 3)
+        self.assertEqual(len(ddf.std(numeric_only=False)), 3)
+
+        self.assertEqual(len(ddf.kurtosis(numeric_only=False)), 3)
+        self.assertEqual(len(ddf.skew(numeric_only=False)), 3)


### PR DESCRIPTION
Solves #280 

Ensure stats functions other than min/max/count are applied on numeric/boolean columns only by default.