### PR TITLE
Fix MLflow version to `0.9.1`.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,9 @@
 pandas>=0.23
 pyarrow>=0.10
 numpy>=1.14
-mlflow
+
+# TODO: support mlflow 1.0.0
+mlflow==0.9.1
 
 # Documentation build
 sphinx==2.0.1


### PR DESCRIPTION
Now that MLflow on PyPI was upgraded to 1.0.0, but it has API breaking changes.
I'd fix the MLflow version to 0.9.1 for now to unblock PRs.