### PR TITLE
Add 'Option` class to support type check and value check in options

### DIFF
--- a/databricks/koalas/config.py
+++ b/databricks/koalas/config.py
@@ -15,10 +15,10 @@
 #
 
 """
-Infrastructure of configuration for Koalas.
+Infrastructure of options for Koalas.
 """
 import json
-from typing import Dict, Union, Any
+from typing import Union, Any, Tuple, Callable, List
 
 from pyspark._globals import _NoValue, _NoValueType
 
@@ -28,42 +28,166 @@ from databricks.koalas.utils import default_session
 __all__ = ['get_option', 'set_option', 'reset_option']
 
 
-# dict to store registered options and their default values (key -> default).
-_registered_options = {
-    # This sets the maximum number of rows koalas should output when printing out various output.
-    # For example, this value determines whether the repr() for a dataframe prints out fully or
-    # just a truncated repr.
-    "display.max_rows": 1000,  # TODO: None should support unlimited.
+class Option:
+    """
+    Option class that defines an option with related properties.
 
-    # 'compute.shortcut_limit' sets the limit for a shortcut.
-    # It computes specified number of rows and use its schema.
-    # When the dataframe length is larger than this limit, Koalas uses PySpark to compute.
-    "compute.shortcut_limit": 1000,  # TODO: None should support unlimited.
+    This class holds all information relevant to the one option. Also,
+    Its instance can validate if the given value is acceptable or not.
 
-    # `plotting.max_rows` sets the visual limit on TopN plots. If it is set to 1000, the first 1000
-    # data points will be used for plotting, and this number will be seen on the right up corner.
-    "plotting.max_rows": 1000,
+    It is currently for internal usage only.
 
-    # `plotting.sample_ratio` sets the proportion of data that will be plotted for SampledPlot like
-    # plts. The default is None, will will basically take roughly 1000 data points.
-    "plotting.sample_ratio": None,
+    Parameters
+    ----------
+    key: str, keyword-only argument
+        the option name to use.
+    doc: str, keyword-only argument
+        the documentation for the current option.
+    default: Any, keyword-only argument
+        default value for this option.
+    types: Union[Tuple[type, ...], type], keyword-only argument
+        default is str. It defines the expected types for this option. It is
+        used with `isinstance` to validate the given value to this option.
+    check_func: Tuple[Callable[[Any], bool], str], keyword-only argument
+        default is a function that always returns `True` with a empty string.
+        It defines:
+          - a function to check the given value to this option
+          - the error message to show when this check is failed
+        When new value is set to this option, this function is called to check
+        if the given value is valid.
 
-    # 'compute.max_rows sets the limit of the current DataFrame. Set `None` to unlimit
-    # the input length. When the limit is set, it is executed by the shortcut by collecting
-    # the data into driver side, and then using pandas API. If the limit is unset,
-    # the operation is executed by PySpark. Default is 1000.
-    "compute.max_rows": 1000,  # TODO: None should support unlimited.
+    Examples
+    --------
+    >>> option = Option(
+    ...     key='option.name',
+    ...     doc="this is a test option",
+    ...     default="default",
+    ...     types=(float, int),
+    ...     check_func=(lambda v: v > 0, "should be a positive float"))
 
-    # This determines whether or not to operate between two different dataframs.
-    # For example, 'combine_frames' function internally performs a join operation which can be
-    # expensive in general.
-    # So, if `compute.ops_on_diff_frames` variable is not True, that method throws an exception.
-    "compute.ops_on_diff_frames": False,
+    >>> option.validate('abc')  # doctest: +NORMALIZE_WHITESPACE
+    Traceback (most recent call last):
+      ...
+    ValueError: The value for option 'option.name' was <class 'str'>;
+    however, expected types are [(<class 'float'>, <class 'int'>)].
 
-    # This sets the default index type: sequence, distributed and distributed-sequence.
-    "compute.default_index_type": "sequence",
-}  # type: Dict[str, Any]
+    >>> option.validate(-1.1)
+    Traceback (most recent call last):
+      ...
+    ValueError: should be a positive float
 
+    >>> option.validate(1.1)
+    """
+
+    def __init__(
+            self,
+            *,
+            key: str,
+            doc: str,
+            default: Any,
+            types: Union[Tuple[type, ...], type] = str,
+            check_func: Tuple[Callable[[Any], bool], str] = (lambda v: True, "")):
+        self.key = key
+        self.doc = doc
+        self.default = default
+        self.types = types
+        self.check_func = check_func
+
+    def validate(self, v: Any) -> None:
+        """
+        Validate the given value and throw an exception with related information such as key.
+        """
+        if not isinstance(v, self.types):
+            raise ValueError("The value for option '%s' was %s; however, expected types are "
+                             "[%s]." % (self.key, type(v), str(self.types)))
+        if not self.check_func[0](v):
+            raise ValueError(self.check_func[1])
+
+
+# Available options.
+_options = [
+    # TODO: None should support unlimited.
+    Option(
+        key='display.max_rows',
+        doc=(
+            "This sets the maximum number of rows koalas should output when printing out "
+            "various output. For example, this value determines whether the repr() for a "
+            "dataframe prints out fully or just a truncated repr."),
+        default=1000,
+        types=int,
+        check_func=(lambda v: v >= 0, "'display.max_rows' should be greater than or equal to 0.")),
+
+    Option(
+        key='compute.max_rows',
+        doc=(
+            "'compute.max_rows sets the limit of the current DataFrame. Set `None` to unlimit "
+            "the input length. When the limit is set, it is executed by the shortcut by "
+            "collecting the data into driver side, and then using pandas API. If the limit is "
+            "unset, the operation is executed by PySpark. Default is 1000."),
+        default=1000,
+        types=(int, type(None)),
+        check_func=(
+            lambda v: v is None or v >= 0,
+            "'compute.max_rows' should be greater than or equal to 0.")),
+
+    # TODO: None should support unlimited.
+    Option(
+        key='compute.shortcut_limit',
+        doc=(
+            "'compute.shortcut_limit' sets the limit for a shortcut."
+            "It computes specified number of rows and use its schema. When the dataframe "
+            "length is larger than this limit, Koalas uses PySpark to compute."),
+        default=1000,
+        types=int,
+        check_func=(
+            lambda v: v >= 0, "'compute.shortcut_limit' should be greater than or equal to 0.")),
+
+    Option(
+        key='compute.ops_on_diff_frames',
+        doc=(
+            "This determines whether or not to operate between two different dataframes. "
+            "For example, 'combine_frames' function internally performs a join operation which "
+            "can be expensive in general. So, if `compute.ops_on_diff_frames` variable is not "
+            "True, that method throws an exception."),
+        default=False,
+        types=bool),
+
+    Option(
+        key='compute.default_index_type',
+        doc=(
+            "This sets the default index type: sequence, distributed and distributed-sequence."),
+        default='sequence',
+        types=str,
+        check_func=(
+            lambda v: v in ('sequence', 'distributed', 'distributed-sequence'),
+            "Index type should be one of 'sequence', 'distributed', 'distributed-sequence'.")),
+
+    Option(
+        key='plotting.max_rows',
+        doc=(
+            "'plotting.max_rows' sets the visual limit on top-n-based plots such as `plot.bar` "
+            "and `plot.pie`. If it is set to 1000, the first 1000 data points will be used "
+            "for plotting. Default is 1000."),
+        default=1000,
+        types=int,
+        check_func=(
+            lambda v: v is v >= 0,
+            "'plotting.max_rows' should be greater than or equal to 0.")),
+
+    Option(
+        key='plotting.sample_ratio',
+        doc=(
+            "'plotting.sample_ratio' sets the proportion of data that will be plotted for sample-"
+            "based plots such as `plot.line` and `plot.area`. "
+            "This option defaults to 'plotting.max_rows' option."),
+        default=None,
+        types=(float, type(None)),
+        check_func=(
+            lambda v: v is None or 1 >= v >= 0,
+            "'plotting.sample_ratio' should be 1 >= value >= 0.")),
+]  # type: List[Option]
+
+_options_dict = dict(zip((option.key for option in _options), _options))
 
 _key_format = 'koalas.{}'.format
 
@@ -72,7 +196,7 @@ class OptionError(AttributeError, KeyError):
     pass
 
 
-def get_option(key: str, default: Union[str, _NoValueType] = _NoValue) -> Any:
+def get_option(key: str, default: Union[Any, _NoValueType] = _NoValue) -> Any:
     """
     Retrieves the value of the specified option.
 
@@ -91,9 +215,11 @@ def get_option(key: str, default: Union[str, _NoValueType] = _NoValue) -> Any:
     ------
     OptionError : if no such option exists and the default is not provided
     """
-    _check_option(key, default)
+    _check_option(key)
     if default is _NoValue:
-        default = _registered_options[key]
+        default = _options_dict[key].default
+    _options_dict[key].validate(default)
+
     return json.loads(default_session().conf.get(_key_format(key), default=json.dumps(default)))
 
 
@@ -112,7 +238,9 @@ def set_option(key: str, value: Any) -> None:
     -------
     None
     """
-    _check_option(key, value)
+    _check_option(key)
+    _options_dict[key].validate(value)
+
     default_session().conf.set(_key_format(key), json.dumps(value))
 
 
@@ -135,20 +263,8 @@ def reset_option(key: str) -> None:
     default_session().conf.unset(_key_format(key))
 
 
-def _check_option(key: str, value: Union[str, _NoValueType] = _NoValue) -> None:
-    if key not in _registered_options:
+def _check_option(key: str) -> None:
+    if key not in _options_dict:
         raise OptionError(
             "No such option: '{}'. Available options are [{}]".format(
-                key, ", ".join(list(_registered_options.keys()))))
-
-    if value is None:
-        return  # None is allowed for all types.
-
-    # this might need to be changed in the future, if default is None, then the current key type
-    # check will raise an error, I could open a new PR to fix this.
-    if value is not _NoValue and key == "plotting.sample_ratio":
-        return
-
-    if value is not _NoValue and not isinstance(value, type(_registered_options[key])):
-        raise TypeError("The configuration value for '%s' was %s; however, %s is expected." % (
-            key, type(value), type(_registered_options[key])))
+                key, ", ".join(list(_options_dict.keys()))))

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -1650,7 +1650,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         if should_infer_schema:
             # Here we execute with the first 1000 to get the return type.
             # If the records were less than 1000, it uses pandas API directly for a shortcut.
-            limit = 1000
+            limit = get_option("compute.shortcut_limit")
             pdf = self.head(limit + 1)._to_internal_pandas()
             transformed = pdf.transform(func)
             kdf = DataFrame(transformed)

--- a/databricks/koalas/plot.py
+++ b/databricks/koalas/plot.py
@@ -82,25 +82,13 @@ class TopNPlot:
 
 
 class SampledPlot:
-
-    @staticmethod
-    def _get_fraction(data):
-        sample_ratio = get_option("plotting.sample_ratio")
-
-        # if sample_ratio is default None, make sure the records are roughly 1000.
-        if sample_ratio is None:
-            fraction = 1 / (len(data) / 1000)
-        else:
-            fraction = sample_ratio
-
-        # check if fraction is larger than 1, and ceil it to 1 if so
-        if fraction > 1:
-            fraction = 1.0
-        return fraction
-
     def get_sampled(self, data):
         from databricks.koalas import DataFrame, Series
-        self.fraction = self._get_fraction(data)
+        fraction = get_option("plotting.sample_ratio")
+        if fraction is None:
+            fraction = 1 / (len(data) / get_option("plotting.max_rows"))
+            fraction = min(1., fraction)
+        self.fraction = fraction
 
         if isinstance(data, DataFrame):
             sampled = data._sdf.sample(fraction=self.fraction)

--- a/databricks/koalas/tests/test_config.py
+++ b/databricks/koalas/tests/test_config.py
@@ -16,23 +16,33 @@
 
 from databricks import koalas as ks
 from databricks.koalas import config
+from databricks.koalas.config import Option
 from databricks.koalas.testing.utils import ReusedSQLTestCase
 
 
 class ConfigTest(ReusedSQLTestCase):
 
     def setUp(self):
-        config._registered_options['test.config'] = 'default'
-        config._registered_options['test.config.list'] = []
-        config._registered_options['test.config.float'] = 1.2
-        config._registered_options['test.config.int'] = 1
+        config._options_dict['test.config'] = Option(key='test.config', doc="", default="default")
+
+        config._options_dict['test.config.list'] = Option(
+            key='test.config.list', doc="", default=[], types=list)
+        config._options_dict['test.config.float'] = Option(
+            key='test.config.float', doc="", default=1.2, types=float)
+
+        config._options_dict['test.config.int'] = Option(
+            key='test.config.int', doc="", default=1,
+            types=int, check_func=(lambda v: v > 0, "bigger then 0"))
+        config._options_dict['test.config.int.none'] = Option(
+            key='test.config.int', doc="", default=None, types=(int, type(None)))
 
     def tearDown(self):
         ks.reset_option('test.config')
-        del config._registered_options['test.config']
-        del config._registered_options['test.config.list']
-        del config._registered_options['test.config.float']
-        del config._registered_options['test.config.int']
+        del config._options_dict['test.config']
+        del config._options_dict['test.config.list']
+        del config._options_dict['test.config.float']
+        del config._options_dict['test.config.int']
+        del config._options_dict['test.config.int.none']
 
     def test_get_set_reset_option(self):
         self.assertEqual(ks.get_option('test.config'), 'default')
@@ -46,29 +56,35 @@ class ConfigTest(ReusedSQLTestCase):
     def test_get_set_reset_option_different_types(self):
         ks.set_option('test.config.list', [1, 2, 3, 4])
         self.assertEqual(ks.get_option('test.config.list'), [1, 2, 3, 4])
-        ks.set_option('test.config.list', None)
-        self.assertEqual(ks.get_option('test.config.list'), None)
 
-        ks.set_option('test.config.float', None)
-        self.assertEqual(ks.get_option('test.config.float'), None)
         ks.set_option('test.config.float', 5.0)
         self.assertEqual(ks.get_option('test.config.float'), 5.0)
 
         ks.set_option('test.config.int', 123)
         self.assertEqual(ks.get_option('test.config.int'), 123)
 
-    def test_different_types(self):
-        with self.assertRaisesRegex(TypeError, "The configuration value for 'test.config'"):
-            ks.set_option('test.config', 1)
+        self.assertEqual(ks.get_option('test.config.int.none'), None)  # default None
+        ks.set_option('test.config.int.none', 123)
+        self.assertEqual(ks.get_option('test.config.int.none'), 123)
+        ks.set_option('test.config.int.none', None)
+        self.assertEqual(ks.get_option('test.config.int.none'), None)
 
-        with self.assertRaisesRegex(TypeError, "was <class 'int'>"):
+    def test_different_types(self):
+        with self.assertRaisesRegex(ValueError, "was <class 'int'>"):
             ks.set_option('test.config.list', 1)
 
-        with self.assertRaisesRegex(TypeError, "however, <class 'float'> is expected."):
+        with self.assertRaisesRegex(ValueError, "however, expected types are"):
             ks.set_option('test.config.float', 'abc')
 
-        with self.assertRaisesRegex(TypeError, "however, <class 'int'> is expected."):
+        with self.assertRaisesRegex(ValueError, "[<class 'int'>]"):
             ks.set_option('test.config.int', 'abc')
+
+        with self.assertRaisesRegex(ValueError, "(<class 'int'>, <class 'NoneType'>)"):
+            ks.set_option('test.config.int.none', 'abc')
+
+    def test_check_func(self):
+        with self.assertRaisesRegex(ValueError, "bigger then 0"):
+            ks.set_option('test.config.int', -1)
 
     def test_unknown_option(self):
         with self.assertRaisesRegex(config.OptionError, 'No such option'):

--- a/databricks/koalas/tests/test_frame_plot.py
+++ b/databricks/koalas/tests/test_frame_plot.py
@@ -225,12 +225,19 @@ class DataFramePlotTest(ReusedSQLTestCase, TestUtils):
         data = TopNPlot().get_top_n(kdf)
         self.assertEqual(len(data), 2000)
 
-    def test_sampled_plot(self):
+    def test_sampled_plot_with_ratio(self):
         set_option('plotting.sample_ratio', 0.5)
-        pdf = pd.DataFrame(np.random.rand(2500, 4), columns=['a', 'b', 'c', 'd'])
-        kdf = koalas.from_pandas(pdf)
+        try:
+            pdf = pd.DataFrame(np.random.rand(2500, 4), columns=['a', 'b', 'c', 'd'])
+            kdf = koalas.from_pandas(pdf)
+            data = SampledPlot().get_sampled(kdf)
+            self.assertEqual(round(len(data) / 2500, 1), 0.5)
+        finally:
+            reset_option('plotting.sample_ratio')
 
-        # this might be a potential bug in sample function in koalas, each time, with same fraction
-        # different length is obtained by running get_sampled().
+    def test_sampled_plot_with_max_rows(self):
+        # 'plotting.max_rows' is 2000
+        pdf = pd.DataFrame(np.random.rand(2000, 4), columns=['a', 'b', 'c', 'd'])
+        kdf = koalas.from_pandas(pdf)
         data = SampledPlot().get_sampled(kdf)
-        self.assertEqual(round(len(data) / 2500, 1), 0.5)
+        self.assertEqual(round(len(data) / 2000, 1), 1)

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -347,24 +347,22 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
                        repr(pdf.groupby("A")['B'].bfill()))
 
     def test_apply(self):
+        pdf = pd.DataFrame({'a': [1, 2, 3, 4, 5, 6],
+                            'b': [1, 1, 2, 3, 5, 8],
+                            'c': [1, 4, 9, 16, 25, 36]}, columns=['a', 'b', 'c'])
+        kdf = koalas.DataFrame(pdf)
+        self.assert_eq(kdf.groupby("b").apply(lambda x: x + 1).sort_index(),
+                       pdf.groupby("b").apply(lambda x: x + 1).sort_index())
+        self.assert_eq(kdf.groupby(['a', 'b']).apply(lambda x: x * x).sort_index(),
+                       pdf.groupby(['a', 'b']).apply(lambda x: x * x).sort_index())
+        self.assert_eq(kdf.groupby(['b'])['a'].apply(lambda x: x).sort_index(),
+                       pdf.groupby(['b'])['a'].apply(lambda x: x).sort_index())
+
         # Less than 'compute.shortcut_limit' will execute a shortcut
         # by using collected pandas dataframe directly.
         # now we set the 'compute.shortcut_limit' as 1000 explicitly
         set_option('compute.shortcut_limit', 1000)
-
         try:
-            pdf = pd.DataFrame({'a': [1, 2, 3, 4, 5, 6],
-                                'b': [1, 1, 2, 3, 5, 8],
-                                'c': [1, 4, 9, 16, 25, 36]}, columns=['a', 'b', 'c'])
-            kdf = koalas.DataFrame(pdf)
-            self.assert_eq(kdf.groupby("b").apply(lambda x: x + 1).sort_index(),
-                           pdf.groupby("b").apply(lambda x: x + 1).sort_index())
-            self.assert_eq(kdf.groupby(['a', 'b']).apply(lambda x: x * x).sort_index(),
-                           pdf.groupby(['a', 'b']).apply(lambda x: x * x).sort_index())
-            self.assert_eq(kdf.groupby(['b'])['a'].apply(lambda x: x).sort_index(),
-                           pdf.groupby(['b'])['a'].apply(lambda x: x).sort_index())
-
-            # Data is intentionally big to test when schema inference is on.
             pdf = pd.DataFrame({'a': [1, 2, 3, 4, 5, 6] * 300,
                                 'b': [1, 1, 2, 3, 5, 8] * 300,
                                 'c': [1, 4, 9, 16, 25, 36] * 300}, columns=['a', 'b', 'c'])
@@ -381,19 +379,18 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             reset_option('compute.shortcut_limit')
 
     def test_apply_with_new_dataframe(self):
+        pdf = pd.DataFrame({
+            "timestamp": [0.0, 0.5, 1.0, 0.0, 0.5],
+            "car_id": ['A', 'A', 'A', 'B', 'B']
+        })
+        kdf = koalas.DataFrame(pdf)
+
+        self.assert_eq(
+            kdf.groupby('car_id').apply(lambda _: pd.DataFrame({"column": [0.0]})).sort_index(),
+            pdf.groupby('car_id').apply(lambda _: pd.DataFrame({"column": [0.0]})).sort_index())
+
         set_option('compute.shortcut_limit', 1000)
-
         try:
-            pdf = pd.DataFrame({
-                "timestamp": [0.0, 0.5, 1.0, 0.0, 0.5],
-                "car_id": ['A', 'A', 'A', 'B', 'B']
-            })
-            kdf = koalas.DataFrame(pdf)
-
-            self.assert_eq(
-                kdf.groupby('car_id').apply(lambda _: pd.DataFrame({"column": [0.0]})).sort_index(),
-                pdf.groupby('car_id').apply(lambda _: pd.DataFrame({"column": [0.0]})).sort_index())
-
             # 1000+ records will only infer the schema.
             pdf = pd.DataFrame({
                 "timestamp": [0.0, 0.5, 1.0, 0.0, 0.5] * 300,
@@ -408,21 +405,19 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             reset_option('compute.shortcut_limit')
 
     def test_transform(self):
+        pdf = pd.DataFrame({'a': [1, 2, 3, 4, 5, 6],
+                            'b': [1, 1, 2, 3, 5, 8],
+                            'c': [1, 4, 9, 16, 25, 36]}, columns=['a', 'b', 'c'])
+        kdf = koalas.DataFrame(pdf)
+        self.assert_eq(kdf.groupby("b").transform(lambda x: x + 1).sort_index(),
+                       pdf.groupby("b").transform(lambda x: x + 1).sort_index())
+        self.assert_eq(kdf.groupby(['a', 'b']).transform(lambda x: x * x).sort_index(),
+                       pdf.groupby(['a', 'b']).transform(lambda x: x * x).sort_index())
+        self.assert_eq(kdf.groupby(['b'])['a'].transform(lambda x: x).sort_index(),
+                       pdf.groupby(['b'])['a'].transform(lambda x: x).sort_index())
+
         set_option('compute.shortcut_limit', 1000)
-
         try:
-            pdf = pd.DataFrame({'a': [1, 2, 3, 4, 5, 6],
-                                'b': [1, 1, 2, 3, 5, 8],
-                                'c': [1, 4, 9, 16, 25, 36]}, columns=['a', 'b', 'c'])
-            kdf = koalas.DataFrame(pdf)
-            self.assert_eq(kdf.groupby("b").transform(lambda x: x + 1).sort_index(),
-                           pdf.groupby("b").transform(lambda x: x + 1).sort_index())
-            self.assert_eq(kdf.groupby(['a', 'b']).transform(lambda x: x * x).sort_index(),
-                           pdf.groupby(['a', 'b']).transform(lambda x: x * x).sort_index())
-            self.assert_eq(kdf.groupby(['b'])['a'].transform(lambda x: x).sort_index(),
-                           pdf.groupby(['b'])['a'].transform(lambda x: x).sort_index())
-
-            # Data is intentionally big to test when schema inference is on.
             pdf = pd.DataFrame({'a': [1, 2, 3, 4, 5, 6] * 300,
                                 'b': [1, 1, 2, 3, 5, 8] * 300,
                                 'c': [1, 4, 9, 16, 25, 36] * 300}, columns=['a', 'b', 'c'])


### PR DESCRIPTION
This PR takes over https://github.com/databricks/koalas/pull/738, and this fix was inspired by the PR. So the commit credits to, and is authored by @charlesdong1991.

This PR adds `Option` class to allow various cases such as type checking, value checking, etc.

See the usage below as a example

```python
Option(
    key='compute.default_index_type',
    doc=(
        "This sets the default index type: sequence, distributed and distributed-sequence."),
    default='sequence',
    types=str,
    check_func=(
        lambda v: v in ('sequence', 'distributed', 'distributed-sequence'),
        "Index type should be one of 'sequence', 'distributed', 'distributed-sequence'."))
```

While I am here, I also fixed `plotting.sample_ratio` respects `plotting.max_rows` by default if this is not set.

Also, let `DataFrame.transform` respect `compute.max_rows` as well with minor cleanups.