### PR TITLE
Add index_col for spark IO reads

### DIFF
--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -456,9 +456,9 @@ def read_parquet(path, columns=None, index_col=None) -> DataFrame:
         for col in index_col:
             if col not in sdf_columns:
                 raise KeyError(col)
-        index_map = [(col, col) for col in index_col]
+        index_map = [(col, col) for col in index_col]  # type: Optional[List[IndexMap]]
     else:
-        index_map = None  # type: Optional[List[IndexMap]]
+        index_map = None
     return DataFrame(_InternalFrame(sdf=sdf, index_map=index_map))
 
 

--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -124,15 +124,8 @@ def range(start: int,
     return DataFrame(sdf)
 
 
-def read_csv(path,
-             sep=',',
-             header='infer',
-             names=None,
-             index_col: Optional[Union[str, List[str]]] = None,
-             usecols=None,
-             mangle_dupe_cols=True,
-             parse_dates=False,
-             comment=None):
+def read_csv(path, sep=',', header='infer', names=None, index_col=None,
+             usecols=None, mangle_dupe_cols=True, parse_dates=False, comment=None):
     """Read CSV (comma-separated) file into DataFrame.
 
     Parameters

--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -458,7 +458,7 @@ def read_parquet(path, columns=None, index_col=None) -> DataFrame:
                 raise KeyError(col)
         index_map = [(col, col) for col in index_col]
     else:
-        index_map = None
+        index_map = None  # type: Optional[List[IndexMap]]
     return DataFrame(_InternalFrame(sdf=sdf, index_map=index_map))
 
 

--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -123,8 +123,8 @@ def range(start: int,
     return DataFrame(sdf)
 
 
-def read_csv(path, header='infer', names=None, usecols=None,
-             mangle_dupe_cols=True, parse_dates=False, comment=None, index_col=None):
+def read_csv(path, header='infer', names=None, index_col=None,
+             usecols=None, mangle_dupe_cols=True, parse_dates=False, comment=None):
     """Read CSV (comma-separated) file into DataFrame.
 
     Parameters
@@ -241,16 +241,7 @@ def read_csv(path, header='infer', names=None, usecols=None,
     else:
         sdf = default_session().createDataFrame([], schema=StructType())
 
-    index_map = None  # type: Optional[List[IndexMap]]
-
-    if index_col is not None:
-        if isinstance(index_col, str):
-            index_col = [index_col]
-        sdf_columns = set(sdf.columns)
-        for col in index_col:
-            if col not in sdf_columns:
-                raise KeyError(col)
-        index_map = [(col, col) for col in index_col]
+    index_map = _get_index_map(sdf, index_col)  # type: Optional[List[IndexMap]]
 
     return DataFrame(_InternalFrame(sdf=sdf, index_map=index_map))
 
@@ -334,16 +325,7 @@ def read_table(name: str, index_col: Optional[Union[str, List[str]]] = None) -> 
     0   0
     """
     sdf = default_session().read.table(name)
-    index_map = None  # type: Optional[List[IndexMap]]
-
-    if index_col is not None:
-        if isinstance(index_col, str):
-            index_col = [index_col]
-        sdf_columns = set(sdf.columns)
-        for col in index_col:
-            if col not in sdf_columns:
-                raise KeyError(col)
-        index_map = [(col, col) for col in index_col]
+    index_map = _get_index_map(sdf, index_col)  # type: Optional[List[IndexMap]]
 
     return DataFrame(_InternalFrame(sdf=sdf, index_map=index_map))
 
@@ -391,16 +373,7 @@ def read_spark_io(path: Optional[str] = None, format: Optional[str] = None,
     0   0
     """
     sdf = default_session().read.load(path=path, format=format, schema=schema, options=options)
-    index_map = None  # type: Optional[List[IndexMap]]
-
-    if index_col is not None:
-        if isinstance(index_col, str):
-            index_col = [index_col]
-        sdf_columns = set(sdf.columns)
-        for col in index_col:
-            if col not in sdf_columns:
-                raise KeyError(col)
-        index_map = [(col, col) for col in index_col]
+    index_map = _get_index_map(sdf, index_col)  # type: Optional[List[IndexMap]]
 
     return DataFrame(_InternalFrame(sdf=sdf, index_map=index_map))
 
@@ -449,16 +422,8 @@ def read_parquet(path, columns=None, index_col=None) -> DataFrame:
     else:
         sdf = default_session().createDataFrame([], schema=StructType())
 
-    if index_col is not None:
-        if isinstance(index_col, str):
-            index_col = [index_col]
-        sdf_columns = set(sdf.columns)
-        for col in index_col:
-            if col not in sdf_columns:
-                raise KeyError(col)
-        index_map = [(col, col) for col in index_col]  # type: Optional[List[IndexMap]]
-    else:
-        index_map = None
+    index_map = _get_index_map(sdf, index_col)  # type: Optional[List[IndexMap]]
+
     return DataFrame(_InternalFrame(sdf=sdf, index_map=index_map))
 
 
@@ -859,16 +824,7 @@ def read_sql_table(table_name, con, schema=None, index_col=None, columns=None, *
         reader.schema(schema)
     reader.options(**options)
     sdf = reader.format("jdbc").load()
-    if index_col is not None:
-        if isinstance(index_col, str):
-            index_col = [index_col]
-        sdf_columns = set(sdf.columns)
-        for col in index_col:
-            if col not in sdf_columns:
-                raise KeyError(col)
-        index_map = [(col, col) for col in index_col]
-    else:
-        index_map = None
+    index_map = _get_index_map(sdf, index_col)  # type: Optional[List[IndexMap]]
     kdf = DataFrame(_InternalFrame(sdf=sdf, index_map=index_map))
     if columns is not None:
         if isinstance(columns, str):
@@ -919,16 +875,7 @@ def read_sql_query(sql, con, index_col=None, **options):
     reader.option('url', con)
     reader.options(**options)
     sdf = reader.format("jdbc").load()
-    if index_col is not None:
-        if isinstance(index_col, str):
-            index_col = [index_col]
-        sdf_columns = set(sdf.columns)
-        for col in index_col:
-            if col not in sdf_columns:
-                raise KeyError(col)
-        index_map = [(col, col) for col in index_col]
-    else:
-        index_map = None
+    index_map = _get_index_map(sdf, index_col)  # type: Optional[List[IndexMap]]
     return DataFrame(_InternalFrame(sdf=sdf, index_map=index_map))
 
 
@@ -1678,6 +1625,23 @@ def _to_datetime2(arg_year, arg_month, arg_day,
         errors=errors,
         format=format,
         infer_datetime_format=infer_datetime_format)
+
+    index_map = None  # type: Optional[List[IndexMap]]
+
+
+def _get_index_map(sdf, index_col=None):
+    if index_col is not None:
+        if isinstance(index_col, str):
+            index_col = [index_col]
+        sdf_columns = set(sdf.columns)
+        for col in index_col:
+            if col not in sdf_columns:
+                raise KeyError(col)
+        index_map = [(col, col) for col in index_col]
+    else:
+        index_map = None
+
+    return index_map
 
 
 _get_dummies_default_accept_types = (

--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -143,6 +143,8 @@ def read_csv(path, header='infer', names=None, index_col=None,
         explicitly pass `header=None`. Duplicates in this list will cause an error to be issued.
         If a string is given, it should be a DDL-formatted string in Spark SQL, which is
         preferred to avoid schema inference for better performance.
+    index_col: str or list of str, optional, default: None
+        Index column of table in Spark.
     usecols : list-like or callable, optional
         Return a subset of the columns. If list-like, all elements must either be
         positional (i.e. integer indices into the document columns) or strings that
@@ -159,8 +161,6 @@ def read_csv(path, header='infer', names=None, index_col=None,
         Currently only `False` is allowed.
     comment: str, optional
         Indicates the line should not be parsed.
-    index_col: str or list of str, optional, default: None
-        Index column of table in Spark.
 
     Returns
     -------

--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -124,8 +124,15 @@ def range(start: int,
     return DataFrame(sdf)
 
 
-def read_csv(path, sep=',', header='infer', names=None, usecols=None,
-             mangle_dupe_cols=True, parse_dates=False, comment=None):
+def read_csv(path,
+             sep=',',
+             header='infer',
+             names=None,
+             index_col: Optional[Union[str, List[str]]] = None,
+             usecols=None,
+             mangle_dupe_cols=True,
+             parse_dates=False,
+             comment=None):
     """Read CSV (comma-separated) file into DataFrame.
 
     Parameters

--- a/databricks/koalas/tests/test_csv.py
+++ b/databricks/koalas/tests/test_csv.py
@@ -131,6 +131,11 @@ class CsvTest(ReusedSQLTestCase, TestUtils):
             self.assertRaisesRegex(ValueError, expected_error_message,
                                    lambda: ks.read_csv(fn, usecols=[1, 'amount']))
 
+            # check with index_col
+            expected = pd.read_csv(fn).set_index('name')
+            actual = ks.read_csv(fn, index_col='name')
+            self.assertPandasAlmostEqual(expected, actual.toPandas())
+
     def test_read_with_spark_schema(self):
         with self.csv_file(self.csv_text_2) as fn:
             actual = ks.read_csv(fn, names="A string, B string, C long, D long, E long")

--- a/databricks/koalas/tests/test_dataframe_spark_io.py
+++ b/databricks/koalas/tests/test_dataframe_spark_io.py
@@ -70,6 +70,16 @@ class DataFrameSparkIOTest(ReusedSQLTestCase, TestUtils):
             actual = ks.read_parquet(tmp)
             self.assertPandasEqual(expected, actual.toPandas())
 
+            # When index columns are known
+            pdf = self.test_pdf
+            expected = ks.DataFrame(pdf)
+
+            expected_idx = expected.set_index('bhello')[['f', 'i32', 'i64']]
+            actual_idx = ks.read_parquet(tmp, index_col='bhello')[['f', 'i32', 'i64']]
+            self.assert_eq(
+                actual_idx.sort_values(by='f').to_spark().toPandas(),
+                expected_idx.sort_values(by='f').to_spark().toPandas())
+
     def test_parquet_write(self):
         with self.temp_dir() as tmp:
             pdf = self.test_pdf
@@ -158,3 +168,14 @@ class DataFrameSparkIOTest(ReusedSQLTestCase, TestUtils):
             self.assert_eq(
                 actual.sort_values(by='f').to_spark().toPandas(),
                 expected.sort_values(by='f').to_spark().toPandas())
+
+            # When index columns are known
+            pdf = self.test_pdf
+            expected = ks.DataFrame(pdf)
+            col_order = ['f', 'i32', 'i64']
+
+            expected_idx = expected.set_index('bhello')[col_order]
+            actual_idx = ks.read_spark_io(tmp, format='json', index_col='bhello')[col_order]
+            self.assert_eq(
+                actual_idx.sort_values(by='f').to_spark().toPandas(),
+                expected_idx.sort_values(by='f').to_spark().toPandas())


### PR DESCRIPTION
Resolves #765 ,

I applied the same logic(as worked on #769) to all of the functions mentioned in above issue.

So when we work with spark IO read, and also know about index column name,

now we can use these functions with index_col like below and avoid creation of default index:

```python
>>> ks.read_parquet(path, index_col=['i32', 'i64'])
           f  bhello
i32 i64
0   1    6.0  people
1   2    7.0      yo
```