### PR TITLE
Add reason for unsupported functions

### DIFF
--- a/databricks/koalas/exceptions.py
+++ b/databricks/koalas/exceptions.py
@@ -52,29 +52,37 @@ class SparkPandasNotImplementedError(NotImplementedError):
 class PandasNotImplementedError(NotImplementedError):
 
     def __init__(self, class_name, method_name=None, arg_name=None, property_name=None,
-                 deprecated=False):
+                 deprecated=False, reason=""):
         assert (method_name is None) != (property_name is None)
         self.class_name = class_name
         self.method_name = method_name
         self.arg_name = arg_name
         if method_name is not None:
             if arg_name is not None:
-                msg = "The method `{0}.{1}()` does not support `{2}` parameter" \
-                    .format(class_name, method_name, arg_name)
+                msg = "The method `{0}.{1}()` does not support `{2}` parameter. {3}" \
+                    .format(class_name, method_name, arg_name, reason)
             else:
                 if deprecated:
                     msg = ("The method `{0}.{1}()` is deprecated in pandas and will therefore " +
-                           "not be supported in Koalas.") \
-                        .format(class_name, method_name)
+                           "not be supported in Koalas. {2}") \
+                        .format(class_name, method_name, reason)
                 else:
-                    msg = "The method `{0}.{1}()` is not implemented yet." \
-                        .format(class_name, method_name)
+                    if reason == "":
+                        reason = " yet."
+                    else:
+                        reason = ". " + reason
+                    msg = "The method `{0}.{1}()` is not implemented{2}" \
+                        .format(class_name, method_name, reason)
         else:
             if deprecated:
                 msg = ("The property `{0}.{1}()` is deprecated in pandas and will therefore " +
-                       "not be supported in Koalas.") \
-                    .format(class_name, property_name)
+                       "not be supported in Koalas. {2}") \
+                    .format(class_name, property_name, reason)
             else:
-                msg = "The property `{0}.{1}()` is not implemented yet." \
-                    .format(class_name, property_name)
+                if reason == "":
+                    reason = " yet."
+                else:
+                    reason = ". " + reason
+                msg = "The property `{0}.{1}()` is not implemented{2}" \
+                    .format(class_name, property_name, reason)
         super(NotImplementedError, self).__init__(msg)

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -43,12 +43,6 @@ class _Frame(object):
     def __init__(self, internal: _InternalFrame):
         self._internal = internal  # type: _InternalFrame
 
-    @property
-    def values(self):
-        raise NotImplementedError("Koalas does not support the 'values' property. " +
-                                  "If you want to collect your data as an NumPy array, " +
-                                  "use 'to_numpy()' instead.")
-
     def get_dtype_counts(self):
         """
         Return counts of unique dtypes in this object.

--- a/databricks/koalas/missing/__init__.py
+++ b/databricks/koalas/missing/__init__.py
@@ -17,27 +17,29 @@
 from databricks.koalas.exceptions import PandasNotImplementedError
 
 
-def _unsupported_function(class_name, method_name, deprecated=False):
+def _unsupported_function(class_name, method_name, deprecated=False, reason=""):
 
     def unsupported_function(*args, **kwargs):
-        raise PandasNotImplementedError(class_name=class_name, method_name=method_name)
+        raise PandasNotImplementedError(class_name=class_name, method_name=method_name,
+                                        reason=reason)
 
     def deprecated_function(*args, **kwargs):
         raise PandasNotImplementedError(class_name=class_name, method_name=method_name,
-                                        deprecated=deprecated)
+                                        deprecated=deprecated, reason=reason)
 
     return deprecated_function if deprecated else unsupported_function
 
 
-def _unsupported_property(class_name, property_name, deprecated=False):
+def _unsupported_property(class_name, property_name, deprecated=False, reason=""):
 
     @property
     def unsupported_property(self):
-        raise PandasNotImplementedError(class_name=class_name, property_name=property_name)
+        raise PandasNotImplementedError(class_name=class_name, property_name=property_name,
+                                        reason=reason)
 
     @property
     def deprecated_property(self):
         raise PandasNotImplementedError(class_name=class_name, property_name=property_name,
-                                        deprecated=deprecated)
+                                        deprecated=deprecated, reason=reason)
 
     return deprecated_property if deprecated else unsupported_property

--- a/databricks/koalas/missing/frame.py
+++ b/databricks/koalas/missing/frame.py
@@ -165,4 +165,5 @@ class _MissingPandasLikeDataFrame(object):
 
     to_pickle = unsupported_function(
         'to_pickle',
-        reason="Pickled data is not designed for a long term.")
+        reason="For storage, we encourage you to use Delta or Parquet, instead of Python pickle "
+               "format.")

--- a/databricks/koalas/missing/frame.py
+++ b/databricks/koalas/missing/frame.py
@@ -17,14 +17,14 @@
 from databricks.koalas.missing import _unsupported_function, _unsupported_property
 
 
-def unsupported_function(method_name, deprecated=False):
+def unsupported_function(method_name, deprecated=False, reason=""):
     return _unsupported_function(class_name='pd.DataFrame', method_name=method_name,
-                                 deprecated=deprecated)
+                                 deprecated=deprecated, reason=reason)
 
 
-def unsupported_property(property_name, deprecated=False):
+def unsupported_property(property_name, deprecated=False, reason=""):
     return _unsupported_property(class_name='pd.DataFrame', property_name=property_name,
-                                 deprecated=deprecated)
+                                 deprecated=deprecated, reason=reason)
 
 
 class _MissingPandasLikeDataFrame(object):
@@ -131,7 +131,6 @@ class _MissingPandasLikeDataFrame(object):
     to_hdf = unsupported_function('to_hdf')
     to_msgpack = unsupported_function('to_msgpack')
     to_period = unsupported_function('to_period')
-    to_pickle = unsupported_function('to_pickle')
     to_sparse = unsupported_function('to_sparse')
     to_sql = unsupported_function('to_sql')
     to_stata = unsupported_function('to_stata')
@@ -158,3 +157,12 @@ class _MissingPandasLikeDataFrame(object):
     select = unsupported_function('select', deprecated=True)
     set_value = unsupported_function('set_value', deprecated=True)
     to_panel = unsupported_function('to_panel', deprecated=True)
+
+    # Functions and properties we won't support.
+    values = unsupported_property(
+        'values',
+        reason="If you want to collect your data as an NumPy array, use 'to_numpy()' instead.")
+
+    to_pickle = unsupported_function(
+        'to_pickle',
+        reason="Pickled data is not designed for a long term.")

--- a/databricks/koalas/missing/groupby.py
+++ b/databricks/koalas/missing/groupby.py
@@ -17,14 +17,14 @@
 from databricks.koalas.missing import _unsupported_function, _unsupported_property
 
 
-def unsupported_function(method_name, deprecated=False):
+def unsupported_function(method_name, deprecated=False, reason=""):
     return _unsupported_function(class_name='pd.groupby.GroupBy', method_name=method_name,
-                                 deprecated=deprecated)
+                                 deprecated=deprecated, reason=reason)
 
 
-def unsupported_property(property_name, deprecated=False):
+def unsupported_property(property_name, deprecated=False, reason=""):
     return _unsupported_property(class_name='pd.groupby.GroupBy', property_name=property_name,
-                                 deprecated=deprecated)
+                                 deprecated=deprecated, reason=reason)
 
 
 class _MissingPandasLikeDataFrameGroupBy(object):

--- a/databricks/koalas/missing/indexes.py
+++ b/databricks/koalas/missing/indexes.py
@@ -17,14 +17,14 @@
 from databricks.koalas.missing import _unsupported_function, _unsupported_property
 
 
-def unsupported_function(method_name, deprecated=False):
+def unsupported_function(method_name, deprecated=False, reason=""):
     return _unsupported_function(class_name='pd.Index', method_name=method_name,
-                                 deprecated=deprecated)
+                                 deprecated=deprecated, reason=reason)
 
 
-def unsupported_property(property_name, deprecated=False):
+def unsupported_property(property_name, deprecated=False, reason=""):
     return _unsupported_property(class_name='pd.Index', property_name=property_name,
-                                 deprecated=deprecated)
+                                 deprecated=deprecated, reason=reason)
 
 
 class _MissingPandasLikeIndex(object):
@@ -46,7 +46,6 @@ class _MissingPandasLikeIndex(object):
     shape = unsupported_property('shape')
     size = unsupported_property('size')
     strides = unsupported_property('strides')
-    values = unsupported_property('values')
 
     # Functions
     append = unsupported_function('append')
@@ -132,6 +131,11 @@ class _MissingPandasLikeIndex(object):
     get_duplicates = unsupported_function('get_duplicates', deprecated=True)
     summary = unsupported_function('summary', deprecated=True)
 
+    # Functions and properties we won't support.
+    values = unsupported_property(
+        'values',
+        reason="If you want to collect your data as an NumPy array, use 'to_numpy()' instead.")
+
 
 class _MissingPandasLikeMultiIndex(object):
 
@@ -154,7 +158,6 @@ class _MissingPandasLikeMultiIndex(object):
     shape = unsupported_property('shape')
     size = unsupported_property('size')
     strides = unsupported_property('strides')
-    values = unsupported_property('values')
 
     # Functions
     append = unsupported_function('append')
@@ -251,3 +254,8 @@ class _MissingPandasLikeMultiIndex(object):
     get_duplicates = unsupported_function('get_duplicates', deprecated=True)
     summary = unsupported_function('summary', deprecated=True)
     to_hierarchical = unsupported_function('to_hierarchical', deprecated=True)
+
+    # Functions and properties we won't support.
+    values = unsupported_property(
+        'values',
+        reason="If you want to collect your data as an NumPy array, use 'to_numpy()' instead.")

--- a/databricks/koalas/missing/series.py
+++ b/databricks/koalas/missing/series.py
@@ -17,14 +17,14 @@
 from databricks.koalas.missing import _unsupported_function, _unsupported_property
 
 
-def unsupported_function(method_name, deprecated=False):
+def unsupported_function(method_name, deprecated=False, reason=""):
     return _unsupported_function(class_name='pd.Series', method_name=method_name,
-                                 deprecated=deprecated)
+                                 deprecated=deprecated, reason=reason)
 
 
-def unsupported_property(property_name, deprecated=False):
+def unsupported_property(property_name, deprecated=False, reason=""):
     return _unsupported_property(class_name='pd.Series', property_name=property_name,
-                                 deprecated=deprecated)
+                                 deprecated=deprecated, reason=reason)
 
 
 class _MissingPandasLikeSeries(object):
@@ -173,3 +173,8 @@ class _MissingPandasLikeSeries(object):
     select = unsupported_function('select', deprecated=True)
     set_value = unsupported_function('set_value', deprecated=True)
     valid = unsupported_function('valid', deprecated=True)
+
+    # Functions and properties we won't support.
+    values = unsupported_property(
+        'values',
+        reason="If you want to collect your data as an NumPy array, use 'to_numpy()' instead.")

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -389,8 +389,9 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         unsupported_functions = [name for (name, type_) in missing_functions
                                  if type_.__name__ == 'unsupported_function']
         for name in unsupported_functions:
-            with self.assertRaisesRegex(PandasNotImplementedError,
-                                        "method.*DataFrame.*{}.*not implemented".format(name)):
+            with self.assertRaisesRegex(
+                    PandasNotImplementedError,
+                    "method.*DataFrame.*{}.*not implemented( yet\\.|\\. .+)".format(name)):
                 getattr(kdf, name)()
 
         deprecated_functions = [name for (name, type_) in missing_functions
@@ -405,8 +406,9 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         unsupported_properties = [name for (name, type_) in missing_properties
                                   if type_.fget.__name__ == 'unsupported_property']
         for name in unsupported_properties:
-            with self.assertRaisesRegex(PandasNotImplementedError,
-                                        "property.*DataFrame.*{}.*not implemented".format(name)):
+            with self.assertRaisesRegex(
+                    PandasNotImplementedError,
+                    "property.*DataFrame.*{}.*not implemented( yet\\.|\\. .+)".format(name)):
                 getattr(kdf, name)
         deprecated_properties = [name for (name, type_) in missing_properties
                                  if type_.fget.__name__ == 'deprecated_property']

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -130,9 +130,9 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         unsupported_functions = [name for (name, type_) in missing_functions
                                  if type_.__name__ == 'unsupported_function']
         for name in unsupported_functions:
-            with self.assertRaisesRegex(PandasNotImplementedError,
-                                        "method.*GroupBy.*{}.*not implemented"
-                                        .format(name)):
+            with self.assertRaisesRegex(
+                    PandasNotImplementedError,
+                    "method.*GroupBy.*{}.*not implemented( yet\\.|\\. .+)".format(name)):
                 getattr(kdf.groupby('a'), name)()
 
         deprecated_functions = [name for (name, type_) in missing_functions
@@ -149,9 +149,9 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         unsupported_functions = [name for (name, type_) in missing_functions
                                  if type_.__name__ == 'unsupported_function']
         for name in unsupported_functions:
-            with self.assertRaisesRegex(PandasNotImplementedError,
-                                        "method.*GroupBy.*{}.*not implemented"
-                                        .format(name)):
+            with self.assertRaisesRegex(
+                    PandasNotImplementedError,
+                    "method.*GroupBy.*{}.*not implemented( yet\\.|\\. .+)".format(name)):
                 getattr(kdf.a.groupby('a'), name)()
 
         deprecated_functions = [name for (name, type_) in missing_functions
@@ -168,9 +168,9 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         unsupported_properties = [name for (name, type_) in missing_properties
                                   if type_.fget.__name__ == 'unsupported_property']
         for name in unsupported_properties:
-            with self.assertRaisesRegex(PandasNotImplementedError,
-                                        "property.*GroupBy.*{}.*not implemented"
-                                        .format(name)):
+            with self.assertRaisesRegex(
+                    PandasNotImplementedError,
+                    "property.*GroupBy.*{}.*not implemented( yet\\.|\\. .+)".format(name)):
                 getattr(kdf.groupby('a'), name)
         deprecated_properties = [name for (name, type_) in missing_properties
                                  if type_.fget.__name__ == 'deprecated_property']
@@ -186,9 +186,9 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         unsupported_properties = [name for (name, type_) in missing_properties
                                   if type_.fget.__name__ == 'unsupported_property']
         for name in unsupported_properties:
-            with self.assertRaisesRegex(PandasNotImplementedError,
-                                        "property.*GroupBy.*{}.*not implemented"
-                                        .format(name)):
+            with self.assertRaisesRegex(
+                    PandasNotImplementedError,
+                    "property.*GroupBy.*{}.*not implemented( yet\\.|\\. .+)".format(name)):
                 getattr(kdf.a.groupby('a'), name)
         deprecated_properties = [name for (name, type_) in missing_properties
                                  if type_.fget.__name__ == 'deprecated_property']

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -115,8 +115,9 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         unsupported_functions = [name for (name, type_) in missing_functions
                                  if type_.__name__ == 'unsupported_function']
         for name in unsupported_functions:
-            with self.assertRaisesRegex(PandasNotImplementedError,
-                                        "method.*Index.*{}.*not implemented".format(name)):
+            with self.assertRaisesRegex(
+                    PandasNotImplementedError,
+                    "method.*Index.*{}.*not implemented( yet\\.|\\. .+)".format(name)):
                 getattr(kdf.set_index('a').index, name)()
 
         deprecated_functions = [name for (name, type_) in missing_functions
@@ -131,8 +132,9 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         unsupported_functions = [name for (name, type_) in missing_functions
                                  if type_.__name__ == 'unsupported_function']
         for name in unsupported_functions:
-            with self.assertRaisesRegex(PandasNotImplementedError,
-                                        "method.*Index.*{}.*not implemented".format(name)):
+            with self.assertRaisesRegex(
+                    PandasNotImplementedError,
+                    "method.*Index.*{}.*not implemented( yet\\.|\\. .+)".format(name)):
                 getattr(kdf.set_index(['a', 'b']).index, name)()
 
         deprecated_functions = [name for (name, type_) in missing_functions
@@ -148,8 +150,9 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         unsupported_properties = [name for (name, type_) in missing_properties
                                   if type_.fget.__name__ == 'unsupported_property']
         for name in unsupported_properties:
-            with self.assertRaisesRegex(PandasNotImplementedError,
-                                        "property.*Index.*{}.*not implemented".format(name)):
+            with self.assertRaisesRegex(
+                    PandasNotImplementedError,
+                    "property.*Index.*{}.*not implemented( yet\\.|\\. .+)".format(name)):
                 getattr(kdf.set_index('a').index, name)
 
         deprecated_properties = [name for (name, type_) in missing_properties
@@ -165,8 +168,9 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         unsupported_properties = [name for (name, type_) in missing_properties
                                   if type_.fget.__name__ == 'unsupported_property']
         for name in unsupported_properties:
-            with self.assertRaisesRegex(PandasNotImplementedError,
-                                        "property.*Index.*{}.*not implemented".format(name)):
+            with self.assertRaisesRegex(
+                    PandasNotImplementedError,
+                    "property.*Index.*{}.*not implemented( yet\\.|\\. .+)".format(name)):
                 getattr(kdf.set_index(['a', 'b']).index, name)
 
         deprecated_properties = [name for (name, type_) in missing_properties

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -306,8 +306,9 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         unsupported_functions = [name for (name, type_) in missing_functions
                                  if type_.__name__ == 'unsupported_function']
         for name in unsupported_functions:
-            with self.assertRaisesRegex(PandasNotImplementedError,
-                                        "method.*Series.*{}.*not implemented".format(name)):
+            with self.assertRaisesRegex(
+                    PandasNotImplementedError,
+                    "method.*Series.*{}.*not implemented( yet\\.|\\. .+)".format(name)):
                 getattr(ks, name)()
 
         deprecated_functions = [name for (name, type_) in missing_functions
@@ -322,8 +323,9 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         unsupported_properties = [name for (name, type_) in missing_properties
                                   if type_.fget.__name__ == 'unsupported_property']
         for name in unsupported_properties:
-            with self.assertRaisesRegex(PandasNotImplementedError,
-                                        "property.*Series.*{}.*not implemented".format(name)):
+            with self.assertRaisesRegex(
+                    PandasNotImplementedError,
+                    "property.*Series.*{}.*not implemented( yet\\.|\\. .+)".format(name)):
                 getattr(ks, name)
         deprecated_properties = [name for (name, type_) in missing_properties
                                  if type_.fget.__name__ == 'deprecated_property']


### PR DESCRIPTION
This PR proposes to add a reason for unsupported functions.

While I am here,
  - `values` at Series, Index, DataFrame were moved into missing package with the reason.
  - `to_pickle` at DataFrame