### PR TITLE
ks.sql()

### DIFF
--- a/databricks/koalas/sql.py
+++ b/databricks/koalas/sql.py
@@ -144,6 +144,8 @@ def _get_local_scope():
     try:
         return inspect.stack()[2][0].f_locals
     except Exception as e:
+        # TODO (rxin, thunterdb): use a more narrow scope exception.
+        # See https://github.com/databricks/koalas/pull/448
         return {}
 
 
@@ -157,6 +159,8 @@ def _get_ipython_scope():
         shell = get_ipython()
         return shell.user_ns
     except Exception as e:
+        # TODO (rxin, thunterdb): use a more narrow scope exception.
+        # See https://github.com/databricks/koalas/pull/448
         return None
 
 

--- a/databricks/koalas/tests/test_sql.py
+++ b/databricks/koalas/tests/test_sql.py
@@ -1,0 +1,38 @@
+#
+# Copyright (C) 2019 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from databricks import koalas as ks
+from databricks.koalas.testing.utils import ReusedSQLTestCase, SQLTestUtils
+
+from pyspark.sql.utils import ParseException
+
+
+class SQLTest(ReusedSQLTestCase, SQLTestUtils):
+
+    def test_error_variable_not_exist(self):
+        msg = 'The key variable_foo in the SQL statement was not found.*'
+        with self.assertRaisesRegex(ValueError, msg):
+            ks.sql('select * from {variable_foo}')
+
+    def test_error_unsupported_type(self):
+        msg = "Unsupported variable type <class 'dict'>: {'a': 1, 'b': 2}"
+        with self.assertRaisesRegex(ValueError, msg):
+            some_dict = {'a': 1, 'b': 2}
+            ks.sql('select * from {some_dict}')
+
+    def test_error_bad_sql(self):
+        with self.assertRaises(ParseException):
+            ks.sql('this is not valid sql')

--- a/databricks/koalas/tests/test_sql.py
+++ b/databricks/koalas/tests/test_sql.py
@@ -28,9 +28,9 @@ class SQLTest(ReusedSQLTestCase, SQLTestUtils):
             ks.sql('select * from {variable_foo}')
 
     def test_error_unsupported_type(self):
-        msg = "Unsupported variable type <class 'dict'>: {'a': 1, 'b': 2}"
+        msg = "Unsupported variable type <class 'dict'>: {'a': 1}"
         with self.assertRaisesRegex(ValueError, msg):
-            some_dict = {'a': 1, 'b': 2}
+            some_dict = {'a': 1}
             ks.sql('select * from {some_dict}')
 
     def test_error_bad_sql(self):

--- a/docs/source/reference/general_functions.rst
+++ b/docs/source/reference/general_functions.rst
@@ -5,14 +5,14 @@ General functions
 =================
 .. currentmodule:: databricks.koalas
 
-Data manipulations
-------------------
+Data manipulations and SQL
+--------------------------
 .. autosummary::
    :toctree: api/
 
    get_dummies
-   sql
    concat
+   sql
 
 Top-level dealing with datetimelike
 -----------------------------------

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,6 @@
 pandas>=0.23
 pyarrow>=0.10
 numpy>=1.14
-pymysql
 
 # TODO: support mlflow 1.0.0
 mlflow==0.9.1

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,6 @@ setup(
         'pandas>=0.23',
         'pyarrow>=0.10',
         'numpy>=1.14',
-        'pymysql'
     ],
     maintainer="Databricks",
     maintainer_email="koalas@databricks.com",


### PR DESCRIPTION
This builds on earlier sql work by @thunterdb and @floscha. I updated the following based on Tim's PR https://github.com/databricks/koalas/pull/360:

- Increased test coverage
- Fixed a bug with string conversion
- Added license header
- Removed pymysql dependency and inlined the string escape function
- Changed the function to instead expose indexes as top level columns, rather than hiding it. I think that makes more sense in general because it's very likely I'd like to query the indexes.

Resolves #285