### PR TITLE
Add a short guide to import 10 minutes to Koalas in Databricks

### DIFF
--- a/docs/source/getting_started/10min.ipynb
+++ b/docs/source/getting_started/10min.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# 10 minutes to Koalas\n",
     "\n",
-    "This is a short introduction to Koalas, geared mainly for new users. This notebook shows you some key differences between pandas and Koalas. You can run this examples by yourself on a live notebook [here](https://mybinder.org/v2/gh/databricks/koalas/master?filepath=docs%2Fsource%2Fgetting_started%2F10min.ipynb).\n",
+    "This is a short introduction to Koalas, geared mainly for new users. This notebook shows you some key differences between pandas and Koalas. You can run this examples by yourself on a live notebook [here](https://mybinder.org/v2/gh/databricks/koalas/master?filepath=docs%2Fsource%2Fgetting_started%2F10min.ipynb). For Databricks users, you can import [the current .ipynb file](https://raw.githubusercontent.com/databricks/koalas/master/docs/source/getting_started/10min.ipynb) and run it after [installing Koalas](https://github.com/databricks/koalas#how-do-i-use-this-on-databricks).\n",
     "\n",
     "Customarily, we import Koalas as follows:"
    ]


### PR DESCRIPTION
Can be reviewed here: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/HyukjinKwon/koalas/add-db-note?filepath=docs%2Fsource%2Fgetting_started%2F10min.ipynb)

This PR adds a short guide to import 10 minutes to Koalas in Databricks:

> For Databricks users, you can import [the current .ipynb file](https://raw.githubusercontent.com/databricks/koalas/master/docs/source/getting_started/10min.ipynb) and run it after [installing Koalas](https://github.com/databricks/koalas#how-do-i-use-this-on-databricks).
