### PR TITLE
Add from_records()

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -1631,22 +1631,17 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         Parameters
         ----------
         data : ndarray (structured dtype), list of tuples, dict, or DataFrame
-
         index : string, list of fields, array-like
             Field of array to use as the index, alternately a specific set of input labels to use
-
         exclude : sequence, default None
             Columns or fields to exclude
-
         columns : sequence, default None
             Column names to use. If the passed data do not have names associated with them, this
             argument provides names for the columns. Otherwise this argument indicates the order of
             the columns in the result (any names not found in the data will become all-NA columns)
-
         coerce_float : boolean, default False
             Attempt to convert values of non-string, non-numeric objects (like decimal.Decimal) to
             floating point, useful for SQL result sets
-
         nrows : int, default None
             Number of rows to read if data is an iterator
 

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -1623,7 +1623,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
     @staticmethod
     def from_records(data: Union[np.array, List[tuple], dict, pd.DataFrame],
                      index: Union[str, list, np.array] = None, exclude: list = None,
-                     columns: list = None, coerce_float: bool = False, nrows: int = None):
+                     columns: list = None, coerce_float: bool = False, nrows: int = None) \
+            -> 'DataFrame':
         """
         Convert structured or record ndarray to DataFrame.
 

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -1620,6 +1620,67 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                           [name for name, _ in pairs if name not in data_columns]))
         return DataFrame(sdf, metadata)
 
+    @staticmethod
+    def from_records(data: Union[np.array, List[tuple], dict, pd.DataFrame],
+                     index: Union[str, list, np.array] = None, exclude: list = None,
+                     columns: list = None, coerce_float: bool = False, nrows: int = None):
+        """
+        Convert structured or record ndarray to DataFrame.
+
+        Parameters
+        ----------
+        data : ndarray (structured dtype), list of tuples, dict, or DataFrame
+
+        index : string, list of fields, array-like
+            Field of array to use as the index, alternately a specific set of input labels to use
+
+        exclude : sequence, default None
+            Columns or fields to exclude
+
+        columns : sequence, default None
+            Column names to use. If the passed data do not have names associated with them, this
+            argument provides names for the columns. Otherwise this argument indicates the order of
+            the columns in the result (any names not found in the data will become all-NA columns)
+
+        coerce_float : boolean, default False
+            Attempt to convert values of non-string, non-numeric objects (like decimal.Decimal) to
+            floating point, useful for SQL result sets
+
+        nrows : int, default None
+            Number of rows to read if data is an iterator
+
+        Returns
+        -------
+        df : DataFrame
+
+        Examples
+        --------
+        Use dict as input
+
+        >>> ks.DataFrame.from_records({'A': [1, 2, 3]})
+           A
+        0  1
+        1  2
+        2  3
+
+        Use list of tuples as input
+
+        >>> ks.DataFrame.from_records([(1, 2), (3, 4)])
+           0  1
+        0  1  2
+        1  3  4
+
+        Use NumPy array as input
+
+        >>> ks.DataFrame.from_records(np.eye(3))
+             0    1    2
+        0  1.0  0.0  0.0
+        1  0.0  1.0  0.0
+        2  0.0  0.0  1.0
+        """
+        return DataFrame(pd.DataFrame.from_records(data, index, exclude, columns, coerce_float,
+                                                   nrows))
+
     def to_records(self, index=True, convert_datetime64=None,
                    column_dtypes=None, index_dtypes=None):
         """

--- a/databricks/koalas/tests/test_dataframe_conversion.py
+++ b/databricks/koalas/tests/test_dataframe_conversion.py
@@ -19,7 +19,7 @@ import string
 import numpy as np
 import pandas as pd
 
-from databricks import koalas
+from databricks import koalas as ks
 from distutils.version import LooseVersion
 from databricks.koalas.testing.utils import ReusedSQLTestCase, SQLTestUtils, TestUtils
 
@@ -35,7 +35,7 @@ class DataFrameConversionTest(ReusedSQLTestCase, SQLTestUtils, TestUtils):
 
     @property
     def kdf(self):
-        return koalas.from_pandas(self.pdf)
+        return ks.from_pandas(self.pdf)
 
     @staticmethod
     def strip_all_whitespace(str):
@@ -53,7 +53,7 @@ class DataFrameConversionTest(ReusedSQLTestCase, SQLTestUtils, TestUtils):
             'b': ["one", "two", None],
         }, index=[0, 1, 3])
 
-        kdf = koalas.from_pandas(pdf)
+        kdf = ks.from_pandas(pdf)
 
         self.assert_eq(kdf.to_csv(na_rep='null'), pdf.to_csv(na_rep='null'))
 
@@ -62,7 +62,7 @@ class DataFrameConversionTest(ReusedSQLTestCase, SQLTestUtils, TestUtils):
             'b': [4.0, 5.0, 6.0],
         }, index=[0, 1, 3])
 
-        kdf = koalas.from_pandas(pdf)
+        kdf = ks.from_pandas(pdf)
 
         self.assert_eq(kdf.to_csv(float_format='%.1f'), pdf.to_csv(float_format='%.1f'))
         self.assert_eq(kdf.to_csv(header=False), pdf.to_csv(header=False))
@@ -128,7 +128,7 @@ class DataFrameConversionTest(ReusedSQLTestCase, SQLTestUtils, TestUtils):
                 'b': ["one", "two", None],
             }, index=[0, 1, 3])
 
-            kdf = koalas.from_pandas(pdf)
+            kdf = ks.from_pandas(pdf)
 
             kdf.to_excel(koalas_location, na_rep='null')
             pdf.to_excel(pandas_location, na_rep='null')
@@ -140,7 +140,7 @@ class DataFrameConversionTest(ReusedSQLTestCase, SQLTestUtils, TestUtils):
                 'b': [4.0, 5.0, 6.0],
             }, index=[0, 1, 3])
 
-            kdf = koalas.from_pandas(pdf)
+            kdf = ks.from_pandas(pdf)
 
             kdf.to_excel(koalas_location, float_format='%.1f')
             pdf.to_excel(pandas_location, float_format='%.1f')
@@ -159,7 +159,7 @@ class DataFrameConversionTest(ReusedSQLTestCase, SQLTestUtils, TestUtils):
 
     def test_to_json(self):
         pdf = self.pdf
-        kdf = koalas.from_pandas(pdf)
+        kdf = ks.from_pandas(pdf)
 
         self.assert_eq(kdf.to_json(), pdf.to_json())
         self.assert_eq(kdf.to_json(orient='split'), pdf.to_json(orient='split'))
@@ -205,10 +205,33 @@ class DataFrameConversionTest(ReusedSQLTestCase, SQLTestUtils, TestUtils):
                 'B': [0.5, 0.75]
             }, index=['a', 'b'])
 
-            kdf = koalas.from_pandas(pdf)
+            kdf = ks.from_pandas(pdf)
 
             self.assert_array_eq(kdf.to_records(), pdf.to_records())
             self.assert_array_eq(kdf.to_records(index=False),
                                  pdf.to_records(index=False))
             self.assert_array_eq(kdf.to_records(index_dtypes="<S2"),
                                  pdf.to_records(index_dtypes="<S2"))
+
+    def test_from_records(self):
+        # Assert using a dict as input
+        self.assert_eq(ks.DataFrame.from_records({'A': [1, 2, 3]}),
+                       pd.DataFrame.from_records({'A': [1, 2, 3]}))
+        # Assert using a list of tuples as input
+        self.assert_eq(repr(ks.DataFrame.from_records([(1, 2), (3, 4)])),
+                       repr(pd.DataFrame.from_records([(1, 2), (3, 4)])))
+        # Assert using a NumPy array as input
+        self.assert_eq(repr(ks.DataFrame.from_records(np.eye(3))),
+                       repr(pd.DataFrame.from_records(np.eye(3))))
+        # Asserting using a custom index
+        self.assert_eq(repr(ks.DataFrame.from_records([(1, 2), (3, 4)], index=[2, 3])),
+                       repr(pd.DataFrame.from_records([(1, 2), (3, 4)], index=[2, 3])))
+        # Assert excluding excluding column(s)
+        self.assert_eq(ks.DataFrame.from_records({'A': [1, 2, 3], 'B': [1, 2, 3]}, exclude=['B']),
+                       pd.DataFrame.from_records({'A': [1, 2, 3], 'B': [1, 2, 3]}, exclude=['B']))
+        # Assert limiting to certain column(s)
+        self.assert_eq(ks.DataFrame.from_records({'A': [1, 2, 3], 'B': [1, 2, 3]}, columns=['A']),
+                       pd.DataFrame.from_records({'A': [1, 2, 3], 'B': [1, 2, 3]}, columns=['A']))
+        # Assert limiting to a number of rows
+        self.assert_eq(repr(ks.DataFrame.from_records([(1, 2), (3, 4)], nrows=1)),
+                       repr(pd.DataFrame.from_records([(1, 2), (3, 4)], nrows=1)))

--- a/docs/source/reference/frame.rst
+++ b/docs/source/reference/frame.rst
@@ -147,6 +147,7 @@ Serialization / IO / Conversion
 .. autosummary::
    :toctree: api/
 
+   DataFrame.from_records
    DataFrame.to_csv
    DataFrame.to_pandas
    DataFrame.to_html


### PR DESCRIPTION
As discussed in #415, this PR adds pandas' `DataFrame.from_records()` method to Koalas.