### PR TITLE
Add missing tests for datetime & Remove unsupported property

### DIFF
--- a/databricks/koalas/datetimes.py
+++ b/databricks/koalas/datetimes.py
@@ -106,14 +106,6 @@ class DatetimeMethods(object):
         return _wrap_accessor_spark(self, F.second, LongType()).alias(self.name)
 
     @property
-    def millisecond(self) -> 'ks.Series':
-        """
-        The milliseconds of the datetime.
-        """
-        return _wrap_accessor_pandas(
-            self, lambda x: x.dt.millisecond, LongType()).alias(self.name)
-
-    @property
     def microsecond(self) -> 'ks.Series':
         """
         The microseconds of the datetime.

--- a/databricks/koalas/tests/test_series_datetime.py
+++ b/databricks/koalas/tests/test_series_datetime.py
@@ -115,6 +115,9 @@ class SeriesDateTimeTest(ReusedSQLTestCase, SQLTestUtils):
     def test_dayofweek(self):
         self.check_func(lambda x: x.dt.dayofweek)
 
+    def test_weekday(self):
+        self.check_func(lambda x: x.dt.weekday)
+
     def test_dayofyear(self):
         self.check_func(lambda x: x.dt.dayofyear)
 

--- a/docs/source/reference/series.rst
+++ b/docs/source/reference/series.rst
@@ -218,7 +218,6 @@ Datetime Properties
    Series.dt.hour
    Series.dt.minute
    Series.dt.second
-   Series.dt.millisecond
    Series.dt.microsecond
    Series.dt.week
    Series.dt.weekofyear


### PR DESCRIPTION
Add missing test for `weekday`
![스크린샷 2019-08-31 오후 3 01 12](https://user-images.githubusercontent.com/44108233/64059916-3acb9e80-cc00-11e9-9b5a-1ac2c7b3fca1.png)

Remove unsupported property `millisecond` for Series Datetime Properties.

<img width="765" alt="스크린샷 2019-08-31 오후 2 49 55" src="https://user-images.githubusercontent.com/44108233/64059919-474ff700-cc00-11e9-8c5e-386cd7c989c5.png">
