### PR TITLE
BUG&TST: Fix area plot for Series and add test

### DIFF
--- a/databricks/koalas/plot.py
+++ b/databricks/koalas/plot.py
@@ -90,8 +90,9 @@ class SampledPlot:
             sampled = data._sdf.sample(fraction=float(self.fraction))
             return DataFrame(data._internal.copy(sdf=sampled)).to_pandas()
         elif isinstance(data, Series):
+            scol = data._kdf._internal.data_scols[0]
             sampled = data._kdf._sdf.sample(fraction=float(self.fraction))
-            return DataFrame(data._kdf._internal.copy(sdf=sampled)).to_pandas()
+            return DataFrame(data._kdf._internal.copy(sdf=sampled, scol=scol)).to_pandas()
         else:
             ValueError("Only DataFrame and Series are supported for plotting.")
 

--- a/databricks/koalas/tests/test_series_plot.py
+++ b/databricks/koalas/tests/test_series_plot.py
@@ -188,11 +188,16 @@ class SeriesPlotTest(ReusedSQLTestCase, TestUtils):
         kdf = koalas.from_pandas(pdf)
 
         ax1 = pdf['sales'].plot("area", colormap='Paired')
-        ax2 = kdf['sales'].plot("barh", colormap='Paired')
+        ax2 = kdf['sales'].plot("area", colormap='Paired')
         self.compare_plots(ax1, ax2)
 
         ax1 = pdf['sales'].plot.area(colormap='Paired')
         ax2 = kdf['sales'].plot.area(colormap='Paired')
+        self.compare_plots(ax1, ax2)
+
+        # just a sanity check for df.col type
+        ax1 = pdf.sales.plot("area", colormap='Paired')
+        ax2 = kdf.sales.plot("area", colormap='Paired')
         self.compare_plots(ax1, ax2)
 
     def boxplot_comparison(self, *args, **kwargs):

--- a/databricks/koalas/tests/test_series_plot.py
+++ b/databricks/koalas/tests/test_series_plot.py
@@ -179,6 +179,22 @@ class SeriesPlotTest(ReusedSQLTestCase, TestUtils):
         self.assert_eq(pd.Series(expected_bins), pd.Series(bins))
         self.assert_eq(pd.Series(expected_histogram), histogram)
 
+    def test_area_plot(self):
+        pdf = pd.DataFrame({
+            'sales': [3, 2, 3, 9, 10, 6],
+            'signups': [5, 5, 6, 12, 14, 13],
+            'visits': [20, 42, 28, 62, 81, 50],
+        }, index=pd.date_range(start='2018/01/01', end='2018/07/01', freq='M'))
+        kdf = koalas.from_pandas(pdf)
+
+        ax1 = pdf['sales'].plot("area", colormap='Paired')
+        ax2 = kdf['sales'].plot("barh", colormap='Paired')
+        self.compare_plots(ax1, ax2)
+
+        ax1 = pdf['sales'].plot.area(colormap='Paired')
+        ax2 = kdf['sales'].plot.area(colormap='Paired')
+        self.compare_plots(ax1, ax2)
+
     def boxplot_comparison(self, *args, **kwargs):
         pdf = self.pdf1
         kdf = self.kdf1


### PR DESCRIPTION
There seems a little bug in SamplePlot that failed area plot. It is due to after sampling, since `scol` is not assigned, it will return a full DataFrame instead of Series. And looks like area plot turns good as well after fixing it.

![Screen Shot 2019-08-27 at 10 21 03 PM](https://user-images.githubusercontent.com/9269816/63805466-c94ad200-c919-11e9-8838-94d4a1587ebb.png)

Before the bug fixing, the area plot looks like:

![Screen Shot 2019-08-27 at 10 40 23 PM](https://user-images.githubusercontent.com/9269816/63806354-b802c500-c91b-11e9-8fc3-6131f9c5ba3f.png)
