### PR TITLE
Fix on wrong error raise in DataFrame.fillna

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -3531,8 +3531,6 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 axis = 0
             if not (axis == 0 or axis == "index"):
                 raise NotImplementedError("fillna currently only works for axis=0 or axis='index'")
-            if (value is None) and (method is None):
-                raise ValueError("Must specify a fillna 'value' or 'method' parameter.")
             if not isinstance(value, (float, int, str, bool, dict, pd.Series)):
                 raise TypeError("Unsupported type %s" % type(value))
             if isinstance(value, pd.Series):
@@ -3547,6 +3545,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             sdf = sdf.fillna(value)
             internal = self._internal.copy(sdf=sdf)
         else:
+            if method is None:
+                raise ValueError("Must specify a fillna 'value' or 'method' parameter.")
+
             applied = []
             for idx in self._internal.column_index:
                 applied.append(self[idx].fillna(value=value, method=method, axis=axis,


### PR DESCRIPTION
https://github.com/databricks/koalas/blob/7ee2a8dff3d61f2fe66f85385bc5af20d2f154f5/databricks/koalas/frame.py#L3534

seems this line won't be touched, and the reason it still passed tests is because it triggered the `Series.fillna()` error raise mechanism in the `else` below.