### PR TITLE
GroupBy.apply should return Koalas DataFrame instead of pandas DataFrame

### DIFF
--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -1515,7 +1515,7 @@ class GroupBy(object):
             kdf = DataFrame(pdf)
             return_schema = kdf._sdf.schema
             if len(pdf) <= limit:
-                return pdf
+                return kdf
 
             sdf = self._spark_group_map_apply(
                 pandas_transform, return_schema, retain_index=True)


### PR DESCRIPTION
It should return Koalas DataFrame always. it was a mistake. Seems this is the only one to fix.