### PR TITLE
Skip index check when `ignore_index` is True.

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -2885,7 +2885,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             raise ValueError("The 'sort' parameter is currently not supported")
 
         index_columns = self._metadata.index_columns
-        if len(index_columns) != len(other._metadata.index_columns):
+        if not ignore_index and len(index_columns) != len(other._metadata.index_columns):
             raise ValueError("Both DataFrames have to have the same number of index levels")
 
         if verify_integrity:

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -2891,7 +2891,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
             if verify_integrity and len(index_columns) > 0:
                 if (self._sdf.select(index_columns)
-                        .intersect(other._sdf.select(index_columns))
+                        .intersect(other._sdf.select(other._metadata.index_columns))
                         .count()) > 0:
                     raise ValueError("Indices have overlapping values")
 

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -2889,9 +2889,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             if len(index_columns) != len(other._metadata.index_columns):
                 raise ValueError("Both DataFrames have to have the same number of index levels")
 
-            if verify_integrity:
-                if (self._sdf.select(index_columns[0])
-                        .intersect(other._sdf.select(index_columns[0]))
+            if verify_integrity and len(index_columns) > 0:
+                if (self._sdf.select(index_columns)
+                        .intersect(other._sdf.select(index_columns))
                         .count()) > 0:
                     raise ValueError("Indices have overlapping values")
 

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -2884,15 +2884,16 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         if sort:
             raise ValueError("The 'sort' parameter is currently not supported")
 
-        index_columns = self._metadata.index_columns
-        if not ignore_index and len(index_columns) != len(other._metadata.index_columns):
-            raise ValueError("Both DataFrames have to have the same number of index levels")
+        if not ignore_index:
+            index_columns = self._metadata.index_columns
+            if len(index_columns) != len(other._metadata.index_columns):
+                raise ValueError("Both DataFrames have to have the same number of index levels")
 
-        if verify_integrity:
-            if (self._sdf.select(index_columns[0])
-                    .intersect(other._sdf.select(index_columns[0]))
-                    .count()) > 0:
-                raise ValueError("Indices have overlapping values")
+            if verify_integrity:
+                if (self._sdf.select(index_columns[0])
+                        .intersect(other._sdf.select(index_columns[0]))
+                        .count()) > 0:
+                    raise ValueError("Indices have overlapping values")
 
         # Lazy import to avoid circular dependency issues
         from databricks.koalas.namespace import concat

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -585,6 +585,9 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         with self.assertRaises(ValueError, msg=msg):
             kdf.append(kdf, verify_integrity=True)
 
+        self.assert_eq(kdf.append(kdf, ignore_index=True, verify_integrity=True),
+                       pdf.append(pdf, ignore_index=True, verify_integrity=True))
+
         # Assert appending multi-index DataFrames
         multi_index_pdf = pd.DataFrame([[1, 2], [3, 4]], columns=list('AB'),
                                        index=[[2, 3], [4, 5]])

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -601,6 +601,10 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(multi_index_kdf.append(multi_index_kdf),
                        multi_index_pdf.append(multi_index_pdf))
 
+        # Assert DataFrames with non-matching columns
+        self.assert_eq(multi_index_kdf.append(other_multi_index_kdf),
+                       multi_index_pdf.append(other_multi_index_pdf))
+
         # Assert using 'verify_integrity' only raises an exception for overlapping indices
         self.assert_eq(multi_index_kdf.append(other_multi_index_kdf, verify_integrity=True),
                        multi_index_pdf.append(other_multi_index_pdf, verify_integrity=True))

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -595,7 +595,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
                                        index=[[2, 3], [4, 5]])
         multi_index_kdf = ks.from_pandas(multi_index_pdf)
         other_multi_index_pdf = pd.DataFrame([[5, 6], [7, 8]], columns=list('AB'),
-                                             index=[[6, 7], [8, 9]])
+                                             index=[[2, 3], [6, 7]])
         other_multi_index_kdf = ks.from_pandas(other_multi_index_pdf)
 
         self.assert_eq(multi_index_kdf.append(multi_index_kdf),

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -597,6 +597,9 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         with self.assertRaises(ValueError, msg=msg):
             kdf.append(multi_index_kdf)
 
+        self.assert_eq(kdf.append(multi_index_kdf, ignore_index=True),
+                       pdf.append(multi_index_pdf, ignore_index=True))
+
     def test_clip(self):
         pdf = pd.DataFrame({'A': [0, 2, 4]})
         kdf = ks.from_pandas(pdf)

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -580,11 +580,13 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             kdf.append(kdf, sort=True)
 
         # Assert using 'verify_integrity' only raises an exception for overlapping indices
-        kdf.append(other_kdf, verify_integrity=True)
+        self.assert_eq(kdf.append(other_kdf, verify_integrity=True),
+                       pdf.append(other_pdf, verify_integrity=True))
         msg = "Indices have overlapping values"
         with self.assertRaises(ValueError, msg=msg):
             kdf.append(kdf, verify_integrity=True)
 
+        # Skip integrity verification when ignore_index=True
         self.assert_eq(kdf.append(kdf, ignore_index=True, verify_integrity=True),
                        pdf.append(pdf, ignore_index=True, verify_integrity=True))
 
@@ -592,14 +594,31 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         multi_index_pdf = pd.DataFrame([[1, 2], [3, 4]], columns=list('AB'),
                                        index=[[2, 3], [4, 5]])
         multi_index_kdf = ks.from_pandas(multi_index_pdf)
+        other_multi_index_pdf = pd.DataFrame([[5, 6], [7, 8]], columns=list('AB'),
+                                             index=[[6, 7], [8, 9]])
+        other_multi_index_kdf = ks.from_pandas(other_multi_index_pdf)
+
         self.assert_eq(multi_index_kdf.append(multi_index_kdf),
                        multi_index_pdf.append(multi_index_pdf))
+
+        # Assert using 'verify_integrity' only raises an exception for overlapping indices
+        self.assert_eq(multi_index_kdf.append(other_multi_index_kdf, verify_integrity=True),
+                       multi_index_pdf.append(other_multi_index_pdf, verify_integrity=True))
+        with self.assertRaises(ValueError, msg=msg):
+            multi_index_kdf.append(multi_index_kdf, verify_integrity=True)
+
+        # Skip integrity verification when ignore_index=True
+        self.assert_eq(multi_index_kdf.append(multi_index_kdf,
+                                              ignore_index=True, verify_integrity=True),
+                       multi_index_pdf.append(multi_index_pdf,
+                                              ignore_index=True, verify_integrity=True))
 
         # Assert trying to append DataFrames with different index levels
         msg = "Both DataFrames have to have the same number of index levels"
         with self.assertRaises(ValueError, msg=msg):
             kdf.append(multi_index_kdf)
 
+        # Skip index level check when ignore_index=True
         self.assert_eq(kdf.append(multi_index_kdf, ignore_index=True),
                        pdf.append(multi_index_pdf, ignore_index=True))
 


### PR DESCRIPTION
This is a follow-up of #388.
We can skip index level check and integrity verification when `ignore_index` is True.