### PR TITLE
Add axis=columns to cumsum, cummin, cummax and cumprod in DataFrame

### DIFF
--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -60,6 +60,7 @@ class _Frame(object):
         ----------
         axis : {0 or ‘index’, 1 or ‘columns’}, default 0
             The index or the name of the axis. 0 is equivalent to None or ‘index’.
+            columns axis is supported in Spark 3.0+.
         skipna : boolean, default True
             Exclude NA/null values. If an entire row/column is NA, the result will be NA.
 
@@ -99,7 +100,7 @@ class _Frame(object):
 
         To iterate over columns and find the sum in each row, use axis=1
 
-        >>> df.cummin(axis=1)
+        >>> df.cummin(axis=1)  # doctest: +SKIP
              A    B
         0  2.0  1.0
         1  3.0  NaN
@@ -130,6 +131,7 @@ class _Frame(object):
         ----------
         axis : {0 or ‘index’, 1 or ‘columns’}, default 0
             The index or the name of the axis. 0 is equivalent to None or ‘index’.
+            columns axis is supported in Spark 3.0+.
         skipna : boolean, default True
             Exclude NA/null values. If an entire row/column is NA, the result will be NA.
 
@@ -170,7 +172,7 @@ class _Frame(object):
 
         To iterate over columns and find the sum in each row, use axis=1
 
-        >>> df.cummax(axis=1)
+        >>> df.cummax(axis=1)  # doctest: +SKIP
              A    B
         0  2.0  2.0
         1  3.0  NaN
@@ -201,6 +203,7 @@ class _Frame(object):
         ----------
         axis : {0 or ‘index’, 1 or ‘columns’}, default 0
             The index or the name of the axis. 0 is equivalent to None or ‘index’.
+            columns axis is supported in Spark 3.0+.
         skipna : boolean, default True
             Exclude NA/null values. If an entire row/column is NA, the result will be NA.
 
@@ -241,7 +244,7 @@ class _Frame(object):
 
         To iterate over columns and find the sum in each row, use axis=1
 
-        >>> df.cumsum(axis=1)
+        >>> df.cumsum(axis=1)  # doctest: +SKIP
              A    B
         0  2.0  3.0
         1  3.0  NaN
@@ -277,6 +280,7 @@ class _Frame(object):
         ----------
         axis : {0 or ‘index’, 1 or ‘columns’}, default 0
             The index or the name of the axis. 0 is equivalent to None or ‘index’.
+            columns axis is supported in Spark 3.0+.
         skipna : boolean, default True
             Exclude NA/null values. If an entire row/column is NA, the result will be NA.
 
@@ -319,7 +323,7 @@ class _Frame(object):
 
         To iterate over columns and find the sum in each row, use axis=1
 
-        >>> df.cumprod(axis=1)
+        >>> df.cumprod(axis=1)  # doctest: +SKIP
              A     B
         0  2.0   2.0
         1  3.0   NaN

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -2741,7 +2741,10 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         else:
             return tuple(values)
 
-    def _cum(self, func, skipna):
+    def _cum(self, func, axis, skipna):
+        if axis in ('columns', 1):
+            raise ValueError("Series does not support columns axis.")
+
         # This is used to cummin, cummax, cumsum, etc.
         if len(self._internal.index_columns) == 0:
             raise ValueError("Index must be set.")

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -15,9 +15,12 @@
 #
 
 import inspect
+import unittest
+from distutils.version import LooseVersion
 
 import numpy as np
 import pandas as pd
+from pyspark import __version__ as pyspark_version
 from pyspark.sql.utils import AnalysisException
 
 from databricks import koalas as ks
@@ -1079,7 +1082,13 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(pdf.cummin(), kdf.cummin())
         self.assert_eq(pdf.cummin(skipna=False), kdf.cummin(skipna=False))
 
+    @unittest.skipIf(
+        LooseVersion(pyspark_version) < LooseVersion('3.0'),
+        "columns axis is supported in Spark 3.0+.")
+    def test_cummin_columns_axis(self):
         # The number of each count is intentionally to trigger Spark execution path
+        pdf = pd.DataFrame([
+            [2.0, 1.0], [5, None], [1.0, 0.0], [2.0, 4.0], [4.0, 9.0]], columns=list('AB'))
         pdf = pd.concat([pdf] * 600, ignore_index=True)
         kdf = ks.from_pandas(pdf)
         self.assert_eq(pdf.cummin(axis=1), kdf.cummin(axis=1))
@@ -1092,7 +1101,13 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(pdf.cummax(), kdf.cummax())
         self.assert_eq(pdf.cummax(skipna=False), kdf.cummax(skipna=False))
 
+    @unittest.skipIf(
+        LooseVersion(pyspark_version) < LooseVersion('3.0'),
+        "columns axis is supported in Spark 3.0+.")
+    def test_cummax_columns_axis(self):
         # The number of each count is intentionally to trigger Spark execution path
+        pdf = pd.DataFrame([
+            [2.0, 1.0], [5, None], [1.0, 0.0], [2.0, 4.0], [4.0, 9.0]], columns=list('AB'))
         pdf = pd.concat([pdf] * 600, ignore_index=True)
         kdf = ks.from_pandas(pdf)
         self.assert_eq(pdf.cummax(axis='columns'), kdf.cummax(axis='columns'))
@@ -1106,7 +1121,13 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(pdf.cumsum(), kdf.cumsum())
         self.assert_eq(pdf.cumsum(skipna=False), kdf.cumsum(skipna=False))
 
+    @unittest.skipIf(
+        LooseVersion(pyspark_version) < LooseVersion('3.0'),
+        "columns axis is supported in Spark 3.0+.")
+    def test_cumsum_columns_axis(self):
         # The number of each count is intentionally to trigger Spark execution path
+        pdf = pd.DataFrame([
+            [2.0, 1.0], [5, None], [1.0, 0.0], [2.0, 4.0], [4.0, 9.0]], columns=list('AB'))
         pdf = pd.concat([pdf] * 600, ignore_index=True)
         kdf = ks.from_pandas(pdf)
         self.assert_eq(pdf.cumsum(axis=1), kdf.cumsum(axis=1))
@@ -1119,7 +1140,13 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assertEqual(repr(pdf.cumprod()), repr(kdf.cumprod()))
         self.assertEqual(repr(pdf.cumprod(skipna=False)), repr(kdf.cumprod(skipna=False)))
 
+    @unittest.skipIf(
+        LooseVersion(pyspark_version) < LooseVersion('3.0'),
+        "columns axis is supported in Spark 3.0+.")
+    def test_cumprod_columns_axis(self):
         # The number of each count is intentionally to trigger Spark execution path
+        pdf = pd.DataFrame([
+            [2.0, 1.0], [5, None], [1.0, 0.0], [2.0, 4.0], [4.0, 9.0]], columns=list('AB'))
         pdf = pd.concat([pdf] * 600, ignore_index=True)
         kdf = ks.from_pandas(pdf)
         self.assert_eq(

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -1079,12 +1079,25 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(pdf.cummin(), kdf.cummin())
         self.assert_eq(pdf.cummin(skipna=False), kdf.cummin(skipna=False))
 
+        # The number of each count is intentionally to trigger Spark execution path
+        pdf = pd.concat([pdf] * 600, ignore_index=True)
+        kdf = ks.from_pandas(pdf)
+        self.assert_eq(pdf.cummin(axis=1), kdf.cummin(axis=1))
+        self.assert_eq(pdf.cummin(axis=1, skipna=False), kdf.cummin(axis=1, skipna=False))
+
     def test_cummax(self):
         pdf = pd.DataFrame([
             [2.0, 1.0], [5, None], [1.0, 0.0], [2.0, 4.0], [4.0, 9.0]], columns=list('AB'))
         kdf = ks.from_pandas(pdf)
         self.assert_eq(pdf.cummax(), kdf.cummax())
         self.assert_eq(pdf.cummax(skipna=False), kdf.cummax(skipna=False))
+
+        # The number of each count is intentionally to trigger Spark execution path
+        pdf = pd.concat([pdf] * 600, ignore_index=True)
+        kdf = ks.from_pandas(pdf)
+        self.assert_eq(pdf.cummax(axis='columns'), kdf.cummax(axis='columns'))
+        self.assert_eq(
+            pdf.cummax(axis='columns', skipna=False), kdf.cummax(axis='columns', skipna=False))
 
     def test_cumsum(self):
         pdf = pd.DataFrame([
@@ -1093,12 +1106,27 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(pdf.cumsum(), kdf.cumsum())
         self.assert_eq(pdf.cumsum(skipna=False), kdf.cumsum(skipna=False))
 
+        # The number of each count is intentionally to trigger Spark execution path
+        pdf = pd.concat([pdf] * 600, ignore_index=True)
+        kdf = ks.from_pandas(pdf)
+        self.assert_eq(pdf.cumsum(axis=1), kdf.cumsum(axis=1))
+        self.assert_eq(pdf.cumsum(axis=1, skipna=False), kdf.cumsum(axis=1, skipna=False))
+
     def test_cumprod(self):
         pdf = pd.DataFrame([
             [2.0, 1.0], [5, None], [1.0, 1.0], [2.0, 4.0], [4.0, 9.0]], columns=list('AB'))
         kdf = ks.from_pandas(pdf)
         self.assertEqual(repr(pdf.cumprod()), repr(kdf.cumprod()))
         self.assertEqual(repr(pdf.cumprod(skipna=False)), repr(kdf.cumprod(skipna=False)))
+
+        # The number of each count is intentionally to trigger Spark execution path
+        pdf = pd.concat([pdf] * 600, ignore_index=True)
+        kdf = ks.from_pandas(pdf)
+        self.assert_eq(
+            pdf.cumprod(axis='columns'), kdf.cumprod(axis='columns'))
+        self.assert_eq(
+            pdf.cumprod(axis='columns', skipna=False),
+            kdf.cumprod(axis='columns', skipna=False))
 
     def test_reindex(self):
         index = ['A', 'B', 'C', 'D', 'E']

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -464,11 +464,19 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         self.assertEqual(repr(pser.cummin()), repr(kser.cummin()))
         self.assertEqual(repr(pser.cummin(skipna=False)), repr(kser.cummin(skipna=False)))
 
+        msg = "Series.*not.*support"
+        with self.assertRaisesRegex(ValueError, msg):
+            kser.cummin(axis='columns')
+
     def test_cummax(self):
         pser = pd.Series([1.0, None, 0.0, 4.0, 9.0]).rename("a")
         kser = koalas.from_pandas(pser)
         self.assertEqual(repr(pser.cummax()), repr(kser.cummax()))
         self.assertEqual(repr(pser.cummax(skipna=False)), repr(kser.cummax(skipna=False)))
+
+        msg = "Series.*not.*support"
+        with self.assertRaisesRegex(ValueError, msg):
+            kser.cummax(axis=1)
 
     def test_cumsum(self):
         pser = pd.Series([1.0, None, 0.0, 4.0, 9.0]).rename("a")
@@ -476,11 +484,19 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         self.assertEqual(repr(pser.cumsum()), repr(kser.cumsum()))
         self.assertEqual(repr(pser.cumsum(skipna=False)), repr(kser.cumsum(skipna=False)))
 
+        msg = "Series.*not.*support"
+        with self.assertRaisesRegex(ValueError, msg):
+            kser.cumsum(axis='columns')
+
     def test_cumprod(self):
         pser = pd.Series([1.0, None, 1.0, 4.0, 9.0]).rename("a")
         kser = koalas.from_pandas(pser)
         self.assertEqual(repr(pser.cumprod()), repr(kser.cumprod()))
         self.assertEqual(repr(pser.cumprod(skipna=False)), repr(kser.cumprod(skipna=False)))
+
+        msg = "Series.*not.*support"
+        with self.assertRaisesRegex(ValueError, msg):
+            kser.cumprod(axis=1)
 
         # TODO: due to unknown reason, this test passes in Travis CI. Unable to reproduce in local.
         # with self.assertRaisesRegex(Exception, "values should be bigger than 0"):


### PR DESCRIPTION
This PR proposes to add axis=columns to cumsum, cummin, cummax and cumprod in DataFrame.
The approach is similar with https://github.com/databricks/koalas/pull/605 (and therefore this PR tries to deduplicate it).

*This requires Spark 3.0+**