### PR TITLE
Add documentation for 'User Guide' with available options

### DIFF
--- a/databricks/koalas/config.py
+++ b/databricks/koalas/config.py
@@ -141,7 +141,7 @@ _options = [
     Option(
         key='compute.shortcut_limit',
         doc=(
-            "'compute.shortcut_limit' sets the limit for a shortcut."
+            "'compute.shortcut_limit' sets the limit for a shortcut. "
             "It computes specified number of rows and use its schema. When the dataframe "
             "length is larger than this limit, Koalas uses PySpark to compute."),
         default=1000,
@@ -212,18 +212,18 @@ def show_options():
     import textwrap
 
     header = ["Option", "Default", "Description"]
-    row_format = "{:<33} {:<11} {:<54}"
+    row_format = "{:<31} {:<14} {:<53}"
 
-    print(row_format.format("=" * 33, "=" * 11, "=" * 54))
+    print(row_format.format("=" * 31, "=" * 14, "=" * 53))
     print(row_format.format(*header))
-    print(row_format.format("=" * 33, "=" * 11, "=" * 54))
+    print(row_format.format("=" * 31, "=" * 14, "=" * 53))
 
     for option in _options:
-        doc = textwrap.fill(option.doc, 54)
-        formatted = "".join([line + "\n" + (" " * 46) for line in doc.split("\n")]).rstrip()
-        print(row_format.format(option.key, str(option.default), formatted))
+        doc = textwrap.fill(option.doc, 53)
+        formatted = "".join([line + "\n" + (" " * 47) for line in doc.split("\n")]).rstrip()
+        print(row_format.format(option.key, repr(option.default), formatted))
 
-    print(row_format.format("=" * 33, "=" * 11, "=" * 54))
+    print(row_format.format("=" * 31, "=" * 14, "=" * 53))
 
 
 def get_option(key: str, default: Union[Any, _NoValueType] = _NoValue) -> Any:

--- a/databricks/koalas/config.py
+++ b/databricks/koalas/config.py
@@ -105,6 +105,12 @@ class Option:
 
 
 # Available options.
+#
+# NOTE: if you are fixing or adding an option here, make sure you execute `show_options()` and
+#     copy & paste the results into show_options 'docs/source/user_guide/options.rst' as well.
+#     See the examples below:
+#     >>> from databricks.koalas.config import show_options
+#     >>> show_options()
 _options = [
     Option(
         key='display.max_rows',
@@ -195,6 +201,29 @@ _key_format = 'koalas.{}'.format
 
 class OptionError(AttributeError, KeyError):
     pass
+
+
+def show_options():
+    """
+    Make a pretty table that can be copied and pasted into public documentation.
+    This is currently for an internal purpose.
+    """
+
+    import textwrap
+
+    header = ["Option", "Default", "Description"]
+    row_format = "{:<33} {:<11} {:<54}"
+
+    print(row_format.format("=" * 33, "=" * 11, "=" * 54))
+    print(row_format.format(*header))
+    print(row_format.format("=" * 33, "=" * 11, "=" * 54))
+
+    for option in _options:
+        doc = textwrap.fill(option.doc, 54)
+        formatted = "".join([line + "\n" + (" " * 46) for line in doc.split("\n")]).rstrip()
+        print(row_format.format(option.key, str(option.default), formatted))
+
+    print(row_format.format("=" * 33, "=" * 11, "=" * 54))
 
 
 def get_option(key: str, default: Union[Any, _NoValueType] = _NoValue) -> Any:

--- a/databricks/koalas/internal.py
+++ b/databricks/koalas/internal.py
@@ -416,62 +416,7 @@ class _InternalFrame(object):
         """
         This method attaches a default index to Spark DataFrame. Spark does not have the index
         notion so corresponding column should be generated.
-
-        There are three types of default index can be configured by `compute.default_index_type`
-
-        - sequence: It implements a sequence that increases one by one, by Window function without
-            specifying partition. Therefore, it ends up with whole partition in single node.
-            This index type should be avoided when the data is large. This is default.
-            See example below:
-
-            >>> ks.range(3).index  # doctest: +SKIP
-            Int64Index([0, 1, 2], dtype='int64')
-
-            This is conceptually equivalent to the Spark example as below:
-
-            >>> from pyspark.sql import functions as F, Window
-            >>> spark_df = ks.range(3).to_spark()
-            >>> sequential_index = F.row_number().over(
-            ...    Window.orderBy(F.monotonically_increasing_id().asc())) - 1
-            >>> spark_df.select(sequential_index).rdd.map(lambda r: r[0]).collect()
-            [0, 1, 2]
-
-        - distributed-sequence: It implements a sequence that increases one by one, by group-by and
-            group-map approach. It still generates the sequential index globally.
-            If the default index must be the sequence in a large dataset, this
-            index has to be used.
-            Note that if more data are added to the data source after creating this index,
-            then it does not guarantee the sequential index.
-            See example below:
-
-            >>> ks.range(3).index  # doctest: +SKIP
-            Int64Index([0, 1, 2], dtype='int64')
-
-            This is conceptually equivalent to the Spark example as below:
-
-            >>> spark_df = ks.range(3).to_spark()
-            >>> spark_df.rdd.zipWithIndex().map(lambda p: p[1]).collect()
-            [0, 1, 2]
-
-        - distributed: It implements a monotonically increasing sequence simply by using
-            Spark's `monotonically_increasing_id` function. If the index does not have to be
-            a sequence that increases one by one, this index should be used.
-            Performance-wise, this index almost does not have any penalty comparing to
-            other index types. Note that we cannot use this type of index for combining
-            two dataframes because it is not guaranteed to have the same indexes in two
-            dataframes. See example below:
-
-            >>> ks.range(3).index  # doctest: +SKIP
-            Int64Index([25769803776, 60129542144, 94489280512], dtype='int64')
-
-            This is conceptually equivalent to the Spark example as below:
-
-            >>> from pyspark.sql import functions as F
-            >>> spark_df = ks.range(3).to_spark()
-            >>> spark_df.select(F.monotonically_increasing_id()) \
-            ...     .rdd.map(lambda r: r[0]).collect()  # doctest: +SKIP
-            [25769803776, 60129542144, 94489280512]
-
+        There are several types of default index can be configured by `compute.default_index_type`.
         """
         default_index_type = get_option("compute.default_index_type")
         if default_index_type == "sequence":

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -14,4 +14,6 @@ pandas is the de facto standard (single-node) DataFrame implementation in Python
     :maxdepth: 3
 
     quickstart
+    user_guide/index
     reference/index
+

--- a/docs/source/reference/general_functions.rst
+++ b/docs/source/reference/general_functions.rst
@@ -5,6 +5,16 @@ General functions
 =================
 .. currentmodule:: databricks.koalas
 
+Working with options
+--------------------
+
+.. autosummary::
+   :toctree: api/
+
+    reset_option
+    get_option
+    set_option
+
 Data manipulations and SQL
 --------------------------
 .. autosummary::

--- a/docs/source/user_guide/index.rst
+++ b/docs/source/user_guide/index.rst
@@ -1,0 +1,8 @@
+==========
+User Guide
+==========
+
+.. toctree::
+    :maxdepth: 2
+
+    options

--- a/docs/source/user_guide/options.rst
+++ b/docs/source/user_guide/options.rst
@@ -1,0 +1,216 @@
+====================
+Options and settings
+====================
+
+Overview
+--------
+Koalas has an options system that lets you customize some aspects of its behaviour,
+display-related options being those the user is most likely to adjust.
+
+Options have a full "dotted-style", case-insensitive name (e.g. ``display.max_rows``).
+
+The API is composed of 3 relevant functions, available directly from the ``koalas``
+namespace:
+
+* :func:`~koalas.get_option` / :func:`~koalas.set_option` - get/set the value of a single option.
+* :func:`~koalas.reset_option` - reset one or more options to their default value.
+
+**Note:** Developers can check out `databricks/koalas/config.py <https://github.com/databricks/koalas/blob/master/databricks/koalas/config.py>`_ for more information.
+
+.. code-block:: python
+
+   >>> import databricks.koalas as ks
+   >>> ks.get_option("display.max_rows")
+   1000
+   >>> ks.set_option("display.max_rows", 101)
+   >>> ks.get_option("display.max_rows")
+   101
+
+
+Getting and setting options
+---------------------------
+
+As described above, :func:`~koalas.get_option` and :func:`~koalas.set_option`
+are available from the koalas namespace.  To change an option, call
+``set_option('option name', new_value)``.
+
+.. code-block:: python
+
+   >>> import databricks.koalas as ks
+   >>> ks.get_option('compute.max_rows')
+   1000
+   >>> ks.set_option('compute.max_rows', 2000)
+   >>> ks.get_option('compute.max_rows')
+   2000
+
+All options also have a default value, and you can use ``reset_option`` to do just that:
+
+.. code-block:: python
+
+   >>> import databricks.koalas as ks
+   >>> ks.reset_option("display.max_rows")
+
+.. code-block:: python
+
+   >>> import databricks.koalas as ks
+   >>> ks.get_option("display.max_rows")
+   1000
+   >>> ks.set_option("display.max_rows", 999)
+   >>> ks.get_option("display.max_rows")
+   999
+   >>> ks.reset_option("display.max_rows")
+   >>> ks.get_option("display.max_rows")
+   1000
+
+
+Operations on different DataFrames
+----------------------------------
+
+Koalas disallows the operations on different DataFrames (or Series) by default to prevent expensive
+operations. It internally performs a join operation which can be expensive in general.
+
+This can be enabled by setting `compute.ops_on_diff_frames` to `True` to allow such cases.
+See the examples below.
+
+.. code-block:: python
+
+    >>> import databricks.koalas as ks
+    >>> kdf = ks.range(5)
+    >>> kser_a = ks.Series([1, 2, 3, 4])
+    >>> # 'kser_a' is not from 'kdf' DataFrame. So it is considered as a Series not from 'kdf'.
+    >>> kdf['new_col'] = kser_a
+    >>> kdf
+       id  new_col
+    0   0      1.0
+    1   1      2.0
+    3   3      4.0
+    2   2      3.0
+    4   4      NaN
+
+.. code-block:: python
+
+    >>> import databricks.koalas as ks
+    >>> kdf1 = ks.range(5)
+    >>> kdf2 = ks.DataFrame({'id': [5, 4, 3]})
+    >>> (kdf1 - kdf2).sort_index()
+        id
+    0 -5.0
+    1 -3.0
+    2 -1.0
+    3  NaN
+    4  NaN
+
+
+Index type
+----------
+
+In Koalas, the default index is used in several cases, for instance,
+when Spark DataFrame is converted into Koalas DataFrame. In this case, internally Koalas attaches a
+default index column into Koalas DataFrame.
+
+There are several types of the default index that can be configured by `compute.default_index_type` as below:
+
+**sequence**: It implements a sequence that increases one by one, by Window function without
+specifying partition. Therefore, it can end up with whole partition in single node.
+This index type should be avoided when the data is large. This is default. See example below:
+
+.. code-block:: python
+
+    >>> ks.range(3).index  # doctest: +SKIP
+    Int64Index([0, 1, 2], dtype='int64')
+
+This is conceptually equivalent to the Spark example as below:
+
+.. code-block:: python
+
+    >>> from pyspark.sql import functions as F, Window
+    >>> spark_df = ks.range(3).to_spark()
+    >>> sequential_index = F.row_number().over(
+    ...    Window.orderBy(F.monotonically_increasing_id().asc())) - 1
+    >>> spark_df.select(sequential_index).rdd.map(lambda r: r[0]).collect()
+    [0, 1, 2]
+
+**distributed-sequence**: It implements a sequence that increases one by one, by group-by and
+group-map approach. It still generates the sequential index globally.
+If the default index must be the sequence in a large dataset, this
+index has to be used.
+Note that if more data are added to the data source after creating this index,
+then it does not guarantee the sequential index. See example below:
+
+.. code-block:: python
+
+    >>> ks.range(3).index  # doctest: +SKIP
+    Int64Index([0, 1, 2], dtype='int64')
+
+This is conceptually equivalent to the Spark example as below:
+
+.. code-block:: python
+
+    >>> spark_df = ks.range(3).to_spark()
+    >>> spark_df.rdd.zipWithIndex().map(lambda p: p[1]).collect()
+    [0, 1, 2]
+
+**distributed**: It implements a monotonically increasing sequence simply by using
+Spark's `monotonically_increasing_id` function. If the index does not have to be
+a sequence that increases one by one, this index should be used.
+Performance-wise, this index almost does not have any penalty comparing to
+other index types. Note that we cannot use this type of index for combining
+two dataframes because it is not guaranteed to have the same indexes in two
+dataframes. See example below:
+
+.. code-block:: python
+
+    >>> ks.range(3).index  # doctest: +SKIP
+    Int64Index([25769803776, 60129542144, 94489280512], dtype='int64')
+
+This is conceptually equivalent to the Spark example as below:
+
+.. code-block:: python
+
+    >>> from pyspark.sql import functions as F
+    >>> spark_df = ks.range(3).to_spark()
+    >>> spark_df.select(F.monotonically_increasing_id()) \
+    ...     .rdd.map(lambda r: r[0]).collect()  # doctest: +SKIP
+    [25769803776, 60129542144, 94489280512]
+
+
+Available options
+-----------------
+
+================================= =========== ======================================================
+Option                            Default     Description
+================================= =========== ======================================================
+display.max_rows                  1000        This sets the maximum number of rows koalas should
+                                              output when printing out various output. For example,
+                                              this value determines the number of rows to be shown
+                                              at the repr() in a dataframe. Set `None` to unlimit
+                                              the input length. Default is 1000.
+compute.max_rows                  1000        'compute.max_rows' sets the limit of the current
+                                              DataFrame. Set `None` to unlimit the input length.
+                                              When the limit is set, it is executed by the shortcut
+                                              by collecting the data into driver side, and then
+                                              using pandas API. If the limit is unset, the operation
+                                              is executed by PySpark. Default is 1000.
+compute.shortcut_limit            1000        'compute.shortcut_limit' sets the limit for a
+                                              shortcut.It computes specified number of rows and use
+                                              its schema. When the dataframe length is larger than
+                                              this limit, Koalas uses PySpark to compute.
+compute.ops_on_diff_frames        False       This determines whether or not to operate between two
+                                              different dataframes. For example, 'combine_frames'
+                                              function internally performs a join operation which
+                                              can be expensive in general. So, if
+                                              `compute.ops_on_diff_frames` variable is not True,
+                                              that method throws an exception.
+compute.default_index_type        sequence    This sets the default index type: sequence,
+                                              distributed and distributed-sequence.
+plotting.max_rows                 1000        'plotting.max_rows' sets the visual limit on top-n-
+                                              based plots such as `plot.bar` and `plot.pie`. If it
+                                              is set to 1000, the first 1000 data points will be
+                                              used for plotting. Default is 1000.
+plotting.sample_ratio             None        'plotting.sample_ratio' sets the proportion of data
+                                              that will be plotted for sample-based plots such as
+                                              `plot.line` and `plot.area`. This option defaults to
+                                              'plotting.max_rows' option.
+================================= =========== ======================================================
+
+

--- a/docs/source/user_guide/options.rst
+++ b/docs/source/user_guide/options.rst
@@ -1,6 +1,7 @@
 ====================
 Options and settings
 ====================
+.. currentmodule:: databricks.koalas
 
 Overview
 --------
@@ -12,8 +13,8 @@ Options have a full "dotted-style", case-insensitive name (e.g. ``display.max_ro
 The API is composed of 3 relevant functions, available directly from the ``koalas``
 namespace:
 
-* :func:`~koalas.get_option` / :func:`~koalas.set_option` - get/set the value of a single option.
-* :func:`~koalas.reset_option` - reset one or more options to their default value.
+* :func:`get_option` / :func:`set_option` - get/set the value of a single option.
+* :func:`reset_option` - reset one or more options to their default value.
 
 **Note:** Developers can check out `databricks/koalas/config.py <https://github.com/databricks/koalas/blob/master/databricks/koalas/config.py>`_ for more information.
 
@@ -30,7 +31,7 @@ namespace:
 Getting and setting options
 ---------------------------
 
-As described above, :func:`~koalas.get_option` and :func:`~koalas.set_option`
+As described above, :func:`get_option` and :func:`set_option`
 are available from the koalas namespace.  To change an option, call
 ``set_option('option name', new_value)``.
 
@@ -75,6 +76,22 @@ See the examples below.
 .. code-block:: python
 
     >>> import databricks.koalas as ks
+    >>> ks.set_option('compute.ops_on_diff_frames', True)
+    >>> kdf1 = ks.range(5)
+    >>> kdf2 = ks.DataFrame({'id': [5, 4, 3]})
+    >>> (kdf1 - kdf2).sort_index()
+        id
+    0 -5.0
+    1 -3.0
+    2 -1.0
+    3  NaN
+    4  NaN
+    >>> ks.reset_option('compute.ops_on_diff_frames')
+
+.. code-block:: python
+
+    >>> import databricks.koalas as ks
+    >>> ks.set_option('compute.ops_on_diff_frames', True)
     >>> kdf = ks.range(5)
     >>> kser_a = ks.Series([1, 2, 3, 4])
     >>> # 'kser_a' is not from 'kdf' DataFrame. So it is considered as a Series not from 'kdf'.
@@ -86,44 +103,37 @@ See the examples below.
     3   3      4.0
     2   2      3.0
     4   4      NaN
-
-.. code-block:: python
-
-    >>> import databricks.koalas as ks
-    >>> kdf1 = ks.range(5)
-    >>> kdf2 = ks.DataFrame({'id': [5, 4, 3]})
-    >>> (kdf1 - kdf2).sort_index()
-        id
-    0 -5.0
-    1 -3.0
-    2 -1.0
-    3  NaN
-    4  NaN
+    >>> ks.reset_option('compute.ops_on_diff_frames')
 
 
-Index type
-----------
+Default Index type
+------------------
 
 In Koalas, the default index is used in several cases, for instance,
 when Spark DataFrame is converted into Koalas DataFrame. In this case, internally Koalas attaches a
-default index column into Koalas DataFrame.
+default index into Koalas DataFrame.
 
 There are several types of the default index that can be configured by `compute.default_index_type` as below:
 
-**sequence**: It implements a sequence that increases one by one, by Window function without
+**sequence**: It implements a sequence that increases one by one, by PySpark's Window function without
 specifying partition. Therefore, it can end up with whole partition in single node.
 This index type should be avoided when the data is large. This is default. See example below:
 
 .. code-block:: python
 
-    >>> ks.range(3).index  # doctest: +SKIP
+    >>> import databricks.koalas as ks
+    >>> ks.set_option('compute.default_index_type', 'sequence')
+    >>> kdf = ks.range(3)
+    >>> ks.reset_option('compute.default_index_type')
+    >>> kdf.index
     Int64Index([0, 1, 2], dtype='int64')
 
-This is conceptually equivalent to the Spark example as below:
+This is conceptually equivalent to the PySpark example as below:
 
 .. code-block:: python
 
     >>> from pyspark.sql import functions as F, Window
+    >>> import databricks.koalas as ks
     >>> spark_df = ks.range(3).to_spark()
     >>> sequential_index = F.row_number().over(
     ...    Window.orderBy(F.monotonically_increasing_id().asc())) - 1
@@ -131,7 +141,7 @@ This is conceptually equivalent to the Spark example as below:
     [0, 1, 2]
 
 **distributed-sequence**: It implements a sequence that increases one by one, by group-by and
-group-map approach. It still generates the sequential index globally.
+group-map approach in a distributed manner. It still generates the sequential index globally.
 If the default index must be the sequence in a large dataset, this
 index has to be used.
 Note that if more data are added to the data source after creating this index,
@@ -139,78 +149,87 @@ then it does not guarantee the sequential index. See example below:
 
 .. code-block:: python
 
-    >>> ks.range(3).index  # doctest: +SKIP
+    >>> import databricks.koalas as ks
+    >>> ks.set_option('compute.default_index_type', 'distributed-sequence')
+    >>> kdf = ks.range(3)
+    >>> ks.reset_option('compute.default_index_type')
+    >>> kdf.index
     Int64Index([0, 1, 2], dtype='int64')
 
-This is conceptually equivalent to the Spark example as below:
+This is conceptually equivalent to the PySpark example as below:
 
 .. code-block:: python
 
+    >>> import databricks.koalas as ks
     >>> spark_df = ks.range(3).to_spark()
     >>> spark_df.rdd.zipWithIndex().map(lambda p: p[1]).collect()
     [0, 1, 2]
 
 **distributed**: It implements a monotonically increasing sequence simply by using
-Spark's `monotonically_increasing_id` function. If the index does not have to be
-a sequence that increases one by one, this index should be used.
-Performance-wise, this index almost does not have any penalty comparing to
-other index types. Note that we cannot use this type of index for combining
-two dataframes because it is not guaranteed to have the same indexes in two
-dataframes. See example below:
+PySpark's `monotonically_increasing_id` function in a fully distributed manner.
+If the index does not have to be a sequence that increases one by one, this index
+should be used. Performance-wise, this index almost does not have any penalty
+comparing to other index types. Note that we cannot use this type of index for
+combining two dataframes because it is not guaranteed to have the same indexes in
+two dataframes. See example below:
 
 .. code-block:: python
 
-    >>> ks.range(3).index  # doctest: +SKIP
+    >>> import databricks.koalas as ks
+    >>> ks.set_option('compute.default_index_type', 'distributed')
+    >>> kdf = ks.range(3)
+    >>> ks.reset_option('compute.default_index_type')
+    >>> kdf.index
     Int64Index([25769803776, 60129542144, 94489280512], dtype='int64')
 
-This is conceptually equivalent to the Spark example as below:
+This is conceptually equivalent to the PySpark example as below:
 
 .. code-block:: python
 
     >>> from pyspark.sql import functions as F
+    >>> import databricks.koalas as ks
     >>> spark_df = ks.range(3).to_spark()
     >>> spark_df.select(F.monotonically_increasing_id()) \
-    ...     .rdd.map(lambda r: r[0]).collect()  # doctest: +SKIP
+    ...     .rdd.map(lambda r: r[0]).collect()
     [25769803776, 60129542144, 94489280512]
 
 
 Available options
 -----------------
 
-================================= =========== ======================================================
-Option                            Default     Description
-================================= =========== ======================================================
-display.max_rows                  1000        This sets the maximum number of rows koalas should
-                                              output when printing out various output. For example,
-                                              this value determines the number of rows to be shown
-                                              at the repr() in a dataframe. Set `None` to unlimit
-                                              the input length. Default is 1000.
-compute.max_rows                  1000        'compute.max_rows' sets the limit of the current
-                                              DataFrame. Set `None` to unlimit the input length.
-                                              When the limit is set, it is executed by the shortcut
-                                              by collecting the data into driver side, and then
-                                              using pandas API. If the limit is unset, the operation
-                                              is executed by PySpark. Default is 1000.
-compute.shortcut_limit            1000        'compute.shortcut_limit' sets the limit for a
-                                              shortcut.It computes specified number of rows and use
-                                              its schema. When the dataframe length is larger than
-                                              this limit, Koalas uses PySpark to compute.
-compute.ops_on_diff_frames        False       This determines whether or not to operate between two
-                                              different dataframes. For example, 'combine_frames'
-                                              function internally performs a join operation which
-                                              can be expensive in general. So, if
-                                              `compute.ops_on_diff_frames` variable is not True,
-                                              that method throws an exception.
-compute.default_index_type        sequence    This sets the default index type: sequence,
-                                              distributed and distributed-sequence.
-plotting.max_rows                 1000        'plotting.max_rows' sets the visual limit on top-n-
-                                              based plots such as `plot.bar` and `plot.pie`. If it
-                                              is set to 1000, the first 1000 data points will be
-                                              used for plotting. Default is 1000.
-plotting.sample_ratio             None        'plotting.sample_ratio' sets the proportion of data
-                                              that will be plotted for sample-based plots such as
-                                              `plot.line` and `plot.area`. This option defaults to
-                                              'plotting.max_rows' option.
-================================= =========== ======================================================
-
+=============================== ============== =====================================================
+Option                          Default        Description
+=============================== ============== =====================================================
+display.max_rows                1000           This sets the maximum number of rows koalas should
+                                               output when printing out various output. For example,
+                                               this value determines the number of rows to be shown
+                                               at the repr() in a dataframe. Set `None` to unlimit
+                                               the input length. Default is 1000.
+compute.max_rows                1000           'compute.max_rows' sets the limit of the current
+                                               DataFrame. Set `None` to unlimit the input length.
+                                               When the limit is set, it is executed by the shortcut
+                                               by collecting the data into driver side, and then
+                                               using pandas API. If the limit is unset, the
+                                               operation is executed by PySpark. Default is 1000.
+compute.shortcut_limit          1000           'compute.shortcut_limit' sets the limit for a
+                                               shortcut. It computes specified number of rows and
+                                               use its schema. When the dataframe length is larger
+                                               than this limit, Koalas uses PySpark to compute.
+compute.ops_on_diff_frames      False          This determines whether or not to operate between two
+                                               different dataframes. For example, 'combine_frames'
+                                               function internally performs a join operation which
+                                               can be expensive in general. So, if
+                                               `compute.ops_on_diff_frames` variable is not True,
+                                               that method throws an exception.
+compute.default_index_type      'sequence'     This sets the default index type: sequence,
+                                               distributed and distributed-sequence.
+plotting.max_rows               1000           'plotting.max_rows' sets the visual limit on top-n-
+                                               based plots such as `plot.bar` and `plot.pie`. If it
+                                               is set to 1000, the first 1000 data points will be
+                                               used for plotting. Default is 1000.
+plotting.sample_ratio           None           'plotting.sample_ratio' sets the proportion of data
+                                               that will be plotted for sample-based plots such as
+                                               `plot.line` and `plot.area`. This option defaults to
+                                               'plotting.max_rows' option.
+=============================== ============== =====================================================
 


### PR DESCRIPTION
This PR adds 'User Guide' with available options.
Can be verified as below:

```bash
./dev/lint-python
open docs/build/html/index.html
```

Resolves #715 