### PR TITLE
Implement DataFrame.xs

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -1940,14 +1940,6 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         DataFrame.iloc : Purely integer-location based indexing
             for selection by position.
 
-        Notes
-        -----
-        `xs` can not be used to set values.
-        MultiIndex Slicers is a generic way to get/set values on
-        any level or levels.
-        It is a superset of `xs` functionality, see
-        :ref:`MultiIndex Slicers <advanced.mi_slicers>`.
-
         Examples
         --------
         >>> d = {'num_legs': [4, 4, 2, 2],

--- a/databricks/koalas/missing/frame.py
+++ b/databricks/koalas/missing/frame.py
@@ -104,7 +104,6 @@ class _MissingPandasLikeDataFrame(object):
     tz_localize = unsupported_function('tz_localize')
     unstack = unsupported_function('unstack')
     where = unsupported_function('where')
-    xs = unsupported_function('xs')
 
     # Deprecated functions
     as_blocks = unsupported_function('as_blocks', deprecated=True)

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -734,6 +734,9 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
              'locomotion': ['walks', 'walks', 'flies', 'walks']}
         kdf = ks.DataFrame(data=d)
         kdf = kdf.set_index(['class', 'animal', 'locomotion'])
+        pdf = kdf.to_pandas()
+
+        self.assert_eq(kdf.xs(('mammal', 'dog', 'walks')), pdf.xs(('mammal', 'dog', 'walks')))
 
         msg = "'key' should be string or tuple that contains strings"
         with self.assertRaisesRegex(ValueError, msg):

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -726,6 +726,26 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(kdf.nsmallest(n=5, columns='a'), pdf.nsmallest(5, columns='a'))
         self.assert_eq(kdf.nsmallest(n=5, columns=['a', 'b']), pdf.nsmallest(5, columns=['a', 'b']))
 
+    def test_xs(self):
+        d = {'num_legs': [4, 4, 2, 2],
+             'num_wings': [0, 0, 2, 2],
+             'class': ['mammal', 'mammal', 'mammal', 'bird'],
+             'animal': ['cat', 'dog', 'bat', 'penguin'],
+             'locomotion': ['walks', 'walks', 'flies', 'walks']}
+        kdf = ks.DataFrame(data=d)
+        kdf = kdf.set_index(['class', 'animal', 'locomotion'])
+
+        msg = "'key' should be string or tuple that contains strings"
+        with self.assertRaisesRegex(ValueError, msg):
+            kdf.xs(1)
+        msg = ("'key' should have index names as only strings "
+               "or a tuple that contain index names as only strings")
+        with self.assertRaisesRegex(ValueError, msg):
+            kdf.xs(('mammal', 1))
+        msg = 'axis should be either 0 or "index" currently.'
+        with self.assertRaisesRegex(ValueError, msg):
+            kdf.xs('num_wings', axis=1)
+
     def test_missing(self):
         kdf = self.kdf
 

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -745,6 +745,9 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         msg = 'axis should be either 0 or "index" currently.'
         with self.assertRaisesRegex(ValueError, msg):
             kdf.xs('num_wings', axis=1)
+        msg = r"'Key length \(4\) exceeds index depth \(3\)'"
+        with self.assertRaisesRegex(KeyError, msg):
+            kdf.xs(('mammal', 'dog', 'walks', 'foo'))
 
     def test_missing(self):
         kdf = self.kdf

--- a/docs/source/reference/frame.rst
+++ b/docs/source/reference/frame.rst
@@ -54,6 +54,7 @@ Indexing, iteration
    DataFrame.iloc
    DataFrame.items
    DataFrame.iteritems
+   DataFrame.xs
    DataFrame.get
 
 Binary operator functions


### PR DESCRIPTION
Implement DataFrame.xs (https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.xs.html#pandas.DataFrame.xs)

```python
>>> d = {'num_legs': [4, 4, 2, 2],
...      'num_wings': [0, 0, 2, 2],
...      'class': ['mammal', 'mammal', 'mammal', 'bird'],
...      'animal': ['cat', 'dog', 'bat', 'penguin'],
...      'locomotion': ['walks', 'walks', 'flies', 'walks']}
>>> df = ks.DataFrame(data=d)
>>> df = df.set_index(['class', 'animal', 'locomotion'])
>>> df
                           num_legs  num_wings
class  animal  locomotion
mammal cat     walks              4          0
       dog     walks              4          0
       bat     flies              2          2
bird   penguin walks              2          2



>>> df.xs('mammal')
                   num_legs  num_wings
animal locomotion
cat    walks              4          0
dog    walks              4          0
bat    flies              2          2



>>> df.xs(('mammal', 'dog'))
            num_legs  num_wings
locomotion
walks              4          0



>>> df.xs('cat', level=1)
                   num_legs  num_wings
class  locomotion
mammal walks              4          0
```

above example same as pandas one, 

axis parameter for '1' or 'columns' not yet implemented.