### PR TITLE
Add docstring and doctests for new dt APIs

### DIFF
--- a/databricks/koalas/datetimes.py
+++ b/databricks/koalas/datetimes.py
@@ -146,11 +146,11 @@ class DatetimeMethods(object):
         Return the day of the week. It is assumed the week starts on
         Monday, which is denoted by 0 and ends on Sunday which is denoted
         by 6. This method is available on both Series with datetime
-        values (using the `dt` accessor) or DatetimeIndex.
+        values (using the `dt` accessor).
 
         Returns
         -------
-        Series or Index
+        Series
             Containing integers indicating the day number.
 
         See Also
@@ -203,6 +203,34 @@ class DatetimeMethods(object):
     def is_month_start(self) -> 'ks.Series':
         """
         Indicates whether the date is the first day of the month.
+
+        Returns
+        -------
+        Series
+            For Series, returns a Series with boolean values.
+
+        See Also
+        --------
+        is_month_end : Return a boolean indicating whether the date
+            is the last day of the month.
+
+        Examples
+        --------
+        This method is available on Series with datetime values under
+        the ``.dt`` accessor.
+
+        >>> s = ks.Series(pd.date_range("2018-02-27", periods=3))
+        >>> s
+        0   2018-02-27
+        1   2018-02-28
+        2   2018-03-01
+        Name: 0, dtype: datetime64[ns]
+
+        >>> s.dt.is_month_start
+        0    False
+        1    False
+        2     True
+        Name: 0, dtype: bool
         """
         return _wrap_accessor_pandas(
             self, lambda s: s.dt.is_month_start, BooleanType()).alias(self._data.name)
@@ -211,6 +239,34 @@ class DatetimeMethods(object):
     def is_month_end(self) -> 'ks.Series':
         """
         Indicates whether the date is the last day of the month.
+
+        Returns
+        -------
+        Series
+            For Series, returns a Series with boolean values.
+
+        See Also
+        --------
+        is_month_start : Return a boolean indicating whether the date
+            is the first day of the month.
+
+        Examples
+        --------
+        This method is available on Series with datetime values under
+        the ``.dt`` accessor.
+
+        >>> s = ks.Series(pd.date_range("2018-02-27", periods=3))
+        >>> s
+        0   2018-02-27
+        1   2018-02-28
+        2   2018-03-01
+        Name: 0, dtype: datetime64[ns]
+
+        >>> s.dt.is_month_end
+        0    False
+        1     True
+        2    False
+        Name: 0, dtype: bool
         """
         return _wrap_accessor_pandas(
             self, lambda s: s.dt.is_month_end, BooleanType()).alias(self._data.name)
@@ -219,6 +275,45 @@ class DatetimeMethods(object):
     def is_quarter_start(self) -> 'ks.Series':
         """
         Indicator for whether the date is the first day of a quarter.
+
+        Returns
+        -------
+        is_quarter_start : Series
+            The same type as the original data with boolean values. Series will
+            have the same name and index.
+
+        See Also
+        --------
+        quarter : Return the quarter of the date.
+        is_quarter_end : Similar property for indicating the quarter start.
+
+        Examples
+        --------
+        This method is available on Series with datetime values under
+        the ``.dt`` accessor.
+
+        >>> df = ks.DataFrame({'dates': pd.date_range("2017-03-30",
+        ...                   periods=4)})
+        >>> df
+               dates
+        0 2017-03-30
+        1 2017-03-31
+        2 2017-04-01
+        3 2017-04-02
+
+        >>> df.dates.dt.quarter
+        0    1
+        1    1
+        2    2
+        3    2
+        Name: dates, dtype: int64
+
+        >>> df.dates.dt.is_quarter_start
+        0    False
+        1    False
+        2     True
+        3    False
+        Name: dates, dtype: bool
         """
         return _wrap_accessor_pandas(
             self, lambda s: s.dt.is_quarter_start, BooleanType()).alias(self._data.name)
@@ -227,6 +322,45 @@ class DatetimeMethods(object):
     def is_quarter_end(self) -> 'ks.Series':
         """
         Indicator for whether the date is the last day of a quarter.
+
+        Returns
+        -------
+        is_quarter_end : Series
+            The same type as the original data with boolean values. Series will
+            have the same name and index.
+
+        See Also
+        --------
+        quarter : Return the quarter of the date.
+        is_quarter_start : Similar property indicating the quarter start.
+
+        Examples
+        --------
+        This method is available on Series with datetime values under
+        the ``.dt`` accessor.
+
+        >>> df = ks.DataFrame({'dates': pd.date_range("2017-03-30",
+        ...                   periods=4)})
+        >>> df
+               dates
+        0 2017-03-30
+        1 2017-03-31
+        2 2017-04-01
+        3 2017-04-02
+
+        >>> df.dates.dt.quarter
+        0    1
+        1    1
+        2    2
+        3    2
+        Name: dates, dtype: int64
+
+        >>> df.dates.dt.is_quarter_start
+        0    False
+        1    False
+        2     True
+        3    False
+        Name: dates, dtype: bool
         """
         return _wrap_accessor_pandas(
             self, lambda s: s.dt.is_quarter_end, BooleanType()).alias(self._data.name)
@@ -235,6 +369,34 @@ class DatetimeMethods(object):
     def is_year_start(self) -> 'ks.Series':
         """
         Indicate whether the date is the first day of a year.
+
+        Returns
+        -------
+        Series
+            The same type as the original data with boolean values. Series will
+            have the same name and index.
+
+        See Also
+        --------
+        is_year_end : Similar property indicating the last day of the year.
+
+        Examples
+        --------
+        This method is available on Series with datetime values under
+        the ``.dt`` accessor.
+
+        >>> dates = ks.Series(pd.date_range("2017-12-30", periods=3))
+        >>> dates
+        0   2017-12-30
+        1   2017-12-31
+        2   2018-01-01
+        Name: 0, dtype: datetime64[ns]
+
+        >>> dates.dt.is_year_start
+        0    False
+        1    False
+        2     True
+        Name: 0, dtype: bool
         """
         return _wrap_accessor_pandas(
             self, lambda s: s.dt.is_year_start, BooleanType()).alias(self._data.name)
@@ -243,6 +405,34 @@ class DatetimeMethods(object):
     def is_year_end(self) -> 'ks.Series':
         """
         Indicate whether the date is the last day of the year.
+
+        Returns
+        -------
+        Series
+            The same type as the original data with boolean values. Series will
+            have the same name and index.
+
+        See Also
+        --------
+        is_year_start : Similar property indicating the start of the year.
+
+        Examples
+        --------
+        This method is available on Series with datetime values under
+        the ``.dt`` accessor.
+
+        >>> dates = ks.Series(pd.date_range("2017-12-30", periods=3))
+        >>> dates
+        0   2017-12-30
+        1   2017-12-31
+        2   2018-01-01
+        Name: 0, dtype: datetime64[ns]
+
+        >>> dates.dt.is_year_end
+        0    False
+        1     True
+        2    False
+        Name: 0, dtype: bool
         """
         return _wrap_accessor_pandas(
             self, lambda s: s.dt.is_year_end, BooleanType()).alias(self._data.name)
@@ -251,6 +441,34 @@ class DatetimeMethods(object):
     def is_leap_year(self) -> 'ks.Series':
         """
         Boolean indicator if the date belongs to a leap year.
+
+        A leap year is a year, which has 366 days (instead of 365) including
+        29th of February as an intercalary day.
+        Leap years are years which are multiples of four with the exception
+        of years divisible by 100 but not by 400.
+
+        Returns
+        -------
+        Series
+             Booleans indicating if dates belong to a leap year.
+
+        Examples
+        --------
+        This method is available on Series with datetime values under
+        the ``.dt`` accessor.
+
+        >>> dates_series = ks.Series(pd.date_range("2012-01-01", "2015-01-01", freq="Y"))
+        >>> dates_series
+        0   2012-12-31
+        1   2013-12-31
+        2   2014-12-31
+        Name: 0, dtype: datetime64[ns]
+
+        >>> dates_series.dt.is_leap_year
+        0     True
+        1    False
+        2    False
+        Name: 0, dtype: bool
         """
         return _wrap_accessor_pandas(
             self, lambda s: s.dt.is_leap_year, BooleanType()
@@ -289,6 +507,34 @@ class DatetimeMethods(object):
     def normalize(self) -> 'ks.Series':
         """
         Convert times to midnight.
+
+        The time component of the date-time is converted to midnight i.e.
+        00:00:00. This is useful in cases, when the time does not matter.
+        Length is unaltered. The timezones are unaffected.
+
+        This method is available on Series with datetime values under
+        the ``.dt`` accessor, and directly on Datetime Array.
+
+        Returns
+        -------
+        Series
+            The same type as the original data. Series will have the same
+            name and index.
+
+        See Also
+        --------
+        floor : Floor the series to the specified freq.
+        ceil : Ceil the series to the specified freq.
+        round : Round the series to the specified freq.
+
+        Examples
+        --------
+        >>> series = ks.Series(pd.Series(pd.date_range('2012-1-1 12:45:31', periods=3, freq='M')))
+        >>> series.dt.normalize()
+        0   2012-01-31
+        1   2012-02-29
+        2   2012-03-31
+        Name: 0, dtype: datetime64[ns]
         """
         return _wrap_accessor_pandas(
             self,
@@ -298,7 +544,45 @@ class DatetimeMethods(object):
 
     def strftime(self, date_format) -> 'ks.Series':
         """
-        Convert to a String Series using specified date_format.
+        Convert to a string Series using specified date_format.
+
+        Return an series of formatted strings specified by date_format, which
+        supports the same string format as the python standard library. Details
+        of the string format can be found in python string format
+        doc.
+
+        Parameters
+        ----------
+        date_format : str
+            Date format string (e.g. "%%Y-%%m-%%d").
+
+        Returns
+        -------
+        Series
+            Series of formatted strings.
+
+        See Also
+        --------
+        to_datetime : Convert the given argument to datetime.
+        normalize : Return series with times to midnight.
+        round : Round the series to the specified freq.
+        floor : Floor the series to the specified freq.
+
+        Examples
+        --------
+        >>> series = ks.Series(pd.date_range(pd.Timestamp("2018-03-10 09:00"),
+        ...                                  periods=3, freq='s'))
+        >>> series
+        0   2018-03-10 09:00:00
+        1   2018-03-10 09:00:01
+        2   2018-03-10 09:00:02
+        Name: 0, dtype: datetime64[ns]
+
+        >>> series.dt.strftime('%B %d, %Y, %r')
+        0    March 10, 2018, 09:00:00 AM
+        1    March 10, 2018, 09:00:01 AM
+        2    March 10, 2018, 09:00:02 AM
+        Name: 0, dtype: object
         """
         return _wrap_accessor_pandas(
             self,
@@ -306,19 +590,109 @@ class DatetimeMethods(object):
             StringType()
         ).alias(self.name)
 
-    def round(self, freq) -> 'ks.Series':
+    def round(self, freq, *args, **kwargs) -> 'ks.Series':
         """
         Perform round operation on the data to the specified freq.
+
+        Parameters
+        ----------
+        freq : str or Offset
+            The frequency level to round the index to. Must be a fixed
+            frequency like 'S' (second) not 'ME' (month end).
+
+        nonexistent : 'shift_forward', 'shift_backward, 'NaT', timedelta, default 'raise'
+            A nonexistent time does not exist in a particular timezone
+            where clocks moved forward due to DST.
+
+            - 'shift_forward' will shift the nonexistent time forward to the
+              closest existing time
+            - 'shift_backward' will shift the nonexistent time backward to the
+              closest existing time
+            - 'NaT' will return NaT where there are nonexistent times
+            - timedelta objects will shift nonexistent times by the timedelta
+            - 'raise' will raise an NonExistentTimeError if there are
+              nonexistent times
+
+            .. note:: this option only works with pandas 0.24.0+
+
+        Returns
+        -------
+        Series
+            a Series with the same index for a Series.
+
+        Raises
+        ------
+        ValueError if the `freq` cannot be converted.
+
+        Examples
+        --------
+        >>> series = ks.Series(pd.date_range('1/1/2018 11:59:00', periods=3, freq='min'))
+        >>> series
+        0   2018-01-01 11:59:00
+        1   2018-01-01 12:00:00
+        2   2018-01-01 12:01:00
+        Name: 0, dtype: datetime64[ns]
+
+        >>> series.dt.round("H")
+        0   2018-01-01 12:00:00
+        1   2018-01-01 12:00:00
+        2   2018-01-01 12:00:00
+        Name: 0, dtype: datetime64[ns]
         """
         return _wrap_accessor_pandas(
             self,
-            lambda x: x.dt.round(freq),
+            lambda x: x.dt.round(freq, *args, **kwargs),
             TimestampType()
         ).alias(self.name)
 
-    def floor(self, freq) -> 'ks.Series':
+    def floor(self, freq, *args, **kwargs) -> 'ks.Series':
         """
         Perform floor operation on the data to the specified freq.
+
+        Parameters
+        ----------
+        freq : str or Offset
+            The frequency level to floor the index to. Must be a fixed
+            frequency like 'S' (second) not 'ME' (month end).
+
+        nonexistent : 'shift_forward', 'shift_backward, 'NaT', timedelta, default 'raise'
+            A nonexistent time does not exist in a particular timezone
+            where clocks moved forward due to DST.
+
+            - 'shift_forward' will shift the nonexistent time forward to the
+              closest existing time
+            - 'shift_backward' will shift the nonexistent time backward to the
+              closest existing time
+            - 'NaT' will return NaT where there are nonexistent times
+            - timedelta objects will shift nonexistent times by the timedelta
+            - 'raise' will raise an NonExistentTimeError if there are
+              nonexistent times
+
+            .. note:: this option only works with pandas 0.24.0+
+
+        Returns
+        -------
+        Series
+            a Series with the same index for a Series.
+
+        Raises
+        ------
+        ValueError if the `freq` cannot be converted.
+
+        Examples
+        --------
+        >>> series = ks.Series(pd.date_range('1/1/2018 11:59:00', periods=3, freq='min'))
+        >>> series
+        0   2018-01-01 11:59:00
+        1   2018-01-01 12:00:00
+        2   2018-01-01 12:01:00
+        Name: 0, dtype: datetime64[ns]
+
+        >>> series.dt.floor("H")
+        0   2018-01-01 11:00:00
+        1   2018-01-01 12:00:00
+        2   2018-01-01 12:00:00
+        Name: 0, dtype: datetime64[ns]
         """
         return _wrap_accessor_pandas(
             self,
@@ -326,9 +700,54 @@ class DatetimeMethods(object):
             TimestampType()
         ).alias(self.name)
 
-    def ceil(self, freq) -> 'ks.Series':
+    def ceil(self, freq, *args, **kwargs) -> 'ks.Series':
         """
         Perform ceil operation on the data to the specified freq.
+
+        Parameters
+        ----------
+        freq : str or Offset
+            The frequency level to round the index to. Must be a fixed
+            frequency like 'S' (second) not 'ME' (month end).
+
+        nonexistent : 'shift_forward', 'shift_backward, 'NaT', timedelta, default 'raise'
+            A nonexistent time does not exist in a particular timezone
+            where clocks moved forward due to DST.
+
+            - 'shift_forward' will shift the nonexistent time forward to the
+              closest existing time
+            - 'shift_backward' will shift the nonexistent time backward to the
+              closest existing time
+            - 'NaT' will return NaT where there are nonexistent times
+            - timedelta objects will shift nonexistent times by the timedelta
+            - 'raise' will raise an NonExistentTimeError if there are
+              nonexistent times
+
+            .. note:: this option only works with pandas 0.24.0+
+
+        Returns
+        -------
+        Series
+            a Series with the same index for a Series.
+
+        Raises
+        ------
+        ValueError if the `freq` cannot be converted.
+
+        Examples
+        --------
+        >>> series = ks.Series(pd.date_range('1/1/2018 11:59:00', periods=3, freq='min'))
+        >>> series
+        0   2018-01-01 11:59:00
+        1   2018-01-01 12:00:00
+        2   2018-01-01 12:01:00
+        Name: 0, dtype: datetime64[ns]
+
+        >>> series.dt.ceil("H")
+        0   2018-01-01 12:00:00
+        1   2018-01-01 12:00:00
+        2   2018-01-01 13:00:00
+        Name: 0, dtype: datetime64[ns]
         """
         return _wrap_accessor_pandas(
             self,
@@ -338,7 +757,33 @@ class DatetimeMethods(object):
 
     def month_name(self, locale=None) -> 'ks.Series':
         """
-        Return the month names of the DateTimeIndex with specified locale.
+        Return the month names of the series with specified locale.
+
+        Parameters
+        ----------
+        locale : str, optional
+            Locale determining the language in which to return the month name.
+            Default is English locale.
+
+        Returns
+        -------
+        Series
+            Series of month names.
+
+        Examples
+        --------
+        >>> series = ks.Series(pd.date_range(start='2018-01', freq='M', periods=3))
+        >>> series
+        0   2018-01-31
+        1   2018-02-28
+        2   2018-03-31
+        Name: 0, dtype: datetime64[ns]
+
+        >>> series.dt.month_name()
+        0     January
+        1    February
+        2       March
+        Name: 0, dtype: object
         """
         return _wrap_accessor_pandas(
             self,
@@ -348,7 +793,33 @@ class DatetimeMethods(object):
 
     def day_name(self, locale=None) -> 'ks.Series':
         """
-        Return the day names of the DateTimeIndex with specified locale.
+        Return the day names of the series with specified locale.
+
+        Parameters
+        ----------
+        locale : str, optional
+            Locale determining the language in which to return the day name.
+            Default is English locale.
+
+        Returns
+        -------
+        Series
+            Series of day names.
+
+        Examples
+        --------
+        >>> series = ks.Series(pd.date_range(start='2018-01-01', freq='D', periods=3))
+        >>> series
+        0   2018-01-01
+        1   2018-01-02
+        2   2018-01-03
+        Name: 0, dtype: datetime64[ns]
+
+        >>> series.dt.day_name()
+        0       Monday
+        1      Tuesday
+        2    Wednesday
+        Name: 0, dtype: object
         """
         return _wrap_accessor_pandas(
             self,


### PR DESCRIPTION
This is a followup for #478. Inline the documentation and doctests.