### PR TITLE
Raise a more helpful error for duplicated columns in Join

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -5433,6 +5433,14 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         2  K1  A1    B1
         3  K2  A2    B2
         """
+        if isinstance(right, ks.Series):
+            common = list(self.columns.intersection([right.name]))
+        else:
+            common = list(self.columns.intersection(right.columns))
+        if len(common) > 0 and not lsuffix and not rsuffix:
+            raise ValueError(
+                "columns overlap but no suffix specified: "
+                "{rename}".format(rename=common))
         if on:
             self = self.set_index(on)
             join_kdf = self.merge(right, left_index=True, right_index=True, how=how,

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -1001,7 +1001,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
                              'A': ['A0', 'A1', 'A2', 'A3']}, columns=['key', 'A'])
         kdf2 = ks.DataFrame({'key': ['K0', 'K1', 'K2'],
                              'B': ['B0', 'B1', 'B2']}, columns=['key', 'B'])
-        ks1 = ks.Series(['A1','A5'], index=[1,2], name='A')
+        ks1 = ks.Series(['A1', 'A5'], index=[1, 2], name='A')
         join_pdf = pdf1.join(pdf2, lsuffix='_left', rsuffix='_right')
         join_pdf.sort_values(by=list(join_pdf.columns), inplace=True)
 

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -1001,6 +1001,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
                              'A': ['A0', 'A1', 'A2', 'A3']}, columns=['key', 'A'])
         kdf2 = ks.DataFrame({'key': ['K0', 'K1', 'K2'],
                              'B': ['B0', 'B1', 'B2']}, columns=['key', 'B'])
+        ks1 = ks.Series(['A1','A5'], index=[1,2], name='A')
         join_pdf = pdf1.join(pdf2, lsuffix='_left', rsuffix='_right')
         join_pdf.sort_values(by=list(join_pdf.columns), inplace=True)
 
@@ -1009,6 +1010,11 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         self.assert_eq(join_pdf, join_kdf)
 
+        # join with duplicated columns in Series and DataFrame
+        with self.assertRaisesRegex(ValueError,
+                                    "columns overlap but no suffix specified"):
+            kdf1.join(ks1, how='outer')
+            kdf1.join(kdf2, how='outer')
         # check `on` parameter
         join_pdf = pdf1.join(pdf2.set_index('key'), on='key', lsuffix='_left', rsuffix='_right')
         join_pdf.sort_values(by=list(join_pdf.columns), inplace=True)


### PR DESCRIPTION
Fix #819 

Raise an error `>>> ValueError: columns overlap but no suffix specified: ['letter']` if the duplicated column(s) is found but no suffix is specified. 

Also added the pytests. 