### PR TITLE
Add plot.barh in Series

### DIFF
--- a/databricks/koalas/tests/test_series_plot.py
+++ b/databricks/koalas/tests/test_series_plot.py
@@ -112,6 +112,27 @@ class SeriesPlotTest(ReusedSQLTestCase, TestUtils):
         ax2 = kdf['a'].plot("line", colormap='Paired')
         self.compare_plots(ax1, ax2)
 
+    def test_barh_plot(self):
+        pdf = self.pdf1
+        kdf = self.kdf1
+
+        ax1 = pdf['a'].plot("barh", colormap='Paired')
+        ax2 = kdf['a'].plot("barh", colormap='Paired')
+        self.compare_plots(ax1, ax2)
+
+    def test_barh_plot_limited(self):
+        pdf = self.pdf2
+        kdf = self.kdf2
+
+        _, ax1 = plt.subplots(1, 1)
+        ax1 = pdf['id'][:1000].plot.barh(colormap='Paired')
+        ax1.text(1, 1, 'showing top 1,000 elements only', size=6, ha='right', va='bottom',
+                 transform=ax1.transAxes)
+        _, ax2 = plt.subplots(1, 1)
+        ax2 = kdf['id'].plot.barh(colormap='Paired')
+
+        self.compare_plots(ax1, ax2)
+
     def test_hist_plot(self):
         pdf = self.pdf1
         kdf = self.kdf1
@@ -210,7 +231,11 @@ class SeriesPlotTest(ReusedSQLTestCase, TestUtils):
     def test_missing(self):
         ks = self.kdf1['a']
 
+<<<<<<< HEAD
         unsupported_functions = ['kde', 'barh']
+=======
+        unsupported_functions = ['area', 'kde', 'pie', 'line']
+>>>>>>> Add plot.barh in Series
         for name in unsupported_functions:
             with self.assertRaisesRegex(PandasNotImplementedError,
                                         "method.*Series.*{}.*not implemented".format(name)):

--- a/databricks/koalas/tests/test_series_plot.py
+++ b/databricks/koalas/tests/test_series_plot.py
@@ -231,11 +231,7 @@ class SeriesPlotTest(ReusedSQLTestCase, TestUtils):
     def test_missing(self):
         ks = self.kdf1['a']
 
-<<<<<<< HEAD
-        unsupported_functions = ['kde', 'barh']
-=======
-        unsupported_functions = ['area', 'kde', 'pie', 'line']
->>>>>>> Add plot.barh in Series
+        unsupported_functions = ['kde']
         for name in unsupported_functions:
             with self.assertRaisesRegex(PandasNotImplementedError,
                                         "method.*Series.*{}.*not implemented".format(name)):

--- a/docs/source/reference/series.rst
+++ b/docs/source/reference/series.rst
@@ -331,6 +331,7 @@ specific plotting methods of the form ``Series.plot.<kind>``.
    Series.plot
    Series.plot.area
    Series.plot.bar
+   Series.plot.barh
    Series.plot.box
    Series.plot.hist
    Series.plot.line


### PR DESCRIPTION
This PR add series.plot.barh in Series.

Can be tested as below:

```python
import databricks.koalas as ks

kdf = ks.range(10)
kdf.to_pandas()['id'].plot.barh(colormap='Paired').figure.savefig("image1.png")
kdf['id'].plot.barh(colormap='Paired').figure.savefig("image2.png")
```

![image1](https://user-images.githubusercontent.com/6477701/63411569-c68b4100-c430-11e9-9d88-9f1113663def.png)

In case of this plot, we sample and match the row numbers around 1000.

```python
import databricks.koalas as ks

ks.range(1001)['id'].plot.barh(colormap='Paired').figure.savefig("image3.png")
```

![image3](https://user-images.githubusercontent.com/6477701/63411580-cc812200-c430-11e9-945b-0f74305c2507.png)


Partially addresses #665