### PR TITLE
Add axis=columns to count, var, std, max, sum, min, kurtosis, skew and mean in DataFrame

### DIFF
--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -839,12 +839,14 @@ class _Frame(object):
         return validate_arguments_and_invoke_function(
             kdf.to_pandas(), self.to_excel, f, args)
 
-    def mean(self, numeric_only=True):
+    def mean(self, axis=None, numeric_only=True):
         """
         Return the mean of the values.
 
         Parameters
         ----------
+        axis : {index (0), columns (1)}
+            Axis for the function to be applied on.
         numeric_only : bool, default None
             Include only float, int, boolean columns. If None, will attempt to use
             everything, then use only numeric data. Not implemented for Series.
@@ -866,19 +868,29 @@ class _Frame(object):
         b    0.2
         dtype: float64
 
+        >>> df.mean(axis=1)
+        0    0.55
+        1    1.10
+        2    1.65
+        3     NaN
+        Name: 0, dtype: float64
+
         On a Series:
 
         >>> df['a'].mean()
         2.0
         """
-        return self._reduce_for_stat_function(F.mean, numeric_only=numeric_only)
+        return self._reduce_for_stat_function(
+            F.mean, name="mean", numeric_only=numeric_only, axis=axis)
 
-    def sum(self, numeric_only=True):
+    def sum(self, axis=None, numeric_only=True):
         """
         Return the sum of the values.
 
         Parameters
         ----------
+        axis : {index (0), columns (1)}
+            Axis for the function to be applied on.
         numeric_only : bool, default None
             Include only float, int, boolean columns. If None, will attempt to use
             everything, then use only numeric data. Not implemented for Series.
@@ -900,19 +912,29 @@ class _Frame(object):
         b    0.6
         dtype: float64
 
+        >>> df.sum(axis=1)
+        0    1.1
+        1    2.2
+        2    3.3
+        3    0.0
+        Name: 0, dtype: float64
+
         On a Series:
 
         >>> df['a'].sum()
         6.0
         """
-        return self._reduce_for_stat_function(F.sum, numeric_only=numeric_only)
+        return self._reduce_for_stat_function(
+            F.sum, name="sum", numeric_only=numeric_only, axis=axis)
 
-    def skew(self, numeric_only=True):
+    def skew(self, axis=None, numeric_only=True):
         """
         Return unbiased skew normalized by N-1.
 
         Parameters
         ----------
+        axis : {index (0), columns (1)}
+            Axis for the function to be applied on.
         numeric_only : bool, default None
             Include only float, int, boolean columns. If None, will attempt to use
             everything, then use only numeric data. Not implemented for Series.
@@ -939,15 +961,18 @@ class _Frame(object):
         >>> df['a'].skew()
         0.0
         """
-        return self._reduce_for_stat_function(F.skewness, numeric_only=numeric_only)
+        return self._reduce_for_stat_function(
+            F.skewness, name="skew", numeric_only=numeric_only, axis=axis)
 
-    def kurtosis(self, numeric_only=True):
+    def kurtosis(self, axis=None, numeric_only=True):
         """
         Return unbiased kurtosis using Fisher’s definition of kurtosis (kurtosis of normal == 0.0).
         Normalized by N-1.
 
         Parameters
         ----------
+        axis : {index (0), columns (1)}
+            Axis for the function to be applied on.
         numeric_only : bool, default None
             Include only float, int, boolean columns. If None, will attempt to use
             everything, then use only numeric data. Not implemented for Series.
@@ -974,16 +999,19 @@ class _Frame(object):
         >>> df['a'].kurtosis()
         -1.5
         """
-        return self._reduce_for_stat_function(F.kurtosis, numeric_only=numeric_only)
+        return self._reduce_for_stat_function(
+            F.kurtosis, name="kurtosis", numeric_only=numeric_only, axis=axis)
 
     kurt = kurtosis
 
-    def min(self, numeric_only=False):
+    def min(self, axis=None, numeric_only=False):
         """
         Return the minimum of the values.
 
         Parameters
         ----------
+        axis : {index (0), columns (1)}
+            Axis for the function to be applied on.
         numeric_only : bool, default None
             Include only float, int, boolean columns. If None, will attempt to use
             everything, then use only numeric data. Not implemented for Series.
@@ -1005,19 +1033,29 @@ class _Frame(object):
         b    0.1
         dtype: float64
 
+        >>> df.min(axis=1)
+        0    0.1
+        1    0.2
+        2    0.3
+        3    NaN
+        Name: 0, dtype: float64
+
         On a Series:
 
         >>> df['a'].min()
         1.0
         """
-        return self._reduce_for_stat_function(F.min, numeric_only=numeric_only)
+        return self._reduce_for_stat_function(
+            F.min, name="min", numeric_only=numeric_only, axis=axis)
 
-    def max(self, numeric_only=False):
+    def max(self, axis=None, numeric_only=False):
         """
         Return the maximum of the values.
 
         Parameters
         ----------
+        axis : {index (0), columns (1)}
+            Axis for the function to be applied on.
         numeric_only : bool, default None
             Include only float, int, boolean columns. If None, will attempt to use
             everything, then use only numeric data. Not implemented for Series.
@@ -1039,19 +1077,29 @@ class _Frame(object):
         b    0.3
         dtype: float64
 
+        >>> df.max(axis=1)
+        0    1.0
+        1    2.0
+        2    3.0
+        3    NaN
+        Name: 0, dtype: float64
+
         On a Series:
 
         >>> df['a'].max()
         3.0
         """
-        return self._reduce_for_stat_function(F.max, numeric_only=numeric_only)
+        return self._reduce_for_stat_function(
+            F.max, name="max", numeric_only=numeric_only, axis=axis)
 
-    def std(self, numeric_only=True):
+    def std(self, axis=None, numeric_only=True):
         """
         Return sample standard deviation.
 
         Parameters
         ----------
+        axis : {index (0), columns (1)}
+            Axis for the function to be applied on.
         numeric_only : bool, default None
             Include only float, int, boolean columns. If None, will attempt to use
             everything, then use only numeric data. Not implemented for Series.
@@ -1073,19 +1121,29 @@ class _Frame(object):
         b    0.1
         dtype: float64
 
+        >>> df.std(axis=1)
+        0    0.636396
+        1    1.272792
+        2    1.909188
+        3         NaN
+        Name: 0, dtype: float64
+
         On a Series:
 
         >>> df['a'].std()
         1.0
         """
-        return self._reduce_for_stat_function(F.stddev, numeric_only=numeric_only)
+        return self._reduce_for_stat_function(
+            F.stddev, name="std", numeric_only=numeric_only, axis=axis)
 
-    def var(self, numeric_only=True):
+    def var(self, axis=None, numeric_only=True):
         """
         Return unbiased variance.
 
         Parameters
         ----------
+        axis : {index (0), columns (1)}
+            Axis for the function to be applied on.
         numeric_only : bool, default None
             Include only float, int, boolean columns. If None, will attempt to use
             everything, then use only numeric data. Not implemented for Series.
@@ -1107,12 +1165,20 @@ class _Frame(object):
         b    0.01
         dtype: float64
 
+        >>> df.var(axis=1)
+        0    0.405
+        1    1.620
+        2    3.645
+        3      NaN
+        Name: 0, dtype: float64
+
         On a Series:
 
         >>> df['a'].var()
         1.0
         """
-        return self._reduce_for_stat_function(F.variance, numeric_only=numeric_only)
+        return self._reduce_for_stat_function(
+            F.variance, name="var", numeric_only=numeric_only, axis=axis)
 
     @property
     def size(self) -> int:
@@ -1342,7 +1408,8 @@ class _Frame(object):
         if isinstance(kdf_or_ks, Series):
             ks = kdf_or_ks
             return self._reduce_for_stat_function(
-                lambda _: F.expr("approx_percentile(`%s`, 0.5, %s)" % (ks.name, accuracy)))
+                lambda _: F.expr(
+                    "approx_percentile(`%s`, 0.5, %s)" % (ks.name, accuracy)), name="median")
         assert isinstance(kdf_or_ks, DataFrame)
 
         # This code path cannot reuse `_reduce_for_stat_function` since there looks no proper way

--- a/databricks/koalas/tests/test_stats.py
+++ b/databricks/koalas/tests/test_stats.py
@@ -56,6 +56,24 @@ class StatsTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(kdf[['B', 'C']].abs(), pdf[['B', 'C']].abs())
         # self.assert_eq(kdf.select('A', 'B').abs(), pdf[['A', 'B']].abs())
 
+    def test_axis_on_dataframe(self):
+        # The number of each count is intentionally big
+        # because when data is small, it executes a shortcut.
+        pdf = pd.DataFrame({'A': [1, -2, 3, -4, 5] * 300,
+                            'B': [1., -2, 3, -4, 5] * 300,
+                            'C': [-6., -7, -8, -9, 10] * 300,
+                            'D': [True, False, True, False, False] * 300})
+        kdf = koalas.from_pandas(pdf)
+        self.assert_eq(kdf.count(axis=1), pdf.count(axis=1))
+        self.assert_eq(kdf.var(axis=1), pdf.var(axis=1))
+        self.assert_eq(kdf.std(axis=1), pdf.std(axis=1))
+        self.assert_eq(kdf.max(axis=1), pdf.max(axis=1))
+        self.assert_eq(kdf.min(axis=1), pdf.min(axis=1))
+        self.assert_eq(kdf.sum(axis=1), pdf.sum(axis=1))
+        self.assert_eq(kdf.kurtosis(axis=1), pdf.kurtosis(axis=1))
+        self.assert_eq(kdf.skew(axis=1), pdf.skew(axis=1))
+        self.assert_eq(kdf.mean(axis=1), pdf.mean(axis=1))
+
     def test_corr(self):
         # Disable arrow execution since corr() is using UDT internally which is not supported.
         with self.sql_conf({'spark.sql.execution.arrow.enabled': False}):


### PR DESCRIPTION
This PR proposes to suppose axis=columns or 1 to count, var, std, max, sum, min, kurtosis, skew and mean in DataFrame. It was implemented via using pandas UDF.

Note that, to infer the return type, it executes the first 1000 and get the return type from it.

  - If the results is less then 1000, it just uses pandas API as a shortcut
  - Otherwise, it is executed via pandas UDF.

Resolves #599