### PR TITLE
Always use `column_index`.

### DIFF
--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -113,7 +113,7 @@ class Index(IndexOpsMixin):
         internal = self._kdf._internal.copy(
             sdf=sdf,
             index_map=[(sdf.schema[0].name, self._kdf._internal.index_names[0])],
-            data_columns=[])
+            data_columns=[], column_index=[], column_index_names=None)
         return DataFrame(internal).to_pandas().index
 
     toPandas = to_pandas

--- a/databricks/koalas/internal.py
+++ b/databricks/koalas/internal.py
@@ -481,10 +481,10 @@ class _InternalFrame(object):
         """ Return as Spark DataFrame. """
         index_columns = set(self.index_columns)
         data_columns = []
-        for column, name in zip(self._data_columns, self.column_index):
+        for column, idx in zip(self._data_columns, self.column_index):
             if column not in index_columns:
                 scol = self.scol_for(column)
-                name = str(name) if len(name) > 1 else name[0]
+                name = str(idx) if len(idx) > 1 else idx[0]
                 if column != name:
                     scol = scol.alias(name)
                 data_columns.append(scol)

--- a/databricks/koalas/internal.py
+++ b/databricks/koalas/internal.py
@@ -29,7 +29,7 @@ from pyspark.sql.types import DataType, StructField, StructType, to_arrow_type
 
 from databricks import koalas as ks  # For running doctests and reference resolution in PyCharm.
 from databricks.koalas.typedef import infer_pd_series_spark_type
-from databricks.koalas.utils import default_session, lazy_property, scol_for
+from databricks.koalas.utils import column_index_level, default_session, lazy_property, scol_for
 
 
 IndexMap = Tuple[str, Optional[str]]
@@ -372,16 +372,20 @@ class _InternalFrame(object):
         if scol is not None:
             self._data_columns = sdf.select(scol).columns
             column_index = None
+            column_index_names = None
         elif data_columns is None:
             index_columns = set(index_column for index_column, _ in self._index_map)
             self._data_columns = [column for column in sdf.columns if column not in index_columns]
         else:
             self._data_columns = data_columns
 
-        assert column_index is None or (len(column_index) == len(self._data_columns) and
-                                        all(isinstance(i, tuple) for i in column_index) and
-                                        len(set(len(i) for i in column_index)) <= 1)
-        self._column_index = column_index
+        if column_index is None:
+            self._column_index = [(col,) for col in self._data_columns]
+        else:
+            assert (len(column_index) == len(self._data_columns) and
+                    all(isinstance(i, tuple) for i in column_index) and
+                    len(set(len(i) for i in column_index)) <= 1)
+            self._column_index = column_index
 
         if column_index_names is not None and not is_list_like(column_index_names):
             raise ValueError('Column_index_names should be list-like or None for a MultiIndex')
@@ -458,9 +462,14 @@ class _InternalFrame(object):
         return self._scol
 
     @property
-    def column_index(self) -> Optional[List[Tuple[str]]]:
+    def column_index(self) -> List[Tuple[str]]:
         """ Return the managed column index. """
         return self._column_index
+
+    @lazy_property
+    def column_index_level(self) -> int:
+        """ Return the level of the column index. """
+        return column_index_level(self._column_index)
 
     @property
     def column_index_names(self) -> Optional[List[str]]:
@@ -470,7 +479,16 @@ class _InternalFrame(object):
     @lazy_property
     def spark_df(self) -> spark.DataFrame:
         """ Return as Spark DataFrame. """
-        return self._sdf.select(self.scols)
+        index_columns = set(self.index_columns)
+        data_columns = []
+        for column, name in zip(self._data_columns, self.column_index):
+            if column not in index_columns:
+                scol = self.scol_for(column)
+                name = str(name) if len(name) > 1 else name[0]
+                if column != name:
+                    scol = scol.alias(name)
+                data_columns.append(scol)
+        return self._sdf.select(self.index_scols + data_columns)
 
     @lazy_property
     def pandas_df(self):
@@ -488,19 +506,18 @@ class _InternalFrame(object):
                 drop = index_field not in self.data_columns
                 pdf = pdf.set_index(index_field, drop=drop, append=append)
                 append = True
-            pdf = pdf[self.data_columns]
+            pdf = pdf[[str(name) if len(name) > 1 else name[0] for name in self.column_index]]
 
-        if self._column_index is not None:
+        if self.column_index_level > 1:
             pdf.columns = pd.MultiIndex.from_tuples(self._column_index)
+        else:
+            pdf.columns = [idx[0] for idx in self._column_index]
         if self._column_index_names is not None:
             pdf.columns.names = self._column_index_names
 
         index_names = self.index_names
         if len(index_names) > 0:
-            if isinstance(pdf.index, pd.MultiIndex):
-                pdf.index.names = index_names
-            else:
-                pdf.index.name = index_names[0]
+            pdf.index.names = index_names
         return pdf
 
     def copy(self, sdf: Union[spark.DataFrame, _NoValueType] = _NoValue,
@@ -525,10 +542,17 @@ class _InternalFrame(object):
             index_map = self._index_map
         if scol is _NoValue:
             scol = self._scol
+        # FIXME(ueshin): this if-clause should be removed.
+        if column_index is _NoValue:
+            if data_columns is not _NoValue:
+                column_index = None
+            else:
+                column_index = self._column_index
         if data_columns is _NoValue:
             data_columns = self._data_columns
-        if column_index is _NoValue:
-            column_index = self._column_index
+        # FIXME(ueshin): this if-clause should be used instead of the above.
+        # if column_index is _NoValue:
+        #     column_index = self._column_index
         if column_index_names is _NoValue:
             column_index_names = self._column_index_names
         return _InternalFrame(sdf, index_map=index_map, scol=scol, data_columns=data_columns,

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -1796,7 +1796,7 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
                                    scol_for(sdf, index_column)).alias(index_column)
                           for index_column in internal.index_columns] + internal.data_columns)
         kdf._internal = internal.copy(sdf=sdf)
-        return Series(kdf._internal.copy(scol=self._scol), anchor=kdf)
+        return _col(kdf)
 
     def add_suffix(self, suffix):
         """
@@ -1846,7 +1846,7 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
                                    F.lit(suffix)).alias(index_column)
                           for index_column in internal.index_columns] + internal.data_columns)
         kdf._internal = internal.copy(sdf=sdf)
-        return Series(kdf._internal.copy(scol=self._scol), anchor=kdf)
+        return _col(kdf)
 
     def corr(self, other, method='pearson'):
         """

--- a/databricks/koalas/utils.py
+++ b/databricks/koalas/utils.py
@@ -18,7 +18,7 @@ Commonly used utils in Koalas.
 """
 
 import functools
-from typing import Callable, Dict, Union
+from typing import Callable, Dict, List, Tuple, Union
 
 from pyspark import sql as spark
 import pandas as pd
@@ -108,3 +108,13 @@ def lazy_property(fn):
 def scol_for(sdf: spark.DataFrame, column_name: str) -> spark.Column:
     """ Return Spark Column for the given column name. """
     return sdf['`{}`'.format(column_name)]
+
+
+def column_index_level(column_index: List[Tuple[str]]) -> int:
+    """ Return the level of the column index. """
+    if len(column_index) == 0:
+        return 0
+    else:
+        levels = set(len(idx) for idx in column_index)
+        assert len(levels) == 1, levels
+        return list(levels)[0]


### PR DESCRIPTION
Now that we introduced multi-index columns, we should use `column_index` rather than `data_columns` to be consistent access between single and multi index.
We still have a ways to go, so this includes a workaround to work with the `data_columns`-based approach.
I will address them in the separate PRs.