### PR TITLE
Clean generated rst files at Sphinx instead of linter script

### DIFF
--- a/dev/lint-python
+++ b/dev/lint-python
@@ -251,8 +251,6 @@ function sphinx_test {
     echo "starting $SPHINX_BUILD tests..."
     pushd docs &> /dev/null
     make clean &> /dev/null
-    # Remove previously generated rst files
-    rm -fr $DIR/../docs/source/reference/api/*
     # Treat warnings as errors so we stop correctly
     SPHINX_REPORT=$( (SPHINXOPTS="-a -W" make html) 2>&1)
     SPHINX_STATUS=$?

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,10 +12,20 @@
 
 import os
 import sys
+import shutil
 import importlib.util
+import errno
 
 from databricks import koalas
 sys.path.insert(0, os.path.abspath('.'))
+
+# Remove previously generated rst files. Ignore errors just in case it stops generating whole docs.
+shutil.rmtree("%s/reference/api" % os.path.dirname(os.path.abspath(__file__)), ignore_errors=True)
+try:
+    os.mkdir("%s/reference/api" % os.path.dirname(os.path.abspath(__file__)))
+except OSError as e:
+    if e.errno != errno.EEXIST:
+        raise
 
 
 def gendoc():


### PR DESCRIPTION
So, `make clean html` removes auto-generated files under `docs/source/references/api` as well. Manually tested.