### PR TITLE
Fix some typos in README.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,7 +120,7 @@ We follow [PEP 8](https://www.python.org/dev/peps/pep-0008/) with one exception:
 ## Doctest Conventions
 
 When writing doctests, usually the doctests in pandas are converted into Koalas to make sure the same codes work in Koalas.
-In general, doctests should be grouped logically by seperating a newline.
+In general, doctests should be grouped logically by separating a newline.
 
 For instance, the first block is for the statements for preparation, the second block is for using the function with a specific argument,
 and third block is for another argument. As a example, please refer [DataFrame.rsub](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.rsub.html#pandas.DataFrame.rsub) in pandas.
@@ -154,7 +154,7 @@ python3 -m twine upload --repository-url https://upload.pypi.org/legacy/ dist/ko
 ```
 
 Step 5. Verify the uploaded package can be installed and executed.
-One unofficial tip is to run the doctests of Koalas within a Python interpretor after installing it.
+One unofficial tip is to run the doctests of Koalas within a Python interpreter after installing it.
 
 ```python
 import os

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Project docs are published here: https://koalas.readthedocs.io
 
 ## Mailing List
 
-We use Google Groups for mailling list: https://groups.google.com/forum/#!forum/koalas-dev
+We use Google Groups for mailing list: https://groups.google.com/forum/#!forum/koalas-dev
 
 
 ## Development Guide
@@ -115,7 +115,7 @@ See [CONTRIBUTING.md](https://github.com/databricks/koalas/blob/master/CONTRIBUT
 
 ## Design Principles
 
-This section outlines design princples guiding the Koalas project.
+This section outlines design principles guiding the Koalas project.
 
 ### Be Pythonic
 


### PR DESCRIPTION
It's nothing special, but I found a few typos, so please check it out.

mailling -> mailing
princples -> principles

Thanks.