### PR TITLE
Add plot.area in Series

### DIFF
--- a/databricks/koalas/tests/test_series_plot.py
+++ b/databricks/koalas/tests/test_series_plot.py
@@ -18,7 +18,6 @@ import base64
 from io import BytesIO
 
 import matplotlib
-matplotlib.use('agg')
 from matplotlib import pyplot as plt
 import numpy as np
 import pandas as pd
@@ -27,6 +26,9 @@ from databricks import koalas
 from databricks.koalas.exceptions import PandasNotImplementedError
 from databricks.koalas.testing.utils import ReusedSQLTestCase, TestUtils
 from databricks.koalas.plot import KoalasHistPlotSummary, KoalasBoxPlotSummary
+
+
+matplotlib.use('agg')
 
 
 class SeriesPlotTest(ReusedSQLTestCase, TestUtils):
@@ -201,7 +203,7 @@ class SeriesPlotTest(ReusedSQLTestCase, TestUtils):
     def test_missing(self):
         ks = self.kdf1['a']
 
-        unsupported_functions = ['area', 'kde', 'barh', 'line']
+        unsupported_functions = ['kde', 'barh', 'line']
         for name in unsupported_functions:
             with self.assertRaisesRegex(PandasNotImplementedError,
                                         "method.*Series.*{}.*not implemented".format(name)):

--- a/docs/source/reference/series.rst
+++ b/docs/source/reference/series.rst
@@ -329,6 +329,7 @@ specific plotting methods of the form ``Series.plot.<kind>``.
    :toctree: api/
 
    Series.plot
+   Series.plot.area
    Series.plot.bar
    Series.plot.box
    Series.plot.hist


### PR DESCRIPTION
This PR add series.plot.pie in Series.

Can be tested as below:

```python
import databricks.koalas as ks
import pandas as pd

pdf = pd.DataFrame({
          'a': [1, 2, 3, 4, 5, 6, 7, 8, 9, 15, 50],
      }, index=[0, 1, 3, 5, 6, 8, 9, 9, 9, 10, 10])

kdf = ks.DataFrame(pdf)
pdf['a'].plot.area(colormap='Paired').figure.savefig("image1.png")
kdf['a'].plot.area(colormap='Paired').figure.savefig("image2.png")
```

![image2](https://user-images.githubusercontent.com/6477701/63408309-aa37d600-c429-11e9-9ab0-ddaac4be59a9.png)

In case of this plot, we sample and match the row numbers around 1000.

```python
import databricks.koalas as ks
import pandas as pd

pdf = pd.DataFrame({'a': [1, 2, 3, 4, 5, 6, 7, 8, 9, 15, 50, 100] * 100})
kdf = ks.DataFrame(pdf)
kdf['a'].plot.area(colormap='Paired').figure.savefig("image4.png")
```

![image4](https://user-images.githubusercontent.com/6477701/63408340-c176c380-c429-11e9-8880-cc0fab13bfe2.png)

Partially addresses #665