### PR TITLE
Add missing tests for indexes

### DIFF
--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -56,15 +56,6 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
                 kdf = ks.from_pandas(pdf)
                 self.assert_eq(kdf.index, pdf.index)
 
-    def test_index_repr(self):
-        kidx = ks.DataFrame({'a': range(max_display_count + 1)}).index
-
-        # Check that the footer outputs correctly
-        # when the index length exceeds the maximum value.
-        expected_footer = ("Showing only the first {}"
-                           .format(max_display_count))
-        self.assert_eq(repr(kidx)[-len(expected_footer):], expected_footer)
-
     def test_index_getattr(self):
         kidx = self.kdf.index
         item = 'databricks'

--- a/databricks/koalas/tests/test_repr.py
+++ b/databricks/koalas/tests/test_repr.py
@@ -36,6 +36,16 @@ class ReprTests(ReusedSQLTestCase):
         kser = ks.range(max_display_count + 1).id
         self.assertTrue("Showing only the first" in repr(kser))
 
+    def test_repr_indexes(self):
+        kdf = ks.range(max_display_count)
+        kidx = kdf.index
+        self.assertTrue("Showing only the first" not in repr(kidx))
+        self.assert_eq(repr(kidx), repr(kidx.to_pandas()))
+
+        kdf = ks.range(max_display_count + 1)
+        kidx = kdf.index
+        self.assertTrue("Showing only the first" in repr(kidx))
+
     def test_html_repr(self):
         kdf = ks.range(max_display_count)
         self.assertTrue("Showing only the first" not in kdf._repr_html_())


### PR DESCRIPTION
 I found that there was not enough exception testing for the names property.

![image](https://user-images.githubusercontent.com/44108233/63647783-526ad900-c761-11e9-8140-61201cdf268e.png)


So I added tests for those exceptions,

And also added tests for some other code that isn't being tested yet.

It's very appreciate it if someone check it out when available. :)

Thanks.
