### PR TITLE
[MINOR] Fix duplicated function 'Dataframe.plot.hist'

### DIFF
--- a/docs/source/reference/frame.rst
+++ b/docs/source/reference/frame.rst
@@ -243,6 +243,6 @@ specific plotting methods of the form ``DataFrame.plot.<kind>``.
    DataFrame.plot.line
    DataFrame.plot.pie
    DataFrame.plot.scatter
-   DataFrame.plot.hist
    DataFrame.plot.kde
    DataFrame.plot.density
+   DataFrame.hist


### PR DESCRIPTION
Fix duplicated function name `DataFrame.plot.hist` to `DataFrame.hist`