### PR TITLE
Add unit and origin options for to_datetime

### DIFF
--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -997,7 +997,7 @@ def to_datetime(arg, errors='raise', format=None, unit=None, infer_datetime_form
         datetime strings, and if it can be inferred, switch to a faster
         method of parsing them. In some cases this can increase the parsing
         speed by ~5-10x.
-    origin : scalar, default is 'unix'
+    origin : scalar, default 'unix'
         Define the reference date. The numeric values would be parsed as number
         of units (defined by `unit`) since this reference date.
 

--- a/databricks/koalas/tests/test_namespace.py
+++ b/databricks/koalas/tests/test_namespace.py
@@ -47,6 +47,14 @@ class NamespaceTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(pd.to_datetime(pdf), ks.to_datetime(kdf))
         self.assert_eq(pd.to_datetime(dict_from_pdf), ks.to_datetime(dict_from_pdf))
 
+        self.assert_eq(pd.to_datetime(1490195805, unit='s'),
+                       ks.to_datetime(1490195805, unit='s'))
+        self.assert_eq(pd.to_datetime(1490195805433502912, unit='ns'),
+                       ks.to_datetime(1490195805433502912, unit='ns'))
+
+        self.assert_eq(pd.to_datetime([1, 2, 3], unit='D', origin=pd.Timestamp('1960-01-01')),
+                       ks.to_datetime([1, 2, 3], unit='D', origin=pd.Timestamp('1960-01-01')))
+
     def test_concat(self):
         pdf = pd.DataFrame({'A': [0, 2, 4], 'B': [1, 3, 5]})
         kdf = ks.from_pandas(pdf)


### PR DESCRIPTION
This PR adds `unit` and `origin` options for `to_datetime` and resolves #837 .