### PR TITLE
Add missing & TODO tests for generic.py

### DIFF
--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -54,9 +54,9 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(kdf[kdf['b'] > 2], pdf[pdf['b'] > 2])
         self.assert_eq(kdf[['a', 'b']], pdf[['a', 'b']])
         self.assert_eq(kdf.a, pdf.a)
-        # TODO: assert d.b.mean().compute() == pdf.b.mean()
-        # TODO: assert np.allclose(d.b.var().compute(), pdf.b.var())
-        # TODO: assert np.allclose(d.b.std().compute(), pdf.b.std())
+        self.assert_eq(kdf.compute().b.mean(), pdf.b.mean())
+        self.assert_eq(np.allclose(kdf.compute().b.var(), pdf.b.var()), True)
+        self.assert_eq(np.allclose(kdf.compute().b.std(), pdf.b.std()), True)
 
         assert repr(kdf)
 
@@ -1542,3 +1542,15 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         with self.assertRaisesRegex(TypeError, "mutually exclusive"):
             kdf.filter(regex='b.*', like="aaa")
+
+    def test_pipe(self):
+        kdf = ks.DataFrame({'category': ['A', 'A', 'B'],
+                            'col1': [1, 2, 3],
+                            'col2': [4, 5, 6]},
+                           columns=['category', 'col1', 'col2'])
+
+        self.assertRaisesRegex(
+            ValueError,
+            "arg is both the pipe target and a keyword argument",
+            lambda: kdf.pipe((lambda x: x, 'arg'), arg='1')
+        )

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -60,6 +60,8 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         self.assertRaises(ValueError, lambda: kdf.groupby('a', as_index=False)['a'])
         self.assertRaises(ValueError, lambda: kdf.groupby('a', as_index=False)[['a']])
         self.assertRaises(ValueError, lambda: kdf.groupby('a', as_index=False)[['a', 'c']])
+        self.assertRaises(ValueError, lambda: kdf.groupby(0, as_index=False)[['a', 'c']])
+        self.assertRaises(ValueError, lambda: kdf.groupby([0], as_index=False)[['a', 'c']])
 
         self.assertRaises(TypeError, lambda: kdf.a.groupby(kdf.b, as_index=False))
 


### PR DESCRIPTION
Found some missing & TODO tests in generic.py

<img width="855" alt="스크린샷 2019-08-31 오후 6 41 14" src="https://user-images.githubusercontent.com/44108233/64062260-598d5d80-cc1f-11e9-9102-0a4bb9ca288d.png">

<img width="858" alt="스크린샷 2019-08-31 오후 6 40 33" src="https://user-images.githubusercontent.com/44108233/64062262-5befb780-cc1f-11e9-9d9b-909fdc136e75.png">

<img width="848" alt="스크린샷 2019-08-31 오후 6 41 54" src="https://user-images.githubusercontent.com/44108233/64062264-5c884e00-cc1f-11e9-848b-338630e01ce7.png">

<img width="963" alt="스크린샷 2019-08-31 오후 6 42 04" src="https://user-images.githubusercontent.com/44108233/64062266-5db97b00-cc1f-11e9-9849-39fae26e34bf.png">

![스크린샷 2019-08-31 오후 6 45 42](https://user-images.githubusercontent.com/44108233/64062287-8e011980-cc1f-11e9-8245-eea827052aa3.png)

Could someone check this changes If available?

Have a good weekend, Thanks.
