### PR TITLE
Add plot.line in Series

### DIFF
--- a/databricks/koalas/plot.py
+++ b/databricks/koalas/plot.py
@@ -490,7 +490,8 @@ class KoalasLinePlot(LinePlot):
         super(KoalasLinePlot, self)._make_plot()
 
 
-_klasses = [KoalasHistPlot, KoalasBarPlot, KoalasBoxPlot, KoalasAreaPlot, KoalasLinePlot]
+_klasses = [
+    KoalasHistPlot, KoalasBarPlot, KoalasBoxPlot, KoalasPiePlot, KoalasAreaPlot, KoalasLinePlot]
 _plot_klass = {getattr(klass, '_kind'): klass for klass in _klasses}
 
 

--- a/databricks/koalas/tests/test_series_plot.py
+++ b/databricks/koalas/tests/test_series_plot.py
@@ -210,11 +210,7 @@ class SeriesPlotTest(ReusedSQLTestCase, TestUtils):
     def test_missing(self):
         ks = self.kdf1['a']
 
-<<<<<<< HEAD
-        unsupported_functions = ['kde', 'barh', 'line']
-=======
-        unsupported_functions = ['area', 'kde', 'pie', 'barh']
->>>>>>> Add plot.line in Series
+        unsupported_functions = ['kde', 'barh']
         for name in unsupported_functions:
             with self.assertRaisesRegex(PandasNotImplementedError,
                                         "method.*Series.*{}.*not implemented".format(name)):

--- a/databricks/koalas/tests/test_series_plot.py
+++ b/databricks/koalas/tests/test_series_plot.py
@@ -102,7 +102,14 @@ class SeriesPlotTest(ReusedSQLTestCase, TestUtils):
                  transform=ax1.transAxes)
         _, ax2 = plt.subplots(1, 1)
         ax2 = kdf['id'].plot.pie(colormap='Paired')
+        self.compare_plots(ax1, ax2)
 
+    def test_line_plot(self):
+        pdf = self.pdf1
+        kdf = self.kdf1
+
+        ax1 = pdf['a'].plot("line", colormap='Paired')
+        ax2 = kdf['a'].plot("line", colormap='Paired')
         self.compare_plots(ax1, ax2)
 
     def test_hist_plot(self):
@@ -203,7 +210,11 @@ class SeriesPlotTest(ReusedSQLTestCase, TestUtils):
     def test_missing(self):
         ks = self.kdf1['a']
 
+<<<<<<< HEAD
         unsupported_functions = ['kde', 'barh', 'line']
+=======
+        unsupported_functions = ['area', 'kde', 'pie', 'barh']
+>>>>>>> Add plot.line in Series
         for name in unsupported_functions:
             with self.assertRaisesRegex(PandasNotImplementedError,
                                         "method.*Series.*{}.*not implemented".format(name)):

--- a/docs/source/reference/series.rst
+++ b/docs/source/reference/series.rst
@@ -333,7 +333,9 @@ specific plotting methods of the form ``Series.plot.<kind>``.
    Series.plot.bar
    Series.plot.box
    Series.plot.hist
+   Series.plot.line
    Series.plot.pie
+   Series.plot.line
 
 .. currentmodule:: databricks.koalas
 .. autosummary::


### PR DESCRIPTION
This PR add series.plot.pie in Series.

Can be tested as below:

```python
import databricks.koalas as ks
import pandas as pd

pdf = pd.DataFrame({
          'a': [1, 2, 3, 4, 5, 6, 7, 8, 9, 15, 50],
      }, index=[0, 1, 3, 5, 6, 8, 9, 9, 9, 10, 10])

kdf = ks.DataFrame(pdf)
pdf['a'].plot.line(colormap='Paired').figure.savefig("image1.png")
kdf['a'].plot.line(colormap='Paired').figure.savefig("image2.png")
```

![image1](https://user-images.githubusercontent.com/6477701/63409929-11a35500-c42d-11e9-9ce1-f2e16881ee98.png)


In case of this plot, we sample and match the row numbers around 1000.

```python
import databricks.koalas as ks
import pandas as pd

pdf = pd.DataFrame({'a': [1, 2, 3, 4, 5, 6, 7, 8, 9, 15, 50, 100] * 100})
kdf = ks.DataFrame(pdf)
kdf['a'].plot.line(colormap='Paired').figure.savefig("image4.png")
```

![image4](https://user-images.githubusercontent.com/6477701/63409938-16680900-c42d-11e9-96b6-c5038a5412b1.png)

Partially addresses #665