### PR TITLE
Clean up after test_table.

### DIFF
--- a/databricks/koalas/tests/test_dataframe_spark_io.py
+++ b/databricks/koalas/tests/test_dataframe_spark_io.py
@@ -90,22 +90,23 @@ class DataFrameSparkIOTest(ReusedSQLTestCase, TestUtils):
             self.assert_eq(actual.sort_values(by='f'), expected.sort_values(by='f'))
 
     def test_table(self):
-        pdf = self.test_pdf
-        expected = ks.DataFrame(pdf)
+        with self.table('test_table'):
+            pdf = self.test_pdf
+            expected = ks.DataFrame(pdf)
 
-        # Write out partitioned by one column
-        expected.to_table('test_table', mode='overwrite', partition_cols='i32')
-        # Reset column order, as once the data is written out, Spark rearranges partition
-        # columns to appear first.
-        actual = ks.read_table('test_table')[self.test_column_order]
-        self.assert_eq(actual.sort_values(by='f'), expected.sort_values(by='f'))
+            # Write out partitioned by one column
+            expected.to_table('test_table', mode='overwrite', partition_cols='i32')
+            # Reset column order, as once the data is written out, Spark rearranges partition
+            # columns to appear first.
+            actual = ks.read_table('test_table')[self.test_column_order]
+            self.assert_eq(actual.sort_values(by='f'), expected.sort_values(by='f'))
 
-        # Write out partitioned by two columns
-        expected.to_table('test_table', mode='overwrite', partition_cols=['i32', 'bhello'])
-        # Reset column order, as once the data is written out, Spark rearranges partition
-        # columns to appear first.
-        actual = ks.read_table('test_table')[self.test_column_order]
-        self.assert_eq(actual.sort_values(by='f'), expected.sort_values(by='f'))
+            # Write out partitioned by two columns
+            expected.to_table('test_table', mode='overwrite', partition_cols=['i32', 'bhello'])
+            # Reset column order, as once the data is written out, Spark rearranges partition
+            # columns to appear first.
+            actual = ks.read_table('test_table')[self.test_column_order]
+            self.assert_eq(actual.sort_values(by='f'), expected.sort_values(by='f'))
 
     def test_spark_io(self):
         with self.temp_dir() as tmp:


### PR DESCRIPTION
This is a follow-up of #449.
The test `DataFrameSparkIOTest.test_table()` needs a clean-up.