### PR TITLE
Add Series[T] and DataFrame[Types[T, ...]] type hint

### DIFF
--- a/databricks/koalas/__init__.py
+++ b/databricks/koalas/__init__.py
@@ -39,11 +39,11 @@ from databricks.koalas.namespace import *
 from databricks.koalas.frame import DataFrame
 from databricks.koalas.indexes import Index, MultiIndex
 from databricks.koalas.series import Series
-from databricks.koalas.typedef import Col, pandas_wraps
+from databricks.koalas.typedef import pandas_wraps, Types
 from databricks.koalas.sql import sql
 
 __all__ = ['read_csv', 'read_parquet', 'to_datetime', 'from_pandas',
-           'get_dummies', 'DataFrame', 'Series', 'Index', 'MultiIndex', 'Col', 'pandas_wraps',
+           'get_dummies', 'DataFrame', 'Series', 'Index', 'MultiIndex', 'Types', 'pandas_wraps',
            'sql', 'range', 'concat']
 
 

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -20,7 +20,7 @@ A wrapper class for Spark DataFrame to behave similar to pandas DataFrame.
 import re
 import warnings
 from functools import partial, reduce
-from typing import Any, Optional, List, Tuple, Union
+from typing import Any, Optional, List, Tuple, Union, TypeVar, Generic
 
 import numpy as np
 import pandas as pd
@@ -33,13 +33,13 @@ from pyspark.sql.types import (BooleanType, ByteType, DecimalType, DoubleType, F
 from pyspark.sql.utils import AnalysisException
 
 from databricks import koalas as ks  # For running doctests and reference resolution in PyCharm.
+from databricks.koalas.typedef import Types
 from databricks.koalas.utils import validate_arguments_and_invoke_function
 from databricks.koalas.generic import _Frame, max_display_count
 from databricks.koalas.internal import _InternalFrame
 from databricks.koalas.metadata import Metadata
 from databricks.koalas.missing.frame import _MissingPandasLikeDataFrame
 from databricks.koalas.ml import corr
-from databricks.koalas.typedef import infer_pd_series_spark_type
 
 
 # These regular expression patterns are complied and defined here to avoid to compile the same
@@ -153,7 +153,10 @@ rectangle     4.0    360.0
 """
 
 
-class DataFrame(_Frame):
+T = TypeVar('T', bound=Types)
+
+
+class DataFrame(_Frame, Generic[T]):
     """
     Koala DataFrame that corresponds to Pandas DataFrame logically. This holds Spark DataFrame
     internally.
@@ -2515,7 +2518,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         }
         by = [mapper[(asc, na_position)](self[colname]._scol)
               for colname, asc in zip(by, ascending)]
-        kdf = DataFrame(self._sdf.sort(*by), self._metadata.copy())
+        kdf = DataFrame(self._sdf.sort(*by), self._metadata.copy())  # type: ks.DataFrame
         if inplace:
             self._sdf = kdf._sdf
             self._metadata = kdf._metadata

--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -32,7 +32,7 @@ from pyspark.sql.types import ByteType, ShortType, IntegerType, LongType, FloatT
 from databricks import koalas as ks  # For running doctests and reference resolution in PyCharm.
 from databricks.koalas.utils import default_session
 from databricks.koalas.frame import DataFrame, _reduce_spark_multi
-from databricks.koalas.typedef import Col, pandas_wraps
+from databricks.koalas.typedef import pandas_wraps
 from databricks.koalas.series import Series, _col
 
 
@@ -1175,7 +1175,7 @@ def concat(objs, axis=0, join='outer', ignore_index=False):
 
 # @pandas_wraps(return_col=np.datetime64)
 @pandas_wraps
-def _to_datetime1(arg, errors, format, infer_datetime_format) -> Col[np.datetime64]:
+def _to_datetime1(arg, errors, format, infer_datetime_format) -> Series[np.datetime64]:
     return pd.to_datetime(
         arg,
         errors=errors,
@@ -1186,7 +1186,7 @@ def _to_datetime1(arg, errors, format, infer_datetime_format) -> Col[np.datetime
 # @pandas_wraps(return_col=np.datetime64)
 @pandas_wraps
 def _to_datetime2(arg_year, arg_month, arg_day,
-                  errors, format, infer_datetime_format) -> Col[np.datetime64]:
+                  errors, format, infer_datetime_format) -> Series[np.datetime64]:
     arg = dict(year=arg_year, month=arg_month, day=arg_day)
     for key in arg:
         if arg[key] is None:

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -20,7 +20,7 @@ A wrapper class for Spark Column to behave similar to pandas Series.
 import re
 import inspect
 from functools import partial, wraps
-from typing import Any, Optional, List, Union
+from typing import Any, Optional, List, Union, Generic, TypeVar
 
 import numpy as np
 import pandas as pd
@@ -160,12 +160,13 @@ d    NaN
 Name: a, dtype: float64
 """
 
+T = TypeVar("T")
 
 # Needed to disambiguate Series.str and str type
 str_type = str
 
 
-class Series(_Frame, IndexOpsMixin):
+class Series(_Frame, IndexOpsMixin, Generic[T]):
     """
     Koala Series that corresponds to Pandas Series logically. This holds Spark Column
     internally.

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -419,7 +419,7 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         # name as its internal expression which contains, for instance, '`f(x)`' in the middle of
         # column name which currently cannot be recognized in PySpark.
         @koalas.pandas_wraps
-        def f(x) -> koalas.Col[int]:
+        def f(x) -> koalas.Series[int]:
             return 2 * x
 
         df = koalas.DataFrame({"x": [1, None]})

--- a/databricks/koalas/typedef.py
+++ b/databricks/koalas/typedef.py
@@ -33,65 +33,63 @@ import pyspark.sql.types as types
 from databricks import koalas as ks  # For running doctests and reference resolution in PyCharm.
 
 
-__all__ = ['Col', 'pandas_wraps', 'as_spark_type',
+__all__ = ['pandas_wraps', 'as_spark_type',
            'as_python_type', 'infer_pd_series_spark_type']
 
 
-T = typing.TypeVar("T")
-
-
-class Col(typing.Generic[T]):
-    def is_col(self):
-        return self
+# This is a workaround to support variadic generic in DataFrame.
+# See https://github.com/python/typing/issues/193
+Types = typing.Tuple
 
 
 # A column of data, with the data type.
-class _Column(object):
-    def __init__(self, inner):
-        self.inner = inner  # type: types.DataType
+class _Series(object):
+    def __init__(self, tpe):
+        self.tpe = tpe  # type: types.DataType
 
     def __repr__(self):
-        return "_ColumnType[{}]".format(self.inner)
+        return "_SeriesType[{}]".format(self.tpe)
 
 
 class _DataFrame(object):
+    def __init__(self, tpe):
+        # Seems we cannot specify field names. I currently gave some default names
+        # `c0, c1, ... cn`.
+        self.tpe = types.StructType(
+            [types.StructField("c%s" % i, tpe[i])
+             for i in range(len(tpe))])  # type: types.StructType
+
     def __repr__(self):
-        return "_DataFrameType"
+        return "_DataFrameType[{}]".format(self.tpe)
 
 
 # The type is a scalar type that is furthermore understood by Spark.
 class _Scalar(object):
     def __init__(self, tpe):
-        self.type = tpe  # type: types.DataType
+        self.tpe = tpe  # type: types.DataType
 
     def __repr__(self):
-        return "_ScalarType[{}]".format(self.type)
+        return "_ScalarType[{}]".format(self.tpe)
 
 
 # The type is left unspecified or we do not know about this type.
 class _Unknown(object):
     def __init__(self, tpe):
-        self.type = tpe
+        self.tpe = tpe
 
     def __repr__(self):
-        return "_UnknownType[{}]".format(self.type)
+        return "_UnknownType[{}]".format(self.tpe)
 
 
-X = typing.Union[_Column, _DataFrame, _Scalar, _Unknown]
-
-
-def _is_col(tpe):
-    return hasattr(tpe, "is_col")
-
-
-def _get_col_inner(tpe):
-    return tpe.__args__[0]
+X = typing.Union[_Series, _DataFrame, _Scalar, _Unknown]
 
 
 def _to_stype(tpe) -> X:
-    if _is_col(tpe):
-        inner = as_spark_type(_get_col_inner(tpe))
-        return _Column(inner)
+    if hasattr(tpe, "__origin__") and tpe.__origin__ == ks.Series:
+        inner = as_spark_type(tpe.__args__[0])
+        return _Series(inner)
+    if hasattr(tpe, "__origin__") and tpe.__origin__ == ks.DataFrame:
+        return _DataFrame([as_spark_type(t) for t in tpe.__args__[0].__args__])
     inner = as_spark_type(tpe)
     if inner is None:
         return _Unknown(tpe)
@@ -251,7 +249,7 @@ def _make_fun(f: typing.Callable, return_type: types.DataType, *args, **kwargs) 
         spark_col_args.append(col._scol)
         kw_name_tokens.append("{}={}".format(key, col.name))
     col = wrapped_udf(*spark_col_args)
-    series = Series(data=col, index=index_map, anchor=kdf)
+    series = Series(data=col, index=index_map, anchor=kdf)  # type: 'ks.Series'
     all_name_tokens = name_tokens + sorted(kw_name_tokens)
     name = "{}({})".format(f.__name__, ", ".join(all_name_tokens))
     series = series.astype(return_type).alias(name)
@@ -280,7 +278,7 @@ def pandas_wraps(function=None, return_col=None, return_scalar=None):
 
     Wrapping a function with python 3's type annotations:
 
-    >>> from databricks.koalas import pandas_wraps, Col
+    >>> from databricks.koalas import pandas_wraps
     >>> pdf = pd.DataFrame({"col1": [1, 2], "col2": [10, 20]}, dtype=np.int64)
     >>> df = ks.DataFrame(pdf)
 
@@ -298,7 +296,7 @@ def pandas_wraps(function=None, return_col=None, return_scalar=None):
     returns a Series of integers:
 
     >>> @pandas_wraps
-    ... def fun(col1) -> Col[np.int64]:
+    ... def fun(col1) -> ks.Series[np.int64]:
     ...     return col1.apply(lambda x: x * 2)  # Arbitrary pandas code.
 
     This function works as before on pandas Series:
@@ -358,10 +356,10 @@ def pandas_wraps(function=None, return_col=None, return_scalar=None):
         def wrapper(*args, **kwargs):
             # Extract the signature arguments from this function.
             sig_return = _infer_return_type(f, return_col, return_scalar)
-            if not isinstance(sig_return, _Column):
+            if not isinstance(sig_return, _Series):
                 raise ValueError("Expected the return type of this function to be of type column,"
                                  " but found type {}".format(sig_return))
-            spark_return_type = sig_return.inner
+            spark_return_type = sig_return.tpe
             return _make_fun(f, spark_return_type, *args, **kwargs)
         return wrapper
     if callable(function):
@@ -370,28 +368,42 @@ def pandas_wraps(function=None, return_col=None, return_scalar=None):
         return function_wrapper
 
 
-def _infer_return_type(f, return_col_hint=None, return_scalar_hint=None) -> X:
+def _infer_return_type(f, return_col=None, return_scalar=None) -> X:
+    """
+    >>> def func() -> int:
+    ...    pass
+    >>> _infer_return_type(func).tpe
+    IntegerType
+
+    >>> def func() -> ks.Series[int]:
+    ...    pass
+    >>> _infer_return_type(func).tpe
+    IntegerType
+
+    >>> def func() -> ks.DataFrame[Types[np.float, str]]:
+    ...    pass
+    >>> _infer_return_type(func).tpe
+    StructType(List(StructField(c0,FloatType,true),StructField(c1,StringType,true)))
+
+    >>> def func() -> ks.DataFrame[Types[np.float]]:
+    ...    pass
+    >>> _infer_return_type(func).tpe
+    StructType(List(StructField(c0,FloatType,true)))
+    """
     spec = getfullargspec(f)
     return_sig = spec.annotations.get("return", None)
-    return _get_return_type(return_sig, return_col_hint, return_scalar_hint)
 
-
-def _get_return_type(return_sig, return_col, return_scalar) -> X:
-    """
-    Resolves the return type.
-    :return: X
-    """
     if not (return_col or return_sig or return_scalar):
         raise ValueError(
             "Missing type information. It should either be provided as an argument to "
             "pandas_wraps, or as a python typing hint")
     if return_col is not None:
-        if isinstance(return_col, Col):
+        if isinstance(return_col, ks.Series):
             return _to_stype(return_col)
         inner = as_spark_type(return_col)
-        return _Column(inner)
+        return _Series(inner)
     if return_scalar is not None:
-        if isinstance(return_scalar, Col):
+        if isinstance(return_scalar, ks.Series):
             raise ValueError("Column return type {}, you should use 'return_col' to specify"
                              " it.".format(return_scalar))
         inner = as_spark_type(return_scalar)


### PR DESCRIPTION
This PR proposes to add a generic type hint support for both `Series` and `DataFrame`.

Looks we need a way to specify type hint in order for them to be set when we run Python native functions via, for instance, `apply(func)`. For `DataFrame`, `groupby(..).apply(func)` needs it if we implement it. Consider this example:

```python
def func(pdf) -> DataFrame[...]
    return pdf

df.groupby.apply(func)
```

We already have a way in case of `Series` (previously `Col`). I renamed and refactored it to `Series`.

The new type hints are used as below:

```python
def func(...) -> Series[np.float]:
    ...

def func(...) -> DataFrame[Types[np.float, int, str]]:
    ...
```

There are some backgrounds about why `DataFrame` happened to need another `Types`. Seems variadic generic type hint isn't supported yet: https://github.com/python/typing/issues/193

**Note:** there is an internal API called `_VariadicGenericAlias` in Python 3.7. Python 3.5 and 3.6 uses a different way since it's internal. If `DataFrame[Types[np.float, int, str]]` is really ugly and it should be `DataFrame[np.float, int, str]`, I can try to reuse those internal stuff that works from 3.5, 3.6 3.7 - the code amount will be considerable. UPDATE: I took a look and seems not possible.

So, I renamed `Tuple` (existing variadic generic type) to `Types` and let `DataFrame` takes this. Seems inheritance doesn't work and I couldn't find other workarounds.

Another point is that:

```python
def func(...) -> DataFrame[Types[np.float, int, str]]
    ...
```

Seems we cannot specify field names. I currently gave some default names `c0, c1, ... cn`.

Please let me know if you guys have a different or better idea than this.