### PR TITLE
Fix columns setter to rename Spark DataFrame columns

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -4214,7 +4214,14 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                     "Length mismatch: Expected axis has %d elements, new values have %d elements"
                     % (len(old_names), len(column_index)))
             column_index_names = columns.names
-            self._internal = self._internal.copy(column_index=column_index,
+            data_columns = [str(idx) if len(idx) > 1 else idx[0] for idx in column_index]
+            sdf = self._sdf.select(
+                self._internal.index_scols +
+                [self._internal.scol_for(idx).alias(name)
+                 for idx, name in zip(self._internal.column_index, data_columns)])
+            self._internal = self._internal.copy(sdf=sdf,
+                                                 data_columns=data_columns,
+                                                 column_index=column_index,
                                                  column_index_names=column_index_names)
         else:
             old_names = self._internal.column_index
@@ -4227,7 +4234,14 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 column_index_names = columns.names
             else:
                 column_index_names = None
-            self._internal = self._internal.copy(column_index=column_index,
+            data_columns = [str(idx) if len(idx) > 1 else idx[0] for idx in column_index]
+            sdf = self._sdf.select(
+                self._internal.index_scols +
+                [self._internal.scol_for(idx).alias(name)
+                 for idx, name in zip(self._internal.column_index, data_columns)])
+            self._internal = self._internal.copy(sdf=sdf,
+                                                 data_columns=data_columns,
+                                                 column_index=column_index,
                                                  column_index_names=column_index_names)
 
     @property

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -324,6 +324,8 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         pdf.columns = ['x', 'y']
         self.assert_eq(kdf.columns, pd.Index(['x', 'y']))
         self.assert_eq(kdf, pdf)
+        self.assert_eq(kdf._internal.data_columns, ['x', 'y'])
+        self.assert_eq(kdf._internal.spark_df.columns, ['x', 'y'])
 
         columns = pdf.columns
         columns.name = 'lvl_1'
@@ -348,17 +350,23 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         kdf.columns = ['x', 'y']
         self.assert_eq(kdf.columns, pd.Index(['x', 'y']))
         self.assert_eq(kdf, pdf)
+        self.assert_eq(kdf._internal.data_columns, ['x', 'y'])
+        self.assert_eq(kdf._internal.spark_df.columns, ['x', 'y'])
 
         pdf.columns = columns
         kdf.columns = columns
         self.assert_eq(kdf.columns, columns)
         self.assert_eq(kdf, pdf)
+        self.assert_eq(kdf._internal.data_columns, ["('A', '0')", "('B', 1)"])
+        self.assert_eq(kdf._internal.spark_df.columns, ["('A', '0')", "('B', 1)"])
 
         columns.names = ['lvl_1', 'lvl_2']
 
         kdf.columns = columns
         self.assert_eq(kdf.columns.names, ['lvl_1', 'lvl_2'])
         self.assert_eq(kdf, pdf)
+        self.assert_eq(kdf._internal.data_columns, ["('A', '0')", "('B', 1)"])
+        self.assert_eq(kdf._internal.spark_df.columns, ["('A', '0')", "('B', 1)"])
 
     def test_dot_in_column_name(self):
         self.assert_eq(


### PR DESCRIPTION
The current columns setter doesn't rename the Spark columns and might cause issues such as #782 and #804.
This PR fixes that.

Resolves #782
Resolves #804