### PR TITLE
add squeeze argument to read_csv

### DIFF
--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -125,7 +125,8 @@ def range(start: int,
 
 
 def read_csv(path, sep=',', header='infer', names=None, index_col=None,
-             usecols=None, mangle_dupe_cols=True, parse_dates=False, comment=None):
+             usecols=None, squeeze=False, mangle_dupe_cols=True,
+             parse_dates=False, comment=None):
     """Read CSV (comma-separated) file into DataFrame.
 
     Parameters
@@ -155,6 +156,8 @@ def read_csv(path, sep=',', header='infer', names=None, index_col=None,
         from the document header row(s).
         If callable, the callable function will be evaluated against the column names,
         returning names where the callable function evaluates to `True`.
+    squeeze : bool, default False
+        If the parsed data only contains one column then return a Series.
     mangle_dupe_cols : bool, default True
         Duplicate columns will be specified as 'X0', 'X1', ... 'XN', rather
         than 'X' ... 'X'. Passing in False will cause data to be overwritten if
@@ -246,8 +249,11 @@ def read_csv(path, sep=',', header='infer', names=None, index_col=None,
         sdf = default_session().createDataFrame([], schema=StructType())
 
     index_map = _get_index_map(sdf, index_col)
+    kdf = DataFrame(_InternalFrame(sdf=sdf, index_map=index_map))
 
-    return DataFrame(_InternalFrame(sdf=sdf, index_map=index_map))
+    if squeeze and len(kdf.columns) == 1:
+        return kdf[kdf.columns[0]]
+    return kdf
 
 
 def read_json(path: str, index_col: Optional[Union[str, List[str]]] = None, **options):

--- a/databricks/koalas/tests/test_csv.py
+++ b/databricks/koalas/tests/test_csv.py
@@ -173,6 +173,16 @@ class CsvTest(ReusedSQLTestCase, TestUtils):
             actual = ks.read_csv(fn, sep='\t')
             self.assertPandasAlmostEqual(expected, actual.toPandas())
 
+    def test_read_csv_with_squeeze(self):
+        with self.csv_file(self.csv_text) as fn:
+            expected = pd.read_csv(fn, squeeze=True, usecols=['name'])
+            actual = ks.read_csv(fn, squeeze=True, usecols=['name'])
+            self.assertPandasAlmostEqual(expected, actual.toPandas())
+
+            expected = pd.read_csv(fn, squeeze=True, usecols=['name', 'amount'])
+            actual = ks.read_csv(fn, squeeze=True, usecols=['name', 'amount'])
+            self.assertPandasAlmostEqual(expected, actual.toPandas())
+
     def test_read_csv_with_mangle_dupe_cols(self):
         self.assertRaisesRegex(ValueError, 'mangle_dupe_cols',
                                lambda: ks.read_csv('path', mangle_dupe_cols=False))


### PR DESCRIPTION
Fix #808 

Add `squeeze` argument to `DataFrame.read_csv` so that it is more aligned with `pandas.DataFrame.read_csv` and the behavior will be the same as in `pandas`. Also add pytests for this feature. 