### PR TITLE
Use Spark 2.4.4 in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
       env:
         - PATH=$(echo "$PATH" | sed -e 's/:\/usr\/local\/lib\/jvm\/openjdk11\/bin//')
         - JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
-        - SPARK_VERSION=2.4.3
+        - SPARK_VERSION=2.4.4
         - PANDAS_VERSION=0.24.2
         - PYARROW_VERSION=0.10.0
         - KOALAS_USAGE_LOGGER='databricks.koalas.usage_logging.usage_logger'
@@ -35,7 +35,7 @@ matrix:
       env:
         - PATH=$(echo "$PATH" | sed -e 's/:\/usr\/local\/lib\/jvm\/openjdk11\/bin//')
         - JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
-        - SPARK_VERSION=2.4.3
+        - SPARK_VERSION=2.4.4
         - PANDAS_VERSION=0.25.0
         - PYARROW_VERSION=0.13.0
 


### PR DESCRIPTION
Spark 2.4.4 is released and Apache mirror only contains latest versions.

See, for instance:

https://dist.apache.org/repos/dist/release//spark/spark-2.4.3/spark-2.4.3-bin-hadoop2.7.tgz
https://dist.apache.org/repos/dist/release//spark/spark-2.4.4/spark-2.4.4-bin-hadoop2.7.tgz