### PR TITLE
Add Series.idxmax() and Series.idxmin()

### DIFF
--- a/databricks/koalas/missing/series.py
+++ b/databricks/koalas/missing/series.py
@@ -52,8 +52,6 @@ class _MissingPandasLikeSeries(object):
     agg = unsupported_function('agg')
     aggregate = unsupported_function('aggregate')
     align = unsupported_function('align')
-    argmax = unsupported_function('argmax')
-    argmin = unsupported_function('argmin')
     argsort = unsupported_function('argsort')
     asfreq = unsupported_function('asfreq')
     asof = unsupported_function('asof')
@@ -80,8 +78,6 @@ class _MissingPandasLikeSeries(object):
     first = unsupported_function('first')
     first_valid_index = unsupported_function('first_valid_index')
     get = unsupported_function('get')
-    idxmax = unsupported_function('idxmax')
-    idxmin = unsupported_function('idxmin')
     infer_objects = unsupported_function('infer_objects')
     interpolate = unsupported_function('interpolate')
     items = unsupported_function('items')
@@ -151,6 +147,8 @@ class _MissingPandasLikeSeries(object):
     put = unsupported_function('put', deprecated=True)
     item = unsupported_function('item', deprecated=True)
     ptp = unsupported_function('ptp', deprecated=True)
+    argmax = unsupported_function('argmax', deprecated=True)
+    argmin = unsupported_function('argmin', deprecated=True)
 
     # Properties we won't support.
     values = common.values(unsupported_property)

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -2628,6 +2628,8 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         sdf = self._kdf._sdf
         scol = self._scol
         index_scols = self._kdf._internal.index_scols
+        # desc_nulls_(last|first) is used via Py4J directly because
+        # it's not supported in Spark 2.3.
         if skipna:
             sdf = sdf.orderBy(Column(scol._jc.desc_nulls_last()))
         else:
@@ -2718,6 +2720,8 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         sdf = self._kdf._sdf
         scol = self._scol
         index_scols = self._kdf._internal.index_scols
+        # asc_nulls_(list|first)is used via Py4J directly because
+        # it's not supported in Spark 2.3.
         if skipna:
             sdf = sdf.orderBy(Column(scol._jc.asc_nulls_last()))
         else:

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -29,7 +29,7 @@ from pandas.api.types import is_list_like
 from pandas.core.accessor import CachedAccessor
 
 from pyspark import sql as spark
-from pyspark.sql import functions as F
+from pyspark.sql import functions as F, Column
 from pyspark.sql.types import BooleanType, StructType
 from pyspark.sql.window import Window
 
@@ -2559,6 +2559,181 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         col = self._scol
         window = Window.orderBy(self._internal.index_scols).rowsBetween(-periods, -periods)
         return self._with_new_scol(col - F.lag(col, periods).over(window)).alias(self.name)
+
+    def idxmax(self, skipna=True):
+        """
+        Return the row label of the maximum value.
+
+        If multiple values equal the maximum, the row label with that
+        value is returned.
+
+        Parameters
+        ----------
+        skipna : bool, default True
+            Exclude NA/null values. If the entire Series is NA, the result
+            will be NA.
+
+        Returns
+        -------
+        Index
+            Label of the maximum value.
+
+        Raises
+        ------
+        ValueError
+            If the Series is empty.
+
+        See Also
+        --------
+        Series.idxmin : Return index *label* of the first occurrence
+            of minimum of values.
+
+        Examples
+        --------
+        >>> s = ks.Series(data=[1, None, 4, 3, 5],
+        ...               index=['A', 'B', 'C', 'D', 'E'])
+        >>> s
+        A    1.0
+        B    NaN
+        C    4.0
+        D    3.0
+        E    5.0
+        Name: 0, dtype: float64
+
+        >>> s.idxmax()
+        'E'
+
+        If `skipna` is False and there is an NA value in the data,
+        the function returns ``nan``.
+
+        >>> s.idxmax(skipna=False)
+        nan
+
+        In case of multi-index, you get a tuple:
+
+        >>> index = pd.MultiIndex.from_arrays([
+        ...     ['a', 'a', 'b', 'b'], ['c', 'd', 'e', 'f']], names=('first', 'second'))
+        >>> s = ks.Series(data=[1, None, 4, 5], index=index)
+        >>> s
+        first  second
+        a      c         1.0
+               d         NaN
+        b      e         4.0
+               f         5.0
+        Name: 0, dtype: float64
+
+        >>> s.idxmax()
+        ('b', 'f')
+        """
+        sdf = self._kdf._sdf
+        scol = self._scol
+        index_scols = self._kdf._internal.index_scols
+        if skipna:
+            sdf = sdf.orderBy(Column(scol._jc.desc_nulls_last()))
+        else:
+            sdf = sdf.orderBy(Column(scol._jc.desc_nulls_first()))
+        results = sdf.select([scol] + index_scols).take(1)
+        if len(results) == 0:
+            raise ValueError("attempt to get idxmin of an empty sequence")
+        if results[0][0] is None:
+            # This will only happens when skipna is False because we will
+            # place nulls first.
+            return np.nan
+        values = list(results[0][1:])
+        if len(values) == 1:
+            return values[0]
+        else:
+            return tuple(values)
+
+    def idxmin(self, skipna=True):
+        """
+        Return the row label of the minimum value.
+
+        If multiple values equal the minimum, the row label with that
+        value is returned.
+
+        Parameters
+        ----------
+        skipna : bool, default True
+            Exclude NA/null values. If the entire Series is NA, the result
+            will be NA.
+
+        Returns
+        -------
+        Index
+            Label of the minimum value.
+
+        Raises
+        ------
+        ValueError
+            If the Series is empty.
+
+        See Also
+        --------
+        Series.idxmax : Return index *label* of the first occurrence
+            of maximum of values.
+
+        Notes
+        -----
+        This method is the Series version of ``ndarray.argmin``. This method
+        returns the label of the minimum, while ``ndarray.argmin`` returns
+        the position. To get the position, use ``series.values.argmin()``.
+
+        Examples
+        --------
+        >>> s = ks.Series(data=[1, None, 4, 0],
+        ...               index=['A', 'B', 'C', 'D'])
+        >>> s
+        A    1.0
+        B    NaN
+        C    4.0
+        D    0.0
+        Name: 0, dtype: float64
+
+        >>> s.idxmin()
+        'D'
+
+        If `skipna` is False and there is an NA value in the data,
+        the function returns ``nan``.
+
+        >>> s.idxmin(skipna=False)
+        nan
+
+        In case of multi-index, you get a tuple:
+
+        >>> index = pd.MultiIndex.from_arrays([
+        ...     ['a', 'a', 'b', 'b'], ['c', 'd', 'e', 'f']], names=('first', 'second'))
+        >>> s = ks.Series(data=[1, None, 4, 0], index=index)
+        >>> s
+        first  second
+        a      c         1.0
+               d         NaN
+        b      e         4.0
+               f         0.0
+        Name: 0, dtype: float64
+
+        >>> s.idxmin()
+        ('b', 'f')
+        """
+        sdf = self._kdf._sdf
+        scol = self._scol
+        index_scols = self._kdf._internal.index_scols
+        if skipna:
+            sdf = sdf.orderBy(Column(scol._jc.asc_nulls_last()))
+        else:
+            sdf = sdf.orderBy(Column(scol._jc.asc_nulls_first()))
+        results = sdf.select([scol] + index_scols).take(1)
+        if len(results) == 0:
+            raise ValueError("attempt to get idxmin of an empty sequence")
+        if results[0][0] is None:
+            # This will only happens when skipna is False because we will
+            # place nulls first.
+            return np.nan
+        values = list(results[0][1:])
+        if len(values) == 1:
+            return values[0]
+        else:
+            return tuple(values)
 
     def _cum(self, func, skipna):
         # This is used to cummin, cummax, cumsum, etc.

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -527,3 +527,41 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
             koalas.Series([24., 21., 25., 33., 26.]).quantile(q="a")
         with self.assertRaisesRegex(ValueError, "q must be a float of an array of floats;"):
             koalas.Series([24., 21., 25., 33., 26.]).quantile(q=["a"])
+
+    def test_idxmax(self):
+        pser = pd.Series(data=[1, 4, 5], index=['A', 'B', 'C'])
+        kser = koalas.Series(pser)
+
+        self.assertEqual(kser.idxmax(), pser.idxmax())
+        self.assertEqual(kser.idxmax(skipna=False), pser.idxmax(skipna=False))
+
+        index = pd.MultiIndex.from_arrays([
+            ['a', 'a', 'b', 'b'], ['c', 'd', 'e', 'f']], names=('first', 'second'))
+        pser = pd.Series(data=[1, 2, 4, 5], index=index)
+        kser = koalas.Series(pser)
+
+        self.assertEqual(kser.idxmax(), pser.idxmax())
+        self.assertEqual(kser.idxmax(skipna=False), pser.idxmax(skipna=False))
+
+        kser = koalas.Series([])
+        with self.assertRaisesRegex(ValueError, "an empty sequence"):
+            kser.idxmax()
+
+    def test_idxmin(self):
+        pser = pd.Series(data=[1, 4, 5], index=['A', 'B', 'C'])
+        kser = koalas.Series(pser)
+
+        self.assertEqual(kser.idxmin(), pser.idxmin())
+        self.assertEqual(kser.idxmin(skipna=False), pser.idxmin(skipna=False))
+
+        index = pd.MultiIndex.from_arrays([
+            ['a', 'a', 'b', 'b'], ['c', 'd', 'e', 'f']], names=('first', 'second'))
+        pser = pd.Series(data=[1, 2, 4, 5], index=index)
+        kser = koalas.Series(pser)
+
+        self.assertEqual(kser.idxmin(), pser.idxmin())
+        self.assertEqual(kser.idxmin(skipna=False), pser.idxmin(skipna=False))
+
+        kser = koalas.Series([])
+        with self.assertRaisesRegex(ValueError, "an empty sequence"):
+            kser.idxmin()

--- a/docs/source/reference/series.rst
+++ b/docs/source/reference/series.rst
@@ -138,6 +138,8 @@ Reindexing / Selection / Label manipulation
    Series.add_prefix
    Series.add_suffix
    Series.head
+   Series.idxmax
+   Series.idxmin
    Series.isin
    Series.rename
    Series.reset_index


### PR DESCRIPTION
This PR adds `Series.idxmax()` and `Series.idxmin()` and mark deprecated equivalent APIs `Series.argmax()` and `Series.argmin()`.