### PR TITLE
Add a missing exception test for groupby

### DIFF
--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -442,6 +442,8 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
                        pdf.groupby("b").filter(lambda x: x.b.mean() < 4).sort_index())
         self.assert_eq(kdf.groupby(['a', 'b']).filter(lambda x: any(x.a == 2)).sort_index(),
                        pdf.groupby(['a', 'b']).filter(lambda x: any(x.a == 2)).sort_index())
+        with self.assertRaisesRegex(TypeError, "<class 'int'> object is not callable"):
+            kdf.groupby("b").filter(1)
 
     def test_idxmax(self):
         pdf = pd.DataFrame({'a': [1, 1, 2, 2, 3],


### PR DESCRIPTION
Found A missing exception test for groupby

<img width="723" alt="스크린샷 2019-09-07 오후 12 47 57" src="https://user-images.githubusercontent.com/44108233/64469487-fa26d480-d16d-11e9-9745-546cef6a3f1a.png">

could someone check this out when available?

have a great weekend, Thanks :)