### PR TITLE
Add namespace support in options

### DIFF
--- a/databricks/koalas/__init__.py
+++ b/databricks/koalas/__init__.py
@@ -39,12 +39,12 @@ from databricks.koalas.frame import DataFrame
 from databricks.koalas.indexes import Index, MultiIndex
 from databricks.koalas.series import Series
 from databricks.koalas.typedef import pandas_wraps
-from databricks.koalas.config import get_option, set_option, reset_option
+from databricks.koalas.config import get_option, set_option, reset_option, options
 
 __all__ = ['read_csv', 'read_parquet', 'to_datetime', 'from_pandas',
            'get_dummies', 'DataFrame', 'Series', 'Index', 'MultiIndex', 'pandas_wraps',
            'sql', 'range', 'concat', 'melt', 'get_option', 'set_option', 'reset_option',
-           'read_sql_table', 'read_sql_query', 'read_sql']
+           'read_sql_table', 'read_sql_query', 'read_sql', 'options']
 
 
 def _auto_patch():

--- a/databricks/koalas/config.py
+++ b/databricks/koalas/config.py
@@ -318,12 +318,10 @@ class DictWrapper:
             k for k in d.keys() if all(x in k.split(".") for x in canonical_key.split("."))]
         if len(candidates) == 1 and candidates[0] == canonical_key:
             return set_option(canonical_key, val)
-        elif len(candidates) == 0:
+        else:
             raise OptionError(
                 "No such option: '{}'. Available options are [{}]".format(
                     key, ", ".join(list(_options_dict.keys()))))
-        else:
-            return DictWrapper(d, canonical_key)
 
     def __getattr__(self, key):
         prefix = object.__getattribute__(self, "prefix")
@@ -344,7 +342,17 @@ class DictWrapper:
             return DictWrapper(d, canonical_key)
 
     def __dir__(self):
-        return list(self.d.keys())
+        prefix = object.__getattribute__(self, "prefix")
+        d = object.__getattribute__(self, "d")
+
+        if prefix == "":
+            candidates = d.keys()
+            offset = 0
+        else:
+            candidates = [
+                k for k in d.keys() if all(x in k.split(".") for x in prefix.split("."))]
+            offset = len(prefix) + 1  # prefix (e.g. "compute.") to trim.
+        return [c[offset:] for c in candidates]
 
 
 options = DictWrapper(_options_dict)

--- a/databricks/koalas/config.py
+++ b/databricks/koalas/config.py
@@ -18,14 +18,14 @@
 Infrastructure of options for Koalas.
 """
 import json
-from typing import Union, Any, Tuple, Callable, List
+from typing import Union, Any, Tuple, Callable, List, Dict
 
 from pyspark._globals import _NoValue, _NoValueType
 
 from databricks.koalas.utils import default_session
 
 
-__all__ = ['get_option', 'set_option', 'reset_option']
+__all__ = ['get_option', 'set_option', 'reset_option', 'options']
 
 
 class Option:
@@ -194,7 +194,7 @@ _options = [
             "'plotting.sample_ratio' should be 1 >= value >= 0.")),
 ]  # type: List[Option]
 
-_options_dict = dict(zip((option.key for option in _options), _options))
+_options_dict = dict(zip((option.key for option in _options), _options))  # type: Dict[str, Option]
 
 _key_format = 'koalas.{}'.format
 
@@ -298,3 +298,53 @@ def _check_option(key: str) -> None:
         raise OptionError(
             "No such option: '{}'. Available options are [{}]".format(
                 key, ", ".join(list(_options_dict.keys()))))
+
+
+class DictWrapper:
+    """ provide attribute-style access to a nested dict"""
+
+    def __init__(self, d, prefix=""):
+        object.__setattr__(self, "d", d)
+        object.__setattr__(self, "prefix", prefix)
+
+    def __setattr__(self, key, val):
+        prefix = object.__getattribute__(self, "prefix")
+        d = object.__getattribute__(self, "d")
+        if prefix:
+            prefix += "."
+        canonical_key = prefix + key
+
+        candidates = [
+            k for k in d.keys() if all(x in k.split(".") for x in canonical_key.split("."))]
+        if len(candidates) == 1 and candidates[0] == canonical_key:
+            return set_option(canonical_key, val)
+        elif len(candidates) == 0:
+            raise OptionError(
+                "No such option: '{}'. Available options are [{}]".format(
+                    key, ", ".join(list(_options_dict.keys()))))
+        else:
+            return DictWrapper(d, canonical_key)
+
+    def __getattr__(self, key):
+        prefix = object.__getattribute__(self, "prefix")
+        d = object.__getattribute__(self, "d")
+        if prefix:
+            prefix += "."
+        canonical_key = prefix + key
+
+        candidates = [
+            k for k in d.keys() if all(x in k.split(".") for x in canonical_key.split("."))]
+        if len(candidates) == 1 and candidates[0] == canonical_key:
+            return get_option(canonical_key)
+        elif len(candidates) == 0:
+            raise OptionError(
+                "No such option: '{}'. Available options are [{}]".format(
+                    key, ", ".join(list(_options_dict.keys()))))
+        else:
+            return DictWrapper(d, canonical_key)
+
+    def __dir__(self):
+        return list(self.d.keys())
+
+
+options = DictWrapper(_options_dict)

--- a/databricks/koalas/tests/test_config.py
+++ b/databricks/koalas/tests/test_config.py
@@ -116,8 +116,19 @@ class ConfigTest(ReusedSQLTestCase):
 
             with self.assertRaisesRegex(config.OptionError, "No such option"):
                 ks.options.compute.max = 0
+            with self.assertRaisesRegex(config.OptionError, "No such option"):
+                ks.options.compute = 0
+            with self.assertRaisesRegex(config.OptionError, "No such option"):
+                ks.options.com = 0
         finally:
             ks.reset_option("compute.max_rows")
 
     def test_dir_options(self):
-        self.assertTrue("compute.max_rows" in dir(ks.options))
+        self.assertTrue("compute.default_index_type" in dir(ks.options))
+        self.assertTrue("plotting.sample_ratio" in dir(ks.options))
+
+        self.assertTrue("default_index_type" in dir(ks.options.compute))
+        self.assertTrue("sample_ratio" not in dir(ks.options.compute))
+
+        self.assertTrue("default_index_type" not in dir(ks.options.plotting))
+        self.assertTrue("sample_ratio" in dir(ks.options.plotting))

--- a/databricks/koalas/tests/test_config.py
+++ b/databricks/koalas/tests/test_config.py
@@ -113,5 +113,11 @@ class ConfigTest(ReusedSQLTestCase):
                 config.OptionError, "No such option", lambda: ks.options.compute.max)
             self.assertRaisesRegex(
                 config.OptionError, "No such option", lambda: ks.options.max_rows1)
+
+            with self.assertRaisesRegex(config.OptionError, "No such option"):
+                ks.options.compute.max = 0
         finally:
             ks.reset_option("compute.max_rows")
+
+    def test_dir_options(self):
+        self.assertTrue("compute.max_rows" in dir(ks.options))

--- a/docs/source/user_guide/options.rst
+++ b/docs/source/user_guide/options.rst
@@ -9,6 +9,17 @@ Koalas has an options system that lets you customize some aspects of its behavio
 display-related options being those the user is most likely to adjust.
 
 Options have a full "dotted-style", case-insensitive name (e.g. ``display.max_rows``).
+You can get/set options directly as attributes of the top-level ``options`` attribute:
+
+
+.. code-block:: python
+
+   >>> import databricks.koalas as ks
+   >>> ks.options.display.max_rows
+   1000
+   >>> ks.options.display.max_rows = 10
+   >>> ks.options.display.max_rows
+   10
 
 The API is composed of 3 relevant functions, available directly from the ``koalas``
 namespace:


### PR DESCRIPTION
This PR adds the support for options to be set like attributes.

```python
>>> import databricks.koalas as ks
>>> ks.options.display.max_rows
1000
>>> ks.options.display.max_rows = 10
>>> ks.options.display.max_rows
10
```