### PR TITLE
Add some missing exception tests for base.py

### DIFF
--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -385,6 +385,9 @@ class IndexOpsMixin(object):
 
         >>> ser.rename("a").to_frame().set_index("a").index.astype('int64')
         Int64Index([1, 2], dtype='int64', name='a')
+
+        >>> ser.astype('int63')
+        ValueError: Type int63 not understood
         """
         from databricks.koalas.typedef import as_spark_type
         spark_type = as_spark_type(dtype)
@@ -560,6 +563,9 @@ class IndexOpsMixin(object):
         >>> df = ks.Series([True, False, None]).rename("a").to_frame()
         >>> df.set_index("a").index.all()
         False
+
+        >>> df.all(axis=1)
+        ValueError: axis should be either 0 or "index" currently.
         """
 
         if axis not in [0, 'index']:
@@ -623,6 +629,9 @@ class IndexOpsMixin(object):
         >>> df = ks.Series([True, False, None]).rename("a").to_frame()
         >>> df.set_index("a").index.any()
         True
+
+        >>> df.any(axis=1)
+        ValueError: axis should be either 0 or "index" currently.
         """
 
         if axis not in [0, 'index']:

--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -385,9 +385,6 @@ class IndexOpsMixin(object):
 
         >>> ser.rename("a").to_frame().set_index("a").index.astype('int64')
         Int64Index([1, 2], dtype='int64', name='a')
-
-        >>> ser.astype('int63')
-        ValueError: Type int63 not understood
         """
         from databricks.koalas.typedef import as_spark_type
         spark_type = as_spark_type(dtype)
@@ -563,9 +560,6 @@ class IndexOpsMixin(object):
         >>> df = ks.Series([True, False, None]).rename("a").to_frame()
         >>> df.set_index("a").index.all()
         False
-
-        >>> df.all(axis=1)
-        ValueError: axis should be either 0 or "index" currently.
         """
 
         if axis not in [0, 'index']:
@@ -629,9 +623,6 @@ class IndexOpsMixin(object):
         >>> df = ks.Series([True, False, None]).rename("a").to_frame()
         >>> df.set_index("a").index.any()
         True
-
-        >>> df.any(axis=1)
-        ValueError: axis should be either 0 or "index" currently.
         """
 
         if axis not in [0, 'index']:

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -1373,6 +1373,9 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         self.assert_eq(kdf.all(), pdf.all())
 
+        with self.assertRaisesRegex(ValueError, 'axis should be either 0 or "index" currently.'):
+            kdf.all(axis=1)
+
     def test_any(self):
         pdf = pd.DataFrame({
             'col1': [False, False, False],
@@ -1397,6 +1400,9 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         kdf.columns = columns
 
         self.assert_eq(kdf.any(), pdf.any())
+
+        with self.assertRaisesRegex(ValueError, 'axis should be either 0 or "index" currently.'):
+            kdf.any(axis=1)
 
     def test_rank(self):
         pdf = pd.DataFrame(data={'col1': [1, 2, 3, 1], 'col2': [3, 4, 3, 1]},

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -621,3 +621,9 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
                              repr(pser.shift(periods=2, fill_value=0)))
         with self.assertRaisesRegex(ValueError, 'periods should be an int; however'):
             kser.shift(periods=1.5)
+
+    def test_astype(self):
+        pser = pd.Series([10, 20, 15, 30, 45], name='x')
+        kser = koalas.Series(pser)
+        with self.assertRaisesRegex(ValueError, 'Type int63 not understood'):
+            kser.astype('int63')

--- a/databricks/koalas/tests/test_series_datetime.py
+++ b/databricks/koalas/tests/test_series_datetime.py
@@ -57,6 +57,13 @@ class SeriesDateTimeTest(ReusedSQLTestCase, SQLTestUtils):
 
         self.assertEqual(list(kdf['diff_seconds'].toPandas()), [35545499, 33644699, 31571099])
 
+        kdf = ks.from_pandas(pd.DataFrame({
+                                          'a': pd.date_range('2016-12-31', '2017-01-08', freq='D'),
+                                          'b': pd.Series(range(9))}))
+        expected_error_message = 'datetime subtraction can only be applied to datetime series.'
+        with self.assertRaisesRegex(TypeError, expected_error_message):
+            kdf['a'] - kdf['b']
+
     @unittest.skip(
         "It fails in certain OSs presumably due to different "
         "timezone behaviours inherited from C library.")


### PR DESCRIPTION
Found some missing exception tests in base.py

<img width="1079" alt="스크린샷 2019-09-02 오후 2 40 33" src="https://user-images.githubusercontent.com/44108233/64093547-c6296900-cd93-11e9-8b30-a96d5f459af1.png">
<img width="791" alt="스크린샷 2019-09-02 오후 2 41 22" src="https://user-images.githubusercontent.com/44108233/64093561-c9245980-cd93-11e9-9f0d-84eecdcb6f12.png">
<img width="887" alt="스크린샷 2019-09-02 오후 2 42 41" src="https://user-images.githubusercontent.com/44108233/64093566-cc1f4a00-cd93-11e9-9eea-a5b7ce623bf7.png">
<img width="888" alt="스크린샷 2019-09-02 오후 2 42 57" src="https://user-images.githubusercontent.com/44108233/64093569-cd507700-cd93-11e9-83b9-783f2618526d.png">

i added them some for doctest,

one for pytest 

(but this test is currently being skipped for some reason 

![스크린샷 2019-09-02 오후 3 14 26](https://user-images.githubusercontent.com/44108233/64093699-5d8ebc00-cd94-11e9-8585-2b1065720406.png)

so maybe does not directly affect coverage.)

could someone check this when if available.

Thanks.