### PR TITLE
Add 'index_col' parameter to DataFrame.to_spark

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -3128,7 +3128,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Likewise, can be converted to back to Koalas DataFrame.
 
-        >>> new_spark_df.to_koalas(index_col=["index_1", "index_2"])  # doctest: +NORMALIZE_WHITESPACE
+        >>> new_spark_df.to_koalas(
+        ...     index_col=["index_1", "index_2"])  # doctest: +NORMALIZE_WHITESPACE
                          b  c
         index_1 index_2
         0       1        4  7

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -3070,8 +3070,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         Parameters
         ----------
         index_col: str or list of str, optional, default: None
-            Column names to be used in Spark to represent Koalas' index. Index's name
-            in Koalas is ignored. By default, index is always lost.
+            Column names to be used in Spark to represent Koalas' index. The index name
+            in Koalas is ignored. By default, the index is always lost.
 
         See Also
         --------
@@ -3104,7 +3104,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Keeping index column is useful when you want to call some Spark APIs and
         convert it back to Koalas DataFrame without creating a default index, which
-        affects performance.
+        can affect performance.
 
         >>> spark_df = df.to_spark(index_col="index")
         >>> spark_df = spark_df.filter("a == 2")
@@ -3146,6 +3146,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             data_columns = []
             data_columns_column_index = \
                 zip(self._internal._data_columns, self._internal.column_index)
+            # TODO: this code is similar with _InternalFrame.spark_df. Might have to deduplicate.
             for i, (column, idx) in enumerate(data_columns_column_index):
                 scol = self._internal.scol_for(idx)
                 name = str(i) if idx is None else str(idx) if len(idx) > 1 else idx[0]

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -957,8 +957,9 @@ class GroupBy(object):
                             (SPARK_INDEX_NAME_FORMAT(i) if name is None else name, name)
                             for i, name in enumerate(index.names)]
                 else:
-                    index_map = [(index.name
-                                  if index.name is not None else SPARK_INDEX_NAME_FORMAT(0), index.name)]
+                    index_map = [(
+                        index.name
+                        if index.name is not None else SPARK_INDEX_NAME_FORMAT(0), index.name)]
 
                 new_index_columns = [index_column for index_column, _ in index_map]
                 new_data_columns = [str(col) for col in columns]

--- a/databricks/koalas/internal.py
+++ b/databricks/koalas/internal.py
@@ -17,7 +17,7 @@
 """
 An internal immutable DataFrame with some metadata to manage indexes.
 """
-
+import re
 from typing import Dict, List, Optional, Tuple, Union
 from itertools import accumulate
 
@@ -35,6 +35,11 @@ from databricks.koalas.config import get_option
 from databricks.koalas.typedef import infer_pd_series_spark_type, spark_type_to_pandas_dtype
 from databricks.koalas.utils import column_index_level, default_session, lazy_property, scol_for
 
+
+# A function to turn given numbers to Spark columns that represent Koalas index.
+SPARK_INDEX_NAME_FORMAT = "__index_level_{}__".format
+# A pattern to check if the name of a Spark column is a Koalas index name or not.
+SPARK_INDEX_NAME_PATTERN = re.compile(r"__index_level_[0-9]+__")
 
 IndexMap = Tuple[str, Optional[Tuple[str, ...]]]
 
@@ -398,11 +403,12 @@ class _InternalFrame(object):
         assert isinstance(sdf, spark.DataFrame)
         if index_map is None:
             # Here is when Koalas DataFrame is created directly from Spark DataFrame.
-            assert "__index_level_0__" not in sdf.schema.names, \
-                "Default index column should not appear in columns of the Spark DataFrame"
+            assert any(SPARK_INDEX_NAME_PATTERN.match(name) for name in sdf.schema.names), \
+                "Index columns should not appear in columns of the Spark DataFrame. Avoid " \
+                "index colum names [%s]." % SPARK_INDEX_NAME_PATTERN
 
             # Create default index.
-            index_map = [('__index_level_0__', None)]
+            index_map = [(SPARK_INDEX_NAME_FORMAT(0), None)]
             sdf = _InternalFrame.attach_default_index(sdf)
 
         assert index_map is not None
@@ -461,7 +467,7 @@ class _InternalFrame(object):
             sequential_index = F.row_number().over(
                 Window.orderBy(F.monotonically_increasing_id().asc())) - 1
             scols = [scol_for(sdf, column) for column in sdf.columns]
-            return sdf.select(sequential_index.alias("__index_level_0__"), *scols)
+            return sdf.select(sequential_index.alias(SPARK_INDEX_NAME_FORMAT(0)), *scols)
         elif default_index_type == "distributed-sequence":
             # 1. Calculates counts per each partition ID. `counts` here is, for instance,
             #     {
@@ -488,12 +494,12 @@ class _InternalFrame(object):
             def default_index(pdf):
                 current_partition_max = sums[pdf["__spark_partition_id"].iloc[0]]
                 offset = len(pdf)
-                pdf["__index_level_0__"] = list(range(
+                pdf[SPARK_INDEX_NAME_FORMAT(0)] = list(range(
                     current_partition_max - offset, current_partition_max))
                 return pdf.drop(columns=["__spark_partition_id"])
 
             return_schema = StructType(
-                [StructField("__index_level_0__", LongType())] + list(sdf.schema))
+                [StructField(SPARK_INDEX_NAME_FORMAT(0), LongType())] + list(sdf.schema))
             grouped_map_func = pandas_udf(return_schema, PandasUDFType.GROUPED_MAP)(default_index)
 
             sdf = sdf.withColumn("__spark_partition_id", F.spark_partition_id())
@@ -501,7 +507,7 @@ class _InternalFrame(object):
         elif default_index_type == "distributed":
             scols = [scol_for(sdf, column) for column in sdf.columns]
             return sdf.select(
-                F.monotonically_increasing_id().alias("__index_level_0__"), *scols)
+                F.monotonically_increasing_id().alias(SPARK_INDEX_NAME_FORMAT(0)), *scols)
         else:
             raise ValueError("'compute.default_index_type' should be one of 'sequence',"
                              " 'distributed-sequence' and 'distributed'")
@@ -599,34 +605,30 @@ class _InternalFrame(object):
         """ Return names of the index levels. """
         return self._column_index_names
 
+    def _data_column_names(self):
+        index_columns = set(self.index_columns)
+        data_columns = []
+        for i, (column, idx) in enumerate(zip(self._data_columns, self.column_index)):
+            assert column not in index_columns
+            scol = self.scol_for(idx)
+            name = str(i) if idx is None else str(idx) if len(idx) > 1 else idx[0]
+            if column != name:
+                scol = scol.alias(name)
+            data_columns.append(scol)
+        return data_columns
+
     @lazy_property
     def spark_internal_df(self) -> spark.DataFrame:
         """
         Return as Spark DataFrame. This contains index columns as well
         and should be only used for internal purposes.
         """
-        index_columns = set(self.index_columns)
-        data_columns = []
-        for i, (column, idx) in enumerate(zip(self._data_columns, self.column_index)):
-            if column not in index_columns:
-                scol = self.scol_for(idx)
-                name = str(i) if idx is None else str(idx) if len(idx) > 1 else idx[0]
-                if column != name:
-                    scol = scol.alias(name)
-                data_columns.append(scol)
-        return self._sdf.select(self.index_scols + data_columns)
+        return self._sdf.select(self.index_scols + self._data_column_names())
 
     @lazy_property
     def spark_df(self) -> spark.DataFrame:
         """ Return as Spark DataFrame. """
-        data_columns = []
-        for i, (column, idx) in enumerate(zip(self._data_columns, self.column_index)):
-            scol = self.scol_for(idx)
-            name = str(i) if idx is None else str(idx) if len(idx) > 1 else idx[0]
-            if column != name:
-                scol = scol.alias(name)
-            data_columns.append(scol)
-        return self._sdf.select(data_columns)
+        return self._sdf.select(self._data_column_names())
 
     @lazy_property
     def pandas_df(self):
@@ -712,15 +714,15 @@ class _InternalFrame(object):
         index_map = []  # type: List[IndexMap]
         if isinstance(index, pd.MultiIndex):
             if index.names is None:
-                index_map = [('__index_level_{}__'.format(i), None)
+                index_map = [(SPARK_INDEX_NAME_FORMAT(i), None)
                              for i in range(len(index.levels))]
             else:
-                index_map = [('__index_level_{}__'.format(i) if name is None else name,
+                index_map = [(SPARK_INDEX_NAME_FORMAT(i) if name is None else name,
                               name if name is None or isinstance(name, tuple) else (name,))
                              for i, name in enumerate(index.names)]
         else:
             name = index.name
-            index_map = [(str(name) if name is not None else '__index_level_0__',
+            index_map = [(str(name) if name is not None else SPARK_INDEX_NAME_FORMAT(0),
                           name if name is None or isinstance(name, tuple) else (name,))]
 
         index_columns = [index_column for index_column, _ in index_map]

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -39,7 +39,7 @@ from databricks.koalas.config import get_option
 from databricks.koalas.base import IndexOpsMixin
 from databricks.koalas.frame import DataFrame
 from databricks.koalas.generic import _Frame
-from databricks.koalas.internal import IndexMap, _InternalFrame
+from databricks.koalas.internal import IndexMap, _InternalFrame, SPARK_INDEX_NAME_FORMAT
 from databricks.koalas.missing.series import _MissingPandasLikeSeries
 from databricks.koalas.plot import KoalasSeriesPlotMethods
 from databricks.koalas.utils import validate_arguments_and_invoke_function, scol_for
@@ -1789,7 +1789,7 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
             sdf_dropna = self._kdf._sdf.filter(self.notna()._scol)
         else:
             sdf_dropna = self._kdf._sdf
-        index_name = '__index_level_0__'
+        index_name = SPARK_INDEX_NAME_FORMAT(0)
         sdf = sdf_dropna.groupby(self._scol.alias(index_name)).count()
         if sort:
             if ascending:
@@ -2754,7 +2754,7 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
                 "approx_percentile(`%s`, array(%s), %s)" % (self.name, args, accuracy))
             sdf = sdf.select(percentile_col.alias("percentiles"))
 
-            internal_index_column = "__index_level_0__"
+            internal_index_column = SPARK_INDEX_NAME_FORMAT(0)
             value_column = "value"
             cols = []
             for i, quantile in enumerate(quantiles):

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -2004,3 +2004,12 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         kdf = ks.from_pandas(pdf)
         self.assert_eq(kdf[kdf['t'] != kdf['t']], pdf[pdf['t'] != pdf['t']])
         self.assert_eq(kdf[kdf['t'] != kdf['t']].dtypes, pdf[pdf['t'] != pdf['t']].dtypes)
+
+    def test_to_spark(self):
+        kdf = ks.from_pandas(self.pdf)
+
+        with self.assertRaisesRegex(ValueError, "'index_col' cannot be overlapped"):
+            kdf.to_spark(index_col="a")
+
+        with self.assertRaisesRegex(ValueError, "length of index columns.*1.*3"):
+            kdf.to_spark(index_col=["x", "y", "z"])


### PR DESCRIPTION
This PR adds `index_col` parameter to `DataFrame.to_spark`. This PR relates to https://github.com/databricks/koalas/pull/901.

After this PR, we can do a roundtrip in Koalas and Spark DataFrame easily.

```python
>>> import databricks.koalas as ks
>>> kdf = ks.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6], 'c': [7, 8, 9]})
>>> sdf = kdf.to_spark(index_col="index").filter("a == 2")  # PySpark API
>>> kdf = sdf.to_koalas(index_col="index")
>>> kdf
       a  b  c
index
1      2  5  8
```