### PR TITLE
Make reference doc header consistent

### DIFF
--- a/docs/source/reference/frame.rst
+++ b/docs/source/reference/frame.rst
@@ -6,14 +6,14 @@ DataFrame
 .. currentmodule:: databricks.koalas
 
 Constructor
-~~~~~~~~~~~
+-----------
 .. autosummary::
    :toctree: api/
 
    DataFrame
 
 Attributes and underlying data
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------------
 
 .. autosummary::
    :toctree: api/
@@ -30,7 +30,7 @@ Attributes and underlying data
    DataFrame.size
 
 Conversion
-~~~~~~~~~~
+----------
 .. autosummary::
    :toctree: api/
 
@@ -42,7 +42,7 @@ Conversion
    DataFrame.notnull
 
 Indexing, iteration
-~~~~~~~~~~~~~~~~~~~
+-------------------
 .. autosummary::
    :toctree: api/
 
@@ -54,7 +54,7 @@ Indexing, iteration
    DataFrame.get
 
 Binary operator functions
-~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------
 .. autosummary::
    :toctree: api/
 
@@ -70,7 +70,7 @@ Binary operator functions
    DataFrame.rsub
 
 Function application, GroupBy & Window
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------------------
 .. autosummary::
    :toctree: api/
 
@@ -81,7 +81,7 @@ Function application, GroupBy & Window
 .. _api.dataframe.stats:
 
 Computations / Descriptive Stats
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------------
 .. autosummary::
    :toctree: api/
 
@@ -102,7 +102,7 @@ Computations / Descriptive Stats
    DataFrame.var
 
 Reindexing / Selection / Label manipulation
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------------------
 .. autosummary::
    :toctree: api/
 
@@ -118,7 +118,7 @@ Reindexing / Selection / Label manipulation
 .. _api.dataframe.missing:
 
 Missing data handling
-~~~~~~~~~~~~~~~~~~~~~
+---------------------
 .. autosummary::
    :toctree: api/
 
@@ -126,7 +126,7 @@ Missing data handling
    DataFrame.fillna
 
 Reshaping, sorting, transposing
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------
 .. autosummary::
    :toctree: api/
 
@@ -134,7 +134,7 @@ Reshaping, sorting, transposing
    DataFrame.sort_values
 
 Combining / joining / merging
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------
 .. autosummary::
    :toctree: api/
 
@@ -143,7 +143,7 @@ Combining / joining / merging
    DataFrame.merge
 
 Serialization / IO / Conversion
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------
 .. autosummary::
    :toctree: api/
 

--- a/docs/source/reference/general_functions.rst
+++ b/docs/source/reference/general_functions.rst
@@ -6,7 +6,7 @@ General functions
 .. currentmodule:: databricks.koalas
 
 Data manipulations
-~~~~~~~~~~~~~~~~~~
+------------------
 .. autosummary::
    :toctree: api/
 
@@ -15,7 +15,7 @@ Data manipulations
    concat
 
 Top-level dealing with datetimelike
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------------
 .. autosummary::
    :toctree: api/
 
@@ -23,7 +23,7 @@ Top-level dealing with datetimelike
 
 
 Integration with Spark and pandas
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---------------------------------
 .. autosummary::
    :toctree: api/
 

--- a/docs/source/reference/io.rst
+++ b/docs/source/reference/io.rst
@@ -7,42 +7,42 @@ Input/Output
 
 
 Data Generator
-~~~~~~~~~~~~~~
+--------------
 .. autosummary::
    :toctree: api/
 
    range
 
 Flat File
-~~~~~~~~~
+---------
 .. autosummary::
    :toctree: api/
 
    read_csv
 
 Clipboard
-~~~~~~~~~
+---------
 .. autosummary::
    :toctree: api/
 
    read_clipboard
 
 Excel
-~~~~~
+-----
 .. autosummary::
    :toctree: api/
 
    read_excel
 
 HTML
-~~~~
+----
 .. autosummary::
    :toctree: api/
 
    read_html
 
 Parquet
-~~~~~~~
+-------
 .. autosummary::
    :toctree: api/
 

--- a/docs/source/reference/ml.rst
+++ b/docs/source/reference/ml.rst
@@ -6,7 +6,7 @@ Machine Learning utilities
 .. currentmodule:: databricks.koalas.mlflow
 
 MLflow
-~~~~~~
+------
 
 Arbitrary MLflow models can be used with Koalas Dataframes,
 provided they implement the 'pyfunc' flavor. This is the case

--- a/docs/source/reference/series.rst
+++ b/docs/source/reference/series.rst
@@ -127,7 +127,7 @@ Missing data handling
    Series.fillna
 
 Reshaping, sorting, transposing
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------
 .. autosummary::
    :toctree: api/
 
@@ -135,7 +135,7 @@ Reshaping, sorting, transposing
    Series.sort_values
 
 Combining / joining / merging
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------
 .. autosummary::
    :toctree: api/
 
@@ -157,15 +157,15 @@ String    :ref:`str <api.series.str>`
 
 .. _api.series.dt:
 
-Datetimelike Properties
-~~~~~~~~~~~~~~~~~~~~~~~
+Date Time Handling
+------------------
 
 ``Series.dt`` can be used to access the values of the series as
 datetimelike and return several properties.
 These can be accessed like ``Series.dt.<property>``.
 
 Datetime Properties
-^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~
 
 .. currentmodule:: databricks.koalas.series
 .. autosummary::
@@ -187,7 +187,7 @@ Datetime Properties
    Series.dt.microsecond
 
 Datetime Methods
-^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~
 
 .. currentmodule:: databricks.koalas.series
 .. autosummary::
@@ -198,7 +198,7 @@ Datetime Methods
 .. _api.series.str:
 
 String Handling
-^^^^^^^^^^^^^^^
+---------------
 
 ``Series.str`` can be used to access the values of the series as
 strings and apply several methods to it. These can be accessed


### PR DESCRIPTION
I changed all top level headers to use `-` rather than a mixture of `-` and `~`, which was error prone and had a few mistakes. As part of this, I also up-leveled Series.dt and Series.str, to make them show up in the table of contents on the left side so it is easier to find.
