### PR TITLE
Place `reset_option()` before `tearDownClass()`.

### DIFF
--- a/databricks/koalas/tests/test_default_index.py
+++ b/databricks/koalas/tests/test_default_index.py
@@ -29,8 +29,8 @@ class OneByOneDefaultIndexTest(ReusedSQLTestCase, TestUtils):
 
     @classmethod
     def tearDownClass(cls):
-        super(OneByOneDefaultIndexTest, cls).tearDownClass()
         reset_option('compute.default_index_type')
+        super(OneByOneDefaultIndexTest, cls).tearDownClass()
 
     def test_default_index(self):
         sdf = self.spark.range(1000)
@@ -46,8 +46,8 @@ class DistributedOneByOneDefaultIndexTest(ReusedSQLTestCase, TestUtils):
 
     @classmethod
     def tearDownClass(cls):
-        super(DistributedOneByOneDefaultIndexTest, cls).tearDownClass()
         reset_option('compute.default_index_type')
+        super(DistributedOneByOneDefaultIndexTest, cls).tearDownClass()
 
     def test_default_index(self):
         sdf = self.spark.range(1000)
@@ -63,8 +63,8 @@ class DistributedDefaultIndexTest(ReusedSQLTestCase, TestUtils):
 
     @classmethod
     def tearDownClass(cls):
-        super(DistributedDefaultIndexTest, cls).tearDownClass()
         reset_option('compute.default_index_type')
+        super(DistributedDefaultIndexTest, cls).tearDownClass()
 
     def test_default_index(self):
         sdf = self.spark.range(1000)

--- a/databricks/koalas/tests/test_frame_plot.py
+++ b/databricks/koalas/tests/test_frame_plot.py
@@ -27,9 +27,9 @@ class DataFramePlotTest(ReusedSQLTestCase, TestUtils):
 
     @classmethod
     def tearDownClass(cls):
-        super(DataFramePlotTest, cls).tearDownClass()
         reset_option('plotting.max_rows')
         reset_option('plotting.sample_ratio')
+        super(DataFramePlotTest, cls).tearDownClass()
 
     @property
     def pdf1(self):

--- a/databricks/koalas/tests/test_ops_on_diff_frames.py
+++ b/databricks/koalas/tests/test_ops_on_diff_frames.py
@@ -29,8 +29,8 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
 
     @classmethod
     def tearDownClass(cls):
-        super(OpsOnDiffFramesEnabledTest, cls).tearDownClass()
         reset_option('compute.ops_on_diff_frames')
+        super(OpsOnDiffFramesEnabledTest, cls).tearDownClass()
 
     @property
     def pdf1(self):
@@ -391,8 +391,8 @@ class OpsOnDiffFramesDisabledTest(ReusedSQLTestCase, SQLTestUtils):
 
     @classmethod
     def tearDownClass(cls):
-        super(OpsOnDiffFramesDisabledTest, cls).tearDownClass()
         reset_option('compute.ops_on_diff_frames')
+        super(OpsOnDiffFramesDisabledTest, cls).tearDownClass()
 
     @property
     def pdf1(self):

--- a/databricks/koalas/tests/test_repr.py
+++ b/databricks/koalas/tests/test_repr.py
@@ -23,11 +23,13 @@ class ReprTests(ReusedSQLTestCase):
 
     @classmethod
     def setUpClass(cls):
+        super(ReprTests, cls).setUpClass()
         set_option("display.max_rows", ReprTests.max_display_count)
 
     @classmethod
     def tearDownClass(cls):
         reset_option("display.max_rows")
+        super(ReprTests, cls).tearDownClass()
 
     def test_repr_dataframe(self):
         kdf = ks.range(ReprTests.max_display_count)

--- a/databricks/koalas/tests/test_series_plot.py
+++ b/databricks/koalas/tests/test_series_plot.py
@@ -41,8 +41,8 @@ class SeriesPlotTest(ReusedSQLTestCase, TestUtils):
 
     @classmethod
     def tearDownClass(cls):
-        super(SeriesPlotTest, cls).tearDownClass()
         reset_option('plotting.max_rows')
+        super(SeriesPlotTest, cls).tearDownClass()
 
     @property
     def pdf1(self):


### PR DESCRIPTION
We should place `reset_option()` before `tearDownClass()`, otherwise another `SparkSession` will start.