### PR TITLE
Add missing tests for DataFrame

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -116,7 +116,7 @@ circle          1      361
 triangle        4      181
 rectangle       5      361
 
-Divide & True Divide by constant with reverse version.
+Divide and true divide by constant with reverse version.
 
 >>> df / 10
            angles  degrees

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -116,7 +116,7 @@ circle          1      361
 triangle        4      181
 rectangle       5      361
 
-Divide by constant with reverse version.
+Divide & True Divide by constant with reverse version.
 
 >>> df / 10
            angles  degrees
@@ -131,6 +131,18 @@ triangle      0.3     18.0
 rectangle     0.4     36.0
 
 >>> df.rdiv(10)
+             angles   degrees
+circle          NaN  0.027778
+triangle   3.333333  0.055556
+rectangle  2.500000  0.027778
+
+>>> df.truediv(10)
+           angles  degrees
+circle        0.0     36.0
+triangle      0.3     18.0
+rectangle     0.4     36.0
+
+>>> df.rtruediv(10)
              angles   degrees
 circle          NaN  0.027778
 triangle   3.333333  0.055556

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -400,6 +400,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(kdf.dropna(), pdf.dropna())
         self.assert_eq(kdf.dropna(how='all'), pdf.dropna(how='all'))
         self.assert_eq(kdf.dropna(subset=['x']), pdf.dropna(subset=['x']))
+        self.assert_eq(kdf.dropna(subset='x'), pdf.dropna(subset=['x']))
         self.assert_eq(kdf.dropna(subset=['y', 'z']), pdf.dropna(subset=['y', 'z']))
         self.assert_eq(kdf.dropna(subset=['y', 'z'], how='all'),
                        pdf.dropna(subset=['y', 'z'], how='all'))
@@ -419,6 +420,12 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             kdf.dropna(axis='column')
         with self.assertRaisesRegex(NotImplementedError, msg):
             kdf.dropna(axis='foo')
+
+        self.assertRaises(KeyError, lambda: kdf.dropna(subset='1'))
+        with self.assertRaisesRegex(ValueError, "invalid how option: 1"):
+            kdf.dropna(how=1)
+        with self.assertRaisesRegex(TypeError, "must specify how or thresh"):
+            kdf.dropna(how=None)
 
     def test_dtype(self):
         pdf = pd.DataFrame({'a': list('abc'),
@@ -514,6 +521,9 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
                        pd.Series([103], index=['A'], name='0'))
         self.assert_eq(ks.DataFrame({'A': range(100)}).nunique(approx=True, rsd=0.01),
                        pd.Series([100], index=['A'], name='0'))
+
+        # Assert improper parameter
+        self.assertRaises(ValueError, lambda: kdf.nunique(axis=1))
 
     def test_sort_values(self):
         pdf = pd.DataFrame({'a': [1, 2, 3, 4, 5, None, 7],

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -442,6 +442,8 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
                        pdf.groupby("b").filter(lambda x: x.b.mean() < 4).sort_index())
         self.assert_eq(kdf.groupby(['a', 'b']).filter(lambda x: any(x.a == 2)).sort_index(),
                        pdf.groupby(['a', 'b']).filter(lambda x: any(x.a == 2)).sort_index())
+        with self.assertRaisesRegex(TypeError, "<class 'int'> object is not callable"):
+            kdf.groupby("b").filter(1)
 
     def test_idxmax(self):
         pdf = pd.DataFrame({'a': [1, 1, 2, 2, 3],

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -442,8 +442,6 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
                        pdf.groupby("b").filter(lambda x: x.b.mean() < 4).sort_index())
         self.assert_eq(kdf.groupby(['a', 'b']).filter(lambda x: any(x.a == 2)).sort_index(),
                        pdf.groupby(['a', 'b']).filter(lambda x: any(x.a == 2)).sort_index())
-        with self.assertRaisesRegex(TypeError, "<class 'int'> object is not callable"):
-            kdf.groupby("b").filter(1)
 
     def test_idxmax(self):
         pdf = pd.DataFrame({'a': [1, 1, 2, 2, 3],


### PR DESCRIPTION
Found some missing doctest & unittests for DataFrame as shown below.


- test for operator truediv & truediv

![스크린샷 2019-09-08 오후 5 42 57](https://user-images.githubusercontent.com/44108233/64485832-39cde900-d260-11e9-889c-35774eabd9b2.png)


- test for nunique

![스크린샷 2019-09-08 오후 5 42 28](https://user-images.githubusercontent.com/44108233/64485834-3c304300-d260-11e9-9fe8-abbdb1932dd3.png)

- test for dropna

![스크린샷 2019-09-08 오후 5 42 07](https://user-images.githubusercontent.com/44108233/64485836-3d617000-d260-11e9-944c-f7eb152ba83c.png)


![스크린샷 2019-09-08 오후 5 42 00](https://user-images.githubusercontent.com/44108233/64485838-3e929d00-d260-11e9-8248-615804905e55.png)

