### PR TITLE
Implement nested renaming for groupby agg

### DIFF
--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -1969,6 +1969,8 @@ def _is_multi_agg_with_relabel(**kwargs):
     >>> _is_multi_agg_with_relabel()
     False
     """
+    if not kwargs:
+        return False
     return all(
         isinstance(v, tuple) and len(v) == 2
         for v in kwargs.values()

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -1972,7 +1972,7 @@ def _is_multi_agg_with_relabel(**kwargs):
     return all(
         isinstance(v, tuple) and len(v) == 2
         for v in kwargs.values()
-    ) and kwargs
+    )
 
 
 def _normalize_keyword_aggregation(kwargs):

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -2030,7 +2030,7 @@ def _normalize_keyword_aggregation(kwargs):
     order = []
     columns, pairs = list(zip(*kwargs.items()))
 
-    for _, (column, aggfunc) in zip(columns, pairs):
+    for column, aggfunc in pairs:
         if column in aggspec:
             aggspec[column].append(aggfunc)
         else:

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -129,7 +129,7 @@ class GroupBy(object):
         1    1    2  0.227  0.362
         2    3    4 -0.562  1.267
 
-        To control the output names with different aggregations per column, koalas
+        To control the output names with different aggregations per column, Koalas
         also supports 'named aggregation' or nested renaming in .agg. And it can be
         used when applying multiple aggragation functions to specific columns.
 

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -129,6 +129,11 @@ class GroupBy(object):
         1    1    2  0.227  0.362
         2    3    4 -0.562  1.267
         """
+        # I think current implementation of func and arguments in koalas for aggregate is different
+        # than pandas, later once arguments are added, this could be removed.
+        if func_or_funcs is None and kwargs is None:
+            raise ValueError("No aggregation argument or function specified.")
+
         relabeling = func_or_funcs is None and _is_multi_agg_with_relabel(**kwargs)
         if relabeling:
             func_or_funcs, columns, order = _normalize_keyword_aggregation(kwargs)
@@ -1941,6 +1946,7 @@ class SeriesGroupBy(GroupBy):
                                              for i, s in enumerate(groupkeys)])
         return _col(DataFrame(internal))
 
+
 def _is_multi_agg_with_relabel(**kwargs):
     """
     Check whether the kwargs pass to .agg look like multi-agg with relabling.
@@ -1968,9 +1974,10 @@ def _is_multi_agg_with_relabel(**kwargs):
         for v in kwargs.values()
     ) and kwargs
 
+
 def _normalize_keyword_aggregation(kwargs):
     """
-    Normalize user-provided "named aggregation" kwargs.
+    Normalize user-provided kwargs.
 
     Transforms from the new ``Dict[str, NamedAgg]`` style kwargs
     to the old OrderedDict[str, List[scalar]]].
@@ -1993,7 +2000,7 @@ def _normalize_keyword_aggregation(kwargs):
     >>> _normalize_keyword_aggregation({'output': ('input', 'sum')})
     (OrderedDict([('input', ['sum'])]), ('output',), [('input', 'sum')])
     """
-    # this is due to python version issue
+    # this is due to python version issue, not sure the impact on koalas
     PY36 = sys.version_info >= (3, 6)
     if not PY36:
         kwargs = OrderedDict(sorted(kwargs.items()))

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -59,7 +59,7 @@ class GroupBy(object):
 
         Parameters
         ----------
-        func : dict, str or list
+        func_or_funcs : dict, str or list
              a dict mapping from column name (string) to
              aggregate functions (string or list of strings).
 
@@ -128,6 +128,24 @@ class GroupBy(object):
         A
         1    1    2  0.227  0.362
         2    3    4 -0.562  1.267
+
+        To control the output names with different aggregations per column, koalas
+        also supports 'named aggregation' or nested renaming in .agg. And it can be
+        used when applying multiple aggragation functions to specific columns.
+
+        >>> aggregated = df.groupby('A').agg(b_max=('B', 'max'), b_min=('B', 'min'))
+        >>> aggregated  # doctest: +NORMALIZE_WHITESPACE
+             b_max   b_min
+        A
+        1        2       1
+        2        4       3
+
+        >>> aggregated = df.groupby('A').agg(b_max=('B', 'max'), c_min=('C', 'min'))
+        >>> aggregated  # doctest: +NORMALIZE_WHITESPACE
+             b_max   c_min
+        A
+        1        2   0.227
+        2        4  -0.562
         """
         # I think current implementation of func and arguments in koalas for aggregate is different
         # than pandas, later once arguments are added, this could be removed.
@@ -2012,7 +2030,7 @@ def _normalize_keyword_aggregation(kwargs):
     order = []
     columns, pairs = list(zip(*kwargs.items()))
 
-    for name, (column, aggfunc) in zip(columns, pairs):
+    for _, (column, aggfunc) in zip(columns, pairs):
         if column in aggspec:
             aggspec[column].append(aggfunc)
         else:

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -190,14 +190,18 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
                             "B": [5, 6, 7, 8]})
         kdf = koalas.from_pandas(pdf)
 
+        # this is only applied in version after 0.25.0
+        if pd.__version__ < "0.25.0":
+            return
+
         # different agg column, same function
-        agg_pdf = pdf.groupby("group").agg(a_max=("A", "max"), b_max=("B", "max"))
-        agg_kdf = kdf.groupby("group").agg(a_max=("A", "max"), b_max=("B", "max"))
+        agg_pdf = pdf.groupby("group").agg(a_max=("A", "max"), b_max=("B", "max")).sort_index()
+        agg_kdf = kdf.groupby("group").agg(a_max=("A", "max"), b_max=("B", "max")).sort_index()
         self.assert_eq(agg_pdf, agg_kdf)
 
         # same agg column, different functions
-        agg_pdf = pdf.groupby("group").agg(b_max=("B", "max"), b_min=("B", "min"))
-        agg_kdf = kdf.groupby("group").agg(b_max=("B", "max"), b_min=("B", "min"))
+        agg_pdf = pdf.groupby("group").agg(b_max=("B", "max"), b_min=("B", "min")).sort_index()
+        agg_kdf = kdf.groupby("group").agg(b_max=("B", "max"), b_min=("B", "min")).sort_index()
         self.assert_eq(agg_pdf, agg_kdf)
 
     def test_all_any(self):

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -183,6 +183,23 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             sorted_agg_pdf = pdf.groupby(('X', 'A')).agg(aggfunc).sort_index()
             self.assert_eq(sorted_agg_kdf, sorted_agg_pdf)
 
+    def test_aggregate_relabel(self):
+        # this is to test named aggregation in groupby
+        pdf = pd.DataFrame({"group": ['a', 'a', 'b', 'b'],
+                            "A": [0, 1, 2, 3],
+                            "B": [5, 6, 7, 8]})
+        kdf = koalas.from_pandas(pdf)
+
+        # different agg column, same function
+        agg_pdf = pdf.groupby("group").agg(a_max=("A", "max"), b_max=("B", "max"))
+        agg_kdf = kdf.groupby("group").agg(a_max=("A", "max"), b_max=("B", "max"))
+        self.assert_eq(agg_pdf, agg_kdf)
+
+        # same agg column, different functions
+        agg_pdf = pdf.groupby("group").agg(b_max=("B", "max"), b_min=("B", "min"))
+        agg_kdf = kdf.groupby("group").agg(b_max=("B", "max"), b_min=("B", "min"))
+        self.assert_eq(agg_pdf, agg_kdf)
+
     def test_all_any(self):
         pdf = pd.DataFrame({'A': [1, 1, 2, 2, 3, 3, 4, 4, 5, 5],
                             'B': [True, True, True, False, False, False, None, True, None, False]})

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -822,3 +822,10 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
                                         "property.*GroupBy.*{}.*is deprecated"
                                         .format(name)):
                 getattr(kdf.a.groupby('a'), name)
+
+    @staticmethod
+    def test_is_multi_agg_with_relabel():
+        from databricks.koalas.groupby import _is_multi_agg_with_relabel
+
+        assert _is_multi_agg_with_relabel(a='max') is False
+        assert _is_multi_agg_with_relabel(a_min=('a', 'max'), a_max=('a', 'min')) is True

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -185,7 +185,7 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             sorted_agg_pdf = pdf.groupby(('X', 'A')).agg(aggfunc).sort_index()
             self.assert_eq(sorted_agg_kdf, sorted_agg_pdf)
 
-    @unittest.skipIf(pd.__version__ < (0, 25), "not supported before pandas 0.25.0")
+    @unittest.skipIf(pd.__version__ < "0.25.0", "not supported before pandas 0.25.0")
     def test_aggregate_relabel(self):
         # this is to test named aggregation in groupby
         pdf = pd.DataFrame({"group": ['a', 'a', 'b', 'b'],


### PR DESCRIPTION
This allows koalas to have nested renaming/selection:
```python
kdf = ks.DataFrame({'A': [1, 1, 2, 2],
                   'B': [1, 2, 3, 4],
                   'C': [0.362, 0.227, 1.267, -0.562]},columns=['A', 'B', 'C'])
```

![Screen Shot 2019-10-07 at 11 15 22 PM](https://user-images.githubusercontent.com/9269816/66349100-6442bd00-e958-11e9-8396-233997e1c903.png)

WIP: still need to add some tests and docstrings