### PR TITLE
Support nunique in groupby.agg

### DIFF
--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -105,8 +105,12 @@ class GroupBy(object):
         groupkeys = self._groupkeys
         groupkey_cols = [s._scol.alias('__index_level_{}__'.format(i))
                          for i, s in enumerate(groupkeys)]
-        reordered = [F.expr('{1}({0}) as {0}'.format(key, value))
-                     for key, value in func_or_funcs.items()]
+        reordered = []
+        for key, value in func_or_funcs.items():
+            if value == "nunique":
+                reordered.append(F.expr('count(DISTINCT {0}) as {0}'.format(key)))
+            else:
+                reordered.append(F.expr('{1}({0}) as {0}'.format(key, value)))
         sdf = sdf.groupby(*groupkey_cols).agg(*reordered)
         internal = _InternalFrame(sdf=sdf,
                                   data_columns=[key for key, _ in func_or_funcs.items()],

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -113,6 +113,14 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         self.assertRaises(KeyError, lambda: kdf.groupby('a')['b', 'x'])
         self.assertRaises(KeyError, lambda: kdf.groupby('a')[['b', 'x']])
 
+    def test_nunique(self):
+        pdf = pd.DataFrame({'a': [1, 1, 1, 1, 1, 0, 0, 0, 0, 0],
+                            'b': [2, 2, 2, 3, 3, 4, 4, 5, 5, 5]})
+        kdf = koalas.DataFrame(pdf)
+
+        self.assert_eq(kdf.groupby("a").agg({"b": "nunique"}),
+                       pdf.groupby("a").agg({"b": "nunique"}))
+
     def test_missing(self):
         kdf = koalas.DataFrame({'a': [1, 2, 3, 4, 5, 6, 7, 8, 9]})
 


### PR DESCRIPTION
This PR adds nunique in groupby.agg:

```
df.groupby('x').agg({'y': 'nunique'})
```

Resolves #506