### PR TITLE
Add read_json and let to_json use spark.write.json

### DIFF
--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -570,7 +570,7 @@ class _Frame(object):
         return validate_arguments_and_invoke_function(
             kdf._to_internal_pandas(), self.to_csv, f, args)
 
-    def to_json(self, path=None, compression='uncompressed', num_files=None, **kwargs):
+    def to_json(self, path=None, compression='uncompressed', num_files=None, **options):
         """
         Convert the object to a JSON string.
 
@@ -593,12 +593,17 @@ class _Frame(object):
         path : string, optional
             File path. If not specified, the result is returned as
             a string.
-        date_format : str, default None
-            Format string for datetime objects.
         compression : {'gzip', 'bz2', 'xz', None}
             A string representing the compression to use in the output file,
             only used when the first argument is a filename. By default, the
             compression is inferred from the filename.
+        num_files : the number of files to be written in `path` directory when
+            this is a path.
+        options: keyword arguments for additional options specific to PySpark.
+            It is specific to PySpark's JSON options to pass. Check
+            the options in PySpark's API documentation for `spark.write.json(...)`.
+            It has a higher priority and overwrites all other options.
+            This parameter only works when `path` is specified.
 
         Examples
         --------
@@ -646,7 +651,7 @@ class _Frame(object):
 
         builder = sdf.write.mode("overwrite")
         OptionUtils._set_opts(builder, compression=compression)
-        builder.options(**kwargs).format("json").save(path)
+        builder.options(**options).format("json").save(path)
 
     def to_excel(self, excel_writer, sheet_name="Sheet1", na_rep="", float_format=None,
                  columns=None, header=True, index=True, index_label=None, startrow=0,

--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -41,7 +41,7 @@ from databricks.koalas.series import Series, _col
 __all__ = ["from_pandas", "range", "read_csv", "read_delta", "read_table", "read_spark_io",
            "read_parquet", "read_clipboard", "read_excel", "read_html", "to_datetime",
            "get_dummies", "concat", "melt", "isna", "isnull", "notna", "notnull",
-           "read_sql_table", "read_sql_query", "read_sql"]
+           "read_sql_table", "read_sql_query", "read_sql", "read_json"]
 
 
 def from_pandas(pobj: Union['pd.DataFrame', 'pd.Series']) -> Union['Series', 'DataFrame']:
@@ -239,6 +239,31 @@ def read_csv(path, header='infer', names=None, usecols=None,
     else:
         sdf = default_session().createDataFrame([], schema=StructType())
     return DataFrame(sdf)
+
+
+def read_json(path: str, **options):
+    """
+    Convert a JSON string to pandas object.
+
+    Parameters
+    ----------
+    path : string
+        File path
+
+    Examples
+    --------
+    >>> df = ks.DataFrame([['a', 'b'], ['c', 'd']],
+    ...                   columns=['col 1', 'col 2'])
+
+    >>> df.to_json(path=r'%s/read_json/foo.json' % path, num_files=1)
+    >>> ks.read_json(
+    ...     path=r'%s/read_json/foo.json' % path
+    ... ).sort_values(by="col 1")
+      col 1 col 2
+    0     a     b
+    1     c     d
+    """
+    return read_spark_io(path, format='json', options=options)
 
 
 def read_delta(path: str, version: Optional[str] = None, timestamp: Optional[str] = None,

--- a/databricks/koalas/tests/test_dataframe_conversion.py
+++ b/databricks/koalas/tests/test_dataframe_conversion.py
@@ -13,8 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+import os
+import shutil
 import string
+import tempfile
 
 import numpy as np
 import pandas as pd
@@ -26,6 +28,12 @@ from databricks.koalas.testing.utils import ReusedSQLTestCase, SQLTestUtils, Tes
 
 class DataFrameConversionTest(ReusedSQLTestCase, SQLTestUtils, TestUtils):
     """Test cases for "small data" conversion and I/O."""
+
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp(prefix=DataFrameConversionTest.__name__)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp_dir, ignore_errors=True)
 
     @property
     def pdf(self):
@@ -162,16 +170,19 @@ class DataFrameConversionTest(ReusedSQLTestCase, SQLTestUtils, TestUtils):
         pdf = self.pdf
         kdf = ks.from_pandas(pdf)
 
-        self.assert_eq(kdf.to_json(), pdf.to_json())
-        self.assert_eq(kdf.to_json(orient='split'), pdf.to_json(orient='split'))
-        self.assert_eq(kdf.to_json(orient='records'), pdf.to_json(orient='records'))
-        self.assert_eq(kdf.to_json(orient='index'), pdf.to_json(orient='index'))
-        self.assert_eq(kdf.to_json(orient='values'), pdf.to_json(orient='values'))
-        self.assert_eq(kdf.to_json(orient='table'), pdf.to_json(orient='table'))
-        self.assert_eq(kdf.to_json(orient='records', lines=True),
-                       pdf.to_json(orient='records', lines=True))
-        self.assert_eq(kdf.to_json(orient='split', index=False),
-                       pdf.to_json(orient='split', index=False))
+        self.assert_eq(kdf.to_json(), pdf.to_json(orient='records'))
+
+    def test_to_json_with_path(self):
+        pdf = pd.DataFrame({'a': [1], 'b': ['a']})
+        kdf = ks.DataFrame(pdf)
+
+        kdf.to_json(self.tmp_dir, num_files=1)
+        expected = pdf.to_json(orient='records')
+
+        output_paths = [path for path in os.listdir(self.tmp_dir) if path.startswith("part-")]
+        assert len(output_paths) > 0
+        output_path = "%s/%s" % (self.tmp_dir, output_paths[0])
+        self.assertEqual("[%s]" % open(output_path).read().strip(), expected)
 
     def test_to_clipboard(self):
         pdf = self.pdf

--- a/docs/source/reference/io.rst
+++ b/docs/source/reference/io.rst
@@ -69,6 +69,13 @@ Excel
    read_excel
    DataFrame.to_excel
 
+JSON
+----
+.. autosummary::
+   :toctree: api/
+
+   read_json
+
 HTML
 ----
 .. autosummary::


### PR DESCRIPTION
This PR proposes to use `spark.write.json` API to enable distributed computation when `path` is specified. If `path` is not specified, it just calls pandas' `to_json` as was.

Also, this PR adds `read_json` API.