### PR TITLE
Add Series[T] and DataFrame[T, ...] type hint

### DIFF
--- a/databricks/koalas/__init__.py
+++ b/databricks/koalas/__init__.py
@@ -39,7 +39,6 @@ from databricks.koalas.frame import DataFrame
 from databricks.koalas.indexes import Index, MultiIndex
 from databricks.koalas.series import Series
 from databricks.koalas.typedef import pandas_wraps
-from databricks.koalas.sql import sql
 
 __all__ = ['read_csv', 'read_parquet', 'to_datetime', 'from_pandas',
            'get_dummies', 'DataFrame', 'Series', 'Index', 'MultiIndex', 'pandas_wraps',

--- a/databricks/koalas/__init__.py
+++ b/databricks/koalas/__init__.py
@@ -38,10 +38,11 @@ assert_pyspark_version()
 from databricks.koalas.frame import DataFrame
 from databricks.koalas.indexes import Index, MultiIndex
 from databricks.koalas.series import Series
-from databricks.koalas.typedef import Col, pandas_wraps
+from databricks.koalas.typedef import pandas_wraps
+from databricks.koalas.sql import sql
 
 __all__ = ['read_csv', 'read_parquet', 'to_datetime', 'from_pandas',
-           'get_dummies', 'DataFrame', 'Series', 'Index', 'MultiIndex', 'Col', 'pandas_wraps',
+           'get_dummies', 'DataFrame', 'Series', 'Index', 'MultiIndex', 'pandas_wraps',
            'sql', 'range', 'concat', 'melt']
 
 

--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -32,7 +32,7 @@ from pyspark.sql.types import ByteType, ShortType, IntegerType, LongType, FloatT
 from databricks import koalas as ks  # For running doctests and reference resolution in PyCharm.
 from databricks.koalas.utils import default_session
 from databricks.koalas.frame import DataFrame, _reduce_spark_multi
-from databricks.koalas.typedef import Col, pandas_wraps
+from databricks.koalas.typedef import pandas_wraps
 from databricks.koalas.series import Series, _col
 
 
@@ -1249,7 +1249,7 @@ melt.__doc__ = DataFrame.melt.__doc__
 
 # @pandas_wraps(return_col=np.datetime64)
 @pandas_wraps
-def _to_datetime1(arg, errors, format, infer_datetime_format) -> Col[np.datetime64]:
+def _to_datetime1(arg, errors, format, infer_datetime_format) -> Series[np.datetime64]:
     return pd.to_datetime(
         arg,
         errors=errors,
@@ -1260,7 +1260,7 @@ def _to_datetime1(arg, errors, format, infer_datetime_format) -> Col[np.datetime
 # @pandas_wraps(return_col=np.datetime64)
 @pandas_wraps
 def _to_datetime2(arg_year, arg_month, arg_day,
-                  errors, format, infer_datetime_format) -> Col[np.datetime64]:
+                  errors, format, infer_datetime_format) -> Series[np.datetime64]:
     arg = dict(year=arg_year, month=arg_month, day=arg_day)
     for key in arg:
         if arg[key] is None:

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -20,7 +20,7 @@ A wrapper class for Spark Column to behave similar to pandas Series.
 import re
 import inspect
 from functools import partial, wraps
-from typing import Any, Optional, List, Union
+from typing import Any, Optional, List, Union, Generic, TypeVar
 
 import numpy as np
 import pandas as pd
@@ -215,12 +215,13 @@ d    NaN
 Name: a, dtype: float64
 """
 
+T = TypeVar("T")
 
 # Needed to disambiguate Series.str and str type
 str_type = str
 
 
-class Series(_Frame, IndexOpsMixin):
+class Series(_Frame, IndexOpsMixin, Generic[T]):
     """
     Koala Series that corresponds to Pandas Series logically. This holds Spark Column
     internally.

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -424,7 +424,7 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         # name as its internal expression which contains, for instance, '`f(x)`' in the middle of
         # column name which currently cannot be recognized in PySpark.
         @koalas.pandas_wraps
-        def f(x) -> koalas.Col[int]:
+        def f(x) -> koalas.Series[int]:
             return 2 * x
 
         df = koalas.DataFrame({"x": [1, None]})

--- a/databricks/koalas/typedef.py
+++ b/databricks/koalas/typedef.py
@@ -33,65 +33,58 @@ import pyspark.sql.types as types
 from databricks import koalas as ks  # For running doctests and reference resolution in PyCharm.
 
 
-__all__ = ['Col', 'pandas_wraps', 'as_spark_type',
+__all__ = ['pandas_wraps', 'as_spark_type',
            'as_python_type', 'infer_pd_series_spark_type']
 
 
-T = typing.TypeVar("T")
-
-
-class Col(typing.Generic[T]):
-    def is_col(self):
-        return self
-
-
 # A column of data, with the data type.
-class _Column(object):
-    def __init__(self, inner):
-        self.inner = inner  # type: types.DataType
+class _Series(object):
+    def __init__(self, tpe):
+        self.tpe = tpe  # type: types.DataType
 
     def __repr__(self):
-        return "_ColumnType[{}]".format(self.inner)
+        return "_SeriesType[{}]".format(self.tpe)
 
 
 class _DataFrame(object):
+    def __init__(self, tpe):
+        # Seems we cannot specify field names. I currently gave some default names
+        # `c0, c1, ... cn`.
+        self.tpe = types.StructType(
+            [types.StructField("c%s" % i, tpe[i])
+             for i in range(len(tpe))])  # type: types.StructType
+
     def __repr__(self):
-        return "_DataFrameType"
+        return "_DataFrameType[{}]".format(self.tpe)
 
 
 # The type is a scalar type that is furthermore understood by Spark.
 class _Scalar(object):
     def __init__(self, tpe):
-        self.type = tpe  # type: types.DataType
+        self.tpe = tpe  # type: types.DataType
 
     def __repr__(self):
-        return "_ScalarType[{}]".format(self.type)
+        return "_ScalarType[{}]".format(self.tpe)
 
 
 # The type is left unspecified or we do not know about this type.
 class _Unknown(object):
     def __init__(self, tpe):
-        self.type = tpe
+        self.tpe = tpe
 
     def __repr__(self):
-        return "_UnknownType[{}]".format(self.type)
+        return "_UnknownType[{}]".format(self.tpe)
 
 
-X = typing.Union[_Column, _DataFrame, _Scalar, _Unknown]
-
-
-def _is_col(tpe):
-    return hasattr(tpe, "is_col")
-
-
-def _get_col_inner(tpe):
-    return tpe.__args__[0]
+X = typing.Union[_Series, _DataFrame, _Scalar, _Unknown]
 
 
 def _to_stype(tpe) -> X:
-    if _is_col(tpe):
-        inner = as_spark_type(_get_col_inner(tpe))
-        return _Column(inner)
+    if hasattr(tpe, "__origin__") and tpe.__origin__ == ks.Series:
+        inner = as_spark_type(tpe.__args__[0])
+        return _Series(inner)
+    if hasattr(tpe, "__origin__") and tpe.__origin__ == ks.DataFrame:
+        return _DataFrame([as_spark_type(t) for t in tpe.__args__[0].__args__])
     inner = as_spark_type(tpe)
     if inner is None:
         return _Unknown(tpe)
@@ -252,7 +245,7 @@ def _make_fun(f: typing.Callable, return_type: types.DataType, *args, **kwargs) 
         spark_col_args.append(col._scol)
         kw_name_tokens.append("{}={}".format(key, col.name))
     col = wrapped_udf(*spark_col_args)
-    series = Series(kdf._internal.copy(scol=col), anchor=kdf)
+    series = Series(kdf._internal.copy(scol=col), anchor=kdf)  # type: 'ks.Series'
     all_name_tokens = name_tokens + sorted(kw_name_tokens)
     name = "{}({})".format(f.__name__, ", ".join(all_name_tokens))
     series = series.astype(return_type).alias(name)
@@ -281,7 +274,7 @@ def pandas_wraps(function=None, return_col=None, return_scalar=None):
 
     Wrapping a function with python 3's type annotations:
 
-    >>> from databricks.koalas import pandas_wraps, Col
+    >>> from databricks.koalas import pandas_wraps
     >>> pdf = pd.DataFrame({"col1": [1, 2], "col2": [10, 20]}, dtype=np.int64)
     >>> df = ks.DataFrame(pdf)
 
@@ -299,7 +292,7 @@ def pandas_wraps(function=None, return_col=None, return_scalar=None):
     returns a Series of integers:
 
     >>> @pandas_wraps
-    ... def fun(col1) -> Col[np.int64]:
+    ... def fun(col1) -> ks.Series[np.int64]:
     ...     return col1.apply(lambda x: x * 2)  # Arbitrary pandas code.
 
     This function works as before on pandas Series:
@@ -359,10 +352,10 @@ def pandas_wraps(function=None, return_col=None, return_scalar=None):
         def wrapper(*args, **kwargs):
             # Extract the signature arguments from this function.
             sig_return = _infer_return_type(f, return_col, return_scalar)
-            if not isinstance(sig_return, _Column):
+            if not isinstance(sig_return, _Series):
                 raise ValueError("Expected the return type of this function to be of type column,"
                                  " but found type {}".format(sig_return))
-            spark_return_type = sig_return.inner
+            spark_return_type = sig_return.tpe
             return _make_fun(f, spark_return_type, *args, **kwargs)
         return wrapper
     if callable(function):
@@ -371,28 +364,42 @@ def pandas_wraps(function=None, return_col=None, return_scalar=None):
         return function_wrapper
 
 
-def _infer_return_type(f, return_col_hint=None, return_scalar_hint=None) -> X:
+def _infer_return_type(f, return_col=None, return_scalar=None) -> X:
+    """
+    >>> def func() -> int:
+    ...    pass
+    >>> _infer_return_type(func).tpe
+    IntegerType
+
+    >>> def func() -> ks.Series[int]:
+    ...    pass
+    >>> _infer_return_type(func).tpe
+    IntegerType
+
+    >>> def func() -> ks.DataFrame[np.float, str]:
+    ...    pass
+    >>> _infer_return_type(func).tpe
+    StructType(List(StructField(c0,FloatType,true),StructField(c1,StringType,true)))
+
+    >>> def func() -> ks.DataFrame[np.float]:
+    ...    pass
+    >>> _infer_return_type(func).tpe
+    StructType(List(StructField(c0,FloatType,true)))
+    """
     spec = getfullargspec(f)
     return_sig = spec.annotations.get("return", None)
-    return _get_return_type(return_sig, return_col_hint, return_scalar_hint)
 
-
-def _get_return_type(return_sig, return_col, return_scalar) -> X:
-    """
-    Resolves the return type.
-    :return: X
-    """
     if not (return_col or return_sig or return_scalar):
         raise ValueError(
             "Missing type information. It should either be provided as an argument to "
             "pandas_wraps, or as a python typing hint")
     if return_col is not None:
-        if isinstance(return_col, Col):
+        if isinstance(return_col, ks.Series):
             return _to_stype(return_col)
         inner = as_spark_type(return_col)
-        return _Column(inner)
+        return _Series(inner)
     if return_scalar is not None:
-        if isinstance(return_scalar, Col):
+        if isinstance(return_scalar, ks.Series):
             raise ValueError("Column return type {}, you should use 'return_col' to specify"
                              " it.".format(return_scalar))
         inner = as_spark_type(return_scalar)


### PR DESCRIPTION
This PR proposes an alternative take for https://github.com/databricks/koalas/pull/437. The main diff is that:

- In python 3.7, hacks `__class_getitem__` from `Generic` at `DataFrame`. Here, it just wraps the given types into a tuple type, which is existing variadic generic.

- In python 3.6 and python 3.5, similarly it wraps by a tuple type too; however, the logic is defined in metaclass. So, it should be wrapped in a different way from python 3.7's

<br/>
<br/>
<br/>

Looks we need a way to specify type hint in order for them to be set when we run Python native functions via, for instance, `apply(func)`. For `DataFrame`, `groupby(..).apply(func)` needs it if we implement it. Consider this example:

```python
def func(pdf) -> DataFrame[...]
    return pdf

df.groupby.apply(func)
```

We already have a way in case of `Series` (previously `Col`). I renamed and refactored it to `Series`.

The new type hints are used as below:

```python
def func(...) -> Series[np.float]:
    ...

def func(...) -> DataFrame[np.float, int, str]:
    ...
```

Note that:

```python
def func(...) -> DataFrame[np.float, int, str]
    ...
```

Seems we cannot specify field names. I currently gave some default names `c0, c1, ... cn`.
