### PR TITLE
Merge codecov reports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,5 +82,5 @@ script:
 
 # Push the results back to codecov
 after_success:
-  - codecov
+  - bash <(curl -s https://codecov.io/bash)
 


### PR DESCRIPTION
This PR merges the codecov results from different runs caused by the Travis matrix.

See https://docs.codecov.io/docs/merging-reports