### PR TITLE
Allow str and list in aggfunc in DataFrameGroupby.agg

### DIFF
--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -115,7 +115,7 @@ class GroupBy(object):
         """
         if not isinstance(func_or_funcs, (str, list)):
             if not isinstance(func_or_funcs, dict) or \
-                    not all(isinstance(key, str) and
+                    not all(isinstance(key, (str, tuple)) and
                             (isinstance(value, str) or isinstance(value, list) and
                                 all(isinstance(v, str) for v in value))
                             for key, value in func_or_funcs.items()):

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -137,9 +137,7 @@ class GroupBy(object):
                                  "to aggregate functions (string or list of strings).")
 
         else:
-            group_keyname = [key.name for key in self._groupkeys]
-            agg_cols = [key for key in self._kdf.columns if key not in group_keyname]
-
+            agg_cols = [col.name for col in self._agg_columns]
             func_or_funcs = OrderedDict([(col, func_or_funcs) for col in agg_cols])
 
         kdf = DataFrame(GroupBy._spark_groupby(self._kdf, func_or_funcs, self._groupkeys))

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -57,7 +57,7 @@ class GroupBy(object):
 
         Parameters
         ----------
-        func : dict
+        func : dict, str or list
              a dict mapping from column name (string) to
              aggregate functions (string or list of strings).
 

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -115,11 +115,11 @@ class GroupBy(object):
         if not isinstance(func_or_funcs, (str, list)):
             if not isinstance(func_or_funcs, dict) or \
                     not all(isinstance(key, str) and
-                            (isinstance(value, str) or
-                             isinstance(value, list) and all(isinstance(v, str) for v in value))
+                            (isinstance(value, str) or isinstance(value, list) and
+                                all(isinstance(v, str) for v in value))
                             for key, value in func_or_funcs.items()):
-                raise ValueError("aggs must be a dict mapping from column name (string) to aggregate "
-                                 "functions (string or list of strings).")
+                raise ValueError("aggs must be a dict mapping from column name (string) "
+                                 "to aggregate functions (string or list of strings).")
 
         else:
             func_dict = OrderedDict()

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -114,19 +114,19 @@ class GroupBy(object):
 
         >>> aggregated = df.groupby('A').agg('min')
         >>> aggregated  # doctest: +NORMALIZE_WHITESPACE
-            B      C
-          min    min
+             B      C
+           min    min
         A
-        1   1  0.227
-        2   3 -0.562
+        1    1  0.227
+        2    3 -0.562
 
         >>> aggregated = df.groupby('A').agg(['min', 'max'])
         >>> aggregated  # doctest: +NORMALIZE_WHITESPACE
-            B           C
-          min  max    min    max
+             B           C
+           min  max    min    max
         A
-        1   1    2  0.227  0.362
-        2   3    4 -0.562  1.267
+        1    1    2  0.227  0.362
+        2    3    4 -0.562  1.267
         """
         if not isinstance(func_or_funcs, (str, list)):
             if not isinstance(func_or_funcs, dict) or \

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -115,7 +115,6 @@ class GroupBy(object):
         >>> aggregated = df.groupby('A').agg('min')
         >>> aggregated  # doctest: +NORMALIZE_WHITESPACE
              B      C
-           min    min
         A
         1    1  0.227
         2    3 -0.562
@@ -134,7 +133,7 @@ class GroupBy(object):
                             (isinstance(value, str) or isinstance(value, list) and
                                 all(isinstance(v, str) for v in value))
                             for key, value in func_or_funcs.items()):
-                raise ValueError("aggs must be a dict mapping from column name (string) "
+                raise ValueError("aggs must be a dict mapping from column name (string or tuple) "
                                  "to aggregate functions (string or list of strings).")
 
         else:

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -112,6 +112,21 @@ class GroupBy(object):
         1    1    2
         2    3    4
 
+        >>> aggregated = df.groupby('A').agg('min')
+        >>> aggregated  # doctest: +NORMALIZE_WHITESPACE
+            B      C
+          min    min
+        A
+        1   1  0.227
+        2   3 -0.562
+
+        >>> aggregated = df.groupby('A').agg(['min', 'max'])
+        >>> aggregated  # doctest: +NORMALIZE_WHITESPACE
+            B           C
+          min  max    min    max
+        A
+        1   1    2  0.227  0.362
+        2   3    4 -0.562  1.267
         """
         if not isinstance(func_or_funcs, (str, list)):
             if not isinstance(func_or_funcs, dict) or \

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -137,14 +137,10 @@ class GroupBy(object):
                                  "to aggregate functions (string or list of strings).")
 
         else:
-            func_dict = OrderedDict()
             group_keyname = [key.name for key in self._groupkeys]
             agg_cols = [key for key in self._kdf.columns if key not in group_keyname]
 
-            for col in agg_cols:
-                func_dict[col] = func_or_funcs
-
-            func_or_funcs = func_dict
+            func_or_funcs = OrderedDict([(col, func_or_funcs) for col in agg_cols])
 
         kdf = DataFrame(GroupBy._spark_groupby(self._kdf, func_or_funcs, self._groupkeys))
         if not self._as_index:

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -116,6 +116,19 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         with self.assertRaisesRegex(ValueError, expected_error_message):
             kdf.groupby('A', as_index=as_index).agg(0)
 
+    def test_aggregate_func_str_list(self):
+        # this is test for cases where only string or list is assigned
+        pdf = pd.DataFrame({'kind': ['cat', 'dog', 'cat', 'dog'],
+                            'height': [9.1, 6.0, 9.5, 34.0],
+                            'weight': [7.9, 7.5, 9.9, 198.0]}
+                           )
+        kdf = koalas.from_pandas(pdf)
+
+        agg_funcs = ['max', 'min', ['min', 'max']]
+        for aggfunc in agg_funcs:
+            self.assert_eq(kdf.groupby('kind').agg(aggfunc),
+                           pdf.groupby('kind').agg(aggfunc))
+
     def test_all_any(self):
         pdf = pd.DataFrame({'A': [1, 1, 2, 2, 3, 3, 4, 4, 5, 5],
                             'B': [True, True, True, False, False, False, None, True, None, False]})

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -179,8 +179,8 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         kdf.columns = columns
 
         for aggfunc in agg_funcs:
-            sorted_agg_kdf = kdf.groupby('kind').agg(aggfunc).sort_index()
-            sorted_agg_pdf = pdf.groupby('kind').agg(aggfunc).sort_index()
+            sorted_agg_kdf = kdf.groupby(('X', 'A')).agg(aggfunc).sort_index()
+            sorted_agg_pdf = pdf.groupby(('X', 'A')).agg(aggfunc).sort_index()
             self.assert_eq(sorted_agg_kdf, sorted_agg_pdf)
 
     def test_all_any(self):

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -179,8 +179,8 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         kdf.columns = columns
 
         for aggfunc in agg_funcs:
-            sorted_agg_kdf = kdf.groupby('kind').agg(aggfunc)
-            sorted_agg_pdf = pdf.groupby('kind').agg(aggfunc)
+            sorted_agg_kdf = kdf.groupby('kind').agg(aggfunc).sort_index()
+            sorted_agg_pdf = pdf.groupby('kind').agg(aggfunc).sort_index()
             self.assert_eq(sorted_agg_kdf, sorted_agg_pdf)
 
     def test_all_any(self):

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -168,6 +168,21 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             sorted_agg_pdf = pdf.groupby('kind').agg(aggfunc).sort_index()
             self.assert_eq(sorted_agg_kdf, sorted_agg_pdf)
 
+        # test on multi index column case
+        pdf = pd.DataFrame({'A': [1, 1, 2, 2],
+                            'B': [1, 2, 3, 4],
+                            'C': [0.362, 0.227, 1.267, -0.562]})
+        kdf = koalas.from_pandas(pdf)
+
+        columns = pd.MultiIndex.from_tuples([('X', 'A'), ('X', 'B'), ('Y', 'C')])
+        pdf.columns = columns
+        kdf.columns = columns
+
+        for aggfunc in agg_funcs:
+            sorted_agg_kdf = kdf.groupby('kind').agg(aggfunc)
+            sorted_agg_pdf = pdf.groupby('kind').agg(aggfunc)
+            self.assert_eq(sorted_agg_kdf, sorted_agg_pdf)
+
     def test_all_any(self):
         pdf = pd.DataFrame({'A': [1, 1, 2, 2, 3, 3, 4, 4, 5, 5],
                             'B': [True, True, True, False, False, False, None, True, None, False]})


### PR DESCRIPTION
right now, when I look at Groupby, it does not accept str or list, but in pandas, it's allowed. So before implementing named aggregation, i think this is a better thing to deal first.
e.g. in pandas we could have:

![Screen Shot 2019-09-24 at 10 58 52 PM](https://user-images.githubusercontent.com/9269816/65549980-ec6ba000-df1e-11e9-98fe-daad9ac94c7b.png)

now koalas can also accept this:

![Screen Shot 2019-09-24 at 11 00 13 PM](https://user-images.githubusercontent.com/9269816/65550069-1624c700-df1f-11e9-8987-ab6566b7290d.png)
