### PR TITLE
Fix DataFrame.drop() to remove fields from Spark DataFrame also.

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -4371,10 +4371,12 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                               for column, idx
                               in zip(self._internal.data_columns, self._internal.column_index)
                               if idx not in drop_column_index))
-            internal = self._internal.copy(data_columns=list(cols), column_index=list(idx))
-            # To drop internal Spark DataFrame's columns also
-            for col in columns:
-                internal._sdf = internal._sdf.drop(col[0])
+            # make column string list to drop internal spark dataframe fields
+            columns = [col[0] for col in columns]
+            internal = self._internal.copy(
+                sdf=self._sdf.drop(*columns),
+                data_columns=list(cols),
+                column_index=list(idx))
             return DataFrame(internal)
         else:
             raise ValueError("Need to specify at least one of 'labels' or 'columns'")

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -4348,14 +4348,14 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         >>> columns = [('a', 'x'), ('a', 'y'), ('b', 'z'), ('b', 'w')]
         >>> pdf.columns = pd.MultiIndex.from_tuples(columns)
         >>> kdf = ks.DataFrame(pdf)
-        >>> kdf
-           a     b   
+        >>> kdf  # doctest: +NORMALIZE_WHITESPACE
+           a     b
            x  y  z  w
         0  1  3  5  7
         1  2  4  6  8
 
-        >>> kdf.drop('a')
-           b   
+        >>> kdf.drop('a')  # doctest: +NORMALIZE_WHITESPACE
+           b
            z  w
         0  5  7
         1  6  8

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -4371,10 +4371,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                               for column, idx
                               in zip(self._internal.data_columns, self._internal.column_index)
                               if idx not in drop_column_index))
-            # make column string list to drop internal spark dataframe fields
-            columns = [col[0] for col in columns]
             internal = self._internal.copy(
-                sdf=self._sdf.drop(*columns),
+                sdf=self._sdf.select(
+                    self._internal.index_scols + [self._internal.scol_for(col) for col in cols]),
                 data_columns=list(cols),
                 column_index=list(idx))
             return DataFrame(internal)

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -4348,13 +4348,15 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         >>> columns = [('a', 'x'), ('a', 'y'), ('b', 'z'), ('b', 'w')]
         >>> pdf.columns = pd.MultiIndex.from_tuples(columns)
         >>> kdf = ks.DataFrame(pdf)
-        >>> kdf # doctest: +NORMALIZE_WHITESPACE
+        >>> kdf
+        ... # doctest: +NORMALIZE_WHITESPACE
            a     b
            x  y  z  w
         0  1  3  5  7
         1  2  4  6  8
 
-        >>> kdf.drop('a') # doctest: +NORMALIZE_WHITESPACE
+        >>> kdf.drop('a')
+        ... # doctest: +NORMALIZE_WHITESPACE
            b
            z  w
         0  5  7

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -4344,6 +4344,22 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         0  1  7
         1  2  8
 
+        >>> pdf = pd.DataFrame({'x': [1, 2], 'y': [3, 4], 'z': [5, 6], 'w': [7, 8]})
+        >>> columns = [('a', 'x'), ('a', 'y'), ('b', 'z'), ('b', 'w')]
+        >>> pdf.columns = pd.MultiIndex.from_tuples(columns)
+        >>> kdf = ks.DataFrame(pdf)
+        >>> kdf
+           a     b   
+           x  y  z  w
+        0  1  3  5  7
+        1  2  4  6  8
+
+        >>> kdf.drop('a')
+           b   
+           z  w
+        0  5  7
+        1  6  8
+
         Notes
         -----
         Currently only axis = 1 is supported in this function,

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -4344,15 +4344,17 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         0  1  7
         1  2  8
 
-        >>> df = ks.DataFrame({('a', 'x'): [1, 2], ('a', 'y'): [3, 4],
-        ...                    ('b', 'z'): [5, 6], ('b', 'w'): [7, 8]},
-        ...                   columns=[('a', 'x'), ('a', 'y'), ('b', 'z'), ('b', 'w')])
-        >>> df  # doctest: +NORMALIZE_WHITESPACE
+        >>> pdf = pd.DataFrame({'x': [1, 2], 'y': [3, 4], 'z': [5, 6], 'w': [7, 8]},
+        ...                    columns=['x', 'y', 'z', 'w'])
+        >>> columns = [('a', 'x'), ('a', 'y'), ('b', 'z'), ('b', 'w')]
+        >>> pdf.columns = pd.MultiIndex.from_tuples(columns)
+        >>> kdf = ks.DataFrame(pdf)
+        >>> kdf  # doctest: +NORMALIZE_WHITESPACE
            a     b
            x  y  z  w
         0  1  3  5  7
         1  2  4  6  8
-        >>> df.drop('a')  # doctest: +NORMALIZE_WHITESPACE
+        >>> kdf.drop('a')  # doctest: +NORMALIZE_WHITESPACE
            b
            z  w
         0  5  7

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -4344,17 +4344,16 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         0  1  7
         1  2  8
 
-        >>> pdf = pd.DataFrame({'x': [1, 2], 'y': [3, 4], 'z': [5, 6], 'w': [7, 8]},
-        ...                    columns=['x', 'y', 'z', 'w'])
+        >>> df = ks.DataFrame({'x': [1, 2], 'y': [3, 4], 'z': [5, 6], 'w': [7, 8]},
+        ...                   columns=['x', 'y', 'z', 'w'])
         >>> columns = [('a', 'x'), ('a', 'y'), ('b', 'z'), ('b', 'w')]
-        >>> pdf.columns = pd.MultiIndex.from_tuples(columns)
-        >>> kdf = ks.DataFrame(pdf)
-        >>> kdf  # doctest: +NORMALIZE_WHITESPACE
+        >>> df.columns = pd.MultiIndex.from_tuples(columns)
+        >>> df  # doctest: +NORMALIZE_WHITESPACE
            a     b
            x  y  z  w
         0  1  3  5  7
         1  2  4  6  8
-        >>> kdf.drop('a')  # doctest: +NORMALIZE_WHITESPACE
+        >>> df.drop('a')  # doctest: +NORMALIZE_WHITESPACE
            b
            z  w
         0  5  7

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -4344,24 +4344,6 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         0  1  7
         1  2  8
 
-        >>> pdf = pd.DataFrame({'x': [1, 2], 'y': [3, 4], 'z': [5, 6], 'w': [7, 8]})
-        >>> columns = [('a', 'x'), ('a', 'y'), ('b', 'z'), ('b', 'w')]
-        >>> pdf.columns = pd.MultiIndex.from_tuples(columns)
-        >>> kdf = ks.DataFrame(pdf)
-        >>> kdf
-        ... # doctest: +NORMALIZE_WHITESPACE
-           a     b
-           x  y  z  w
-        0  1  3  5  7
-        1  2  4  6  8
-
-        >>> kdf.drop('a')
-        ... # doctest: +NORMALIZE_WHITESPACE
-           b
-           z  w
-        0  5  7
-        1  6  8
-
         Notes
         -----
         Currently only axis = 1 is supported in this function,

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -4344,6 +4344,20 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         0  1  7
         1  2  8
 
+        >>> df = ks.DataFrame({('a', 'x'): [1, 2], ('a', 'y'): [3, 4],
+        ...                    ('b', 'z'): [5, 6], ('b', 'w'): [7, 8]},
+        ...                   columns=[('a', 'x'), ('a', 'y'), ('b', 'z'), ('b', 'w')])
+        >>> df  # doctest: +NORMALIZE_WHITESPACE
+           a     b
+           x  y  z  w
+        0  1  3  5  7
+        1  2  4  6  8
+        >>> df.drop('a')  # doctest: +NORMALIZE_WHITESPACE
+           b
+           z  w
+        0  5  7
+        1  6  8
+
         Notes
         -----
         Currently only axis = 1 is supported in this function,
@@ -4367,15 +4381,15 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                                     if idx[:len(col)] == col)
             if len(drop_column_index) == 0:
                 raise KeyError(columns)
-            cols, idx = zip(*((column, idx)
+            cols, idxes = zip(*((column, idx)
                               for column, idx
                               in zip(self._internal.data_columns, self._internal.column_index)
                               if idx not in drop_column_index))
             internal = self._internal.copy(
                 sdf=self._sdf.select(
-                    self._internal.index_scols + [self._internal.scol_for(col) for col in cols]),
+                    self._internal.index_scols + [self._internal.scol_for(idx) for idx in idxes]),
                 data_columns=list(cols),
-                column_index=list(idx))
+                column_index=list(idxes))
             return DataFrame(internal)
         else:
             raise ValueError("Need to specify at least one of 'labels' or 'columns'")

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -4348,13 +4348,13 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         >>> columns = [('a', 'x'), ('a', 'y'), ('b', 'z'), ('b', 'w')]
         >>> pdf.columns = pd.MultiIndex.from_tuples(columns)
         >>> kdf = ks.DataFrame(pdf)
-        >>> kdf  # doctest: +NORMALIZE_WHITESPACE
+        >>> kdf # doctest: +NORMALIZE_WHITESPACE
            a     b
            x  y  z  w
         0  1  3  5  7
         1  2  4  6  8
 
-        >>> kdf.drop('a')  # doctest: +NORMALIZE_WHITESPACE
+        >>> kdf.drop('a') # doctest: +NORMALIZE_WHITESPACE
            b
            z  w
         0  5  7

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -4372,6 +4372,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                               in zip(self._internal.data_columns, self._internal.column_index)
                               if idx not in drop_column_index))
             internal = self._internal.copy(data_columns=list(cols), column_index=list(idx))
+            # To drop internal Spark DataFrame's columns also
+            for col in columns:
+                internal._sdf = internal._sdf.drop(col[0])
             return DataFrame(internal)
         else:
             raise ValueError("Need to specify at least one of 'labels' or 'columns'")


### PR DESCRIPTION
When we drop columns from dataframe with `DataFrame.drop()`,

We can get a dataframe which columns are dropped properly like below.

```python
>>> df
     name   class  max_speed
0  falcon    bird      389.0
1  parrot    bird       24.0
2    lion  mammal       80.5
3  monkey  mammal        NaN
>>>
>>> df = df.drop('name')
>>> df
    class  max_speed
0    bird      389.0
1    bird       24.0
2  mammal       80.5
3  mammal        NaN
```

But when we try to get an internal spark dataframe after then,

it shows us original one which is not delete columns like below.

```
>>> df._sdf.show()
+-----------------+------+------+---------+
|__index_level_0__|  name| class|max_speed|
+-----------------+------+------+---------+
|                0|falcon|  bird|    389.0|
|                1|parrot|  bird|     24.0|
|                2|  lion|mammal|     80.5|
|                3|monkey|mammal|     null|
+-----------------+------+------+---------+
```

(Although I dropped a column 'name' above example, it still shown in internal spark dataframe)

so i think maybe we need to drop them, too.

like:

```
>>> df._sdf.show()
+-----------------+------+---------+
|__index_level_0__| class|max_speed|
+-----------------+------+---------+
|                0|  bird|    389.0|
|                1|  bird|     24.0|
|                2|mammal|     80.5|
|                3|mammal|     null|
+-----------------+------+---------+
```