### PR TITLE
Set the color explicitly in plot.bar tests

### DIFF
--- a/databricks/koalas/tests/test_series_plot.py
+++ b/databricks/koalas/tests/test_series_plot.py
@@ -15,9 +15,7 @@
 #
 
 import base64
-from distutils.version import LooseVersion
 from io import BytesIO
-import unittest
 
 import matplotlib
 matplotlib.use('agg')
@@ -67,22 +65,20 @@ class SeriesPlotTest(ReusedSQLTestCase, TestUtils):
         pdf = self.pdf1
         kdf = self.kdf1
 
-        ax1 = pdf['a'].plot.bar()
-        ax2 = kdf['a'].plot.bar()
+        ax1 = pdf['a'].plot.bar(colormap='Paired')
+        ax2 = kdf['a'].plot.bar(colormap='Paired')
         self.compare_plots(ax1, ax2)
 
-    @unittest.skipIf(LooseVersion(pd.__version__) < LooseVersion('0.24'),
-                     'TODO: support pandas 0.23')
     def test_bar_plot_limited(self):
         pdf = self.pdf2
         kdf = self.kdf2
 
         _, ax1 = plt.subplots(1, 1)
-        ax1 = pdf['id'][:1000].plot.bar()
+        ax1 = pdf['id'][:1000].plot.bar(colormap='Paired')
         ax1.text(1, 1, 'showing top 1,000 elements only', size=6, ha='right', va='bottom',
                  transform=ax1.transAxes)
         _, ax2 = plt.subplots(1, 1)
-        ax2 = kdf['id'].plot.bar()
+        ax2 = kdf['id'].plot.bar(colormap='Paired')
 
         self.compare_plots(ax1, ax2)
 


### PR DESCRIPTION
When we use Pandas 0.23.x, seems it sets the color for each bar as below:

![output](https://user-images.githubusercontent.com/6477701/60639276-ec4a8f80-9e5c-11e9-8dc4-0a054d45aea1.png)

whereas Koalas' creates as below:

![output2](https://user-images.githubusercontent.com/6477701/60639275-ec4a8f80-9e5c-11e9-82ca-1065203feaca.png)

Seems it creates the same color as Koalas' from Pandas 0.24.x. So seems we're fine here since we follow higher versions of Pandas.

In order to make the tests passed with Pandas 0.23.X too, it explicitly sets the color so that image binary comparison can be done. After this PR:

![output2](https://user-images.githubusercontent.com/6477701/60639337-2b78e080-9e5d-11e9-8fef-a814791a58f6.png)
![output](https://user-images.githubusercontent.com/6477701/60639338-2c117700-9e5d-11e9-940e-005d3ad35b51.png)

Can be checked via:

```python
import databricks.koalas as ks
import pandas as pd
pdf = ks.range(1002).to_pandas()

from matplotlib import pyplot as plt
kdf = ks.range(1002)
pdf = ks.range(1002).to_pandas()
_, ax1 = plt.subplots(1, 1)
ax1 = pdf['id'][:1000].plot.bar(colormap='Paired')
ax1.text(1, 1, 'showing top 1,000 elements only', size=6, ha='right', va='bottom',
                 transform=ax1.transAxes)
_, ax2 = plt.subplots(1, 1)
ax2 = kdf['id'].plot.bar(colormap='Paired')
ax1

ax1.figure.savefig("output.png")
ax2.figure.savefig("output2.png")
```

```python
import databricks.koalas as ks
import pandas as pd

pdf_1 = pd.DataFrame({
            'a': [1, 2, 3, 4, 5, 6, 7, 8, 9, 15, 50],
        }, index=[0, 1, 3, 5, 6, 8, 9, 9, 9, 10, 10])

kdf_1 = ks.DataFrame(pdf_1)
pdf_1['a'].plot.bar(colormap='Paired').figure.savefig("output3.png")
kdf_1['a'].plot.bar(colormap='Paired').figure.savefig("output4.png")
```