### PR TITLE
Make tests runnable with Spark 3.0 (changing Detla Scala version for Spark 3.0.0+)

### DIFF
--- a/databricks/conftest.py
+++ b/databricks/conftest.py
@@ -30,7 +30,9 @@ from databricks.koalas import utils
 # Initialize Spark session that should be used in doctests or unittests.
 # Delta requires Spark 2.4.2+. See
 # https://github.com/delta-io/delta#compatibility-with-apache-spark-versions.
-if LooseVersion(__version__) >= LooseVersion("2.4.2"):
+if LooseVersion(__version__) >= LooseVersion("3.0.0"):
+    session = utils.default_session({"spark.jars.packages": "io.delta:delta-core_2.12:0.1.0"})
+elif LooseVersion(__version__) >= LooseVersion("2.4.2"):
     session = utils.default_session({"spark.jars.packages": "io.delta:delta-core_2.11:0.1.0"})
 else:
     session = utils.default_session()


### PR DESCRIPTION
I use Spark upstream (3.0.0) in dev to pre-test and find any issue. This PR makes Koalas testing working with Spark upstream (3.0.0).

Currently, it fails even when I test other APIs like:

```
 ./dev/pytest -k read_parquet --doctest-modules databricks
```