### PR TITLE
Fix build with pandas 0.23.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,6 @@ install:
   - |
     if [[ $TRAVIS_PYTHON_VERSION == "3.5" ]]; then
       pip install -r requirements-dev.txt && \
-      pip install pandas==$PANDAS_VERSION pyarrow==$PYARROW_VERSION && \
       pip list;
     else
       conda config --env --add pinned_packages python=$TRAVIS_PYTHON_VERSION && \

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,8 @@ install:
 
   # Test PyPI installation at Python 3.5. This is also because
   # one of the dependency requires Python 3.6 Conda specifically.
-  - if [[ $TRAVIS_PYTHON_VERSION == "3.5" ]]; then
+  - |
+    if [[ $TRAVIS_PYTHON_VERSION == "3.5" ]]; then
       pip install -r requirements-dev.txt && \
       pip install pandas==$PANDAS_VERSION pyarrow==$PYARROW_VERSION && \
       pip list;

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,11 @@ matrix:
         - PYARROW_VERSION=0.10.0
     - python: "3.6"
       env:
+        - SPARK_VERSION=2.3.3
+        - PANDAS_VERSION=0.23.4
+        - PYARROW_VERSION=0.10.0
+    - python: "3.6"
+      env:
         - SPARK_VERSION=2.4.3
         - PANDAS_VERSION=0.24.2
         - PYARROW_VERSION=0.10.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,7 @@ install:
   # Replace dep1 dep2 ... with your dependencies
   - conda create -c conda-forge -q -n test-environment python=$TRAVIS_PYTHON_VERSION
   - conda activate test-environment
+  - conda install -c conda-forge --yes codecov
 
   # Test PyPI installation at Python 3.5. This is also because
   # one of the dependency requires Python 3.6 Conda specifically.
@@ -67,7 +68,6 @@ install:
       conda config --env --add pinned_packages python=$TRAVIS_PYTHON_VERSION && \
       conda config --env --add pinned_packages pandas==$PANDAS_VERSION && \
       conda config --env --add pinned_packages pyarrow==$PYARROW_VERSION && \
-      conda install -c conda-forge --yes codecov && \
       conda install -c conda-forge --yes --file requirements-dev.txt && \
       conda list;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,7 @@ install:
   - |
     if [[ $TRAVIS_PYTHON_VERSION == "3.5" ]]; then
       pip install -r requirements-dev.txt && \
+      pip install pandas==$PANDAS_VERSION pyarrow==$PYARROW_VERSION && \
       pip list;
     else
       conda config --env --add pinned_packages python=$TRAVIS_PYTHON_VERSION && \

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,6 @@ matrix:
         - PYARROW_VERSION=0.10.0
     - python: "3.6"
       env:
-        - SPARK_VERSION=2.3.3
-        - PANDAS_VERSION=0.23.4
-        - PYARROW_VERSION=0.10.0
-    - python: "3.6"
-      env:
         - SPARK_VERSION=2.4.3
         - PANDAS_VERSION=0.24.2
         - PYARROW_VERSION=0.10.0
@@ -60,17 +55,20 @@ install:
   # Replace dep1 dep2 ... with your dependencies
   - conda create -c conda-forge -q -n test-environment python=$TRAVIS_PYTHON_VERSION
   - conda activate test-environment
-  - conda config --env --add pinned_packages python=$TRAVIS_PYTHON_VERSION
-  - conda config --env --add pinned_packages pandas==$PANDAS_VERSION
-  - conda config --env --add pinned_packages pyarrow==$PYARROW_VERSION
-  - conda install -c conda-forge --yes codecov
 
   # Test PyPI installation at Python 3.5. This is also because
   # one of the dependency requires Python 3.6 Conda specifically.
   - if [[ $TRAVIS_PYTHON_VERSION == "3.5" ]]; then
-      pip install -r requirements-dev.txt && pip list;
+      pip install -r requirements-dev.txt && \
+      pip install pandas==$PANDAS_VERSION pyarrow==$PYARROW_VERSION && \
+      pip list;
     else
-      conda install -c conda-forge --yes --file requirements-dev.txt && conda list;
+      conda config --env --add pinned_packages python=$TRAVIS_PYTHON_VERSION && \
+      conda config --env --add pinned_packages pandas==$PANDAS_VERSION && \
+      conda config --env --add pinned_packages pyarrow==$PYARROW_VERSION && \
+      conda install -c conda-forge --yes codecov && \
+      conda install -c conda-forge --yes --file requirements-dev.txt && \
+      conda list;
     fi
 
   # Useful for to_clipboard test

--- a/databricks/conftest.py
+++ b/databricks/conftest.py
@@ -23,6 +23,8 @@ import uuid
 import logging
 from distutils.version import LooseVersion
 
+import pandas as pd
+import pyarrow as pa
 from pyspark import __version__
 
 from databricks import koalas
@@ -43,6 +45,20 @@ else:
 @pytest.fixture(autouse=True)
 def add_ks(doctest_namespace):
     doctest_namespace['ks'] = koalas
+
+
+@pytest.fixture(autouse=True)
+def add_pd(doctest_namespace):
+    if os.getenv("PANDAS_VERSION", None) is not None:
+        assert pd.__version__ == os.getenv("PANDAS_VERSION")
+    doctest_namespace['pd'] = pd
+
+
+@pytest.fixture(autouse=True)
+def add_pa(doctest_namespace):
+    if os.getenv("PYARROW_VERSION", None) is not None:
+        assert pa.__version__ == os.getenv("PYARROW_VERSION")
+    doctest_namespace['pa'] = pa
 
 
 @pytest.fixture(autouse=True)

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -17,6 +17,7 @@
 """
 A wrapper class for Spark DataFrame to behave similar to pandas DataFrame.
 """
+from distutils.version import LooseVersion
 import re
 import warnings
 from functools import partial, reduce
@@ -26,7 +27,10 @@ from typing import Any, Optional, List, Tuple, Union, Generic, TypeVar
 import numpy as np
 import pandas as pd
 from pandas.api.types import is_list_like, is_dict_like
-from pandas.core.dtypes.common import infer_dtype_from_object
+if LooseVersion(pd.__version__) >= LooseVersion('0.24'):
+    from pandas.core.dtypes.common import infer_dtype_from_object
+else:
+    from pandas.core.dtypes.common import _get_dtype_from_object as infer_dtype_from_object
 from pandas.core.dtypes.inference import is_sequence
 from pyspark import sql as spark
 from pyspark.sql.window import Window

--- a/databricks/koalas/mlflow.py
+++ b/databricks/koalas/mlflow.py
@@ -139,7 +139,7 @@ def load_model(model_uri, predict_type='infer') -> PythonModelWrapper:
     >>> with mlflow.start_run():
     ...     lr = LinearRegression()
     ...     lr.fit(train_x, train_y)
-    ...     mlflow.sklearn.log_model(lr, "model")
+    ...     mlflow.sklearn.log_model(lr, "model")  # doctest: +NORMALIZE_WHITESPACE
     LinearRegression(copy_X=True, fit_intercept=True, n_jobs=None, normalize=False)
 
     Now that our model is logged using MLflow, we load it back and apply it on a Koalas dataframe:

--- a/databricks/koalas/plot.py
+++ b/databricks/koalas/plot.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 
+from distutils.version import LooseVersion
 import matplotlib
 import numpy as np
 import pandas as pd
@@ -563,7 +564,11 @@ class KoalasSeriesPlotMethods(BasePlotMethods):
                  rot=None, fontsize=None, colormap=None, table=False,
                  yerr=None, xerr=None,
                  label=None, secondary_y=False, **kwds):
-        return plot_series(self._parent, kind=kind, ax=ax, figsize=figsize,
+        if LooseVersion(pd.__version__) < LooseVersion('0.24'):
+            data = self._data
+        else:
+            data = self._parent
+        return plot_series(data, kind=kind, ax=ax, figsize=figsize,
                            use_index=use_index, title=title, grid=grid,
                            legend=legend, style=style, logx=logx, logy=logy,
                            loglog=loglog, xticks=xticks, yticks=yticks,

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -854,7 +854,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         # Checking if both DataFrames have the same results (Temporary)
         np.testing.assert_equal(kdf.pivot_table(columns="a", values="b").to_numpy(),
-                                pdf.pivot_table(columns=["a"], values="b").to_numpy())
+                                pdf.pivot_table(columns=["a"], values="b").values)
 
         # Todo: self.assert_eq(kdf.pivot_table(columns="a", values="b"),
         #  pdf.pivot_table(columns=["a"], values="b"))

--- a/databricks/koalas/tests/test_series_plot.py
+++ b/databricks/koalas/tests/test_series_plot.py
@@ -15,7 +15,10 @@
 #
 
 import base64
+from distutils.version import LooseVersion
 from io import BytesIO
+import unittest
+
 import matplotlib
 matplotlib.use('agg')
 from matplotlib import pyplot as plt
@@ -68,6 +71,8 @@ class SeriesPlotTest(ReusedSQLTestCase, TestUtils):
         ax2 = kdf['a'].plot.bar()
         self.compare_plots(ax1, ax2)
 
+    @unittest.skipIf(LooseVersion(pd.__version__) < LooseVersion('0.24'),
+                     'TODO: support pandas 0.23')
     def test_bar_plot_limited(self):
         pdf = self.pdf2
         kdf = self.kdf2


### PR DESCRIPTION
Currently only the travis build with Python 3.5 is supposed to use the older versions of pandas and pyarrow, but the 3.5 build doesn't work with the older versions because the libraries are not pinned and the newest versions are used since the 3.5 build uses `pip` instead of `conda`.
As as result, we missed the failures with pandas 0.23.
Resolves #525.