### PR TITLE
Add plot.pie in Series

### DIFF
--- a/databricks/koalas/plot.py
+++ b/databricks/koalas/plot.py
@@ -724,11 +724,6 @@ class KoalasSeriesPlotMethods(PandasObject):
 
         Examples
         --------
-        In the example below we have a DataFrame with the information about
-        planet's mass and radius. We pass the the 'mass' column to the
-        pie function to get a pie plot.
-
-
         >>> df = ks.DataFrame({'mass': [0.330, 4.87 , 5.97],
         ...                    'radius': [2439.7, 6051.8, 6378.1]},
         ...                   index=['Mercury', 'Venus', 'Earth'])

--- a/databricks/koalas/tests/test_series_plot.py
+++ b/databricks/koalas/tests/test_series_plot.py
@@ -82,6 +82,27 @@ class SeriesPlotTest(ReusedSQLTestCase, TestUtils):
 
         self.compare_plots(ax1, ax2)
 
+    def test_pie_plot(self):
+        pdf = self.pdf1
+        kdf = self.kdf1
+
+        ax1 = pdf['a'].plot.pie(colormap='Paired')
+        ax2 = kdf['a'].plot.pie(colormap='Paired')
+        self.compare_plots(ax1, ax2)
+
+    def test_pie_plot_limited(self):
+        pdf = self.pdf2
+        kdf = self.kdf2
+
+        _, ax1 = plt.subplots(1, 1)
+        ax1 = pdf['id'][:1000].plot.pie(colormap='Paired')
+        ax1.text(1, 1, 'showing top 1,000 elements only', size=6, ha='right', va='bottom',
+                 transform=ax1.transAxes)
+        _, ax2 = plt.subplots(1, 1)
+        ax2 = kdf['id'].plot.pie(colormap='Paired')
+
+        self.compare_plots(ax1, ax2)
+
     def test_hist_plot(self):
         pdf = self.pdf1
         kdf = self.kdf1

--- a/databricks/koalas/tests/test_series_plot.py
+++ b/databricks/koalas/tests/test_series_plot.py
@@ -201,7 +201,7 @@ class SeriesPlotTest(ReusedSQLTestCase, TestUtils):
     def test_missing(self):
         ks = self.kdf1['a']
 
-        unsupported_functions = ['area', 'kde', 'pie', 'barh', 'line']
+        unsupported_functions = ['area', 'kde', 'barh', 'line']
         for name in unsupported_functions:
             with self.assertRaisesRegex(PandasNotImplementedError,
                                         "method.*Series.*{}.*not implemented".format(name)):

--- a/docs/source/reference/series.rst
+++ b/docs/source/reference/series.rst
@@ -332,6 +332,7 @@ specific plotting methods of the form ``Series.plot.<kind>``.
    Series.plot.bar
    Series.plot.box
    Series.plot.hist
+   Series.plot.pie
 
 .. currentmodule:: databricks.koalas
 .. autosummary::


### PR DESCRIPTION
This PR add series.plot.pie in Series.

Can be tested as below:

```python
import databricks.koalas as ks
ks.range(10).to_pandas().id.plot.pie().figure.savefig("image.png")
ks.range(10).id.plot.pie().figure.savefig("image.png")
```

![image](https://user-images.githubusercontent.com/6477701/63404049-aa7da480-c41c-11e9-9472-f33e5c302dc6.png)


If there are more than 1000 rows, it shows as below:

```
ks.range(1001).id.plot.pie().figure.savefig("image.png")
```

![image](https://user-images.githubusercontent.com/6477701/63404022-8a4de580-c41c-11e9-8bc3-848343007f8d.png)

Most of people will use, for instance `df.x.value_counts().plot.pie()`.  This case is similar as bar plot.



Partially addresses #665