### PR TITLE
Temporaly repr of MultiIndex & Add some Tests for Indexes.py

### DIFF
--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -273,6 +273,10 @@ class MultiIndex(Index):
         """
         return MultiIndex(self._kdf, scol)
 
+    # TODO: This is a temporary measure to avoid confusion, so the logic should be changed later.
+    def __repr__(self):
+        return super().__repr__().replace("Index", "MultiIndex", 1)
+
     def any(self, *args, **kwargs):
         raise TypeError("cannot perform any with this index type: MultiIndex")
 
@@ -297,4 +301,4 @@ class MultiIndex(Index):
         raise AttributeError("'MultiIndex' object has no attribute '{}'".format(item))
 
     def rename(self, name, inplace=False):
-        raise NotImplementedError()
+        raise PandasNotImplementedError(class_name='pd.MultiIndex')

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -93,6 +93,14 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         self.assertEqual(kidx.names, pidx.names)
         self.assert_eq(kidx, pidx)
 
+        with self.assertRaisesRegex(ValueError, "Names must be a list-like"):
+            kidx.names = 'hi'
+
+        expected_error_message = ("Length of new names must be {}, got {}"
+            .format(len(kdf._internal.index_map), len(['0', '1'])))
+        with self.assertRaisesRegex(ValueError, expected_error_message):
+            kidx.names = ['0', '1']
+
     def test_multi_index_names(self):
         arrays = [[1, 1, 2, 2], ['red', 'blue', 'red', 'blue']]
         idx = pd.MultiIndex.from_arrays(arrays, names=('number', 'color'))

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -22,6 +22,7 @@ import pandas as pd
 import pyspark
 
 import databricks.koalas as ks
+from databricks.koalas.generic import max_display_count
 from databricks.koalas.exceptions import PandasNotImplementedError
 from databricks.koalas.missing.indexes import _MissingPandasLikeIndex, _MissingPandasLikeMultiIndex
 from databricks.koalas.testing.utils import ReusedSQLTestCase, TestUtils
@@ -54,6 +55,35 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
             else:
                 kdf = ks.from_pandas(pdf)
                 self.assert_eq(kdf.index, pdf.index)
+
+    def test_index_repr(self):
+        kidx = ks.DataFrame({'a': range(max_display_count + 1)}).index
+
+        # Check that the footer outputs correctly
+        # when the index length exceeds the maximum value.
+        expected_footer = ("Showing only the first {}"
+                           .format(max_display_count))
+        self.assert_eq(repr(kidx)[-len(expected_footer):], expected_footer)
+
+    def test_index_getattr(self):
+        kidx = self.kdf.index
+        item = 'databricks'
+
+        expected_error_message = ("'Index' object has no attribute '{}'".format(item))
+        with self.assertRaisesRegex(AttributeError, expected_error_message):
+            kidx.__getattr__(item)
+
+    def test_multi_index_getattr(self):
+        arrays = [[1, 1, 2, 2], ['red', 'blue', 'red', 'blue']]
+        idx = pd.MultiIndex.from_arrays(arrays, names=('number', 'color'))
+        pdf = pd.DataFrame(np.random.randn(4, 5), idx)
+        kdf = ks.from_pandas(pdf)
+        kidx = kdf.index
+        item = 'databricks'
+
+        expected_error_message = ("'MultiIndex' object has no attribute '{}'".format(item))
+        with self.assertRaisesRegex(AttributeError, expected_error_message):
+            kidx.__getattr__(item)
 
     def test_to_series(self):
         pidx = self.pdf.index
@@ -97,7 +127,7 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
             kidx.names = 'hi'
 
         expected_error_message = ("Length of new names must be {}, got {}"
-            .format(len(kdf._internal.index_map), len(['0', '1'])))
+                                  .format(len(kdf._internal.index_map), len(['0', '1'])))
         with self.assertRaisesRegex(ValueError, expected_error_message):
             kidx.names = ['0', '1']
 


### PR DESCRIPTION
### \# 1

When I checked repr for MultiIndex,

It was confusing because it was printed as 'Index' instead of 'MultiIndex'.

```python
>>> import databricks.koalas as ks
>>> import pandas as pd
>>> import numpy as np
>>>
>>> arrays = [[1, 1, 2, 2], ['red', 'blue', 'red', 'blue']]
>>> idx = pd.MultiIndex.from_arrays(arrays, names=('Index', 'color'))
>>> pdf = pd.DataFrame(np.random.randn(4, 5), idx)
>>> kdf = ks.from_pandas(pdf)
>>>
>>> kidx = kdf.index
>>> kidx
Index([(1, 'red'), (1, 'blue'), (2, 'red'), (2, 'blue')], dtype='object', name='number')
```

So of course this is not the correct answer,

I suggest changing the MuntiIndex repr temporarily to avoid confusion.

<img width="694" alt="스크린샷 2019-08-26 오전 12 14 45" src="https://user-images.githubusercontent.com/44108233/63652032-890f1680-c796-11e9-8dfb-f99bb06dfb35.png">

then we can get repr result like this

```python
>>> kidx = kdf.index
>>> kidx
MultiIndex([(1, 'red'), (1, 'blue'), (2, 'red'), (2, 'blue')], dtype='object', name='number')
```

### \# 2

And I found that there was not enough error testing for the names property.

![image](https://user-images.githubusercontent.com/44108233/63647783-526ad900-c761-11e9-8140-61201cdf268e.png)


I added tests for those errors,

And I've added tests for some other code that isn't being tested yet.

It's very appreciate it if someone check it out when available. :)

Thanks.

