### PR TITLE
Modify `.travis.yml` to notify the installation error.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,11 +62,9 @@ install:
   # Test PyPI installation at Python 3.5. This is also because
   # one of the dependency requires Python 3.6 Conda specifically.
   - if [[ $TRAVIS_PYTHON_VERSION == "3.5" ]]; then
-      pip install -r requirements-dev.txt;
-      pip list;
+      pip install -r requirements-dev.txt && pip list;
     else
-      conda install -c conda-forge --yes --file requirements-dev.txt;
-      conda list;
+      conda install -c conda-forge --yes --file requirements-dev.txt && conda list;
     fi
 
   # Useful for to_clipboard test

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -20,3 +20,5 @@ pytest
 pytest-cov
 openpyxl
 xlrd
+
+somethingwrong

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -20,5 +20,3 @@ pytest
 pytest-cov
 openpyxl
 xlrd
-
-somethingwrong


### PR DESCRIPTION
Currently travis ignores the pip/conda installation error.