### PR TITLE
raise error when hist on non-numeric cols

### DIFF
--- a/databricks/koalas/plot.py
+++ b/databricks/koalas/plot.py
@@ -407,6 +407,9 @@ class KoalasHistPlotSummary:
                       .map(tuple)
                       .collect()[0])
         # divides the boundaries into bins
+        if boundaries[0] == boundaries[1]:
+            boundaries = (boundaries[0] - 0.5, boundaries[1] + 0.5)
+
         return np.linspace(boundaries[0], boundaries[1], n_bins + 1)
 
     def calc_histogram(self, bins):
@@ -438,6 +441,22 @@ class KoalasHistPlotSummary:
 
 class KoalasHistPlot(HistPlot):
     def _args_adjust(self):
+        from databricks.koalas.series import Series
+
+        data = self.data
+        if isinstance(data, Series):
+            data = data.to_frame()
+
+        numeric_data = data.select_dtypes(include=['byte', 'decimal', 'integer', 'float',
+                                                   'long', 'double', np.datetime64])
+
+        is_empty = not len(numeric_data.columns)
+
+        # no empty frames or series allowed
+        if is_empty:
+            raise TypeError('Empty {0!r}: no numeric data to '
+                            'plot'.format(numeric_data.__class__.__name__))
+
         if is_integer(self.bins):
             summary = KoalasHistPlotSummary(self.data, self.data.name)
             # computes boundaries for the column

--- a/databricks/koalas/tests/test_series_plot.py
+++ b/databricks/koalas/tests/test_series_plot.py
@@ -284,3 +284,22 @@ class SeriesPlotTest(ReusedSQLTestCase, TestUtils):
             with self.assertRaisesRegex(PandasNotImplementedError,
                                         "method.*Series.*{}.*not implemented".format(name)):
                 getattr(ks.plot, name)()
+
+    def test_empty_hist(self):
+        pdf = self.pdf1.assign(categorical='A')
+        kdf = koalas.from_pandas(pdf)
+        ks = kdf['categorical']
+
+        with self.assertRaisesRegex(TypeError,
+                                    "Empty 'DataFrame': no numeric data to plot"):
+            ks.plot.hist()
+
+    def test_single_value_hist(self):
+        pdf = self.pdf1.assign(single=2)
+        kdf = koalas.from_pandas(pdf)
+
+        _, ax1 = plt.subplots(1, 1)
+        ax1 = pdf['single'].plot.hist()
+        _, ax2 = plt.subplots(1, 1)
+        ax2 = kdf['single'].plot.hist()
+        self.compare_plots(ax1, ax2)


### PR DESCRIPTION
This PR takes over #536. It raises an exception for non-numeric columns in `plot.hist()`.