### PR TITLE
Triage Series/DataFrame/Index/GroupBy APIs not to support

### DIFF
--- a/databricks/koalas/missing/common.py
+++ b/databricks/koalas/missing/common.py
@@ -24,3 +24,24 @@ memory_usage = lambda f: f(
 values = lambda f: f(
     'values',
     reason="If you want to collect your data as an NumPy array, use 'to_numpy()' instead.")
+
+array = lambda f: f(
+    'array',
+    reason="If you want to collect your data as an NumPy array, use 'to_numpy()' instead.")
+
+to_pickle = lambda f: f(
+    'to_pickle',
+    reason="For storage, we encourage you to use Delta or Parquet, instead of Python pickle "
+           "format.")
+
+to_xarray = lambda f: f(
+    'to_xarray',
+    reason="If you want to collect your data as an NumPy array, use 'to_numpy()' instead.")
+
+to_list = lambda f: f(
+    'to_list',
+    reason="If you want to collect your data as an NumPy array, use 'to_numpy()' instead.")
+
+tolist = lambda f: f(
+    'tolist',
+    reason="If you want to collect your data as an NumPy array, use 'to_numpy()' instead.")

--- a/databricks/koalas/missing/frame.py
+++ b/databricks/koalas/missing/frame.py
@@ -31,15 +31,15 @@ class _MissingPandasLikeDataFrame(object):
 
     # Properties
     axes = unsupported_property('axes')
-    ftypes = unsupported_property('ftypes')
     iat = unsupported_property('iat')
-    is_copy = unsupported_property('is_copy')
-    ix = unsupported_property('ix')
     ndim = unsupported_property('ndim')
     style = unsupported_property('style')
 
     # Deprecated properties
     blocks = unsupported_property('blocks', deprecated=True)
+    ftypes = unsupported_property('ftypes', deprecated=True)
+    is_copy = unsupported_property('is_copy', deprecated=True)
+    ix = unsupported_property('ix', deprecated=True)
 
     # Functions
     agg = unsupported_function('agg')
@@ -65,7 +65,6 @@ class _MissingPandasLikeDataFrame(object):
     filter = unsupported_function('filter')
     first = unsupported_function('first')
     first_valid_index = unsupported_function('first_valid_index')
-    get_values = unsupported_function('get_values')
     hist = unsupported_function('hist')
     idxmax = unsupported_function('idxmax')
     idxmin = unsupported_function('idxmin')
@@ -105,17 +104,13 @@ class _MissingPandasLikeDataFrame(object):
     swaplevel = unsupported_function('swaplevel')
     tail = unsupported_function('tail')
     take = unsupported_function('take')
-    to_dense = unsupported_function('to_dense')
     to_feather = unsupported_function('to_feather')
     to_gbq = unsupported_function('to_gbq')
     to_hdf = unsupported_function('to_hdf')
-    to_msgpack = unsupported_function('to_msgpack')
     to_period = unsupported_function('to_period')
-    to_sparse = unsupported_function('to_sparse')
     to_sql = unsupported_function('to_sql')
     to_stata = unsupported_function('to_stata')
     to_timestamp = unsupported_function('to_timestamp')
-    to_xarray = unsupported_function('to_xarray')
     truncate = unsupported_function('truncate')
     tshift = unsupported_function('tshift')
     tz_convert = unsupported_function('tz_convert')
@@ -135,12 +130,15 @@ class _MissingPandasLikeDataFrame(object):
     select = unsupported_function('select', deprecated=True)
     set_value = unsupported_function('set_value', deprecated=True)
     to_panel = unsupported_function('to_panel', deprecated=True)
+    get_values = unsupported_function('get_values', deprecated=True)
+    to_dense = unsupported_function('to_dense', deprecated=True)
+    to_sparse = unsupported_function('to_sparse', deprecated=True)
+    to_msgpack = unsupported_function('to_msgpack', deprecated=True)
 
-    # Functions and properties we won't support.
-    to_pickle = unsupported_function(
-        'to_pickle',
-        reason="For storage, we encourage you to use Delta or Parquet, instead of Python pickle "
-               "format.")
-
+    # Properties we won't support.
     values = common.values(unsupported_property)
+
+    # Functions we won't support.
+    to_pickle = common.to_pickle(unsupported_function)
     memory_usage = common.memory_usage(unsupported_function)
+    to_xarray = common.to_xarray(unsupported_function)

--- a/databricks/koalas/missing/indexes.py
+++ b/databricks/koalas/missing/indexes.py
@@ -31,18 +31,19 @@ class _MissingPandasLikeIndex(object):
 
     # Properties
     T = unsupported_property('T')
-    array = unsupported_property('array')
-    base = unsupported_property('base')
-    data = unsupported_property('data')
     flags = unsupported_property('flags')
     has_duplicates = unsupported_property('has_duplicates')
-    itemsize = unsupported_property('itemsize')
     nbytes = unsupported_property('nbytes')
     ndim = unsupported_property('ndim')
     nlevels = unsupported_property('nlevels')
     shape = unsupported_property('shape')
     size = unsupported_property('size')
-    strides = unsupported_property('strides')
+
+    # Deprecated properties
+    strides = unsupported_property('strides', deprecated=True)
+    data = unsupported_property('data', deprecated=True)
+    base = unsupported_property('base', deprecated=True)
+    itemsize = unsupported_property('itemsize', deprecated=True)
 
     # Functions
     append = unsupported_function('append')
@@ -71,7 +72,6 @@ class _MissingPandasLikeIndex(object):
     get_loc = unsupported_function('get_loc')
     get_slice_bound = unsupported_function('get_slice_bound')
     get_value = unsupported_function('get_value')
-    get_values = unsupported_function('get_values')
     groupby = unsupported_function('groupby')
     holds_integer = unsupported_function('holds_integer')
     identical = unsupported_function('identical')
@@ -111,10 +111,8 @@ class _MissingPandasLikeIndex(object):
     take = unsupported_function('take')
     to_flat_index = unsupported_function('to_flat_index')
     to_frame = unsupported_function('to_frame')
-    to_list = unsupported_function('to_list')
     to_native_types = unsupported_function('to_native_types')
     to_numpy = unsupported_function('to_numpy')
-    tolist = unsupported_function('tolist')
     transpose = unsupported_function('transpose')
     union = unsupported_function('union')
     unique = unsupported_function('unique')
@@ -125,24 +123,26 @@ class _MissingPandasLikeIndex(object):
     # Deprecated functions
     get_duplicates = unsupported_function('get_duplicates', deprecated=True)
     summary = unsupported_function('summary', deprecated=True)
+    get_values = unsupported_function('get_values', deprecated=True)
 
-    # Functions and properties we won't support.
+    # Properties we won't support.
     values = common.values(unsupported_property)
+    array = common.array(unsupported_property)
+
+    # Functions we won't support.
     memory_usage = common.memory_usage(unsupported_function)
+    to_list = common.to_list(unsupported_function)
+    tolist = common.tolist(unsupported_function)
 
 
 class _MissingPandasLikeMultiIndex(object):
 
     # Properties
     T = unsupported_property('T')
-    array = unsupported_property('array')
-    base = unsupported_property('base')
     codes = unsupported_property('codes')
-    data = unsupported_property('data')
     flags = unsupported_property('flags')
     has_duplicates = unsupported_property('has_duplicates')
     is_all_dates = unsupported_property('is_all_dates')
-    itemsize = unsupported_property('itemsize')
     labels = unsupported_property('labels')
     levels = unsupported_property('levels')
     levshape = unsupported_property('levshape')
@@ -150,7 +150,12 @@ class _MissingPandasLikeMultiIndex(object):
     nlevels = unsupported_property('nlevels')
     shape = unsupported_property('shape')
     size = unsupported_property('size')
-    strides = unsupported_property('strides')
+
+    # Deprecated properties
+    strides = unsupported_property('strides', deprecated=True)
+    data = unsupported_property('data', deprecated=True)
+    base = unsupported_property('base', deprecated=True)
+    itemsize = unsupported_property('itemsize', deprecated=True)
 
     # Functions
     append = unsupported_function('append')
@@ -182,7 +187,6 @@ class _MissingPandasLikeMultiIndex(object):
     get_locs = unsupported_function('get_locs')
     get_slice_bound = unsupported_function('get_slice_bound')
     get_value = unsupported_function('get_value')
-    get_values = unsupported_function('get_values')
     groupby = unsupported_function('groupby')
     holds_integer = unsupported_function('holds_integer')
     identical = unsupported_function('identical')
@@ -229,10 +233,8 @@ class _MissingPandasLikeMultiIndex(object):
     take = unsupported_function('take')
     to_flat_index = unsupported_function('to_flat_index')
     to_frame = unsupported_function('to_frame')
-    to_list = unsupported_function('to_list')
     to_native_types = unsupported_function('to_native_types')
     to_numpy = unsupported_function('to_numpy')
-    tolist = unsupported_function('tolist')
     transpose = unsupported_function('transpose')
     truncate = unsupported_function('truncate')
     union = unsupported_function('union')
@@ -245,7 +247,13 @@ class _MissingPandasLikeMultiIndex(object):
     get_duplicates = unsupported_function('get_duplicates', deprecated=True)
     summary = unsupported_function('summary', deprecated=True)
     to_hierarchical = unsupported_function('to_hierarchical', deprecated=True)
+    get_values = unsupported_function('get_values', deprecated=True)
 
-    # Functions and properties we won't support.
+    # Functions we won't support.
     values = common.values(unsupported_property)
+    array = common.array(unsupported_property)
+
+    # Properties we won't support.
     memory_usage = common.memory_usage(unsupported_function)
+    to_list = common.to_list(unsupported_function)
+    tolist = common.tolist(unsupported_function)

--- a/databricks/koalas/missing/series.py
+++ b/databricks/koalas/missing/series.py
@@ -30,23 +30,21 @@ def unsupported_property(property_name, deprecated=False, reason=""):
 class _MissingPandasLikeSeries(object):
 
     # Properties
-    array = unsupported_property('array')
-    asobject = unsupported_property('asobject')
     axes = unsupported_property('axes')
     base = unsupported_property('base')
     flags = unsupported_property('flags')
-    ftype = unsupported_property('ftype')
-    ftypes = unsupported_property('ftypes')
     iat = unsupported_property('iat')
     imag = unsupported_property('imag')
-    is_copy = unsupported_property('is_copy')
-    ix = unsupported_property('ix')
     nbytes = unsupported_property('nbytes')
-    real = unsupported_property('real')
-    strides = unsupported_property('strides')
 
     # Deprecated properties
     blocks = unsupported_property('blocks', deprecated=True)
+    ftypes = unsupported_property('ftypes', deprecated=True)
+    ftype = unsupported_property('ftype', deprecated=True)
+    is_copy = unsupported_property('is_copy', deprecated=True)
+    ix = unsupported_property('ix', deprecated=True)
+    asobject = unsupported_property('asobject', deprecated=True)
+    strides = unsupported_property('strides', deprecated=True)
 
     # Functions
     agg = unsupported_function('agg')
@@ -81,7 +79,6 @@ class _MissingPandasLikeSeries(object):
     first = unsupported_function('first')
     first_valid_index = unsupported_function('first_valid_index')
     get = unsupported_function('get')
-    get_values = unsupported_function('get_values')
     idxmax = unsupported_function('idxmax')
     idxmin = unsupported_function('idxmin')
     infer_objects = unsupported_function('infer_objects')
@@ -120,14 +117,10 @@ class _MissingPandasLikeSeries(object):
     swaplevel = unsupported_function('swaplevel')
     tail = unsupported_function('tail')
     take = unsupported_function('take')
-    to_dense = unsupported_function('to_dense')
     to_hdf = unsupported_function('to_hdf')
-    to_msgpack = unsupported_function('to_msgpack')
     to_period = unsupported_function('to_period')
-    to_sparse = unsupported_function('to_sparse')
     to_sql = unsupported_function('to_sql')
     to_timestamp = unsupported_function('to_timestamp')
-    to_xarray = unsupported_function('to_xarray')
     truncate = unsupported_function('truncate')
     tshift = unsupported_function('tshift')
     tz_convert = unsupported_function('tz_convert')
@@ -154,12 +147,19 @@ class _MissingPandasLikeSeries(object):
     select = unsupported_function('select', deprecated=True)
     set_value = unsupported_function('set_value', deprecated=True)
     valid = unsupported_function('valid', deprecated=True)
+    get_values = unsupported_function('get_values', deprecated=True)
+    to_dense = unsupported_function('to_dense', deprecated=True)
+    to_sparse = unsupported_function('to_sparse', deprecated=True)
+    to_msgpack = unsupported_function('to_msgpack', deprecated=True)
 
-    # Functions and properties we won't support.
+    # Properties we won't support.
     values = common.values(unsupported_property)
+    array = common.array(unsupported_property)
+    real = unsupported_property(
+        'real',
+        reason="If you want to collect your data as an NumPy array, use 'to_numpy()' instead.")
+
+    # Functions we won't support.
     memory_usage = common.memory_usage(unsupported_function)
-    # Functions and properties we won't support.
-    to_pickle = unsupported_function(
-        'to_pickle',
-        reason="For storage, we encourage you to use Delta or Parquet, instead of Python pickle "
-               "format.")
+    to_pickle = common.to_pickle(unsupported_function)
+    to_xarray = common.to_xarray(unsupported_function)

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -159,7 +159,7 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
                                  if type_.fget.__name__ == 'deprecated_property']
         for name in deprecated_properties:
             with self.assertRaisesRegex(PandasNotImplementedError,
-                                        "property.*GroupBy.*{}.*is deprecated".format(name)):
+                                        "property.*Index.*{}.*is deprecated".format(name)):
                 getattr(kdf.set_index('a').index, name)
 
         # MultiIndex properties
@@ -177,7 +177,7 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
                                  if type_.fget.__name__ == 'deprecated_property']
         for name in deprecated_properties:
             with self.assertRaisesRegex(PandasNotImplementedError,
-                                        "property.*GroupBy.*{}.*is deprecated".format(name)):
+                                        "property.*Index.*{}.*is deprecated".format(name)):
                 getattr(kdf.set_index(['a', 'b']).index, name)
 
     def test_multi_index_not_supported(self):


### PR DESCRIPTION
This PR proposes:

1. Mark deprecated APIs (per https://pandas.pydata.org/pandas-docs/stable/search.html?q=&check_keywords=yes&area=default# )
2. Don't explicitly support some APIs virtually similar with what we don't support.