### PR TITLE
Add some missing tests for namespace

### DIFF
--- a/databricks/koalas/tests/test_csv.py
+++ b/databricks/koalas/tests/test_csv.py
@@ -120,6 +120,12 @@ class CsvTest(ReusedSQLTestCase, TestUtils):
                                    lambda: koalas.read_csv(fn, usecols=[1, 3]))
             self.assertRaisesRegex(ValueError, 'Usecols do not match.*col',
                                    lambda: koalas.read_csv(fn, usecols=['amount', 'col']))
+            self.assertRaisesRegex(ValueError, 'Unknown header argument 1',
+                                   lambda: koalas.read_csv(fn, header='1'))
+            expected_error_message = ("'usecols' must either be list-like of all strings, "
+                                      "all unicode, all integers or a callable.")
+            self.assertRaisesRegex(ValueError, expected_error_message,
+                                   lambda: koalas.read_csv(fn, usecols=[1, 'amount']))
 
     def test_read_with_spark_schema(self):
         with self.csv_file(self.csv_text_2) as fn:

--- a/databricks/koalas/tests/test_namespace.py
+++ b/databricks/koalas/tests/test_namespace.py
@@ -30,10 +30,10 @@ class NamespaceTest(ReusedSQLTestCase, SQLTestUtils):
         pidx = pdf.index
         kidx = kdf.index
 
-        expected_error_message = f'Unknown data type: {type(kidx)}'
+        expected_error_message = 'Unknown data type: {}'.format(type(kidx))
         with self.assertRaisesRegex(ValueError, expected_error_message):
             ks.from_pandas(kidx)
-        expected_error_message = f'Unknown data type: {type(pidx)}'
+        expected_error_message = 'Unknown data type: {}'.format(type(pidx))
         with self.assertRaisesRegex(ValueError, expected_error_message):
             ks.from_pandas(pidx)
 


### PR DESCRIPTION
I found some untested codes in namespace.py like:

<img width="876" alt="스크린샷 2019-08-29 오후 1 37 49" src="https://user-images.githubusercontent.com/44108233/63910644-8ba59080-ca62-11e9-9bbf-730fe6a5226b.png">
<img width="667" alt="스크린샷 2019-08-29 오후 1 38 07" src="https://user-images.githubusercontent.com/44108233/63910645-8cd6bd80-ca62-11e9-93e4-5229a3a1f4b2.png">
<img width="759" alt="스크린샷 2019-08-29 오후 1 38 15" src="https://user-images.githubusercontent.com/44108233/63910650-8ea08100-ca62-11e9-82a4-88defb897a17.png">
<img width="694" alt="스크린샷 2019-08-29 오후 1 38 47" src="https://user-images.githubusercontent.com/44108233/63910653-919b7180-ca62-11e9-83f3-219ffe664dc8.png">

so i added tests for cover them.

I would appreciate it if someone available.
