### PR TITLE
Add scikit-learn to `requirements-dev.txt`.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,3 +18,4 @@ pytest
 pytest-cov
 openpyxl
 xlrd
+scikit-learn


### PR DESCRIPTION
MLflow in PyPI was upgraded to `1.0.0` and `scikit-learn` is now an "extra" dependency.
This will also happen with conda soon.
This PR adds it to `requirements-dev.txt` as a test dependency.