### PR TITLE
Remove setters for old metadata.

### DIFF
--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -119,10 +119,6 @@ class IndexOpsMixin(object):
     def _scol(self):
         return self._internal.scol
 
-    @_scol.setter
-    def _scol(self, scol: spark.Column) -> None:
-        self._internal = self._internal.copy(scol=scol)
-
     # arithmetic operators
     __neg__ = _column_op(spark.Column.__neg__)
 

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -3735,8 +3735,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             raise KeyError("none key")
         if isinstance(key, str):
             try:
-                return Series(self._sdf.__getitem__(key), anchor=self,
-                              index=self._metadata.index_map)
+                return Series(self._internal.copy(scol=self._sdf.__getitem__(key)), anchor=self)
             except AnalysisException:
                 raise KeyError(key)
         if np.isscalar(key) or isinstance(key, (tuple, str)):
@@ -3750,7 +3749,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             return self.loc[:, key]
         if isinstance(key, DataFrame):
             # TODO Should not implement alignment, too dangerous?
-            return Series(self._sdf.__getitem__(key), anchor=self, index=self._metadata.index_map)
+            return Series(self._internal.copy(scol=self._sdf.__getitem__(key)), anchor=self)
         if isinstance(key, Series):
             # TODO Should not implement alignment, too dangerous?
             # It is assumed to be only a filter, otherwise .loc should be used.
@@ -3819,7 +3818,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 return property_or_func.fget(self)  # type: ignore
             else:
                 return partial(property_or_func, self)
-        return Series(self._sdf.__getattr__(key), anchor=self, index=self._metadata.index_map)
+        return Series(self._internal.copy(scol=self._sdf.__getattr__(key)), anchor=self)
 
     def __len__(self):
         return self._sdf.count()

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -27,7 +27,7 @@ import pandas as pd
 from pandas.api.types import is_list_like, is_dict_like
 from pandas.core.dtypes.inference import is_sequence
 from pyspark import sql as spark
-from pyspark.sql import functions as F, Column, DataFrame as SDataFrame
+from pyspark.sql import functions as F, Column
 from pyspark.sql.types import (BooleanType, ByteType, DecimalType, DoubleType, FloatType,
                                IntegerType, LongType, NumericType, ShortType, StructType)
 from pyspark.sql.utils import AnalysisException
@@ -39,7 +39,6 @@ from databricks.koalas.internal import _InternalFrame
 from databricks.koalas.metadata import Metadata
 from databricks.koalas.missing.frame import _MissingPandasLikeDataFrame
 from databricks.koalas.ml import corr
-from databricks.koalas.typedef import infer_pd_series_spark_type
 
 
 # These regular expression patterns are complied and defined here to avoid to compile the same

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -995,7 +995,7 @@ def _spark_col_apply(kdf_or_ks, sfun):
     from databricks.koalas.series import Series
     if isinstance(kdf_or_ks, Series):
         ks = kdf_or_ks
-        return Series(sfun(kdf_or_ks._scol), anchor=ks._kdf, index=ks._index_map)
+        return Series(ks._kdf._internal.copy(scol=sfun(kdf_or_ks._scol)), anchor=ks._kdf)
     assert isinstance(kdf_or_ks, DataFrame)
     kdf = kdf_or_ks
     sdf = kdf._sdf

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -27,6 +27,7 @@ from pyspark.sql.types import FloatType, DoubleType, NumericType
 
 from databricks import koalas as ks  # For running doctests and reference resolution in PyCharm.
 from databricks.koalas.frame import DataFrame
+from databricks.koalas.internal import _InternalFrame
 from databricks.koalas.metadata import Metadata
 from databricks.koalas.missing.groupby import _MissingPandasLikeDataFrameGroupBy, \
     _MissingPandasLikeSeriesGroupBy
@@ -104,10 +105,11 @@ class GroupBy(object):
         reordered = [F.expr('{1}({0}) as {0}'.format(key, value))
                      for key, value in func_or_funcs.items()]
         sdf = sdf.groupby(*groupkey_cols).agg(*reordered)
-        metadata = Metadata(data_columns=[key for key, _ in func_or_funcs.items()],
-                            index_map=[('__index_level_{}__'.format(i), s.name)
-                                       for i, s in enumerate(groupkeys)])
-        return DataFrame(sdf, metadata)
+        internal = _InternalFrame(sdf=sdf,
+                                  data_columns=[key for key, _ in func_or_funcs.items()],
+                                  index_map=[('__index_level_{}__'.format(i), s.name)
+                                             for i, s in enumerate(groupkeys)])
+        return DataFrame(internal)
 
     agg = aggregate
 
@@ -255,10 +257,11 @@ class GroupBy(object):
         else:
             sdf = sdf.select(*groupkey_cols).distinct()
         sdf = sdf.sort(*groupkey_cols)
-        metadata = Metadata(data_columns=data_columns,
-                            index_map=[('__index_level_{}__'.format(i), s.name)
-                                       for i, s in enumerate(groupkeys)])
-        return DataFrame(sdf, metadata)
+        internal = _InternalFrame(sdf=sdf,
+                                  data_columns=data_columns,
+                                  index_map=[('__index_level_{}__'.format(i), s.name)
+                                             for i, s in enumerate(groupkeys)])
+        return DataFrame(internal)
 
 
 class DataFrameGroupBy(GroupBy):

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -28,7 +28,6 @@ from pyspark.sql.types import FloatType, DoubleType, NumericType
 from databricks import koalas as ks  # For running doctests and reference resolution in PyCharm.
 from databricks.koalas.frame import DataFrame
 from databricks.koalas.internal import _InternalFrame
-from databricks.koalas.metadata import Metadata
 from databricks.koalas.missing.groupby import _MissingPandasLikeDataFrameGroupBy, \
     _MissingPandasLikeSeriesGroupBy
 from databricks.koalas.series import Series, _col

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -31,7 +31,6 @@ from databricks.koalas.exceptions import PandasNotImplementedError
 from databricks.koalas.base import IndexOpsMixin
 from databricks.koalas.frame import DataFrame
 from databricks.koalas.generic import max_display_count
-from databricks.koalas.internal import _InternalFrame
 from databricks.koalas.missing.indexes import _MissingPandasLikeIndex, _MissingPandasLikeMultiIndex
 from databricks.koalas.series import Series
 
@@ -125,11 +124,11 @@ class Index(IndexOpsMixin):
     def names(self, names: List[str]) -> None:
         if not is_list_like(names):
             raise ValueError('Names must be a list-like')
-        metadata = self._kdf._metadata
-        if len(metadata.index_map) != len(names):
+        internal = self._kdf._internal
+        if len(internal.index_map) != len(names):
             raise ValueError('Length of new names must be {}, got {}'
-                             .format(len(metadata.index_map), len(names)))
-        self._kdf._metadata = metadata.copy(index_map=list(zip(metadata.index_columns, names)))
+                             .format(len(internal.index_map), len(names)))
+        self._kdf._internal = internal.copy(index_map=list(zip(internal.index_columns, names)))
 
     def to_series(self, name: str = None) -> Series:
         """

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -159,9 +159,8 @@ class Index(IndexOpsMixin):
         """
         kdf = self._kdf
         scol = self._scol
-        return Series(scol if name is None else scol.alias(name),
-                      anchor=kdf,
-                      index=kdf._metadata.index_map)
+        return Series(kdf._internal.copy(scol=scol if name is None else scol.alias(name)),
+                      anchor=kdf)
 
     def __getattr__(self, item: str) -> Any:
         if hasattr(_MissingPandasLikeIndex, item):

--- a/databricks/koalas/indexing.py
+++ b/databricks/koalas/indexing.py
@@ -421,8 +421,9 @@ class LocIndexer(object):
         except AnalysisException:
             raise KeyError('[{}] don\'t exist in columns'
                            .format([col._jc.toString() for col in columns]))
-        kdf._metadata = self._kdf._metadata.copy(
-            data_columns=kdf._metadata.data_columns[-len(columns):])
+        kdf._internal = kdf._internal.copy(
+            data_columns=kdf._internal.data_columns[-len(columns):],
+            index_map=self._kdf._internal.index_map)
         if cols_sel is not None and isinstance(cols_sel, spark.Column):
             from databricks.koalas.series import _col
             return _col(kdf)
@@ -654,8 +655,9 @@ class ILocIndexer(object):
         except AnalysisException:
             raise KeyError('[{}] don\'t exist in columns'
                            .format([col._jc.toString() for col in columns]))
-        kdf._metadata = self._kdf._metadata.copy(
-            data_columns=kdf._metadata.data_columns[-len(columns):])
+        kdf._internal = kdf._internal.copy(
+            data_columns=kdf._internal.data_columns[-len(columns):],
+            index_map=self._kdf._internal.index_map)
         if cols_sel is not None and isinstance(cols_sel, (Series, int)):
             from databricks.koalas.series import _col
             return _col(kdf)

--- a/databricks/koalas/mlflow.py
+++ b/databricks/koalas/mlflow.py
@@ -19,7 +19,6 @@ MLflow-related functions to load models and apply them to Koalas dataframes.
 """
 from mlflow.pyfunc import load_pyfunc, spark_udf
 from pyspark.sql.types import DataType
-import pyspark.sql.functions as F
 import pandas as pd
 import numpy as np
 from typing import Any

--- a/databricks/koalas/mlflow.py
+++ b/databricks/koalas/mlflow.py
@@ -92,7 +92,7 @@ class PythonModelWrapper(object):
             # However, this is only possible with spark >= 3.0
             # s = F.struct(*data.columns)
             # return_col = self._model_udf(s)
-            return Series(data=return_col, anchor=data, index=data._metadata.index_map)
+            return Series(data._internal.copy(scol=return_col), anchor=data)
 
 
 def load_model(path, run_id=None, predict_type='infer') -> PythonModelWrapper:

--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -1189,7 +1189,7 @@ def concat(objs, axis=0, join='outer', ignore_index=False):
                 if ignore_index:
                     kdfs.append(DataFrame(sdf))
                 else:
-                    kdfs.append(DataFrame(sdf, first_kdf._metadata.copy()))
+                    kdfs.append(DataFrame(first_kdf._internal.copy(sdf=sdf)))
         elif join == "outer":
             # If there are columns unmatched, just sort the column names.
             merged_columns = set(
@@ -1211,8 +1211,8 @@ def concat(objs, axis=0, join='outer', ignore_index=False):
                     sdf = kdf._sdf.select(
                         kdf._metadata.index_columns + sorted(kdf._metadata.data_columns))
 
-                kdf = DataFrame(sdf, kdf._metadata.copy(
-                    data_columns=sorted(kdf._metadata.data_columns)))
+                kdf = DataFrame(kdf._internal.copy(sdf=sdf,
+                                                   data_columns=sorted(kdf._metadata.data_columns)))
                 kdfs.append(kdf)
         else:
             raise ValueError(
@@ -1225,7 +1225,7 @@ def concat(objs, axis=0, join='outer', ignore_index=False):
     if ignore_index:
         result_kdf = DataFrame(concatenated.select(kdfs[0]._metadata.data_columns))
     else:
-        result_kdf = DataFrame(concatenated, kdfs[0]._metadata.copy())
+        result_kdf = DataFrame(kdfs[0]._internal.copy(sdf=concatenated))
 
     if should_return_series:
         # If all input were Series, we should return Series.

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -35,7 +35,6 @@ from databricks.koalas.base import IndexOpsMixin
 from databricks.koalas.frame import DataFrame
 from databricks.koalas.generic import _Frame, max_display_count
 from databricks.koalas.internal import IndexMap, _InternalFrame
-from databricks.koalas.metadata import Metadata
 from databricks.koalas.missing.series import _MissingPandasLikeSeries
 from databricks.koalas.plot import KoalasSeriesPlotMethods
 from databricks.koalas.utils import validate_arguments_and_invoke_function

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -1884,9 +1884,10 @@ class Series(_Frame, IndexOpsMixin):
             sdf = self._kdf._sdf.select(
                 self._metadata.index_columns + [c._scol for c in applied])
 
-            metadata = self._metadata.copy(data_columns=[c.name for c in applied])
+            internal = self.to_dataframe()._internal.copy(
+                sdf=sdf, data_columns=[c.name for c in applied])
 
-            return DataFrame(sdf, metadata)
+            return DataFrame(internal)
         else:
             return self.apply(func, args=args, **kwargs)
 


### PR DESCRIPTION
This is part of #322.
This PR removes setters for old metadata structures and refine constructors for `DataFrame` and `Series` to avoid using old metadata structures.
Closes #468.