### PR TITLE
Introduce default index with new three index types

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -4596,11 +4596,11 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         >>> merged.sort_values(by=['lkey', 'value_x', 'rkey', 'value_y'])
           lkey  value_x rkey  value_y
         0  bar        2  bar        6
-        1  baz        3  baz        7
-        2  foo        1  foo        5
-        3  foo        1  foo        8
-        4  foo        5  foo        5
-        5  foo        5  foo        8
+        5  baz        3  baz        7
+        1  foo        1  foo        5
+        2  foo        1  foo        8
+        3  foo        5  foo        5
+        4  foo        5  foo        8
 
         >>> left_kdf = ks.DataFrame({'A': [1, 2]})
         >>> right_kdf = ks.DataFrame({'B': ['x', 'y']}, index=[1, 2])

--- a/databricks/koalas/internal.py
+++ b/databricks/koalas/internal.py
@@ -368,12 +368,13 @@ class _InternalFrame(object):
             assert column_index is None
             assert column_index_names is None
 
-            index_map = [('__index_level_0__', None)]
+            if "__index_level_0__" not in sdf.schema.names:
+                # Create default index.
+                index_map = [('__index_level_0__', None)]
+                sdf = _InternalFrame.attach_default_index(sdf)
 
-            # Create default index.
-            sdf = _InternalFrame.attach_default_index(sdf)
-
-        assert all(isinstance(index_field, str)
+        assert index_map is None \
+            or all(isinstance(index_field, str)
                    and (index_name is None or isinstance(index_name, str))
                    for index_field, index_name in index_map)
         assert scol is None or isinstance(scol, spark.Column)

--- a/databricks/koalas/internal.py
+++ b/databricks/koalas/internal.py
@@ -425,11 +425,15 @@ class _InternalFrame(object):
             group-map approach. It still generates a one-by-one sequential index globally.
             If the default index must be an one-by-one sequence in a large dataset, this
             index has to be used.
+            Note that if more data are added to the data source after creating this index,
+            then it does not guarantee the sequential index.
 
         - distributed: It implements a monotonically increasing sequence simply by using
             Spark's `monotonically_increasing_id` function. If the index does not have to be
             a one-by-one sequence, this index should be used. Performance-wise, this index
             almost does not have any penalty comparing to other index types.
+            Note that we cannot use this type of index for combining two dataframes because
+            it is not guaranteed to have the same indexes in two dataframes.
 
         """
         default_index_type = os.environ.get("DEFAULT_INDEX", "one-by-one")

--- a/databricks/koalas/internal.py
+++ b/databricks/koalas/internal.py
@@ -19,13 +19,17 @@ An internal immutable DataFrame with some metadata to manage indexes.
 """
 
 from typing import List, Optional, Tuple, Union
+import os
+from itertools import accumulate
 
 import numpy as np
 import pandas as pd
 from pandas.api.types import is_datetime64_dtype, is_datetime64tz_dtype, is_list_like
 from pyspark import sql as spark
 from pyspark._globals import _NoValue, _NoValueType
-from pyspark.sql.types import DataType, StructField, StructType, to_arrow_type
+from pyspark.sql import functions as F, Window
+from pyspark.sql.functions import PandasUDFType, pandas_udf
+from pyspark.sql.types import DataType, StructField, StructType, to_arrow_type, LongType
 
 from databricks import koalas as ks  # For running doctests and reference resolution in PyCharm.
 from databricks.koalas.typedef import infer_pd_series_spark_type
@@ -359,8 +363,17 @@ class _InternalFrame(object):
         :param column_index_names: Names for each of the index levels.
         """
         assert isinstance(sdf, spark.DataFrame)
-        assert index_map is None \
-            or all(isinstance(index_field, str)
+        if index_map is None:
+            # Here is when Koalas DataFrame is created directly from Spark DataFrame.
+            assert column_index is None
+            assert column_index_names is None
+
+            index_map = [('__index_level_0__', None)]
+
+            # Create default index.
+            sdf = _InternalFrame.attach_default_index(sdf)
+
+        assert all(isinstance(index_field, str)
                    and (index_name is None or isinstance(index_name, str))
                    for index_field, index_name in index_map)
         assert scol is None or isinstance(scol, spark.Column)
@@ -393,6 +406,78 @@ class _InternalFrame(object):
                 self._column_index_names = column_index_names
         else:
             self._column_index_names = column_index_names
+
+    @staticmethod
+    def attach_default_index(sdf):
+        """
+        This method attaches a default index to Spark DataFrame. Spark does not have the index
+        notion so corresponding column should be generated.
+
+        There are three types of default index that can be controlled by `DEFAULT_INDEX`
+        environment variable.
+
+        - one-by-one: It implements an one-by-one sequence by Window function without
+            specifying partition. Therefore, it ends up with whole partition in single node.
+            This index type should be avoided when the data is large. This is default.
+
+        - distributed-one-by-one: It implements an one-by-one sequence by group-by and
+            group-map approach. It still generates a one-by-one sequential index globally.
+            If the default index must be an one-by-one sequence in a large dataset, this
+            index has to be used.
+
+        - distributed: It implements a monotonically increasing sequence simply by using
+            Spark's `monotonically_increasing_id` function. If the index does not have to be
+            a one-by-one sequence, this index should be used. Performance-wise, this index
+            almost does not have any penalty comparing to other index types.
+
+        """
+        default_index_type = os.environ.get("DEFAULT_INDEX", "one-by-one")
+        if default_index_type == "one-by-one":
+            sequential_index = F.row_number().over(
+                Window.orderBy(F.monotonically_increasing_id().asc())) - 1
+            return sdf.select(sequential_index.alias("__index_level_0__"), *list(sdf))
+        elif default_index_type == "distributed-one-by-one":
+            # 1. Calculates counts per each partition ID. `counts` here is, for instance,
+            #     {
+            #         1: 83,
+            #         6: 83,
+            #         3: 83,
+            #         ...
+            #     }
+            counts = map(lambda x: (x["key"], x["count"]),
+                         sdf.groupby(F.spark_partition_id().alias("key")).count().collect())
+
+            # 2. Calculates cumulative sum in an order of partition id.
+            #     Note that it does not matter if partition id guarantees its order or not.
+            #     We just need a one-by-one sequential id.
+
+            # sort by partition key.
+            sorted_counts = sorted(counts, key=lambda x: x[0])
+            # get cumulative sum in an order of partition key.
+            cumulative_counts = accumulate(map(lambda count: count[1], sorted_counts))
+            # zip it with partition key.
+            sums = dict(zip(map(lambda count: count[0], sorted_counts), cumulative_counts))
+
+            # 3. Group by partition id and assign each range.
+            def default_index(pdf):
+                current_partition_max = sums[pdf["__spark_partition_id"].iloc[0]]
+                offset = len(pdf)
+                pdf["__index_level_0__"] = list(range(
+                    current_partition_max - offset, current_partition_max))
+                return pdf.drop(columns=["__spark_partition_id"])
+
+            return_schema = StructType(
+                [StructField("__index_level_0__", LongType())] + list(sdf.schema))
+            grouped_map_func = pandas_udf(return_schema, PandasUDFType.GROUPED_MAP)(default_index)
+
+            sdf = sdf.withColumn("__spark_partition_id", F.spark_partition_id())
+            return sdf.groupBy("__spark_partition_id").apply(grouped_map_func)
+        elif default_index_type == "distributed":
+            return sdf.select(
+                F.monotonically_increasing_id().alias("__index_level_0__"), *list(sdf))
+        else:
+            raise ValueError("'DEFAULT_INDEX' environment variable should be one of 'one-by-one',"
+                             " 'distributed-one-by-one' and 'distributed'")
 
     def scol_for(self, column_name: str) -> spark.Column:
         """ Return Spark Column for the given column name. """

--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -273,7 +273,7 @@ def read_delta(path: str, version: Optional[str] = None, timestamp: Optional[str
     Examples
     --------
     >>> ks.range(1).to_delta('%s/read_delta/foo' % path)
-    >>> ks.read_delta('%s/read_delta/foo' % path)
+    >>> ks.read_delta('%s/read_delta/foo' % path)  # doctest: +SKIP
        id
     0   0
     """
@@ -307,7 +307,7 @@ def read_table(name: str) -> DataFrame:
     Examples
     --------
     >>> ks.range(1).to_table('%s.my_table' % db)
-    >>> ks.read_table('%s.my_table' % db)
+    >>> ks.read_table('%s.my_table' % db)  # doctest: +SKIP
        id
     0   0
     """

--- a/databricks/koalas/sql.py
+++ b/databricks/koalas/sql.py
@@ -92,7 +92,7 @@ def sql(query: str, globals=None, locals=None, **kwargs) -> DataFrame:
 
     >>> mydf = ks.range(10)
     >>> x = range(4)
-    >>> ks.sql("SELECT * from {mydf} WHERE id IN {x}")
+    >>> ks.sql("SELECT * from {mydf} WHERE id IN {x}")  # doctest: +SKIP
        id
     0   0
     1   1

--- a/databricks/koalas/tests/test_default_index.py
+++ b/databricks/koalas/tests/test_default_index.py
@@ -1,0 +1,76 @@
+#
+# Copyright (C) 2019 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import os
+
+import pandas as pd
+
+from databricks import koalas as ks
+from databricks.koalas.testing.utils import ReusedSQLTestCase, TestUtils
+
+
+class OneByOneDefaultIndexTest(ReusedSQLTestCase, TestUtils):
+
+    @classmethod
+    def setUpClass(cls):
+        super(OneByOneDefaultIndexTest, cls).setUpClass()
+        cls.default_index = os.environ.get('DEFAULT_INDEX', 'one-by-one')
+        os.environ['DEFAULT_INDEX'] = 'one-by-one'
+
+    @classmethod
+    def tearDownClass(cls):
+        super(OneByOneDefaultIndexTest, cls).tearDownClass()
+        os.environ['DEFAULT_INDEX'] = cls.default_index
+
+    def test_default_index(self):
+        sdf = self.spark.range(1000)
+        self.assert_eq(ks.DataFrame(sdf).sort_index(), pd.DataFrame({'id': list(range(1000))}))
+
+
+class DistributedOneByOneDefaultIndexTest(ReusedSQLTestCase, TestUtils):
+
+    @classmethod
+    def setUpClass(cls):
+        super(DistributedOneByOneDefaultIndexTest, cls).setUpClass()
+        cls.default_index = os.environ.get('DEFAULT_INDEX', 'one-by-one')
+        os.environ['DEFAULT_INDEX'] = 'distributed-one-by-one'
+
+    @classmethod
+    def tearDownClass(cls):
+        super(DistributedOneByOneDefaultIndexTest, cls).tearDownClass()
+        os.environ['DEFAULT_INDEX'] = cls.default_index
+
+    def test_default_index(self):
+        sdf = self.spark.range(1000)
+        self.assert_eq(ks.DataFrame(sdf).sort_index(), pd.DataFrame({'id': list(range(1000))}))
+
+
+class DistributedDefaultIndexTest(ReusedSQLTestCase, TestUtils):
+
+    @classmethod
+    def setUpClass(cls):
+        super(DistributedDefaultIndexTest, cls).setUpClass()
+        cls.default_index = os.environ.get('DEFAULT_INDEX', 'one-by-one')
+        os.environ['DEFAULT_INDEX'] = 'distributed'
+
+    @classmethod
+    def tearDownClass(cls):
+        super(DistributedDefaultIndexTest, cls).tearDownClass()
+        os.environ['DEFAULT_INDEX'] = cls.default_index
+
+    def test_default_index(self):
+        sdf = self.spark.range(1000)
+        pdf = ks.DataFrame(sdf).to_pandas()
+        self.assertEqual(len(set(pdf.index)), len(pdf))


### PR DESCRIPTION
This PR proposes a default index so that we can now forget about the case when index is missing in Koalas DataFrame  - when Koalas DataFrame is directly created from Spark DataFrame.

There are three types of default index that can be controlled by `DEFAULT_INDEX` environment variable.

- **one-by-one**: It implements an one-by-one sequence by Window function without
    specifying partition. Therefore, it ends up with whole partition in single node.
    This index type should be avoided when the data is large. This is default.
    **TL;DR:** `Window` with `row_number` without partitioning spec
 
- **distributed-one-by-one**: It implements an one-by-one sequence by group-by and
    group-map approach. It still generates a one-by-one sequential index globally.
    If the default index must be an one-by-one sequence in a large dataset, this
    index has to be used.
    **TL;DR:** `groupby(partition_id).count().collect()` and `groupby(partition_id).apply(f)`.

 - **distributed**: It implements a monotonically increasing sequence simply by using
    Spark's `monotonically_increasing_id` function. If the index does not have to be
    a one-by-one sequence, this index should be used. Performance-wise, this index
    almost does not have any penalty comparing to other index types.
    **TL;DR:** `moninically_increasing_id()`.
