### PR TITLE
Fix multi-index column access.

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -6172,17 +6172,21 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             sdf = self._sdf.select(self._internal.index_scols +
                                    [self._internal.scol_for(col).alias(idx[0])
                                     for col, idx in columns])
-            return DataFrame(self._internal.copy(
+            kdf = DataFrame(self._internal.copy(
                 sdf=sdf,
                 data_columns=[idx[0] for _, idx in columns],
                 column_index=None))
         else:
             sdf = self._sdf.select(self._internal.index_scols +
                                    [self._internal.scol_for(col) for col, _ in columns])
-            return DataFrame(self._internal.copy(
+            kdf = DataFrame(self._internal.copy(
                 sdf=sdf,
                 data_columns=[col for col, _ in columns],
                 column_index=[idx for _, idx in columns]))
+        if all([idx[0] == '' for _, idx in columns]):
+            return kdf._pd_getitem('')
+        else:
+            return kdf
 
     def _pd_getitem(self, key):
         from databricks.koalas.series import Series

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -6168,6 +6168,11 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                    if idx[0] == key]
         if len(columns) == 0:
             raise KeyError(key)
+        recursive = False
+        if all([idx[0] == '' for _, idx in columns]):
+            recursive = True
+            for i, (col, idx) in enumerate(columns):
+                columns[i] = (col, tuple([key, *idx[1:]]))
         if all(len(idx) == 1 for _, idx in columns):
             sdf = self._sdf.select(self._internal.index_scols +
                                    [self._internal.scol_for(col).alias(idx[0])
@@ -6183,8 +6188,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 sdf=sdf,
                 data_columns=[col for col, _ in columns],
                 column_index=[idx for _, idx in columns]))
-        if all([idx[0] == '' for _, idx in columns]):
-            return kdf._pd_getitem('')
+        if recursive:
+            return kdf._pd_getitem(key)
         else:
             return kdf
 

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -6162,7 +6162,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         else:
             raise TypeError("Must pass either `items`, `like`, or `regex`")
 
-    def _get_from_multilevel_column(self, key):
+    def _get_from_multiindex_column(self, key):
         columns = [(column, idx[1:]) for column, idx
                    in zip(self._internal.data_columns, self._internal.column_index)
                    if idx[0] == key]
@@ -6194,7 +6194,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             raise KeyError("none key")
         if isinstance(key, str):
             if self._internal.column_index is not None:
-                return self._get_from_multilevel_column(key)
+                return self._get_from_multiindex_column(key)
             else:
                 try:
                     return Series(self._internal.copy(scol=self._internal.scol_for(key)),
@@ -6284,7 +6284,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         if self._internal.column_index is not None:
             try:
-                return self._get_from_multilevel_column(key)
+                return self._get_from_multiindex_column(key)
             except KeyError:
                 raise AttributeError(
                     "'%s' object has no attribute '%s'" % (self.__class__.__name__, key))

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -74,7 +74,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         kser = ks.Series([1, 2, 3], name='x')
         self.assert_eq(pd.DataFrame(pser), ks.DataFrame(kser))
 
-    def test_dataframe_multilevel_columns(self):
+    def test_dataframe_multiindex_columns(self):
         pdf = pd.DataFrame({
             ('x', 'a', '1'): [1, 2, 3],
             ('x', 'b', '2'): [4, 5, 6],
@@ -96,7 +96,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assertRaises(KeyError, lambda: kdf['z'])
         self.assertRaises(AttributeError, lambda: kdf.z)
 
-    def test_reset_index_with_multilevel_columns(self):
+    def test_reset_index_with_multiindex_columns(self):
         index = pd.MultiIndex.from_tuples([('bird', 'falcon'),
                                            ('bird', 'parrot'),
                                            ('mammal', 'lion'),

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -125,6 +125,32 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         with self.assertRaisesRegex(IndexError, 'Index has only 2 levels, not 3'):
             kdf.reset_index(col_level=2)
 
+    def test_multiindex_column_access(self):
+        columns = pd.MultiIndex.from_tuples([('a', '', '', 'b'),
+                                             ('c', '', 'd', ''),
+                                             ('e', '', 'f', ''),
+                                             ('e', 'g', '', ''),
+                                             ('', '', '', 'h'),
+                                             ('i', '', '', '')])
+
+        pdf = pd.DataFrame([(1, 'a', 'x', 10, 100, 1000),
+                            (2, 'b', 'y', 20, 200, 2000),
+                            (3, 'c', 'z', 30, 300, 3000)],
+                           columns=columns)
+        kdf = ks.from_pandas(pdf)
+
+        self.assert_eq(kdf, pdf)
+        self.assert_eq(kdf['a'], pdf['a'])
+        self.assert_eq(kdf['a']['b'], pdf['a']['b'])
+        self.assert_eq(kdf['c'], pdf['c'])
+        self.assert_eq(kdf['c']['d'], pdf['c']['d'])
+        self.assert_eq(kdf['e'], pdf['e'])
+        self.assert_eq(kdf['e']['']['f'], pdf['e']['']['f'])
+        self.assert_eq(kdf['e']['g'], pdf['e']['g'])
+        self.assert_eq(kdf[''], pdf[''])
+        self.assert_eq(kdf['']['h'], pdf['']['h'])
+        self.assert_eq(kdf['i'], pdf['i'])
+
     def test_repr_cache_invalidation(self):
         # If there is any cache, inplace operations should invalidate it.
         df = ks.range(10)


### PR DESCRIPTION
Fix complex multi-index column access for something like:

```py
>>> pdf
   a  c  e              i
             g
      d  f
   b              h
0  1  a  x  10  100  1000
1  2  b  y  20  200  2000
2  3  c  z  30  300  3000

>>> pdf['a']
   b
0  1
1  2
2  3

>>> pdf['c']
   d

0  a
1  b
2  c

>>> pdf['e']
       g
   f

0  x  10
1  y  20
2  z  30

>>> pdf['']
     h
0  100
1  200
2  300

>>> pdf['i']
0    1000
1    2000
2    3000
Name: i, dtype: int64
```