### PR TITLE
Implemented `nbytes` of Series

### DIFF
--- a/databricks/koalas/missing/series.py
+++ b/databricks/koalas/missing/series.py
@@ -32,7 +32,6 @@ class _MissingPandasLikeSeries(object):
     # Properties
     axes = unsupported_property('axes')
     iat = unsupported_property('iat')
-    nbytes = unsupported_property('nbytes')
 
     # Deprecated properties
     blocks = unsupported_property('blocks', deprecated=True)

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -354,6 +354,20 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
 
     plot = CachedAccessor("plot", KoalasSeriesPlotMethods)
 
+    @property
+    def nbytes(self):
+        """Return the number of bytes in the underlying data.
+
+        >>> pser = pd.Series(list('abc'))
+        >>> kser = ks.Series(list('abc'))
+        >>> pser.nbytes == kser.nbytes
+        True
+        """
+        n = len(self)
+        if n:
+            return n * self.dtype.itemsize
+        return 0
+
     # Arithmetic Operators
     def add(self, other):
         return (self + other).rename(self.name)

--- a/docs/source/reference/series.rst
+++ b/docs/source/reference/series.rst
@@ -25,6 +25,7 @@ Attributes
 
    Series.dtype
    Series.dtypes
+   Series.nbytes
    Series.name
    Series.schema
    Series.shape


### PR DESCRIPTION
This is my first open source implementation so I'm not sure if it's the correct way,

but I've made it work the same as nbytes in pandas.

```python
>>> import databricks.koalas as ks
>>> import pandas as pd
>>> 
>>> pser = pd.Series(list('abc'))
>>> kser = ks.Series(list('abc'))
>>> 
>>> pser.nbytes
24
>>> kser.nbytes
24
```

I would be grateful if you could confirm when you available.
