### PR TITLE
Add index_col for spark IO reads.

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -343,9 +343,14 @@ class DataFrame(_Frame, Generic[T]):
             assert columns is None
             assert dtype is None
             assert not copy
+
             # When we know index columns
             if index_col is not None:
-                index_map = [(index_column, None) for index_column in index_col]
+                if isinstance(index_col, str):
+                    index_col = [index_col]
+                else:
+                    index_col = list(index_col)
+                index_map = [(col, col) for col in index_col]
                 super(DataFrame, self).__init__(_InternalFrame(data, index_map=index_map))
             else:
                 super(DataFrame, self).__init__(_InternalFrame(data))

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -331,7 +331,7 @@ class DataFrame(_Frame, Generic[T]):
     3  8  7  9  1  0
     4  2  5  4  3  9
     """
-    def __init__(self, data=None, index=None, columns=None, dtype=None, copy=False):
+    def __init__(self, data=None, index=None, columns=None, dtype=None, copy=False, index_col=None):
         if isinstance(data, _InternalFrame):
             assert index is None
             assert columns is None
@@ -343,7 +343,12 @@ class DataFrame(_Frame, Generic[T]):
             assert columns is None
             assert dtype is None
             assert not copy
-            super(DataFrame, self).__init__(_InternalFrame(data))
+            # When we know index columns
+            if index_col is not None:
+                index_map = [(index_column, None) for index_column in index_col]
+                super(DataFrame, self).__init__(_InternalFrame(data, index_map=index_map))
+            else:
+                super(DataFrame, self).__init__(_InternalFrame(data))
         elif isinstance(data, ks.Series):
             assert index is None
             assert columns is None

--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -287,7 +287,7 @@ def read_delta(path: str, version: Optional[str] = None, timestamp: Optional[str
     return read_spark_io(path, format='delta', options=options)
 
 
-def read_table(name: str) -> DataFrame:
+def read_table(name: str, index_col: str = None) -> DataFrame:
     """
     Read a Spark table and return a DataFrame.
 
@@ -315,7 +315,10 @@ def read_table(name: str) -> DataFrame:
     0   0
     """
     sdf = default_session().read.table(name)
-    return DataFrame(sdf)
+    if index_col is None:
+        return DataFrame(sdf)
+    else:
+        return DataFrame(sdf, index_col=[index_col])
 
 
 def read_spark_io(path: Optional[str] = None, format: Optional[str] = None,

--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -17,7 +17,7 @@
 """
 Wrappers around spark that correspond to common pandas functions.
 """
-from typing import Optional, Union
+from typing import Optional, Union, List
 from collections import OrderedDict
 from collections.abc import Iterable
 from functools import reduce
@@ -287,7 +287,7 @@ def read_delta(path: str, version: Optional[str] = None, timestamp: Optional[str
     return read_spark_io(path, format='delta', options=options)
 
 
-def read_table(name: str, index_col: str = None) -> DataFrame:
+def read_table(name: str, index_col: Optional[List[str]] = None) -> DataFrame:
     """
     Read a Spark table and return a DataFrame.
 
@@ -318,7 +318,7 @@ def read_table(name: str, index_col: str = None) -> DataFrame:
     if index_col is None:
         return DataFrame(sdf)
     else:
-        return DataFrame(sdf, index_col=[index_col])
+        return DataFrame(sdf, index_col=index_col)
 
 
 def read_spark_io(path: Optional[str] = None, format: Optional[str] = None,

--- a/databricks/koalas/tests/test_dataframe_spark_io.py
+++ b/databricks/koalas/tests/test_dataframe_spark_io.py
@@ -117,11 +117,23 @@ class DataFrameSparkIOTest(ReusedSQLTestCase, TestUtils):
                 expected.sort_values(by='f').to_spark().toPandas())
 
             # When index columns are known
-            expected = expected.set_index('bhello')[['f', 'i32', 'i64']]
-            actual = ks.read_table('test_table', 'bhello')[['f', 'i32', 'i64']]
+            expected_idx = expected.set_index('bhello')[['f', 'i32', 'i64']]
+            actual_idx = ks.read_table('test_table', 'bhello')[['f', 'i32', 'i64']]
             self.assert_eq(
-                actual.sort_values(by='f').to_spark().toPandas(),
-                expected.sort_values(by='f').to_spark().toPandas())
+                actual_idx.sort_values(by='f').to_spark().toPandas(),
+                expected_idx.sort_values(by='f').to_spark().toPandas())
+
+            expected_idx = expected.set_index(['bhello'])[['f', 'i32', 'i64']]
+            actual_idx = ks.read_table('test_table', ['bhello'])[['f', 'i32', 'i64']]
+            self.assert_eq(
+                actual_idx.sort_values(by='f').to_spark().toPandas(),
+                expected_idx.sort_values(by='f').to_spark().toPandas())
+
+            expected_idx = expected.set_index(['i32', 'bhello'])[['f', 'i64']]
+            actual_idx = ks.read_table('test_table', ['i32', 'bhello'])[['f', 'i64']]
+            self.assert_eq(
+                actual_idx.sort_values(by='f').to_spark().toPandas(),
+                expected_idx.sort_values(by='f').to_spark().toPandas())
 
     def test_spark_io(self):
         with self.temp_dir() as tmp:

--- a/databricks/koalas/tests/test_dataframe_spark_io.py
+++ b/databricks/koalas/tests/test_dataframe_spark_io.py
@@ -116,6 +116,13 @@ class DataFrameSparkIOTest(ReusedSQLTestCase, TestUtils):
                 actual.sort_values(by='f').to_spark().toPandas(),
                 expected.sort_values(by='f').to_spark().toPandas())
 
+            # When index columns are known
+            expected = expected.set_index('bhello')[['f', 'i32', 'i64']]
+            actual = ks.read_table('test_table', 'bhello')[['f', 'i32', 'i64']]
+            self.assert_eq(
+                actual.sort_values(by='f').to_spark().toPandas(),
+                expected.sort_values(by='f').to_spark().toPandas())
+
     def test_spark_io(self):
         with self.temp_dir() as tmp:
             pdf = self.test_pdf


### PR DESCRIPTION
Resolves #765 , I've added index_col for spark IO reads

If we know the index column already, We can prevent the creation of a default index by explicitly typing an index column as function arguments.

For example, now we can use 'read_table' like below.

```python
>>> ks.read_table('test_table1', index_col='i32')
     i64     f  bhello
i32
0      0   0.0  people
2      1  11.0   hello
0      2  12.0  people
1      0  10.0   hello
0      0  15.0   hello
2      0   5.0   hello
0      3   3.0      yo
1      4   4.0  people
0      1   6.0  people
1      2   7.0      yo
0      3  18.0      yo
1      4  19.0   hello
1      1   1.0   hello
2      2   2.0      yo
1      1  16.0   hello
2      2  17.0      yo
2      3   8.0      yo
0      4   9.0   hello
1      3  13.0      yo
2      4  14.0   hello
>>> ks.read_table('test_table1', index_col=['i32', 'i64'])
            f  bhello
i32 i64
0   0     0.0  people
2   1    11.0   hello
0   2    12.0  people
1   0    10.0   hello
0   0    15.0   hello
2   0     5.0   hello
0   3     3.0      yo
1   4     4.0  people
0   1     6.0  people
1   2     7.0      yo
0   3    18.0      yo
1   4    19.0   hello
    1     1.0   hello
2   2     2.0      yo
1   1    16.0   hello
2   2    17.0      yo
    3     8.0      yo
0   4     9.0   hello
1   3    13.0      yo
2   4    14.0   hello
```

Currently only added to 'read_table' functions.

And If you think this way is okay, I'm going to create a PR with all the other functions.

So could you take a look at this maybe if you available??

Thanks :)