### PR TITLE
Fix IndexOpsMixin.all/any.

### DIFF
--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -32,7 +32,7 @@ from pyspark.sql.types import DoubleType, FloatType, LongType, StringType, Times
 from databricks import koalas as ks  # For running doctests and reference resolution in PyCharm.
 from databricks.koalas.internal import _InternalFrame
 from databricks.koalas.typedef import pandas_wraps
-from databricks.koalas.utils import align_diff_series
+from databricks.koalas.utils import align_diff_series, scol_for
 
 
 def _column_op(f):
@@ -582,7 +582,7 @@ class IndexOpsMixin(object):
             raise ValueError('axis should be either 0 or "index" currently.')
 
         sdf = self._kdf._sdf.select(self._scol)
-        col = self._scol
+        col = scol_for(sdf, sdf.columns[0])
 
         # Note that we're ignoring `None`s here for now.
         # any and every was added as of Spark 3.0
@@ -645,7 +645,7 @@ class IndexOpsMixin(object):
             raise ValueError('axis should be either 0 or "index" currently.')
 
         sdf = self._kdf._sdf.select(self._scol)
-        col = self._scol
+        col = scol_for(sdf, sdf.columns[0])
 
         # Note that we're ignoring `None`s here for now.
         # any and every was added as of Spark 3.0

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -254,6 +254,40 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(ks.notnull(), ps.notnull())
         self.assert_eq(ks.isnull(), ps.isnull())
 
+    def test_all(self):
+        for ps in [pd.Series([True, True], name='x'),
+                   pd.Series([True, False], name='x'),
+                   pd.Series([0, 1], name='x'),
+                   pd.Series([1, 2, 3], name='x'),
+                   pd.Series([True, True, None], name='x'),
+                   pd.Series([True, False, None], name='x'),
+                   pd.Series([], name='x'),
+                   pd.Series([np.nan], name='x')]:
+            ks = koalas.from_pandas(ps)
+            self.assert_eq(ks.all(), ps.all())
+
+        ps = pd.Series([1, 2, 3, 4], name='x')
+        ks = koalas.from_pandas(ps)
+
+        self.assert_eq((ks % 2 == 0).all(), (ps % 2 == 0).all())
+
+    def test_any(self):
+        for ps in [pd.Series([False, False], name='x'),
+                   pd.Series([True, False], name='x'),
+                   pd.Series([0, 1], name='x'),
+                   pd.Series([1, 2, 3], name='x'),
+                   pd.Series([True, True, None], name='x'),
+                   pd.Series([True, False, None], name='x'),
+                   pd.Series([], name='x'),
+                   pd.Series([np.nan], name='x')]:
+            ks = koalas.from_pandas(ps)
+            self.assert_eq(ks.any(), ps.any())
+
+        ps = pd.Series([1, 2, 3, 4], name='x')
+        ks = koalas.from_pandas(ps)
+
+        self.assert_eq((ks % 2 == 0).any(), (ps % 2 == 0).any())
+
     def test_sort_values(self):
         ps = pd.Series([1, 2, 3, 4, 5, None, 7], name='0')
         ks = koalas.from_pandas(ps)


### PR DESCRIPTION
This PR fixes `IndexOpsMixin.all()` and `any()` to work the chain of operations, e.g.,:

```py
>>> (ks.Series([1,2,3]) % 2 == 0).all()
```

This fails with the following error.

```
Traceback (most recent call last):
  File "/Users/ueshin/workspace/databricks-koalas/miniconda/envs/databricks-koalas_3.6/lib/python3.6/site-packages/pyspark/sql/utils.py", line 63, in deco
    return f(*a, **kw)
  File "/Users/ueshin/workspace/databricks-koalas/miniconda/envs/databricks-koalas_3.6/lib/python3.6/site-packages/py4j/protocol.py", line 328, in get_return_value
    format(target_id, ".", name), value)
py4j.protocol.Py4JJavaError: An error occurred while calling o143.select.
: org.apache.spark.sql.AnalysisException: Resolved attribute(s) 0#14L missing from ((0 % 2) = 0)#22 in operator !Aggregate [min(coalesce(cast(((0#14L % cast(2 as bigint)) = cast(0 as bigint)) as boolean), true)) AS min(coalesce(CAST(((0 % 2) = 0) AS BOOLEAN), true))#25].;;
!Aggregate [min(coalesce(cast(((0#14L % cast(2 as bigint)) = cast(0 as bigint)) as boolean), true)) AS min(coalesce(CAST(((0 % 2) = 0) AS BOOLEAN), true))#25]
+- Project [((0#14L % cast(2 as bigint)) = cast(0 as bigint)) AS ((0 % 2) = 0)#22]
   +- LogicalRDD [__index_level_0__#13L, 0#14L], false
```
