### PR TITLE
[TEMP] Implement temporaly  repr for multiindex

### DIFF
--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -273,6 +273,10 @@ class MultiIndex(Index):
         """
         return MultiIndex(self._kdf, scol)
 
+    # TODO: This is a temporary measure to avoid confusion, so the logic should be changed later.
+    def __repr__(self):
+        return super().__repr__().replace("Index", "MultiIndex", 1)
+
     def any(self, *args, **kwargs):
         raise TypeError("cannot perform any with this index type: MultiIndex")
 


### PR DESCRIPTION
When I checked repr for MultiIndex,

It was confusing because it was printed as 'Index' instead of 'MultiIndex'.

```python
>>> import databricks.koalas as ks
>>> import pandas as pd
>>> import numpy as np
>>>
>>> arrays = [[1, 1, 2, 2], ['red', 'blue', 'red', 'blue']]
>>> idx = pd.MultiIndex.from_arrays(arrays, names=('Index', 'color'))
>>> pdf = pd.DataFrame(np.random.randn(4, 5), idx)
>>> kdf = ks.from_pandas(pdf)
>>>
>>> kidx = kdf.index
>>> kidx
Index([(1, 'red'), (1, 'blue'), (2, 'red'), (2, 'blue')], dtype='object', name='number')
```

Of course, maybe it's not really necessary,

but I suggest changing the MuntiIndex repr temporarily to avoid confusion.

<img width="694" alt="스크린샷 2019-08-26 오전 12 14 45" src="https://user-images.githubusercontent.com/44108233/63652032-890f1680-c796-11e9-8dfb-f99bb06dfb35.png">

then we can get repr result like this

```python
>>> kidx = kdf.index
>>> kidx
MultiIndex([(1, 'red'), (1, 'blue'), (2, 'red'), (2, 'blue')], dtype='object', name='number')
```

Please check this suggestion when someone available.

Thanks :)
