### PR TITLE
Fix Series from DataFrame's key to change internal schema also

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -7128,9 +7128,13 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 assert len(idxes) == 1
                 index = list(idxes)[0]
                 kdf_or_ser = \
-                    Series(self._internal.copy(scol=self._internal.scol_for(index),
-                                               column_index=[index]),
-                           anchor=self)
+                    Series(self._internal.copy(
+                        sdf=self._sdf.select(
+                            self._internal.index_scols +
+                            [self._internal.scol_for(index)]),
+                        scol=self._internal.scol_for(index),
+                        column_index=[index]),
+                        anchor=self)
             except AnalysisException:
                 raise KeyError(key)
         else:


### PR DESCRIPTION
When we get Series from DataFrame by specific column name as a key like below,

```python
>>> df = ks.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]})
>>> df
   A  B
0  1  4
1  2  5
2  3  6
>>> s = df['A']
>>> s
0    1
1    2
2    3
Name: A, dtype: int64
```
it looks good first time, however when I take a look at this once more,

i notice that the internal schema of the returned Series is not changed.

```
>>> s._internal.sdf.show()
+-----------------+---+---+
|__index_level_0__|  A|  B|
+-----------------+---+---+
|                0|  1|  4|
|                1|  2|  5|
|                2|  3|  6|
+-----------------+---+---+
```

so i think maybe it is better to change internal frame also like,

```
>>> s._internal.sdf.show()
+-----------------+---+
|__index_level_0__|  A|
+-----------------+---+
|                0|  1|
|                1|  2|
|                2|  3|
+-----------------+---+
```