### PR TITLE
Add a 'display.max_rows' configuration with typed configuration support

### DIFF
--- a/databricks/koalas/__init__.py
+++ b/databricks/koalas/__init__.py
@@ -39,10 +39,11 @@ from databricks.koalas.frame import DataFrame
 from databricks.koalas.indexes import Index, MultiIndex
 from databricks.koalas.series import Series
 from databricks.koalas.typedef import pandas_wraps
+from databricks.koalas.config import get_option, set_option, reset_option
 
 __all__ = ['read_csv', 'read_parquet', 'to_datetime', 'from_pandas',
            'get_dummies', 'DataFrame', 'Series', 'Index', 'MultiIndex', 'pandas_wraps',
-           'sql', 'range', 'concat', 'melt']
+           'sql', 'range', 'concat', 'melt', 'get_option', 'set_option', 'reset_option']
 
 
 def _auto_patch():

--- a/databricks/koalas/config.py
+++ b/databricks/koalas/config.py
@@ -30,7 +30,10 @@ __all__ = ['get_option', 'set_option', 'reset_option']
 
 # dict to store registered options and their default values (key -> default).
 _registered_options = {
-    "display.max_rows": 1000,
+    # This sets the maximum number of rows koalas should output when printing out various output.
+    # For example, this value determines whether the repr() for a dataframe prints out fully or
+    # just a truncated repr.
+    "display.max_rows": 1000,  # TODO: None should support unlimited.
 }  # type: Dict[str, Any]
 
 
@@ -110,6 +113,8 @@ def _check_option(key: str, value: Union[str, _NoValueType] = _NoValue) -> None:
             "No such option: '{}'. Available options are [{}]".format(
                 key, ", ".join(list(_registered_options.keys()))))
 
+    if value is None:
+        return  # None is allowed for all types.
     if value is not _NoValue and not isinstance(value, type(_registered_options[key])):
         raise TypeError("The configuration value for '%s' was %s; however, %s is expected." % (
             key, type(value), type(_registered_options[key])))

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -47,13 +47,14 @@ from pyspark.sql.functions import pandas_udf
 
 from databricks import koalas as ks  # For running doctests and reference resolution in PyCharm.
 from databricks.koalas.utils import validate_arguments_and_invoke_function, align_diff_frames
-from databricks.koalas.generic import _Frame, max_display_count
+from databricks.koalas.generic import _Frame
 from databricks.koalas.internal import _InternalFrame, IndexMap
 from databricks.koalas.missing.frame import _MissingPandasLikeDataFrame
 from databricks.koalas.ml import corr
 from databricks.koalas.utils import column_index_level, scol_for
 from databricks.koalas.typedef import as_spark_type
 from databricks.koalas.plot import KoalasFramePlotMethods
+from databricks.koalas.config import get_option
 
 # These regular expression patterns are complied and defined here to avoid to compile the same
 # pattern every time it is used in _repr_ and _repr_html_ in DataFrame.
@@ -6493,6 +6494,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         return self._internal.pandas_df
 
     def __repr__(self):
+        max_display_count = get_option("display.max_rows")
         pdf = self.head(max_display_count + 1)._to_internal_pandas()
         pdf_length = len(pdf)
         repr_string = repr(pdf.iloc[:max_display_count])
@@ -6507,6 +6509,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         return repr_string
 
     def _repr_html_(self):
+        max_display_count = get_option("display.max_rows")
         pdf = self.head(max_display_count + 1)._to_internal_pandas()
         pdf_length = len(pdf)
         repr_html = pdf[:max_display_count]._repr_html_()

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -33,8 +33,6 @@ from databricks.koalas.indexing import AtIndexer, ILocIndexer, LocIndexer
 from databricks.koalas.internal import _InternalFrame
 from databricks.koalas.utils import validate_arguments_and_invoke_function
 
-max_display_count = 1000
-
 
 class _Frame(object):
     """

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -27,10 +27,10 @@ from pyspark import sql as spark
 from pyspark.sql import functions as F
 
 from databricks import koalas as ks  # For running doctests and reference resolution in PyCharm.
+from databricks.koalas.config import get_option
 from databricks.koalas.exceptions import PandasNotImplementedError
 from databricks.koalas.base import IndexOpsMixin
 from databricks.koalas.frame import DataFrame
-from databricks.koalas.generic import max_display_count
 from databricks.koalas.missing.indexes import _MissingPandasLikeIndex, _MissingPandasLikeMultiIndex
 from databricks.koalas.series import Series
 
@@ -239,6 +239,7 @@ class Index(IndexOpsMixin):
         raise AttributeError("'Index' object has no attribute '{}'".format(item))
 
     def __repr__(self):
+        max_display_count = get_option("display.max_rows")
         sdf = self._kdf._sdf.select(self._scol).limit(max_display_count + 1)
         internal = self._kdf._internal.copy(
             sdf=sdf,

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -33,9 +33,10 @@ from pyspark.sql.types import BooleanType, StructType
 from pyspark.sql.window import Window
 
 from databricks import koalas as ks  # For running doctests and reference resolution in PyCharm.
+from databricks.koalas.config import get_option
 from databricks.koalas.base import IndexOpsMixin
 from databricks.koalas.frame import DataFrame
-from databricks.koalas.generic import _Frame, max_display_count
+from databricks.koalas.generic import _Frame
 from databricks.koalas.internal import IndexMap, _InternalFrame
 from databricks.koalas.missing.series import _MissingPandasLikeSeries
 from databricks.koalas.plot import KoalasSeriesPlotMethods
@@ -3025,6 +3026,7 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         return _col(self._internal.pandas_df)
 
     def __repr__(self):
+        max_display_count = get_option("display.max_rows")
         pser = self.head(max_display_count + 1)._to_internal_pandas()
         pser_length = len(pser)
         repr_string = repr(pser.iloc[:max_display_count])

--- a/databricks/koalas/tests/test_config.py
+++ b/databricks/koalas/tests/test_config.py
@@ -23,10 +23,16 @@ class ConfigTest(ReusedSQLTestCase):
 
     def setUp(self):
         config._registered_options['test.config'] = 'default'
+        config._registered_options['test.config.list'] = []
+        config._registered_options['test.config.float'] = 1.2
+        config._registered_options['test.config.int'] = 1
 
     def tearDown(self):
         ks.reset_option('test.config')
         del config._registered_options['test.config']
+        del config._registered_options['test.config.list']
+        del config._registered_options['test.config.float']
+        del config._registered_options['test.config.int']
 
     def test_get_set_reset_option(self):
         self.assertEqual(ks.get_option('test.config'), 'default')
@@ -37,12 +43,35 @@ class ConfigTest(ReusedSQLTestCase):
         ks.reset_option('test.config')
         self.assertEqual(ks.get_option('test.config'), 'default')
 
+    def test_get_set_reset_option_different_types(self):
+        ks.set_option('test.config.list', [1, 2, 3, 4])
+        self.assertEqual(ks.get_option('test.config.list'), [1, 2, 3, 4])
+
+        ks.set_option('test.config.float', 5.0)
+        self.assertEqual(ks.get_option('test.config.float'), 5.0)
+
+        ks.set_option('test.config.int', 123)
+        self.assertEqual(ks.get_option('test.config.int'), 123)
+
+    def test_different_types(self):
+        with self.assertRaisesRegex(TypeError, "The configuration value for 'test.config'"):
+            ks.set_option('test.config', 1)
+
+        with self.assertRaisesRegex(TypeError, "was <class 'NoneType'>"):
+            ks.set_option('test.config.list', None)
+
+        with self.assertRaisesRegex(TypeError, "however, <class 'float'> is expected."):
+            ks.set_option('test.config.float', 'abc')
+
+        with self.assertRaisesRegex(TypeError, "however, <class 'int'> is expected."):
+            ks.set_option('test.config.int', 'abc')
+
     def test_unknown_option(self):
-        with self.assertRaisesRegex(config.OptionError, 'No such key'):
+        with self.assertRaisesRegex(config.OptionError, 'No such option'):
             ks.get_option('unknown')
 
-        with self.assertRaisesRegex(config.OptionError, "No such key"):
+        with self.assertRaisesRegex(config.OptionError, "Available options"):
             ks.set_option('unknown', 'value')
 
-        with self.assertRaisesRegex(config.OptionError, "No such key"):
-            ks.reset_option('unknows')
+        with self.assertRaisesRegex(config.OptionError, "test.config"):
+            ks.reset_option('unknown')

--- a/databricks/koalas/tests/test_config.py
+++ b/databricks/koalas/tests/test_config.py
@@ -46,7 +46,11 @@ class ConfigTest(ReusedSQLTestCase):
     def test_get_set_reset_option_different_types(self):
         ks.set_option('test.config.list', [1, 2, 3, 4])
         self.assertEqual(ks.get_option('test.config.list'), [1, 2, 3, 4])
+        ks.set_option('test.config.list', None)
+        self.assertEqual(ks.get_option('test.config.list'), None)
 
+        ks.set_option('test.config.float', None)
+        self.assertEqual(ks.get_option('test.config.float'), None)
         ks.set_option('test.config.float', 5.0)
         self.assertEqual(ks.get_option('test.config.float'), 5.0)
 
@@ -57,8 +61,8 @@ class ConfigTest(ReusedSQLTestCase):
         with self.assertRaisesRegex(TypeError, "The configuration value for 'test.config'"):
             ks.set_option('test.config', 1)
 
-        with self.assertRaisesRegex(TypeError, "was <class 'NoneType'>"):
-            ks.set_option('test.config.list', None)
+        with self.assertRaisesRegex(TypeError, "was <class 'int'>"):
+            ks.set_option('test.config.list', 1)
 
         with self.assertRaisesRegex(TypeError, "however, <class 'float'> is expected."):
             ks.set_option('test.config.float', 'abc')

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -22,7 +22,6 @@ import pandas as pd
 import pyspark
 
 import databricks.koalas as ks
-from databricks.koalas.generic import max_display_count
 from databricks.koalas.exceptions import PandasNotImplementedError
 from databricks.koalas.missing.indexes import _MissingPandasLikeIndex, _MissingPandasLikeMultiIndex
 from databricks.koalas.testing.utils import ReusedSQLTestCase, TestUtils

--- a/databricks/koalas/tests/test_repr.py
+++ b/databricks/koalas/tests/test_repr.py
@@ -14,42 +14,51 @@
 # limitations under the License.
 #
 from databricks import koalas as ks
-from databricks.koalas.generic import max_display_count
+from databricks.koalas.config import set_option, reset_option
 from databricks.koalas.testing.utils import ReusedSQLTestCase
 
 
 class ReprTests(ReusedSQLTestCase):
+    max_display_count = 123
+
+    @classmethod
+    def setUpClass(cls):
+        set_option("display.max_rows", ReprTests.max_display_count)
+
+    @classmethod
+    def tearDownClass(cls):
+        reset_option("display.max_rows")
 
     def test_repr_dataframe(self):
-        kdf = ks.range(max_display_count)
+        kdf = ks.range(ReprTests.max_display_count)
         self.assertTrue("Showing only the first" not in repr(kdf))
         self.assert_eq(repr(kdf), repr(kdf.to_pandas()))
 
-        kdf = ks.range(max_display_count + 1)
+        kdf = ks.range(ReprTests.max_display_count + 1)
         self.assertTrue("Showing only the first" in repr(kdf))
 
     def test_repr_series(self):
-        kser = ks.range(max_display_count).id
+        kser = ks.range(ReprTests.max_display_count).id
         self.assertTrue("Showing only the first" not in repr(kser))
         self.assert_eq(repr(kser), repr(kser.to_pandas()))
 
-        kser = ks.range(max_display_count + 1).id
+        kser = ks.range(ReprTests.max_display_count + 1).id
         self.assertTrue("Showing only the first" in repr(kser))
 
     def test_repr_indexes(self):
-        kdf = ks.range(max_display_count)
+        kdf = ks.range(ReprTests.max_display_count)
         kidx = kdf.index
         self.assertTrue("Showing only the first" not in repr(kidx))
         self.assert_eq(repr(kidx), repr(kidx.to_pandas()))
 
-        kdf = ks.range(max_display_count + 1)
+        kdf = ks.range(ReprTests.max_display_count + 1)
         kidx = kdf.index
         self.assertTrue("Showing only the first" in repr(kidx))
 
     def test_html_repr(self):
-        kdf = ks.range(max_display_count)
+        kdf = ks.range(ReprTests.max_display_count)
         self.assertTrue("Showing only the first" not in kdf._repr_html_())
         self.assertEqual(kdf._repr_html_(), kdf.to_pandas()._repr_html_())
 
-        kdf = ks.range(max_display_count + 1)
+        kdf = ks.range(ReprTests.max_display_count + 1)
         self.assertTrue("Showing only the first" in kdf._repr_html_())


### PR DESCRIPTION
This PR:

1. Expose `get_option`, `set_option`, `reset_option` to koalas namespace
2. Add typed values supported by JSON ser/de
3. Convert `max_display_count` variable to `display.max_rows` option.