### PR TITLE
Add axis parameter to dataframe.diff

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -2271,7 +2271,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         internal = self._internal.copy(sdf=sdf, data_columns=[c.name for c in applied])
         return DataFrame(internal)
 
-    # TODO: axis should support 1 or 'columns' either
+    # TODO: axis should support 1 or 'columns' either at this moment
     def nunique(self, axis: Union[int, str] = 0, dropna: bool = True, approx: bool = False,
                 rsd: float = 0.05) -> pd.Series:
         """

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -2192,8 +2192,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         internal = self._internal.copy(sdf=sdf, data_columns=[c.name for c in applied])
         return DataFrame(internal)
 
-    # TODO: axis should support 1 or 'columns' either
-    def diff(self, periods: int = 1, axis: int = 0):
+    # TODO: axis should support 1 or 'columns' either at this moment
+    def diff(self, periods: int = 1, axis: Union[int, str] = 0):
         """
         First discrete difference of element.
 
@@ -2272,7 +2272,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         return DataFrame(internal)
 
     # TODO: axis should support 1 or 'columns' either
-    def nunique(self, axis: int = 0, dropna: bool = True, approx: bool = False,
+    def nunique(self, axis: Union[int, str] = 0, dropna: bool = True, approx: bool = False,
                 rsd: float = 0.05) -> pd.Series:
         """
         Return number of unique elements in the object.

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -2192,8 +2192,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         internal = self._internal.copy(sdf=sdf, data_columns=[c.name for c in applied])
         return DataFrame(internal)
 
-    # TODO: add axis parameter
-    def diff(self, periods=1):
+    # TODO: axis should support 1 or 'columns' either
+    def diff(self, periods: int = 1, axis: int = 0):
         """
         First discrete difference of element.
 
@@ -2209,6 +2209,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         ----------
         periods : int, default 1
             Periods to shift for calculating difference, accepts negative values.
+        axis : int, default 0 or 'index'
+            Can only be set to 0 at the moment.
 
         Returns
         -------
@@ -2259,6 +2261,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         4 -1.0 -3.0 -11.0
         5  NaN  NaN   NaN
         """
+        if axis not in [0, 'index']:
+            raise ValueError('axis should be either 0 or "index" currently.')
         applied = []
         for column in self._internal.data_columns:
             applied.append(self[column].diff(periods))
@@ -2267,6 +2271,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         internal = self._internal.copy(sdf=sdf, data_columns=[c.name for c in applied])
         return DataFrame(internal)
 
+    # TODO: axis should support 1 or 'columns' either
     def nunique(self, axis: int = 0, dropna: bool = True, approx: bool = False,
                 rsd: float = 0.05) -> pd.Series:
         """
@@ -2276,7 +2281,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Parameters
         ----------
-        axis : int, default 0
+        axis : int, default 0 or 'index'
             Can only be set to 0 at the moment.
         dropna : bool, default True
             Don’t include NaN in the count.
@@ -2314,8 +2319,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         B    1
         Name: 0, dtype: int64
         """
-        if axis != 0:
-            raise ValueError("The 'nunique' method only works with axis=0 at the moment")
+        if axis not in [0, 'index']:
+            raise ValueError('axis should be either 0 or "index" currently.')
         res = self._sdf.select([self[column]._nunique(dropna, approx, rsd)
                                 for column in self.columns])
         return res.toPandas().T.iloc[:, 0]

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -515,6 +515,11 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(ks.DataFrame({'A': range(100)}).nunique(approx=True, rsd=0.01),
                        pd.Series([100], index=['A'], name='0'))
 
+        # Assert unsupported axis value yet
+        msg = 'axis should be either 0 or "index" currently.'
+        with self.assertRaisesRegex(ValueError, msg):
+            kdf.nunique(axis=1)
+
     def test_sort_values(self):
         pdf = pd.DataFrame({'a': [1, 2, 3, 4, 5, None, 7],
                             'b': [7, 6, 5, 4, 3, 2, 1]})
@@ -1472,6 +1477,9 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         msg = "should be an int"
         with self.assertRaisesRegex(ValueError, msg):
             kdf.diff(1.5)
+        msg = 'axis should be either 0 or "index" currently.'
+        with self.assertRaisesRegex(ValueError, msg):
+            kdf.diff(axis=1)
 
     def test_duplicated(self):
         pdf = pd.DataFrame({'a': [1, 1, 1, 3], 'b': [1, 1, 1, 4], 'c': [1, 1, 1, 5]})


### PR DESCRIPTION
Since pandas dataframe support axis parameter in dataframe.diff.

<img width="772" alt="스크린샷 2019-09-12 오후 1 47 32" src="https://user-images.githubusercontent.com/44108233/64754921-30949300-d564-11e9-8ae6-8f7e52f18951.png">

I think we need to support it either. (And it was already commented as TODO)

In addition, now the nunique function only support the axis parameter as 0 (without 'index'), also fix it.

<img width="922" alt="스크린샷 2019-09-12 오후 1 53 41" src="https://user-images.githubusercontent.com/44108233/64755104-fb3c7500-d564-11e9-83cb-93226ab8b4b7.png">


And currently we only support axis 0, or axis 1 for some functions, so i plan to implement it soon.