### PR TITLE
Add options to ignore specific cases when flake8 test

### DIFF
--- a/databricks/koalas/plot.py
+++ b/databricks/koalas/plot.py
@@ -1266,6 +1266,9 @@ class KoalasSeriesPlotMethods(PandasObject):
             ...                   index=['Mercury', 'Venus', 'Earth'])
             >>> plot = df.mass.plot.pie(figsize=(5, 5))
 
+        .. plot::
+            :context: close-figs
+
             >>> plot = df.mass.plot.pie(subplots=True, figsize=(6, 3))
         """
         return self(kind='pie', **kwds)

--- a/dev/lint-python
+++ b/dev/lint-python
@@ -153,6 +153,7 @@ flake8 checks failed."
 
     echo "starting $FLAKE8_BUILD test..."
     FLAKE8_REPORT=$( ($FLAKE8_BUILD . --count --select=E901,E999,F821,F822,F823 \
+                     --exclude="docs/build/html/reference/api/*.py" \
                      --max-line-length=100 --show-source --statistics) 2>&1)
     FLAKE8_STATUS=$?
 


### PR DESCRIPTION
Related with https://github.com/databricks/koalas/pull/847#pullrequestreview-296428735 ,

Fixed flake8 to ignore "docs/build/html/reference/api/*.py"

in my local test, it works well, and all plots visible in documentation like below:

<img width="927" alt="스크린샷 2019-10-03 오후 2 19 36" src="https://user-images.githubusercontent.com/44108233/66101387-a0d58800-e5e9-11e9-813d-fc48ce117327.png">


