### PR TITLE
Show consistent repr output for index, series and frame

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -6641,12 +6641,13 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
     def __repr__(self):
         max_display_count = get_option("display.max_rows")
         if max_display_count is None:
-            return repr(self._to_internal_pandas())
+            return self._to_internal_pandas().to_string()
 
         pdf = self.head(max_display_count + 1)._to_internal_pandas()
         pdf_length = len(pdf)
-        repr_string = repr(pdf.iloc[:max_display_count])
+        pdf = pdf.iloc[:max_display_count]
         if pdf_length > max_display_count:
+            repr_string = pdf.to_string(show_dimensions=True)
             match = REPR_PATTERN.search(repr_string)
             if match is not None:
                 nrows = match.group("rows")
@@ -6654,17 +6655,18 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 footer = ("\n\n[Showing only the first {nrows} rows x {ncols} columns]"
                           .format(nrows=nrows, ncols=ncols))
                 return REPR_PATTERN.sub(footer, repr_string)
-        return repr_string
+        return pdf.to_string()
 
     def _repr_html_(self):
         max_display_count = get_option("display.max_rows")
         if max_display_count is None:
-            return self._to_internal_pandas()._repr_html_()
+            return self._to_internal_pandas().to_html(notebook=True)
 
         pdf = self.head(max_display_count + 1)._to_internal_pandas()
         pdf_length = len(pdf)
-        repr_html = pdf[:max_display_count]._repr_html_()
+        pdf = pdf[:max_display_count]
         if pdf_length > max_display_count:
+            repr_html = pdf.to_html(show_dimensions=True, notebook=True)
             match = REPR_HTML_PATTERN.search(repr_html)
             if match is not None:
                 nrows = match.group("rows")
@@ -6675,7 +6677,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                                   by=by,
                                   cols=ncols))
                 return REPR_HTML_PATTERN.sub(footer, repr_html)
-        return repr_html
+        return pdf.to_html(notebook=True)
 
     def __getitem__(self, key):
         return self._pd_getitem(key)

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -26,6 +26,7 @@ from typing import Any, Generic, List, Optional, Tuple, TypeVar, Union
 import numpy as np
 import pandas as pd
 from pandas.core.accessor import CachedAccessor
+from pandas.io.formats.printing import pprint_thing
 
 from pyspark import sql as spark
 from pyspark.sql import functions as F, Column
@@ -3046,20 +3047,22 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
     def __repr__(self):
         max_display_count = get_option("display.max_rows")
         if max_display_count is None:
-            return repr(self._to_internal_pandas())
+            return self._to_internal_pandas().to_string(name=self.name, dtype=self.dtype)
 
         pser = self.head(max_display_count + 1)._to_internal_pandas()
         pser_length = len(pser)
-        repr_string = repr(pser.iloc[:max_display_count])
+        pser = pser.iloc[:max_display_count]
         if pser_length > max_display_count:
+            repr_string = pser.to_string(length=True)
             rest, prev_footer = repr_string.rsplit("\n", 1)
             match = REPR_PATTERN.search(prev_footer)
             if match is not None:
                 length = match.group("length")
-                footer = ("\n{prev_footer}\nShowing only the first {length}"
-                          .format(length=length, prev_footer=prev_footer))
+                name = str(self.dtype.name)
+                footer = ("\nName: {name}, dtype: {dtype}\nShowing only the first {length}"
+                          .format(length=length, name=self.name, dtype=pprint_thing(name)))
                 return rest + footer
-        return repr_string
+        return pser.to_string(name=self.name, dtype=self.dtype)
 
     def __dir__(self):
         if not isinstance(self.schema, StructType):

--- a/databricks/koalas/tests/test_repr.py
+++ b/databricks/koalas/tests/test_repr.py
@@ -19,7 +19,7 @@ from databricks.koalas.testing.utils import ReusedSQLTestCase
 
 
 class ReprTests(ReusedSQLTestCase):
-    max_display_count = 123
+    max_display_count = 23
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
Currently, Koalas `display.max_rows` has a weird relationship with pandas' `display.max_rows` because Koalas directly uses pandas' `repr`.

```python
import pandas as pd
import databricks.koalas as ks

ks.set_option("display.max_rows", 5)
pd.set_option("display.max_rows", 5)

ks.range(6)
```

```
   id
0   0
1   1
2   2
3   3
4   4
```

```python
ks.set_option("display.max_rows", 5)
pd.set_option("display.max_rows", 4)

ks.range(6)
```

```
    id
0    0
1    1
..  ..
3    3
4    4

[Showing only the first 5 rows x 1 columns]
```

**The reason** is because pandas appends footer like:

```python
>>> ks.range(6).to_pandas()
    id
0    0
1    1
..  ..
4    4
5    5

[6 rows x 1 columns]
```

only when the value exceeds `display.max_rows`. 

Koalas replaces this footer `[6 rows x 1 columns]` to `[Showing only the first 6 rows x 1 columns]`.


If pandas does now show the footer:

```python
>>> ks.range(3).to_pandas()
   id
0   0
1   1
2   2
```

Koalas cannot replace it.

**The solution** is that to avoid use `repr` but use `to_string` and ignore pandas' `display.max_rows` but always print out fully. Koalas will control it.