### PR TITLE
Fix rpow and rfloordiv to use proper operators in Series

### DIFF
--- a/databricks/koalas/missing/series.py
+++ b/databricks/koalas/missing/series.py
@@ -87,6 +87,7 @@ class _MissingPandasLikeSeries(object):
     last_valid_index = unsupported_function('last_valid_index')
     mad = unsupported_function('mad')
     mask = unsupported_function('mask')
+    made = unsupported_function('made')
     pct_change = unsupported_function('pct_change')
     pop = unsupported_function('pop')
     prod = unsupported_function('prod')

--- a/databricks/koalas/missing/series.py
+++ b/databricks/koalas/missing/series.py
@@ -87,7 +87,7 @@ class _MissingPandasLikeSeries(object):
     last_valid_index = unsupported_function('last_valid_index')
     mad = unsupported_function('mad')
     mask = unsupported_function('mask')
-    made = unsupported_function('made')
+    mode = unsupported_function('mode')
     pct_change = unsupported_function('pct_change')
     pop = unsupported_function('pop')
     prod = unsupported_function('prod')

--- a/databricks/koalas/missing/series.py
+++ b/databricks/koalas/missing/series.py
@@ -87,7 +87,6 @@ class _MissingPandasLikeSeries(object):
     last_valid_index = unsupported_function('last_valid_index')
     mad = unsupported_function('mad')
     mask = unsupported_function('mask')
-    mode = unsupported_function('mode')
     pct_change = unsupported_function('pct_change')
     pop = unsupported_function('pop')
     prod = unsupported_function('prod')

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -204,11 +204,11 @@ d     NaN
 Name: a, dtype: float64
 
 >>> df.a.rpow(df.b)
-a    4.0
-b    NaN
-c   16.0
-d    NaN
-Name: a, dtype: float64
+a     4.0
+b     NaN
+c    16.0
+d     NaN
+Name: b, dtype: float64
 """
 
 _mod_example_SERIES = """

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -204,9 +204,9 @@ d     NaN
 Name: a, dtype: float64
 
 >>> df.a.rpow(df.b)
-a    0.0
+a    4.0
 b    NaN
-c   -2.0
+c   16.0
 d    NaN
 Name: a, dtype: float64
 """
@@ -260,9 +260,9 @@ d    NaN
 Name: a, dtype: float64
 
 >>> df.a.rfloordiv(df.b)
-a    0.0
+a    1.0
 b    NaN
-c   -2.0
+c    0.0
 d    NaN
 Name: a, dtype: float64
 """

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -208,7 +208,7 @@ a     4.0
 b     NaN
 c    16.0
 d     NaN
-Name: b, dtype: float64
+Name: a, dtype: float64
 """
 
 _mod_example_SERIES = """

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -465,6 +465,8 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
     def mod(self, other):
         return (self % other).rename(self.name)
 
+    mode = mod
+
     mod.__doc__ = _flex_doc_SERIES.format(
         desc='Modulo',
         op_name='%',
@@ -493,7 +495,7 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         series_examples=_pow_example_SERIES)
 
     def rpow(self, other):
-        return (other - self).rename(self.name)
+        return (other ** self).rename(self.name)
 
     rpow.__doc__ = _flex_doc_SERIES.format(
         desc='Reverse Exponential power',
@@ -513,7 +515,7 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         series_examples=_floordiv_example_SERIES)
 
     def rfloordiv(self, other):
-        return (other - self).rename(self.name)
+        return (other // self).rename(self.name)
 
     rfloordiv.__doc__ = _flex_doc_SERIES.format(
         desc='Reverse Integer division',

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -465,8 +465,6 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
     def mod(self, other):
         return (self % other).rename(self.name)
 
-    mode = mod
-
     mod.__doc__ = _flex_doc_SERIES.format(
         desc='Modulo',
         op_name='%',


### PR DESCRIPTION
While checking the series.py file,

there was an incorrectly implemented operator.

(I think maybe someone forgot to change the code in the process of copy & paste by mistake)

<img width="400" alt="스크린샷 2019-09-02 오후 3 18 56" src="https://user-images.githubusercontent.com/44108233/64093916-ffaea400-cd94-11e9-892c-ff2d4398f4d3.png">

could someone check this changes if available.

Thanks :)