### PR TITLE
[MINOR] Fix doc of DatetimeMethods.year

### DIFF
--- a/databricks/koalas/datetimes.py
+++ b/databricks/koalas/datetimes.py
@@ -66,7 +66,7 @@ class DatetimeMethods(object):
     def year(self) -> 'ks.Series':
         """
         The year of the datetime.
-        `"""
+        """
         return _wrap_accessor_spark(self, F.year, LongType()).alias(self.name)
 
     @property


### PR DESCRIPTION
Removed an unnecessary backtick in `DatetimeMethods.year`
![156864237347647915](https://user-images.githubusercontent.com/17039389/66247125-a8657000-e754-11e9-80a7-d5a8b1d5f9b0.gif)
