### PR TITLE
Set an upper bound for pyarrow version.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 # Dependencies in Koalas
 pandas>=0.23.2
-pyarrow>=0.10
+pyarrow>=0.10,<0.15
 matplotlib>=3.0.0
 numpy>=1.14
 

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     python_requires='>=3.5',
     install_requires=[
         'pandas>=0.23.2',
-        'pyarrow>=0.10',
+        'pyarrow>=0.10,<0.15',
         'numpy>=1.14',
         'matplotlib>=3.0.0',
     ],


### PR DESCRIPTION
I'd set the upper bound for pyarrow version for now since we need to set an environment variable to work with pyarrow 0.15.

https://github.com/apache/spark/pull/26045:
> Arrow 0.15.0 introduced a change in format which requires an environment variable to maintain compatibility.
