### PR TITLE
Updated frame.replace()

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -25,6 +25,7 @@ from typing import Any, Optional, List, Tuple, Union, Generic, TypeVar
 
 import numpy as np
 import pandas as pd
+import pyspark.sql.functions as F
 from pandas.api.types import is_list_like, is_dict_like
 from pandas.core.dtypes.common import infer_dtype_from_object
 from pandas.core.dtypes.inference import is_sequence
@@ -2758,7 +2759,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 raise ValueError('Length of to_replace and value must be same')
 
         sdf = self._sdf.select(self._internal.data_columns)
-        if isinstance(to_replace, dict):
+        if isinstance(to_replace, dict) and value is None and \
+                (not any(isinstance(i, dict) for i in to_replace.values())):
+            sdf = sdf.replace(to_replace, value, subset)
+        elif isinstance(to_replace, dict):
             for df_column, replacement in to_replace.items():
                 if isinstance(replacement, dict):
                     sdf = sdf.replace(replacement, subset=df_column)

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -25,7 +25,6 @@ from typing import Any, Optional, List, Tuple, Union, Generic, TypeVar
 
 import numpy as np
 import pandas as pd
-import pyspark.sql.functions as F
 from pandas.api.types import is_list_like, is_dict_like
 from pandas.core.dtypes.common import infer_dtype_from_object
 from pandas.core.dtypes.inference import is_sequence

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -789,19 +789,19 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         kdf = ks.from_pandas(pdf)
 
         self.assert_eq(repr(kdf.replace([0, 1, 2, 3], 4)),
-               repr(pdf.replace([0, 1, 2, 3], 4)))
+                       repr(pdf.replace([0, 1, 2, 3], 4)))
 
         self.assert_eq(repr(kdf.replace([0, 1, 2, 3], [4, 3, 2, 1])),
-               repr(pdf.replace([0, 1, 2, 3], [4, 3, 2, 1])))
+                       repr(pdf.replace([0, 1, 2, 3], [4, 3, 2, 1])))
 
         self.assert_eq(repr(kdf.replace({0: 10, 1: 100})),
-               repr(pdf.replace({0: 10, 1: 100})))
+                       repr(pdf.replace({0: 10, 1: 100})))
 
         self.assert_eq(repr(kdf.replace({'A': 0, 'B': 5}, 100)),
-               repr(pdf.replace({'A': 0, 'B': 5}, 100)))
+                       repr(pdf.replace({'A': 0, 'B': 5}, 100)))
 
         self.assert_eq(repr(kdf.replace({'A': {0: 100, 4: 400}})),
-               repr(pdf.replace({'A': {0: 100, 4: 400}})))
+                       repr(pdf.replace({'A': {0: 100, 4: 400}})))
 
     def test_update(self):
         # check base function

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -788,19 +788,19 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         kdf = ks.from_pandas(pdf)
 
-        assert(repr(kdf.replace([0, 1, 2, 3], 4)) ==
+        self.assert_eq(repr(kdf.replace([0, 1, 2, 3], 4)),
                repr(pdf.replace([0, 1, 2, 3], 4)))
 
-        assert(repr(kdf.replace([0, 1, 2, 3], [4, 3, 2, 1])) ==
+        self.assert_eq(repr(kdf.replace([0, 1, 2, 3], [4, 3, 2, 1])),
                repr(pdf.replace([0, 1, 2, 3], [4, 3, 2, 1])))
 
-        assert(repr(kdf.replace({0: 10, 1: 100})) ==
+        self.assert_eq(repr(kdf.replace({0: 10, 1: 100})),
                repr(pdf.replace({0: 10, 1: 100})))
 
-        assert(repr(kdf.replace({'A': 0, 'B': 5}, 100)) ==
+        self.assert_eq(repr(kdf.replace({'A': 0, 'B': 5}, 100)),
                repr(pdf.replace({'A': 0, 'B': 5}, 100)))
 
-        assert(repr(kdf.replace({'A': {0: 100, 4: 400}})) ==
+        self.assert_eq(repr(kdf.replace({'A': {0: 100, 4: 400}})),
                repr(pdf.replace({'A': {0: 100, 4: 400}})))
 
     def test_update(self):

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -788,15 +788,20 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         kdf = ks.from_pandas(pdf)
 
-        assert (repr(kdf.replace([0, 1, 2, 3], 4)) == repr(pdf.replace([0, 1, 2, 3], 4)))
+        assert(repr(kdf.replace([0, 1, 2, 3], 4)) ==
+               repr(pdf.replace([0, 1, 2, 3], 4)))
 
-        assert (repr(kdf.replace([0, 1, 2, 3], [4, 3, 2, 1])) == repr(pdf.replace([0, 1, 2, 3], [4, 3, 2, 1])))
+        assert(repr(kdf.replace([0, 1, 2, 3], [4, 3, 2, 1])) ==
+               repr(pdf.replace([0, 1, 2, 3], [4, 3, 2, 1])))
 
-        assert (repr(kdf.replace({0: 10, 1: 100})) == repr(pdf.replace({0: 10, 1: 100})))
+        assert(repr(kdf.replace({0: 10, 1: 100})) ==
+               repr(pdf.replace({0: 10, 1: 100})))
 
-        assert (repr(kdf.replace({'A': 0, 'B': 5}, 100)) == repr(pdf.replace({'A': 0, 'B': 5}, 100)))
+        assert(repr(kdf.replace({'A': 0, 'B': 5}, 100)) ==
+               repr(pdf.replace({'A': 0, 'B': 5}, 100)))
 
-        assert (repr(kdf.replace({'A': {0: 100, 4: 400}})) == repr(pdf.replace({'A': {0: 100, 4: 400}})))
+        assert(repr(kdf.replace({'A': {0: 100, 4: 400}})) ==
+               repr(pdf.replace({'A': {0: 100, 4: 400}})))
 
     def test_update(self):
         # check base function

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -782,6 +782,22 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             pdf.replace(['Ironman', 'Captain America'], ['Rescue', 'Hawkeye'])
         )
 
+        pdf = pd.DataFrame({'A': [0, 1, 2, 3, 4],
+                            'B': [5, 6, 7, 8, 9],
+                            'C': ['a', 'b', 'c', 'd', 'e']})
+
+        kdf = ks.from_pandas(pdf)
+
+        assert (repr(kdf.replace([0, 1, 2, 3], 4)) == repr(pdf.replace([0, 1, 2, 3], 4)))
+
+        assert (repr(kdf.replace([0, 1, 2, 3], [4, 3, 2, 1])) == repr(pdf.replace([0, 1, 2, 3], [4, 3, 2, 1])))
+
+        assert (repr(kdf.replace({0: 10, 1: 100})) == repr(pdf.replace({0: 10, 1: 100})))
+
+        assert (repr(kdf.replace({'A': 0, 'B': 5}, 100)) == repr(pdf.replace({'A': 0, 'B': 5}, 100)))
+
+        assert (repr(kdf.replace({'A': {0: 100, 4: 400}})) == repr(pdf.replace({'A': {0: 100, 4: 400}})))
+
     def test_update(self):
         # check base function
         def get_data():


### PR DESCRIPTION
Fix for replace to add support for the mapping case as referenced in #495 :

`kdf.replace({0: 10, 1: 100})`