### PR TITLE
Implement Series.aggregate and agg

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -871,7 +871,6 @@ class DataFrame(_Frame, Generic[T]):
                                        column_index=[c._internal.column_index[0] for c in applied])
         return DataFrame(internal)
 
-    # TODO: Series support is not implemented yet.
     # TODO: not all arguments are implemented comparing to Pandas' for now.
     def aggregate(self, func: Union[List[str], Dict[str, List[str]]]):
         """Aggregate using one or more operations over the specified axis.

--- a/databricks/koalas/missing/series.py
+++ b/databricks/koalas/missing/series.py
@@ -48,8 +48,6 @@ class _MissingPandasLikeSeries(object):
     flags = unsupported_property('flags', deprecated=True)
 
     # Functions
-    agg = unsupported_function('agg')
-    aggregate = unsupported_function('aggregate')
     align = unsupported_function('align')
     argsort = unsupported_function('argsort')
     asfreq = unsupported_function('asfreq')

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -2321,14 +2321,14 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
 
         Examples
         --------
-        >>> s = ks.Series([[1, 2, 3, 4])
+        >>> s = ks.Series([1, 2, 3, 4])
         >>> s.agg('min')
         1
 
         >>> s.agg(['min', 'max'])
         min    1
         max    4
-        dtype: int64
+        Name: 0, dtype: int64
         """
         if isinstance(func, list):
             if all((isinstance(f, str) for f in func)):

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -2326,19 +2326,14 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         1
 
         >>> s.agg(['min', 'max'])
-        min    1
         max    4
+        min    1
         Name: 0, dtype: int64
         """
         if isinstance(func, list):
-            if all((isinstance(f, str) for f in func)):
-                rows = OrderedDict((f, eval("self.{}()".format(f), dict(self=self))) for f in func)
-                return Series(rows)
-            else:
-                raise ValueError("If the given function is a list, it "
-                                 "should only contains function names as strings.")
+            return self.to_frame().agg(func)[self.name]
         elif isinstance(func, str):
-            return eval("self.{}()".format(func))
+            return getattr(self, func)()
         else:
             raise ValueError("func must be a string or list of strings")
 

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -19,7 +19,7 @@ A wrapper class for Spark Column to behave similar to pandas Series.
 """
 import re
 import inspect
-from collections import Iterable, OrderedDict
+from collections import Iterable
 from functools import partial, wraps
 from typing import Any, Generic, List, Optional, Tuple, TypeVar, Union
 

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -21,7 +21,7 @@ import re
 import inspect
 from collections import Iterable
 from functools import partial, wraps
-from typing import Any, Generic, List, Optional, Tuple, TypeVar, Union, Dict
+from typing import Any, Generic, List, Optional, Tuple, TypeVar, Union
 
 import numpy as np
 import pandas as pd

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -19,7 +19,7 @@ A wrapper class for Spark Column to behave similar to pandas Series.
 """
 import re
 import inspect
-from collections import Iterable
+from collections import Iterable, OrderedDict
 from functools import partial, wraps
 from typing import Any, Generic, List, Optional, Tuple, TypeVar, Union
 
@@ -2332,7 +2332,7 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         """
         if isinstance(func, list):
             if all((isinstance(f, str) for f in func)):
-                rows = {f: eval("self.{}()".format(f), dict(self=self)) for f in func}
+                rows = OrderedDict((f, eval("self.{}()".format(f), dict(self=self))) for f in func)
                 return Series(rows)
             else:
                 raise ValueError("If the given function is a list, it "

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -2294,6 +2294,7 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         wrapped = ks.pandas_wraps(return_col=return_sig)(apply_each)
         return wrapped(self, *args, **kwds).rename(self.name)
 
+    # TODO: not all arguments are implemented comparing to Pandas' for now.
     def aggregate(self, func: Union[str, List[str]]):
         """Aggregate using one or more operations over the specified axis.
 
@@ -2304,7 +2305,10 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
 
         Returns
         -------
-        DataFrame
+        scalar, Series
+            The return can be:
+            - scalar : when Series.agg is called with single function
+            - Series : when Series.agg is called with several functions
 
         Notes
         -----
@@ -2312,8 +2316,8 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
 
         See Also
         --------
-        databricks.koalas.Series.groupby
-        databricks.koalas.DataFrame.groupby
+        databricks.koalas.Series.apply
+        databricks.koalas.Series.transform
 
         Examples
         --------

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -647,3 +647,14 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         kser = koalas.Series(pser)
         with self.assertRaisesRegex(ValueError, 'Type int63 not understood'):
             kser.astype('int63')
+
+    def test_aggregate(self):
+        pser = pd.Series([10, 20, 15, 30, 45], name='x')
+        kser = koalas.Series(pser)
+        msg = 'func must be a string or list of strings'
+        with self.assertRaisesRegex(ValueError, msg):
+            kser.aggregate({'x': ['min', 'max']})
+        msg = ('If the given function is a list, it '
+               'should only contains function names as strings.')
+        with self.assertRaisesRegex(ValueError, msg):
+            kser.aggregate(['min', max])

--- a/docs/source/reference/series.rst
+++ b/docs/source/reference/series.rst
@@ -85,6 +85,8 @@ Function application, GroupBy & Window
    :toctree: api/
 
    Series.apply
+   Series.agg
+   Series.aggregate
    Series.map
    Series.groupby
    Series.pipe


### PR DESCRIPTION
Like pandas Series.aggregate (https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.aggregate.html)

I implemented aggregate function for series.

Example:

```python
>>> s = ks.Series([1, 2, 3, 4])
>>> s
0    1
1    2
2    3
3    4
Name: 0, dtype: int64

>>> s.agg('min')
1

>>> s.agg(['min', 'max'])
min    1
max    4
Name: 0, dtype: int64
```

(above example is using pandas one)

![스크린샷 2019-09-23 오전 12 01 32](https://user-images.githubusercontent.com/44108233/65389872-52c4b700-dd95-11e9-8526-adba3e915a62.png)
