### PR TITLE
Document and test Series.plot(...) usage

### DIFF
--- a/databricks/koalas/plot.py
+++ b/databricks/koalas/plot.py
@@ -618,7 +618,7 @@ class KoalasSeriesPlotMethods(PandasObject):
 
     def box(self, **kwds):
         """
-        Boxplot.
+        Make a box plot of the DataFrame columns.
 
         Parameters
         ----------
@@ -651,7 +651,7 @@ class KoalasSeriesPlotMethods(PandasObject):
 
     def hist(self, bins=10, **kwds):
         """
-        Histogram.
+        Draw one histogram of the DataFrame’s columns.
 
         Parameters
         ----------

--- a/databricks/koalas/tests/test_series_plot.py
+++ b/databricks/koalas/tests/test_series_plot.py
@@ -65,8 +65,8 @@ class SeriesPlotTest(ReusedSQLTestCase, TestUtils):
         pdf = self.pdf1
         kdf = self.kdf1
 
-        ax1 = pdf['a'].plot.bar(colormap='Paired')
-        ax2 = kdf['a'].plot.bar(colormap='Paired')
+        ax1 = pdf['a'].plot("bar", colormap='Paired')
+        ax2 = kdf['a'].plot("bar", colormap='Paired')
         self.compare_plots(ax1, ax2)
 
     def test_bar_plot_limited(self):

--- a/docs/source/reference/series.rst
+++ b/docs/source/reference/series.rst
@@ -328,6 +328,7 @@ specific plotting methods of the form ``Series.plot.<kind>``.
 .. autosummary::
    :toctree: api/
 
+   Series.plot
    Series.plot.bar
    Series.plot.box
    Series.plot.hist


### PR DESCRIPTION
This PR adds documentation and test for `Series.plot(...)` usage. See https://pandas.pydata.org/pandas-docs/stable/reference/series.html#plotting

```python
import databricks.koalas as ks
import pandas as pd

pdf_1 = pd.DataFrame({
            'a': [1, 2, 3, 4, 5, 6, 7, 8, 9, 15, 50],
        }, index=[0, 1, 3, 5, 6, 8, 9, 9, 9, 10, 10])

kdf_1 = ks.DataFrame(pdf_1)
pdf_1['a'].plot("bar", colormap='Paired').figure.savefig("output3.png")
kdf_1['a'].plot("bar", colormap='Paired').figure.savefig("output4.png")
```

Partially addresses #665 