### PR TITLE
Exclude Index columns for exposed Spark DataFrame and disallow Koalas DataFrame with no index

### DIFF
--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -304,9 +304,6 @@ class IndexOpsMixin(object):
         >>> ser.rename("a").to_frame().set_index("a").index.is_monotonic
         True
         """
-        if len(self._kdf._internal.index_columns) == 0:
-            raise ValueError("Index must be set.")
-
         col = self._scol
         window = Window.orderBy(self._kdf._internal.index_scols).rowsBetween(-1, -1)
         sdf = self._kdf._sdf.withColumn(
@@ -356,9 +353,6 @@ class IndexOpsMixin(object):
         >>> ser.rename("a").to_frame().set_index("a").index.is_monotonic_decreasing
         True
         """
-        if len(self._kdf._internal.index_columns) == 0:
-            raise ValueError("Index must be set.")
-
         col = self._scol
         window = Window.orderBy(self._kdf._internal.index_scols).rowsBetween(-1, -1)
         sdf = self._kdf._sdf.withColumn(
@@ -705,9 +699,6 @@ class IndexOpsMixin(object):
         >>> df.index.shift(periods=3, fill_value=0)
         Int64Index([0, 0, 0, 0, 1], dtype='int64')
         """
-        if len(self._internal.index_columns) == 0:
-            raise ValueError("Index must be set.")
-
         if not isinstance(periods, int):
             raise ValueError('periods should be an int; however, got [%s]' % type(periods))
 

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -1598,9 +1598,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         Index
         """
         from databricks.koalas.indexes import Index, MultiIndex
-        if len(self._internal.index_map) == 0:
-            return None
-        elif len(self._internal.index_map) == 1:
+        if len(self._internal.index_map) == 1:
             return Index(self)
         else:
             return MultiIndex(self)
@@ -1860,9 +1858,6 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         lion           mammal   80.5     run
         monkey         mammal    NaN    jump
         """
-        if len(self._internal.index_map) == 0:
-            raise NotImplementedError('Can\'t reset index because there is no index.')
-
         multi_index = len(self._internal.index_map) > 1
 
         def rename(index):
@@ -1877,7 +1872,15 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         if level is None:
             new_index_map = [(column, name if name is not None else rename(i))
                              for i, (column, name) in enumerate(self._internal.index_map)]
-            index_map = []
+            new_data_columns = [
+                self._internal.scol_for(column).alias(name) for column, name in new_index_map]
+            sdf = self._sdf.select(new_data_columns + self._internal.data_columns)
+
+            # Now, new internal Spark columns are named as same as index name.
+            new_index_map = [(name, name) for column, name in new_index_map]
+
+            index_map = [('__index_level_0__', None)]
+            sdf = _InternalFrame.attach_default_index(sdf)
         else:
             if isinstance(level, (int, str)):
                 level = [level]
@@ -1915,10 +1918,13 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                      index_name if index_name is not None else rename(index_name)))
                 index_map.remove(info)
 
+            sdf = self._sdf
+
         if drop:
             new_index_map = []
 
         internal = self._internal.copy(
+            sdf=sdf,
             data_columns=[column for column, _ in new_index_map] + self._internal.data_columns,
             index_map=index_map,
             column_index=None)
@@ -2382,13 +2388,13 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         >>> spark_df = df.to_spark()
         >>> spark_df
-        DataFrame[__index_level_0__: bigint, col1: bigint, col2: bigint]
+        DataFrame[col1: bigint, col2: bigint]
 
         >>> kdf = spark_df.to_koalas()
         >>> kdf
-           __index_level_0__  col1  col2
-        0                  0     1     3
-        1                  1     2     4
+           col1  col2
+        0     1     3
+        1     2     4
 
         Calling to_koalas on a Koalas DataFrame simply returns itself.
 
@@ -2493,8 +2499,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         >>> df.to_table('%s.my_table' % db, partition_cols='date')
         """
-        self._sdf.write.saveAsTable(name=name, format=format, mode=mode,
-                                    partitionBy=partition_cols, options=options)
+        self.to_spark().write.saveAsTable(name=name, format=format, mode=mode,
+                                          partitionBy=partition_cols, options=options)
 
     def to_delta(self, path: str, mode: str = 'error',
                  partition_cols: Union[str, List[str], None] = None, **options):
@@ -2604,8 +2610,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         ...     mode = 'overwrite',
         ...     partition_cols=['date', 'country'])
         """
-        self._sdf.write.parquet(path=path, mode=mode, partitionBy=partition_cols,
-                                compression=compression)
+        self.to_spark().write.parquet(
+            path=path, mode=mode, partitionBy=partition_cols, compression=compression)
 
     def to_spark_io(self, path: Optional[str] = None, format: Optional[str] = None,
                     mode: str = 'error', partition_cols: Union[str, List[str], None] = None,
@@ -2657,12 +2663,15 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         >>> df.to_spark_io(path='%s/to_spark_io/foo.json' % path, format='json')
         """
-        self._sdf.write.save(path=path, format=format, mode=mode, partitionBy=partition_cols,
-                             options=options)
+        self.to_spark().write.save(
+            path=path, format=format, mode=mode, partitionBy=partition_cols, options=options)
 
     def to_spark(self):
         """
         Return the current DataFrame as a Spark DataFrame.
+
+        .. note:: Index information is lost. So, if the index columns are not present in
+            actual columns, they are lost.
 
         See Also
         --------
@@ -3653,14 +3662,21 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             sdf = sdf.fillna(fill_value)
 
         if index is not None:
-            return DataFrame(sdf).set_index(index)
+            data_columns = [column for column in sdf.columns if column not in index]
+            index_map = [(column, column) for column in index]
+            internal = _InternalFrame(sdf=sdf, data_columns=data_columns, index_map=index_map)
+            return DataFrame(internal)
         else:
             if isinstance(values, list):
                 index_values = values[-1]
             else:
                 index_values = values
 
-            return DataFrame(sdf.withColumn(columns, F.lit(index_values))).set_index(columns)
+            sdf = sdf.withColumn(columns, F.lit(index_values))
+            data_columns = [column for column in sdf.columns if column not in columns]
+            index_map = [(column, column) for column in columns]
+            internal = _InternalFrame(sdf=sdf, data_columns=data_columns, index_map=index_map)
+            return DataFrame(internal)
 
     def pivot(self, index=None, columns=None, values=None):
         """
@@ -4364,9 +4380,6 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         a 1  2  1
         b 1  0  3
         """
-        if len(self._internal.index_map) == 0:
-            raise ValueError("Index should be set.")
-
         if axis != 0:
             raise ValueError("No other axes than 0 are supported at the moment")
         if kind is not None:
@@ -4959,12 +4972,12 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         original DataFrame’s index in the result.
 
         >>> join_kdf = kdf1.join(kdf2.set_index('key'), on='key')
-        >>> join_kdf.sort_values(by=join_kdf.columns)
+        >>> join_kdf.sort_index()
           key   A     B
-        0  K0  A0    B0
-        1  K1  A1    B1
-        2  K2  A2    B2
-        3  K3  A3  None
+        0  K3  A3  None
+        1  K0  A0    B0
+        2  K1  A1    B1
+        3  K2  A2    B2
         """
         if on:
             self = self.set_index(on)
@@ -5542,9 +5555,6 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             func = "cumsum"
         elif func.__name__ == "cumprod":
             func = "cumprod"
-
-        if len(self._internal.index_columns) == 0:
-            raise ValueError("Index must be set.")
 
         applied = []
         for column in self.columns:

--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -273,7 +273,7 @@ def read_delta(path: str, version: Optional[str] = None, timestamp: Optional[str
     Examples
     --------
     >>> ks.range(1).to_delta('%s/read_delta/foo' % path)
-    >>> ks.read_delta('%s/read_delta/foo' % path)  # doctest: +SKIP
+    >>> ks.read_delta('%s/read_delta/foo' % path)
        id
     0   0
     """
@@ -307,7 +307,7 @@ def read_table(name: str) -> DataFrame:
     Examples
     --------
     >>> ks.range(1).to_table('%s.my_table' % db)
-    >>> ks.read_table('%s.my_table' % db)  # doctest: +SKIP
+    >>> ks.read_table('%s.my_table' % db)
        id
     0   0
     """

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -1000,7 +1000,7 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         2    c
         """
         renamed = self.rename(name)
-        sdf = renamed._internal.spark_df
+        sdf = renamed._internal.spark_internal_df
         internal = _InternalFrame(sdf=sdf,
                                   data_columns=[sdf.schema[-1].name],
                                   index_map=renamed._internal.index_map)
@@ -2635,8 +2635,6 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         return self._diff(periods)
 
     def _diff(self, periods, part_cols=()):
-        if len(self._internal.index_columns) == 0:
-            raise ValueError("Index must be set.")
         if not isinstance(periods, int):
             raise ValueError('periods should be an int; however, got [%s]' % type(periods))
         window = Window.partitionBy(*part_cols).orderBy(self._internal.index_scols)\
@@ -2825,9 +2823,6 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
 
     def _cum(self, func, skipna, part_cols=()):
         # This is used to cummin, cummax, cumsum, etc.
-        if len(self._internal.index_columns) == 0:
-            raise ValueError("Index must be set.")
-
         index_columns = self._internal.index_columns
         window = Window.orderBy(
             index_columns).partitionBy(*part_cols).rowsBetween(

--- a/databricks/koalas/sql.py
+++ b/databricks/koalas/sql.py
@@ -92,7 +92,7 @@ def sql(query: str, globals=None, locals=None, **kwargs) -> DataFrame:
 
     >>> mydf = ks.range(10)
     >>> x = range(4)
-    >>> ks.sql("SELECT * from {mydf} WHERE id IN {x}")  # doctest: +SKIP
+    >>> ks.sql("SELECT * from {mydf} WHERE id IN {x}")
        id
     0   0
     1   1
@@ -105,9 +105,9 @@ def sql(query: str, globals=None, locals=None, **kwargs) -> DataFrame:
     ...     mydf2 = ks.DataFrame({"x": range(2)})
     ...     return ks.sql("SELECT * from {mydf2}")
     >>> statement()
-       __index_level_0__  x
-    0                  0  0
-    1                  1  1
+       x
+    0  0
+    1  1
 
     Mixing Koalas and pandas DataFrames in a join operation. Note that the index is dropped.
 

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -540,8 +540,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         kdf = ks.from_pandas(pdf)
         self.assert_eq(kdf.sort_index(), pdf.sort_index())
         self.assert_eq(kdf.sort_index(level=[1, 0]), pdf.sort_index(level=[1, 0]))
-
-        self.assertRaises(ValueError, lambda: kdf.reset_index().sort_index())
+        self.assert_eq(kdf.reset_index().sort_index(), pdf.reset_index().sort_index())
 
         # Assert with multi-index columns
         columns = pd.MultiIndex.from_tuples([('X', 'A'), ('X', 'B')])
@@ -934,7 +933,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         join_kdf = kdf1.join(kdf2.set_index('key'), on='key', lsuffix='_left', rsuffix='_right')
         join_kdf.sort_values(by=list(join_kdf.columns), inplace=True)
-        self.assert_eq(join_pdf, join_kdf)
+        self.assert_eq(join_pdf.reset_index(drop=True), join_kdf.reset_index(drop=True))
 
     def test_replace(self):
         pdf = pd.DataFrame({"name": ['Ironman', 'Captain America', 'Thor', 'Hulk'],

--- a/databricks/koalas/tests/test_dataframe_spark_io.py
+++ b/databricks/koalas/tests/test_dataframe_spark_io.py
@@ -80,14 +80,18 @@ class DataFrameSparkIOTest(ReusedSQLTestCase, TestUtils):
             # Reset column order, as once the data is written out, Spark rearranges partition
             # columns to appear first.
             actual = ks.read_parquet(tmp)[self.test_column_order]
-            self.assert_eq(actual.sort_values(by='f'), expected.sort_values(by='f'))
+            self.assert_eq(
+                actual.sort_values(by='f').to_spark().toPandas(),
+                expected.sort_values(by='f').to_spark().toPandas())
 
             # Write out partitioned by two columns
             expected.to_parquet(tmp, mode='overwrite', partition_cols=['i32', 'bhello'])
             # Reset column order, as once the data is written out, Spark rearranges partition
             # columns to appear first.
             actual = ks.read_parquet(tmp)[self.test_column_order]
-            self.assert_eq(actual.sort_values(by='f'), expected.sort_values(by='f'))
+            self.assert_eq(
+                actual.sort_values(by='f').to_spark().toPandas(),
+                expected.sort_values(by='f').to_spark().toPandas())
 
     def test_table(self):
         with self.table('test_table'):
@@ -99,14 +103,18 @@ class DataFrameSparkIOTest(ReusedSQLTestCase, TestUtils):
             # Reset column order, as once the data is written out, Spark rearranges partition
             # columns to appear first.
             actual = ks.read_table('test_table')[self.test_column_order]
-            self.assert_eq(actual.sort_values(by='f'), expected.sort_values(by='f'))
+            self.assert_eq(
+                actual.sort_values(by='f').to_spark().toPandas(),
+                expected.sort_values(by='f').to_spark().toPandas())
 
             # Write out partitioned by two columns
             expected.to_table('test_table', mode='overwrite', partition_cols=['i32', 'bhello'])
             # Reset column order, as once the data is written out, Spark rearranges partition
             # columns to appear first.
             actual = ks.read_table('test_table')[self.test_column_order]
-            self.assert_eq(actual.sort_values(by='f'), expected.sort_values(by='f'))
+            self.assert_eq(
+                actual.sort_values(by='f').to_spark().toPandas(),
+                expected.sort_values(by='f').to_spark().toPandas())
 
     def test_spark_io(self):
         with self.temp_dir() as tmp:
@@ -118,7 +126,9 @@ class DataFrameSparkIOTest(ReusedSQLTestCase, TestUtils):
             # Reset column order, as once the data is written out, Spark rearranges partition
             # columns to appear first.
             actual = ks.read_spark_io(tmp, format='json')[self.test_column_order]
-            self.assert_eq(actual.sort_values(by='f'), expected.sort_values(by='f'))
+            self.assert_eq(
+                actual.sort_values(by='f').to_spark().toPandas(),
+                expected.sort_values(by='f').to_spark().toPandas())
 
             # Write out partitioned by two columns
             expected.to_spark_io(tmp, format='json', mode='overwrite',
@@ -126,4 +136,6 @@ class DataFrameSparkIOTest(ReusedSQLTestCase, TestUtils):
             # Reset column order, as once the data is written out, Spark rearranges partition
             # columns to appear first.
             actual = ks.read_spark_io(path=tmp, format='json')[self.test_column_order]
-            self.assert_eq(actual.sort_values(by='f'), expected.sort_values(by='f'))
+            self.assert_eq(
+                actual.sort_values(by='f').to_spark().toPandas(),
+                expected.sort_values(by='f').to_spark().toPandas())

--- a/databricks/koalas/tests/test_indexing.py
+++ b/databricks/koalas/tests/test_indexing.py
@@ -109,8 +109,6 @@ class BasicIndexingTest(ComparisonTestBase):
 
         self.assertRaisesRegex(ValueError, 'Level should be all int or all string.',
                                lambda: df.reset_index([1, 'month']))
-        self.assertRaisesRegex(NotImplementedError, 'Can\'t reset index because there is no index.',
-                               lambda: df.reset_index().reset_index())
 
 
 class IndexingTest(ReusedSQLTestCase):
@@ -231,7 +229,7 @@ class IndexingTest(ReusedSQLTestCase):
         self.assert_eq(kdf[['a']], pdf[['a']])
 
         self.assert_eq(kdf.loc[:], pdf.loc[:])
-        self.assertRaises(NotImplementedError, lambda: kdf.loc[5:5])
+        self.assert_eq(kdf.loc[5:5], pdf.loc[5:5])
 
     def test_loc_multiindex(self):
         kdf = self.kdf

--- a/databricks/koalas/tests/test_namespace.py
+++ b/databricks/koalas/tests/test_namespace.py
@@ -34,14 +34,15 @@ class NamespaceTest(ReusedSQLTestCase, SQLTestUtils):
         pdf = pd.DataFrame({'A': [0, 2, 4], 'B': [1, 3, 5]})
         kdf = ks.from_pandas(pdf)
 
+        self.assert_eq(
+            ks.concat([kdf, kdf.reset_index()]),
+            pd.concat([pdf, pdf.reset_index()]))
+
         self.assertRaisesRegex(TypeError, "first argument must be", lambda: ks.concat(kdf))
         self.assertRaisesRegex(
             TypeError, "cannot concatenate object", lambda: ks.concat([kdf, 1]))
 
         kdf2 = kdf.set_index('B', append=True)
-        self.assertRaisesRegex(
-            ValueError, "Index type and names should be same", lambda: ks.concat([kdf, kdf2]))
-        kdf2 = kdf.reset_index()
         self.assertRaisesRegex(
             ValueError, "Index type and names should be same", lambda: ks.concat([kdf, kdf2]))
 

--- a/databricks/koalas/tests/test_ops_on_diff_frames.py
+++ b/databricks/koalas/tests/test_ops_on_diff_frames.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 import os
-import unittest
 
 import pandas as pd
 
@@ -104,10 +103,10 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
     def kdf6(self):
         return ks.from_pandas(self.pdf6)
 
-    @unittest.skip('FIXME: Now that we can handle this case?')
-    def test_no_index(self):
-        with self.assertRaisesRegex(AssertionError, "cannot join with no overlapping index name"):
-            ks.range(10) + ks.range(10)
+    def test_ranges(self):
+        self.assertEqual(
+            ks.range(10) + ks.range(10),
+            ks.DataFrame({'id': list(range(10))}) + ks.DataFrame({'id': list(range(10))}))
 
     def test_no_matched_index(self):
         with self.assertRaisesRegex(ValueError, "Index names must be exactly matched"):
@@ -257,8 +256,8 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
 
         kdf = ks.from_pandas(self.pdf5)
         pdf = self.pdf5.copy()
-        kdf['x'] = self.kdf6.e
-        pdf['x'] = self.pdf6.e
+        kdf['e'] = self.kdf6.e
+        pdf['e'] = self.pdf6.e
 
         self.assert_eq(kdf.sort_index(), pdf.sort_index())
 

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -326,7 +326,7 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(ks.sort_index(), ps.sort_index(), almost=True)
         self.assert_eq(ks.sort_index(level=[1, 0]), ps.sort_index(level=[1, 0]), almost=True)
 
-        self.assertRaises(ValueError, lambda: ks.reset_index().sort_index())
+        self.assert_eq(ks.reset_index().sort_index(), ps.reset_index().sort_index())
 
     def test_to_datetime(self):
         ps = pd.Series(['3/11/2000', '3/12/2000', '3/13/2000'] * 100)


### PR DESCRIPTION
This PR is a followup of  and proposes two things:
  - Exclude Index columns for exposed Spark DataFrame
  - Disallow Koalas DataFrame with no index

So, for instance, `to_spark()`  now shows:

```diff
-       __index_level_0__  x
-    0                  0  0
-    1                  1  1
+       x
+    0  0
+    1  1
```

and `index_map` is not expected to be empty in Koalas DataFrame, always. It sets the default index explicitly per https://github.com/databricks/koalas/pull/639
