### PR TITLE
Add error test for 'names' property of indexes

### DIFF
--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -93,6 +93,14 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         self.assertEqual(kidx.names, pidx.names)
         self.assert_eq(kidx, pidx)
 
+        with self.assertRaisesRegex(ValueError, "Names must be a list-like"):
+            kidx.names = 'hi'
+
+        expected_error_message = ("Length of new names must be {}, got {}"
+            .format(len(kdf._internal.index_map), len(['0', '1'])))
+        with self.assertRaisesRegex(ValueError, expected_error_message):
+            kidx.names = ['0', '1']
+
     def test_multi_index_names(self):
         arrays = [[1, 1, 2, 2], ['red', 'blue', 'red', 'blue']]
         idx = pd.MultiIndex.from_arrays(arrays, names=('number', 'color'))


### PR DESCRIPTION
I found that there was not enough error testing for the names property.

![image](https://user-images.githubusercontent.com/44108233/63647385-788d7a80-c75b-11e9-8559-d8c38d2c5b48.png)

and I added those tests, It's very appreciate it if someone check it out when available. :)

Thanks.