### PR TITLE
Fix minor typos at '_make_missing_functions.py' and 'env_setup.sh'

### DIFF
--- a/dev/_make_missing_functions.py
+++ b/dev/_make_missing_functions.py
@@ -186,7 +186,7 @@ def format_raise_errors(original_type, name, unavailable_arguments, signature):
     return raise_errors
 
 
-def make_misssing_function(original_type, name, signature):
+def make_missing_function(original_type, name, signature):
     """Make a missing functions stub.
 
     :return: the stub definition for the missing function
@@ -234,7 +234,7 @@ def _main():
 
         print('MISSING functions for {}'.format(original_type.__name__))
         for name, signature in missing:
-            # print(make_misssing_function(original_type, name, signature))
+            # print(make_missing_function(original_type, name, signature))
             print("""    {0} = unsupported_function('{0}')""".format(name))
 
         print()

--- a/dev/env_setup.sh
+++ b/dev/env_setup.sh
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-# Sets up enviornment from test. Should be sourced in other scripts.
+# Sets up environment from test. Should be sourced in other scripts.
 
 if [ -z "$SPARK_HOME" ]; then
     echo 'You need to set $SPARK_HOME to run these tests.' >&2


### PR DESCRIPTION
This PR fixes typos at  '_make_missing_functions.py' and 'env_setup.sh'