### PR TITLE
Implement Series.plot.kde

### DIFF
--- a/databricks/koalas/plot.py
+++ b/databricks/koalas/plot.py
@@ -42,11 +42,11 @@ def _get_standard_kind(kind):
 
 if LooseVersion(pd.__version__) < LooseVersion('0.25'):
     from pandas.plotting._core import _all_kinds, BarPlot, BoxPlot, HistPlot, MPLPlot, PiePlot, \
-        AreaPlot, LinePlot, BarhPlot, ScatterPlot
+        AreaPlot, LinePlot, BarhPlot, ScatterPlot, KdePlot
 else:
     from pandas.plotting._core import PlotAccessor
     from pandas.plotting._matplotlib import BarPlot, BoxPlot, HistPlot, PiePlot, AreaPlot, \
-        LinePlot, BarhPlot, ScatterPlot
+        LinePlot, BarhPlot, ScatterPlot, KdePlot
     from pandas.plotting._matplotlib.core import MPLPlot
     _all_kinds = PlotAccessor._all_kinds
 
@@ -536,6 +536,17 @@ class KoalasScatterPlot(ScatterPlot, TopNPlot):
         super(KoalasScatterPlot, self)._make_plot()
 
 
+class KoalasKdePlot(KdePlot, TopNPlot):
+    max_rows = 1000
+
+    def __init__(self, data, **kwargs):
+        super(KoalasKdePlot, self).__init__(self.get_top_n(data), **kwargs)
+
+    def _make_plot(self):
+        self.set_result_text(self._get_ax(0))
+        super(KoalasKdePlot, self)._make_plot()
+
+
 _klasses = [
     KoalasHistPlot,
     KoalasBarPlot,
@@ -545,6 +556,7 @@ _klasses = [
     KoalasLinePlot,
     KoalasBarhPlot,
     KoalasScatterPlot,
+    KoalasKdePlot,
 ]
 _plot_klass = {getattr(klass, '_kind'): klass for klass in _klasses}
 
@@ -860,8 +872,31 @@ class KoalasSeriesPlotMethods(PandasObject):
         """
         return self(kind='hist', bins=bins, **kwds)
 
-    def kde(self, bw_method=None, ind=None, **kwds):
-        return _unsupported_function(class_name='pd.Series', method_name='kde')()
+    def kde(self, bw_method=None, ind=None, **kwargs):
+        """
+        Generate Kernel Density Estimate plot using Gaussian kernels.
+
+        Parameters
+        ----------
+        bw_method : str, scalar or callable, optional
+            The method used to calculate the estimator bandwidth. This can be
+            'scott', 'silverman', a scalar constant or a callable.
+            If None (default), 'scott' is used.
+            See :class:`scipy.stats.gaussian_kde` for more information.
+        ind : NumPy array or integer, optional
+            Evaluation points for the estimated PDF. If None (default),
+            1000 equally spaced points are used. If `ind` is a NumPy array, the
+            KDE is evaluated at the points passed. If `ind` is an integer,
+            `ind` number of equally spaced points are used.
+        **kwargs : optional
+            Additional keyword arguments are documented in
+            :ref:`plot <api.series.plot>`
+
+        Returns
+        -------
+        matplotlib.axes.Axes or numpy.ndarray of them
+        """
+        return self(kind="kde", bw_method=bw_method, ind=ind, **kwargs)
 
     density = kde
 

--- a/databricks/koalas/tests/test_series_plot.py
+++ b/databricks/koalas/tests/test_series_plot.py
@@ -78,12 +78,12 @@ class SeriesPlotTest(ReusedSQLTestCase, TestUtils):
         pdf = self.pdf1
         kdf = self.kdf1
 
-        ax1 = pdf['a'].plot('bar', colormap='Paired')
-        ax2 = kdf['a'].plot('bar', colormap='Paired')
+        ax1 = pdf['a'].plot("bar", colormap='Paired')
+        ax2 = kdf['a'].plot("bar", colormap='Paired')
         self.compare_plots(ax1, ax2)
 
-        ax1 = pdf['a'].plot('bar', colormap='Paired')
-        ax2 = kdf['a'].plot('bar', colormap='Paired')
+        ax1 = pdf['a'].plot(kind='bar', colormap='Paired')
+        ax2 = kdf['a'].plot(kind='bar', colormap='Paired')
         self.compare_plots(ax1, ax2)
 
     def test_bar_plot_limited(self):
@@ -107,8 +107,8 @@ class SeriesPlotTest(ReusedSQLTestCase, TestUtils):
         ax2 = kdf['a'].plot.pie(colormap='Paired')
         self.compare_plots(ax1, ax2)
 
-        ax1 = pdf['a'].plot('pie', colormap='Paired')
-        ax2 = kdf['a'].plot('pie', colormap='Paired')
+        ax1 = pdf['a'].plot(kind='pie', colormap='Paired')
+        ax2 = kdf['a'].plot(kind='pie', colormap='Paired')
         self.compare_plots(ax1, ax2)
 
     def test_pie_plot_limited(self):
@@ -127,8 +127,8 @@ class SeriesPlotTest(ReusedSQLTestCase, TestUtils):
         pdf = self.pdf1
         kdf = self.kdf1
 
-        ax1 = pdf['a'].plot('line', colormap='Paired')
-        ax2 = kdf['a'].plot('line', colormap='Paired')
+        ax1 = pdf['a'].plot("line", colormap='Paired')
+        ax2 = kdf['a'].plot("line", colormap='Paired')
         self.compare_plots(ax1, ax2)
 
         ax1 = pdf['a'].plot.line(colormap='Paired')
@@ -139,8 +139,8 @@ class SeriesPlotTest(ReusedSQLTestCase, TestUtils):
         pdf = self.pdf1
         kdf = self.kdf1
 
-        ax1 = pdf['a'].plot('barh', colormap='Paired')
-        ax2 = kdf['a'].plot('barh', colormap='Paired')
+        ax1 = pdf['a'].plot("barh", colormap='Paired')
+        ax2 = kdf['a'].plot("barh", colormap='Paired')
         self.compare_plots(ax1, ax2)
 
     def test_barh_plot_limited(self):
@@ -170,8 +170,8 @@ class SeriesPlotTest(ReusedSQLTestCase, TestUtils):
         ax2 = kdf['a'].plot.hist(bins=15)
         self.compare_plots(ax1, ax2)
 
-        ax1 = pdf['a'].plot('hist', bins=15)
-        ax2 = kdf['a'].plot('hist', bins=15)
+        ax1 = pdf['a'].plot(kind='hist', bins=15)
+        ax2 = kdf['a'].plot(kind='hist', bins=15)
         self.compare_plots(ax1, ax2)
 
         ax1 = pdf['a'].plot.hist(bins=3, bottom=[2, 1, 3])
@@ -198,8 +198,8 @@ class SeriesPlotTest(ReusedSQLTestCase, TestUtils):
         }, index=pd.date_range(start='2018/01/01', end='2018/07/01', freq='M'))
         kdf = koalas.from_pandas(pdf)
 
-        ax1 = pdf['sales'].plot('area', colormap='Paired')
-        ax2 = kdf['sales'].plot('area', colormap='Paired')
+        ax1 = pdf['sales'].plot("area", colormap='Paired')
+        ax2 = kdf['sales'].plot("area", colormap='Paired')
         self.compare_plots(ax1, ax2)
 
         ax1 = pdf['sales'].plot.area(colormap='Paired')
@@ -207,8 +207,8 @@ class SeriesPlotTest(ReusedSQLTestCase, TestUtils):
         self.compare_plots(ax1, ax2)
 
         # just a sanity check for df.col type
-        ax1 = pdf.sales.plot('area', colormap='Paired')
-        ax2 = kdf.sales.plot('area', colormap='Paired')
+        ax1 = pdf.sales.plot("area", colormap='Paired')
+        ax2 = kdf.sales.plot("area", colormap='Paired')
         self.compare_plots(ax1, ax2)
 
     def boxplot_comparison(self, *args, **kwargs):

--- a/databricks/koalas/tests/test_series_plot.py
+++ b/databricks/koalas/tests/test_series_plot.py
@@ -78,12 +78,12 @@ class SeriesPlotTest(ReusedSQLTestCase, TestUtils):
         pdf = self.pdf1
         kdf = self.kdf1
 
-        ax1 = pdf['a'].plot(kind='bar', colormap='Paired')
-        ax2 = kdf['a'].plot(kind='bar', colormap='Paired')
+        ax1 = pdf['a'].plot('bar', colormap='Paired')
+        ax2 = kdf['a'].plot('bar', colormap='Paired')
         self.compare_plots(ax1, ax2)
 
-        ax1 = pdf['a'].plot(kind='bar', colormap='Paired')
-        ax2 = kdf['a'].plot(kind='bar', colormap='Paired')
+        ax1 = pdf['a'].plot('bar', colormap='Paired')
+        ax2 = kdf['a'].plot('bar', colormap='Paired')
         self.compare_plots(ax1, ax2)
 
     def test_bar_plot_limited(self):
@@ -107,8 +107,8 @@ class SeriesPlotTest(ReusedSQLTestCase, TestUtils):
         ax2 = kdf['a'].plot.pie(colormap='Paired')
         self.compare_plots(ax1, ax2)
 
-        ax1 = pdf['a'].plot(kind='pie', colormap='Paired')
-        ax2 = kdf['a'].plot(kind='pie', colormap='Paired')
+        ax1 = pdf['a'].plot('pie', colormap='Paired')
+        ax2 = kdf['a'].plot('pie', colormap='Paired')
         self.compare_plots(ax1, ax2)
 
     def test_pie_plot_limited(self):
@@ -127,8 +127,8 @@ class SeriesPlotTest(ReusedSQLTestCase, TestUtils):
         pdf = self.pdf1
         kdf = self.kdf1
 
-        ax1 = pdf['a'].plot(kind='line', colormap='Paired')
-        ax2 = kdf['a'].plot(kind='line', colormap='Paired')
+        ax1 = pdf['a'].plot('line', colormap='Paired')
+        ax2 = kdf['a'].plot('line', colormap='Paired')
         self.compare_plots(ax1, ax2)
 
         ax1 = pdf['a'].plot.line(colormap='Paired')
@@ -139,8 +139,8 @@ class SeriesPlotTest(ReusedSQLTestCase, TestUtils):
         pdf = self.pdf1
         kdf = self.kdf1
 
-        ax1 = pdf['a'].plot(kind='barh', colormap='Paired')
-        ax2 = kdf['a'].plot(kind='barh', colormap='Paired')
+        ax1 = pdf['a'].plot('barh', colormap='Paired')
+        ax2 = kdf['a'].plot('barh', colormap='Paired')
         self.compare_plots(ax1, ax2)
 
     def test_barh_plot_limited(self):
@@ -170,8 +170,8 @@ class SeriesPlotTest(ReusedSQLTestCase, TestUtils):
         ax2 = kdf['a'].plot.hist(bins=15)
         self.compare_plots(ax1, ax2)
 
-        ax1 = pdf['a'].plot(kind='hist', bins=15)
-        ax2 = kdf['a'].plot(kind='hist', bins=15)
+        ax1 = pdf['a'].plot('hist', bins=15)
+        ax2 = kdf['a'].plot('hist', bins=15)
         self.compare_plots(ax1, ax2)
 
         ax1 = pdf['a'].plot.hist(bins=3, bottom=[2, 1, 3])
@@ -198,8 +198,8 @@ class SeriesPlotTest(ReusedSQLTestCase, TestUtils):
         }, index=pd.date_range(start='2018/01/01', end='2018/07/01', freq='M'))
         kdf = koalas.from_pandas(pdf)
 
-        ax1 = pdf['sales'].plot(kind='area', colormap='Paired')
-        ax2 = kdf['sales'].plot(kind='area', colormap='Paired')
+        ax1 = pdf['sales'].plot('area', colormap='Paired')
+        ax2 = kdf['sales'].plot('area', colormap='Paired')
         self.compare_plots(ax1, ax2)
 
         ax1 = pdf['sales'].plot.area(colormap='Paired')
@@ -207,8 +207,8 @@ class SeriesPlotTest(ReusedSQLTestCase, TestUtils):
         self.compare_plots(ax1, ax2)
 
         # just a sanity check for df.col type
-        ax1 = pdf.sales.plot(kind='area', colormap='Paired')
-        ax2 = kdf.sales.plot(kind='area', colormap='Paired')
+        ax1 = pdf.sales.plot('area', colormap='Paired')
+        ax2 = kdf.sales.plot('area', colormap='Paired')
         self.compare_plots(ax1, ax2)
 
     def boxplot_comparison(self, *args, **kwargs):
@@ -280,24 +280,24 @@ class SeriesPlotTest(ReusedSQLTestCase, TestUtils):
         pdf = self.pdf1
         kdf = self.kdf1
 
-        pax = pdf['a'].plot(kind='kde', colormap='Paired')
-        kax = kdf['a'].plot(kind='kde', colormap='Paired')
+        pax = pdf['a'].plot('kde', colormap='Paired')
+        kax = kdf['a'].plot('kde', colormap='Paired')
         self.compare_plots(pax, kax)
 
         pax = pdf['a'].plot.kde(colormap='Paired')
         kax = kdf['a'].plot.kde(colormap='Paired')
         self.compare_plots(pax, kax)
 
-        pax = pdf['a'].plot(kind='kde', bw_method=0.3)
-        kax = kdf['a'].plot(kind='kde', bw_method=0.3)
+        pax = pdf['a'].plot('kde', bw_method=0.3)
+        kax = kdf['a'].plot('kde', bw_method=0.3)
         self.compare_plots(pax, kax)
 
         pax = pdf['a'].plot.kde(bw_method=0.3)
         kax = kdf['a'].plot.kde(bw_method=0.3)
         self.compare_plots(pax, kax)
 
-        pax = pdf['a'].plot(kind='kde', ind=[1, 2, 3, 4, 5])
-        kax = kdf['a'].plot(kind='kde', ind=[1, 2, 3, 4, 5])
+        pax = pdf['a'].plot('kde', ind=[1, 2, 3, 4, 5])
+        kax = kdf['a'].plot('kde', ind=[1, 2, 3, 4, 5])
         self.compare_plots(pax, kax)
 
         pax = pdf['a'].plot.kde(ind=[1, 2, 3, 4, 5])

--- a/databricks/koalas/tests/test_series_plot.py
+++ b/databricks/koalas/tests/test_series_plot.py
@@ -78,8 +78,8 @@ class SeriesPlotTest(ReusedSQLTestCase, TestUtils):
         pdf = self.pdf1
         kdf = self.kdf1
 
-        ax1 = pdf['a'].plot("bar", colormap='Paired')
-        ax2 = kdf['a'].plot("bar", colormap='Paired')
+        ax1 = pdf['a'].plot(kind='bar', colormap='Paired')
+        ax2 = kdf['a'].plot(kind='bar', colormap='Paired')
         self.compare_plots(ax1, ax2)
 
         ax1 = pdf['a'].plot(kind='bar', colormap='Paired')
@@ -127,8 +127,8 @@ class SeriesPlotTest(ReusedSQLTestCase, TestUtils):
         pdf = self.pdf1
         kdf = self.kdf1
 
-        ax1 = pdf['a'].plot("line", colormap='Paired')
-        ax2 = kdf['a'].plot("line", colormap='Paired')
+        ax1 = pdf['a'].plot(kind='line', colormap='Paired')
+        ax2 = kdf['a'].plot(kind='line', colormap='Paired')
         self.compare_plots(ax1, ax2)
 
         ax1 = pdf['a'].plot.line(colormap='Paired')
@@ -139,8 +139,8 @@ class SeriesPlotTest(ReusedSQLTestCase, TestUtils):
         pdf = self.pdf1
         kdf = self.kdf1
 
-        ax1 = pdf['a'].plot("barh", colormap='Paired')
-        ax2 = kdf['a'].plot("barh", colormap='Paired')
+        ax1 = pdf['a'].plot(kind='barh', colormap='Paired')
+        ax2 = kdf['a'].plot(kind='barh', colormap='Paired')
         self.compare_plots(ax1, ax2)
 
     def test_barh_plot_limited(self):
@@ -198,8 +198,8 @@ class SeriesPlotTest(ReusedSQLTestCase, TestUtils):
         }, index=pd.date_range(start='2018/01/01', end='2018/07/01', freq='M'))
         kdf = koalas.from_pandas(pdf)
 
-        ax1 = pdf['sales'].plot("area", colormap='Paired')
-        ax2 = kdf['sales'].plot("area", colormap='Paired')
+        ax1 = pdf['sales'].plot(kind='area', colormap='Paired')
+        ax2 = kdf['sales'].plot(kind='area', colormap='Paired')
         self.compare_plots(ax1, ax2)
 
         ax1 = pdf['sales'].plot.area(colormap='Paired')
@@ -207,8 +207,8 @@ class SeriesPlotTest(ReusedSQLTestCase, TestUtils):
         self.compare_plots(ax1, ax2)
 
         # just a sanity check for df.col type
-        ax1 = pdf.sales.plot("area", colormap='Paired')
-        ax2 = kdf.sales.plot("area", colormap='Paired')
+        ax1 = pdf.sales.plot(kind='area', colormap='Paired')
+        ax2 = kdf.sales.plot(kind='area', colormap='Paired')
         self.compare_plots(ax1, ax2)
 
     def boxplot_comparison(self, *args, **kwargs):
@@ -276,14 +276,33 @@ class SeriesPlotTest(ReusedSQLTestCase, TestUtils):
         self.assert_eq(expected_whiskers[1], whiskers[1])
         self.assert_eq(expected_fliers, fliers)
 
-    def test_missing(self):
-        ks = self.kdf1['a']
+    def test_kde_plot(self):
+        pdf = self.pdf1
+        kdf = self.kdf1
 
-        unsupported_functions = ['kde']
-        for name in unsupported_functions:
-            with self.assertRaisesRegex(PandasNotImplementedError,
-                                        "method.*Series.*{}.*not implemented".format(name)):
-                getattr(ks.plot, name)()
+        pax = pdf['a'].plot(kind='kde', colormap='Paired')
+        kax = kdf['a'].plot(kind='kde', colormap='Paired')
+        self.compare_plots(pax, kax)
+
+        pax = pdf['a'].plot.kde(colormap='Paired')
+        kax = kdf['a'].plot.kde(colormap='Paired')
+        self.compare_plots(pax, kax)
+
+        pax = pdf['a'].plot(kind='kde', bw_method=0.3)
+        kax = kdf['a'].plot(kind='kde', bw_method=0.3)
+        self.compare_plots(pax, kax)
+
+        pax = pdf['a'].plot.kde(bw_method=0.3)
+        kax = kdf['a'].plot.kde(bw_method=0.3)
+        self.compare_plots(pax, kax)
+
+        pax = pdf['a'].plot(kind='kde', ind=[1, 2, 3, 4, 5])
+        kax = kdf['a'].plot(kind='kde', ind=[1, 2, 3, 4, 5])
+        self.compare_plots(pax, kax)
+
+        pax = pdf['a'].plot.kde(ind=[1, 2, 3, 4, 5])
+        kax = kdf['a'].plot.kde(ind=[1, 2, 3, 4, 5])
+        self.compare_plots(pax, kax)
 
     def test_empty_hist(self):
         pdf = self.pdf1.assign(categorical='A')

--- a/databricks/koalas/tests/test_series_plot.py
+++ b/databricks/koalas/tests/test_series_plot.py
@@ -24,7 +24,6 @@ import pandas as pd
 
 from databricks import koalas
 from databricks.koalas.config import set_option, reset_option
-from databricks.koalas.exceptions import PandasNotImplementedError
 from databricks.koalas.testing.utils import ReusedSQLTestCase, TestUtils
 from databricks.koalas.plot import KoalasHistPlotSummary, KoalasBoxPlotSummary
 
@@ -280,14 +279,6 @@ class SeriesPlotTest(ReusedSQLTestCase, TestUtils):
         pdf = self.pdf1
         kdf = self.kdf1
 
-        pax = pdf['a'].plot('kde', colormap='Paired')
-        kax = kdf['a'].plot('kde', colormap='Paired')
-        self.compare_plots(pax, kax)
-
-        pax = pdf['a'].plot.kde(colormap='Paired')
-        kax = kdf['a'].plot.kde(colormap='Paired')
-        self.compare_plots(pax, kax)
-
         pax = pdf['a'].plot('kde', bw_method=0.3)
         kax = kdf['a'].plot('kde', bw_method=0.3)
         self.compare_plots(pax, kax)
@@ -296,12 +287,8 @@ class SeriesPlotTest(ReusedSQLTestCase, TestUtils):
         kax = kdf['a'].plot.kde(bw_method=0.3)
         self.compare_plots(pax, kax)
 
-        pax = pdf['a'].plot('kde', ind=[1, 2, 3, 4, 5])
-        kax = kdf['a'].plot('kde', ind=[1, 2, 3, 4, 5])
-        self.compare_plots(pax, kax)
-
-        pax = pdf['a'].plot.kde(ind=[1, 2, 3, 4, 5])
-        kax = kdf['a'].plot.kde(ind=[1, 2, 3, 4, 5])
+        pax = pdf['a'].plot('kde', ind=[1, 2, 3, 4, 5], bw_method=3.0)
+        kax = kdf['a'].plot('kde', ind=[1, 2, 3, 4, 5], bw_method=3.0)
         self.compare_plots(pax, kax)
 
     def test_empty_hist(self):

--- a/docs/source/reference/series.rst
+++ b/docs/source/reference/series.rst
@@ -335,6 +335,7 @@ specific plotting methods of the form ``Series.plot.<kind>``.
    Series.plot.hist
    Series.plot.line
    Series.plot.pie
+   Series.plot.kde
 
 .. currentmodule:: databricks.koalas
 .. autosummary::


### PR DESCRIPTION
This PR takes over https://github.com/databricks/koalas/pull/710

KDE, unlike other plots like line or area, it needs to calculates values via Spark so that we can compute it in a distributed manner.

This PR uses MLlib's KernelDensity API to calculate KDE. Since Spark only support scalar bandwidth, unlike SciPy that pandas' uses, Koalas will currently only support fixed scalar bandwidth only.

Implementation is different so the values are slightly different but seems good enough:

```python
import pandas as pd
pd.Series([1, 2, 2.5, 3, 3.5, 4, 5]).plot.kde(bw_method=0.3).figure.savefig("image.png")
```

![image](https://user-images.githubusercontent.com/6477701/64604705-90bcf500-d3fd-11e9-8cdd-e7dfee4eb5a4.png)

```python
import databricks.koalas as ks
ks.Series([1, 2, 2.5, 3, 3.5, 4, 5]).plot.kde(bw_method=0.3).figure.savefig("image.png")
```

![image](https://user-images.githubusercontent.com/6477701/64604722-9dd9e400-d3fd-11e9-80dc-a61895ce71db.png)


```python
import pandas as pd
pd.Series([1, 2, 2.5, 3, 3.5, 4, 5]).plot.kde(bw_method=3.0).figure.savefig("image.png")
```

![image](https://user-images.githubusercontent.com/6477701/64604769-b21de100-d3fd-11e9-8973-65d02e403321.png)


```python
import databricks.koalas as ks
ks.Series([1, 2, 2.5, 3, 3.5, 4, 5]).plot.kde(bw_method=3.0).figure.savefig("image.png")
```

![image](https://user-images.githubusercontent.com/6477701/64604786-bba74900-d3fd-11e9-8fe5-1e1572f1334d.png)

