### PR TITLE
Avoid copying pandas_df for internal use.

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -370,7 +370,7 @@ class DataFrame(_Frame, Generic[T]):
             # Here we execute with the first 1000 to get the return type.
             # If the records were less than 1000, it uses pandas API directly for a shortcut.
             limit = 1000
-            pdf = self.head(limit + 1)._to_pandas()
+            pdf = self.head(limit + 1)._to_internal_pandas()
             pser = getattr(pdf, name)(axis=axis, numeric_only=numeric_only)
             if len(pdf) <= limit:
                 return Series(pser)
@@ -949,7 +949,7 @@ class DataFrame(_Frame, Generic[T]):
         args = locals()
         kdf = self
         return validate_arguments_and_invoke_function(
-            kdf._to_pandas(), self.to_clipboard, pd.DataFrame.to_clipboard, args)
+            kdf._to_internal_pandas(), self.to_clipboard, pd.DataFrame.to_clipboard, args)
 
     def to_html(self, buf=None, columns=None, col_space=None, header=True, index=True,
                 na_rep='NaN', formatters=None, float_format=None, sparsify=None, index_names=True,
@@ -1048,7 +1048,7 @@ class DataFrame(_Frame, Generic[T]):
             kdf = self
 
         return validate_arguments_and_invoke_function(
-            kdf._to_pandas(), self.to_html, pd.DataFrame.to_html, args)
+            kdf._to_internal_pandas(), self.to_html, pd.DataFrame.to_html, args)
 
     def to_string(self, buf=None, columns=None, col_space=None, header=True,
                   index=True, na_rep='NaN', formatters=None, float_format=None,
@@ -1148,7 +1148,7 @@ class DataFrame(_Frame, Generic[T]):
             kdf = self
 
         return validate_arguments_and_invoke_function(
-            kdf._to_pandas(), self.to_string, pd.DataFrame.to_string, args)
+            kdf._to_internal_pandas(), self.to_string, pd.DataFrame.to_string, args)
 
     def to_dict(self, orient='dict', into=dict):
         """
@@ -1244,7 +1244,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         args = locals()
         kdf = self
         return validate_arguments_and_invoke_function(
-            kdf._to_pandas(), self.to_dict, pd.DataFrame.to_dict, args)
+            kdf._to_internal_pandas(), self.to_dict, pd.DataFrame.to_dict, args)
 
     def to_latex(self, buf=None, columns=None, col_space=None, header=True, index=True,
                  na_rep='NaN', formatters=None, float_format=None, sparsify=None, index_names=True,
@@ -1343,7 +1343,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         args = locals()
         kdf = self
         return validate_arguments_and_invoke_function(
-            kdf._to_pandas(), self.to_latex, pd.DataFrame.to_latex, args)
+            kdf._to_internal_pandas(), self.to_latex, pd.DataFrame.to_latex, args)
 
     # TODO: enable doctests once we drop Spark 2.3.x (due to type coercion logic
     #  when creating arrays)
@@ -1457,7 +1457,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         if len(self._internal.index_columns) != 1:
             raise ValueError("Single index must be set to transpose the current DataFrame.")
         if limit is not None:
-            pdf = self.head(limit + 1)._to_pandas()
+            pdf = self.head(limit + 1)._to_internal_pandas()
             if len(pdf) > limit:
                 raise ValueError(
                     "Current DataFrame has more then the given limit %s rows. Please use "
@@ -2265,7 +2265,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         third   0.9  0.0  0.49
         """
         if isinstance(decimals, ks.Series):
-            decimals_list = [kv for kv in decimals._to_pandas().items()]
+            decimals_list = [kv for kv in decimals._to_internal_pandas().items()]
         elif isinstance(decimals, dict):
             decimals_list = [(k, v) for k, v in decimals.items()]
         elif isinstance(decimals, int):
@@ -2931,7 +2931,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         kdf = self
 
         return validate_arguments_and_invoke_function(
-            kdf._to_pandas(), self.to_records, pd.DataFrame.to_records, args)
+            kdf._to_internal_pandas(), self.to_records, pd.DataFrame.to_records, args)
 
     def copy(self) -> 'DataFrame':
         """
@@ -6425,7 +6425,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             return DataFrame(self._internal.copy(sdf=self._sdf.filter(bcol)))
         raise NotImplementedError(key)
 
-    def _to_pandas(self):
+    def _to_internal_pandas(self):
         """
         Return a pandas DataFrame directly from _internal to avoid overhead of copy.
 
@@ -6434,7 +6434,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         return self._internal.pandas_df
 
     def __repr__(self):
-        pdf = self.head(max_display_count + 1)._to_pandas()
+        pdf = self.head(max_display_count + 1)._to_internal_pandas()
         pdf_length = len(pdf)
         repr_string = repr(pdf.iloc[:max_display_count])
         if pdf_length > max_display_count:
@@ -6448,7 +6448,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         return repr_string
 
     def _repr_html_(self):
-        pdf = self.head(max_display_count + 1)._to_pandas()
+        pdf = self.head(max_display_count + 1)._to_internal_pandas()
         pdf_length = len(pdf)
         repr_html = pdf[:max_display_count]._repr_html_()
         if pdf_length > max_display_count:

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -569,7 +569,7 @@ class _Frame(object):
                             'got [%s]' % (self,))
 
         return validate_arguments_and_invoke_function(
-            kdf.to_pandas(), self.to_csv, f, args)
+            kdf._to_pandas(), self.to_csv, f, args)
 
     def to_json(self, path_or_buf=None, orient=None, date_format=None,
                 double_precision=10, force_ascii=True, date_unit='ms',
@@ -722,7 +722,7 @@ class _Frame(object):
                             'got [%s]' % (self,))
 
         return validate_arguments_and_invoke_function(
-            kdf.to_pandas(), self.to_json, f, args)
+            kdf._to_pandas(), self.to_json, f, args)
 
     def to_excel(self, excel_writer, sheet_name="Sheet1", na_rep="", float_format=None,
                  columns=None, header=True, index=True, index_label=None, startrow=0,
@@ -837,7 +837,7 @@ class _Frame(object):
             raise TypeError('Constructor expects DataFrame or Series; however, '
                             'got [%s]' % (self,))
         return validate_arguments_and_invoke_function(
-            kdf.to_pandas(), self.to_excel, f, args)
+            kdf._to_pandas(), self.to_excel, f, args)
 
     def mean(self, axis=None, numeric_only=True):
         """
@@ -1363,7 +1363,7 @@ class _Frame(object):
         else:
             raise TypeError('bool() expects DataFrame or Series; however, '
                             'got [%s]' % (self,))
-        return df.head(2).to_pandas().bool()
+        return df.head(2)._to_pandas().bool()
 
     def median(self, accuracy=10000):
         """
@@ -1428,7 +1428,7 @@ class _Frame(object):
         median = lambda name: F.expr("approx_percentile(`%s`, 0.5, %s)" % (name, accuracy))
         sdf = sdf.select([median(col).alias(col) for col in kdf.columns])
         # This is expected to be small so it's fine to transpose.
-        return DataFrame(sdf).to_pandas().transpose().iloc[:, 0]
+        return DataFrame(sdf)._to_pandas().transpose().iloc[:, 0]
 
     @property
     def at(self):

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -569,7 +569,7 @@ class _Frame(object):
                             'got [%s]' % (self,))
 
         return validate_arguments_and_invoke_function(
-            kdf._to_pandas(), self.to_csv, f, args)
+            kdf._to_internal_pandas(), self.to_csv, f, args)
 
     def to_json(self, path_or_buf=None, orient=None, date_format=None,
                 double_precision=10, force_ascii=True, date_unit='ms',
@@ -722,7 +722,7 @@ class _Frame(object):
                             'got [%s]' % (self,))
 
         return validate_arguments_and_invoke_function(
-            kdf._to_pandas(), self.to_json, f, args)
+            kdf._to_internal_pandas(), self.to_json, f, args)
 
     def to_excel(self, excel_writer, sheet_name="Sheet1", na_rep="", float_format=None,
                  columns=None, header=True, index=True, index_label=None, startrow=0,
@@ -837,7 +837,7 @@ class _Frame(object):
             raise TypeError('Constructor expects DataFrame or Series; however, '
                             'got [%s]' % (self,))
         return validate_arguments_and_invoke_function(
-            kdf._to_pandas(), self.to_excel, f, args)
+            kdf._to_internal_pandas(), self.to_excel, f, args)
 
     def mean(self, axis=None, numeric_only=True):
         """
@@ -1363,7 +1363,7 @@ class _Frame(object):
         else:
             raise TypeError('bool() expects DataFrame or Series; however, '
                             'got [%s]' % (self,))
-        return df.head(2)._to_pandas().bool()
+        return df.head(2)._to_internal_pandas().bool()
 
     def median(self, accuracy=10000):
         """
@@ -1428,7 +1428,7 @@ class _Frame(object):
         median = lambda name: F.expr("approx_percentile(`%s`, 0.5, %s)" % (name, accuracy))
         sdf = sdf.select([median(col).alias(col) for col in kdf.columns])
         # This is expected to be small so it's fine to transpose.
-        return DataFrame(sdf)._to_pandas().transpose().iloc[:, 0]
+        return DataFrame(sdf)._to_internal_pandas().transpose().iloc[:, 0]
 
     @property
     def at(self):

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -804,7 +804,7 @@ class GroupBy(object):
             # Here we execute with the first 1000 to get the return type.
             # If the records were less than 1000, it uses pandas API directly for a shortcut.
             limit = 1000
-            pdf = self._kdf.head(limit + 1)._to_pandas()
+            pdf = self._kdf.head(limit + 1)._to_internal_pandas()
             pdf = pdf.groupby(input_groupnames).apply(func)
             kdf = DataFrame(pdf)
             return_schema = kdf._sdf.schema
@@ -1382,7 +1382,7 @@ class GroupBy(object):
             # Here we execute with the first 1000 to get the return type.
             # If the records were less than 1000, it uses pandas API directly for a shortcut.
             limit = 1000
-            pdf = self._kdf.head(limit + 1)._to_pandas()
+            pdf = self._kdf.head(limit + 1)._to_internal_pandas()
             pdf = pdf.groupby(input_groupnames).transform(func)
             kdf = DataFrame(pdf)
             return_schema = kdf._sdf.schema

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -804,7 +804,7 @@ class GroupBy(object):
             # Here we execute with the first 1000 to get the return type.
             # If the records were less than 1000, it uses pandas API directly for a shortcut.
             limit = 1000
-            pdf = self._kdf.head(limit + 1).to_pandas()
+            pdf = self._kdf.head(limit + 1)._to_pandas()
             pdf = pdf.groupby(input_groupnames).apply(func)
             kdf = DataFrame(pdf)
             return_schema = kdf._sdf.schema
@@ -1382,7 +1382,7 @@ class GroupBy(object):
             # Here we execute with the first 1000 to get the return type.
             # If the records were less than 1000, it uses pandas API directly for a shortcut.
             limit = 1000
-            pdf = self._kdf.head(limit + 1).to_pandas()
+            pdf = self._kdf.head(limit + 1)._to_pandas()
             pdf = pdf.groupby(input_groupnames).transform(func)
             kdf = DataFrame(pdf)
             return_schema = kdf._sdf.schema

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -114,7 +114,7 @@ class Index(IndexOpsMixin):
             sdf=sdf,
             index_map=[(sdf.schema[0].name, self._kdf._internal.index_names[0])],
             data_columns=[], column_index=[], column_index_names=None)
-        return DataFrame(internal).to_pandas().index
+        return DataFrame(internal)._to_pandas().index
 
     toPandas = to_pandas
 

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -114,7 +114,7 @@ class Index(IndexOpsMixin):
             sdf=sdf,
             index_map=[(sdf.schema[0].name, self._kdf._internal.index_names[0])],
             data_columns=[], column_index=[], column_index_names=None)
-        return DataFrame(internal)._to_pandas().index
+        return DataFrame(internal)._to_internal_pandas().index
 
     toPandas = to_pandas
 

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -1066,7 +1066,7 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
             kseries = self
 
         return validate_arguments_and_invoke_function(
-            kseries._to_pandas(), self.to_string, pd.Series.to_string, args)
+            kseries._to_internal_pandas(), self.to_string, pd.Series.to_string, args)
 
     def to_clipboard(self, excel=True, sep=None, **kwargs):
         # Docstring defined below by reusing DataFrame.to_clipboard's.
@@ -1074,7 +1074,7 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         kseries = self
 
         return validate_arguments_and_invoke_function(
-            kseries._to_pandas(), self.to_clipboard, pd.Series.to_clipboard, args)
+            kseries._to_internal_pandas(), self.to_clipboard, pd.Series.to_clipboard, args)
 
     to_clipboard.__doc__ = DataFrame.to_clipboard.__doc__
 
@@ -1117,7 +1117,7 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         args = locals()
         kseries = self
         return validate_arguments_and_invoke_function(
-            kseries._to_pandas(), self.to_dict, pd.Series.to_dict, args)
+            kseries._to_internal_pandas(), self.to_dict, pd.Series.to_dict, args)
 
     def to_latex(self, buf=None, columns=None, col_space=None, header=True, index=True,
                  na_rep='NaN', formatters=None, float_format=None, sparsify=None, index_names=True,
@@ -1127,7 +1127,7 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         args = locals()
         kseries = self
         return validate_arguments_and_invoke_function(
-            kseries._to_pandas(), self.to_latex, pd.Series.to_latex, args)
+            kseries._to_internal_pandas(), self.to_latex, pd.Series.to_latex, args)
 
     to_latex.__doc__ = DataFrame.to_latex.__doc__
 
@@ -1166,7 +1166,7 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
             to be small, as all the data is loaded into the driver's memory.
 
         """
-        return self._to_pandas().to_list()
+        return self._to_internal_pandas().to_list()
 
     tolist = to_list
 
@@ -2967,7 +2967,7 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
     def __str__(self):
         return self._pandas_orig_repr()
 
-    def _to_pandas(self):
+    def _to_internal_pandas(self):
         """
         Return a pandas Series directly from _internal to avoid overhead of copy.
 
@@ -2976,7 +2976,7 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         return _col(self._internal.pandas_df)
 
     def __repr__(self):
-        pser = self.head(max_display_count + 1)._to_pandas()
+        pser = self.head(max_display_count + 1)._to_internal_pandas()
         pser_length = len(pser)
         repr_string = repr(pser.iloc[:max_display_count])
         if pser_length > max_display_count:

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -1066,7 +1066,7 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
             kseries = self
 
         return validate_arguments_and_invoke_function(
-            kseries.to_pandas(), self.to_string, pd.Series.to_string, args)
+            kseries._to_pandas(), self.to_string, pd.Series.to_string, args)
 
     def to_clipboard(self, excel=True, sep=None, **kwargs):
         # Docstring defined below by reusing DataFrame.to_clipboard's.
@@ -1074,7 +1074,7 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         kseries = self
 
         return validate_arguments_and_invoke_function(
-            kseries.to_pandas(), self.to_clipboard, pd.Series.to_clipboard, args)
+            kseries._to_pandas(), self.to_clipboard, pd.Series.to_clipboard, args)
 
     to_clipboard.__doc__ = DataFrame.to_clipboard.__doc__
 
@@ -1117,7 +1117,7 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         args = locals()
         kseries = self
         return validate_arguments_and_invoke_function(
-            kseries.to_pandas(), self.to_dict, pd.Series.to_dict, args)
+            kseries._to_pandas(), self.to_dict, pd.Series.to_dict, args)
 
     def to_latex(self, buf=None, columns=None, col_space=None, header=True, index=True,
                  na_rep='NaN', formatters=None, float_format=None, sparsify=None, index_names=True,
@@ -1127,7 +1127,7 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         args = locals()
         kseries = self
         return validate_arguments_and_invoke_function(
-            kseries.to_pandas(), self.to_latex, pd.Series.to_latex, args)
+            kseries._to_pandas(), self.to_latex, pd.Series.to_latex, args)
 
     to_latex.__doc__ = DataFrame.to_latex.__doc__
 
@@ -1166,7 +1166,7 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
             to be small, as all the data is loaded into the driver's memory.
 
         """
-        return self.to_pandas().to_list()
+        return self._to_pandas().to_list()
 
     tolist = to_list
 
@@ -2967,8 +2967,16 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
     def __str__(self):
         return self._pandas_orig_repr()
 
+    def _to_pandas(self):
+        """
+        Return a pandas Series directly from _internal to avoid overhead of copy.
+
+        This method is for internal use only.
+        """
+        return _col(self._internal.pandas_df)
+
     def __repr__(self):
-        pser = self.head(max_display_count + 1).to_pandas()
+        pser = self.head(max_display_count + 1)._to_pandas()
         pser_length = len(pser)
         repr_string = repr(pser.iloc[:max_display_count])
         if pser_length > max_display_count:


### PR DESCRIPTION
Currently we use a copy of cached pandas DataFrame/Series when calling `to_pandas()` because the cached pandas DataFrame/Series might be modified by a user and it breaks immutability of `InternalFrame`.
However, for internal use, we can know whether the DataFrame/Series will be modified or not and we don't need to use the copy when the DataFrame/Series will not be modified.