### PR TITLE
Rename the default index 'one-by-one' to 'sequence'

### DIFF
--- a/databricks/koalas/internal.py
+++ b/databricks/koalas/internal.py
@@ -422,32 +422,67 @@ class _InternalFrame(object):
         There are three types of default index that can be controlled by `DEFAULT_INDEX`
         environment variable.
 
-        - one-by-one: It implements an one-by-one sequence by Window function without
+        - sequence: It implements a sequence that increases one by one, by Window function without
             specifying partition. Therefore, it ends up with whole partition in single node.
             This index type should be avoided when the data is large. This is default.
+            See example below:
 
-        - distributed-one-by-one: It implements an one-by-one sequence by group-by and
-            group-map approach. It still generates a one-by-one sequential index globally.
-            If the default index must be an one-by-one sequence in a large dataset, this
+            >>> ks.range(3).index  # doctest: +SKIP
+            Int64Index([0, 1, 2], dtype='int64')
+
+            This is conceptually equivalent to the Spark example as below:
+
+            >>> from pyspark.sql import functions as F, Window
+            >>> spark_df = ks.range(3).to_spark()
+            >>> sequential_index = F.row_number().over(
+            ...    Window.orderBy(F.monotonically_increasing_id().asc())) - 1
+            >>> spark_df.select(sequential_index).rdd.map(lambda r: r[0]).collect()
+            [0, 1, 2]
+
+        - distributed-sequence: It implements a sequence that increases one by one, by group-by and
+            group-map approach. It still generates the sequential index globally.
+            If the default index must be the sequence in a large dataset, this
             index has to be used.
             Note that if more data are added to the data source after creating this index,
             then it does not guarantee the sequential index.
+            See example below:
+
+            >>> ks.range(3).index  # doctest: +SKIP
+            Int64Index([0, 1, 2], dtype='int64')
+
+            This is conceptually equivalent to the Spark example as below:
+
+            >>> spark_df = ks.range(3).to_spark()
+            >>> spark_df.rdd.zipWithIndex().map(lambda p: p[1]).collect()
+            [0, 1, 2]
 
         - distributed: It implements a monotonically increasing sequence simply by using
             Spark's `monotonically_increasing_id` function. If the index does not have to be
-            a one-by-one sequence, this index should be used. Performance-wise, this index
-            almost does not have any penalty comparing to other index types.
-            Note that we cannot use this type of index for combining two dataframes because
-            it is not guaranteed to have the same indexes in two dataframes.
+            a sequence that increases one by one, this index should be used.
+            Performance-wise, this index almost does not have any penalty comparing to
+            other index types. Note that we cannot use this type of index for combining
+            two dataframes because it is not guaranteed to have the same indexes in two
+            dataframes. See example below:
+
+            >>> ks.range(3).index  # doctest: +SKIP
+            Int64Index([25769803776, 60129542144, 94489280512], dtype='int64')
+
+            This is conceptually equivalent to the Spark example as below:
+
+            >>> from pyspark.sql import functions as F
+            >>> spark_df = ks.range(3).to_spark()
+            >>> spark_df.select(F.monotonically_increasing_id()) \
+            ...     .rdd.map(lambda r: r[0]).collect()  # doctest: +SKIP
+            [25769803776, 60129542144, 94489280512]
 
         """
-        default_index_type = os.environ.get("DEFAULT_INDEX", "one-by-one")
-        if default_index_type == "one-by-one":
+        default_index_type = os.environ.get("DEFAULT_INDEX", "sequence")
+        if default_index_type == "sequence":
             sequential_index = F.row_number().over(
                 Window.orderBy(F.monotonically_increasing_id().asc())) - 1
             scols = [scol_for(sdf, column) for column in sdf.columns]
             return sdf.select(sequential_index.alias("__index_level_0__"), *scols)
-        elif default_index_type == "distributed-one-by-one":
+        elif default_index_type == "distributed-sequence":
             # 1. Calculates counts per each partition ID. `counts` here is, for instance,
             #     {
             #         1: 83,
@@ -488,8 +523,8 @@ class _InternalFrame(object):
             return sdf.select(
                 F.monotonically_increasing_id().alias("__index_level_0__"), *scols)
         else:
-            raise ValueError("'DEFAULT_INDEX' environment variable should be one of 'one-by-one',"
-                             " 'distributed-one-by-one' and 'distributed'")
+            raise ValueError("'DEFAULT_INDEX' environment variable should be one of 'sequence',"
+                             " 'distributed-sequence' and 'distributed'")
 
     def scol_for(self, column_name: str) -> spark.Column:
         """ Return Spark Column for the given column name. """

--- a/databricks/koalas/tests/test_default_index.py
+++ b/databricks/koalas/tests/test_default_index.py
@@ -26,8 +26,8 @@ class OneByOneDefaultIndexTest(ReusedSQLTestCase, TestUtils):
     @classmethod
     def setUpClass(cls):
         super(OneByOneDefaultIndexTest, cls).setUpClass()
-        cls.default_index = os.environ.get('DEFAULT_INDEX', 'one-by-one')
-        os.environ['DEFAULT_INDEX'] = 'one-by-one'
+        cls.default_index = os.environ.get('DEFAULT_INDEX', 'sequence')
+        os.environ['DEFAULT_INDEX'] = 'sequence'
 
     @classmethod
     def tearDownClass(cls):
@@ -44,8 +44,8 @@ class DistributedOneByOneDefaultIndexTest(ReusedSQLTestCase, TestUtils):
     @classmethod
     def setUpClass(cls):
         super(DistributedOneByOneDefaultIndexTest, cls).setUpClass()
-        cls.default_index = os.environ.get('DEFAULT_INDEX', 'one-by-one')
-        os.environ['DEFAULT_INDEX'] = 'distributed-one-by-one'
+        cls.default_index = os.environ.get('DEFAULT_INDEX', 'sequence')
+        os.environ['DEFAULT_INDEX'] = 'distributed-sequence'
 
     @classmethod
     def tearDownClass(cls):
@@ -62,7 +62,7 @@ class DistributedDefaultIndexTest(ReusedSQLTestCase, TestUtils):
     @classmethod
     def setUpClass(cls):
         super(DistributedDefaultIndexTest, cls).setUpClass()
-        cls.default_index = os.environ.get('DEFAULT_INDEX', 'one-by-one')
+        cls.default_index = os.environ.get('DEFAULT_INDEX', 'sequence')
         os.environ['DEFAULT_INDEX'] = 'distributed'
 
     @classmethod


### PR DESCRIPTION
There was a concern about the naming 'one-by-one' since it's confusing (see https://groups.google.com/forum/m/#!topic/koalas-dev/xzZ0VvXFsGM)
This PR proposes to rename the default index 'one-by-one' to 'sequence'.