### PR TITLE
BUG: Allow default config option to be None

### DIFF
--- a/databricks/koalas/config.py
+++ b/databricks/koalas/config.py
@@ -57,7 +57,7 @@ _registered_options = {
 
 # dict to store the allowed type for options which default is set to None.
 _registered_options_default_none = {
-    'plotting.sample_ratio': (float, int)
+    'plotting.sample_ratio': float
 }
 
 _key_format = 'koalas.{}'.format

--- a/databricks/koalas/config.py
+++ b/databricks/koalas/config.py
@@ -20,6 +20,7 @@ Infrastructure of configuration for Koalas.
 import json
 from typing import Dict, Union, Any
 
+import numpy as np
 from pyspark._globals import _NoValue, _NoValueType
 
 from databricks.koalas.utils import default_session
@@ -55,6 +56,10 @@ _registered_options = {
     "compute.default_index_type": "sequence",
 }  # type: Dict[str, Any]
 
+# dict to store the allowed type for options which default is set to None.
+_registered_options_default_none = {
+    'plotting.sample_ratio': (float, int)
+}
 
 _key_format = 'koalas.{}'.format
 
@@ -134,6 +139,11 @@ def _check_option(key: str, value: Union[str, _NoValueType] = _NoValue) -> None:
 
     if value is None:
         return  # None is allowed for all types.
-    if value is not _NoValue and not isinstance(value, type(_registered_options[key])):
+
+    # assign allowed option type given it is in _registered_options_default_none or not
+    option_type = type(_registered_options[key])
+    if key in _registered_options_default_none:
+        option_type = _registered_options_default_none[key]
+    if value is not _NoValue and not isinstance(value, option_type):
         raise TypeError("The configuration value for '%s' was %s; however, %s is expected." % (
-            key, type(value), type(_registered_options[key])))
+            key, type(value), option_type))

--- a/databricks/koalas/config.py
+++ b/databricks/koalas/config.py
@@ -20,7 +20,6 @@ Infrastructure of configuration for Koalas.
 import json
 from typing import Dict, Union, Any
 
-import numpy as np
 from pyspark._globals import _NoValue, _NoValueType
 
 from databricks.koalas.utils import default_session

--- a/databricks/koalas/tests/test_config.py
+++ b/databricks/koalas/tests/test_config.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import numpy as np
 
 from databricks import koalas as ks
 from databricks.koalas import config

--- a/databricks/koalas/tests/test_config.py
+++ b/databricks/koalas/tests/test_config.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import numpy as np
 
 from databricks import koalas as ks
 from databricks.koalas import config
@@ -26,6 +27,8 @@ class ConfigTest(ReusedSQLTestCase):
         config._registered_options['test.config.list'] = []
         config._registered_options['test.config.float'] = 1.2
         config._registered_options['test.config.int'] = 1
+        config._registered_options['test.config.none'] = None
+        config._registered_options_default_none['test.config.none'] = int
 
     def tearDown(self):
         ks.reset_option('test.config')
@@ -33,6 +36,8 @@ class ConfigTest(ReusedSQLTestCase):
         del config._registered_options['test.config.list']
         del config._registered_options['test.config.float']
         del config._registered_options['test.config.int']
+        del config._registered_options['test.config.none']
+        del config._registered_options_default_none['test.config.none']
 
     def test_get_set_reset_option(self):
         self.assertEqual(ks.get_option('test.config'), 'default')
@@ -56,6 +61,9 @@ class ConfigTest(ReusedSQLTestCase):
 
         ks.set_option('test.config.int', 123)
         self.assertEqual(ks.get_option('test.config.int'), 123)
+
+        ks.set_option('test.config.none', 5)
+        self.assertEqual(ks.get_option('test.config.none'), 5)
 
     def test_different_types(self):
         with self.assertRaisesRegex(TypeError, "The configuration value for 'test.config'"):


### PR DESCRIPTION
In current setup, when using `set_option`, it will first check if the given value has the same type of default value. In this way, if the default is set to `None` which will result in `NoneType` in the type checking and thus fail to use `set_option`.

And because of this, the PR #737 will fail, if this PR is merged, the #737 will be changed to adopt this.