### PR TITLE
Make is_monotonic~ work properly for index

### DIFF
--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -316,9 +316,9 @@ class IndexOpsMixin(object):
         sdf = self._internal.sdf.withColumn(idx_tmp, monotonically_increasing_id())
         window = Window.orderBy(sdf[idx_tmp]).rowsBetween(-1, -1)
         sdf = sdf.select(
-                  sdf[idx_tmp],
-                  F.when((col >= F.lag(col, 1).over(window)) & col.isNotNull(), True)
-                   .otherwise(False).alias('__temp__'))
+            sdf[idx_tmp],
+            F.when((col >= F.lag(col, 1).over(window)) & col.isNotNull(), True)
+             .otherwise(False).alias('__temp__'))
         return sdf.where(F.col('__temp__') == 'false').count() < 2
 
     is_monotonic_increasing = is_monotonic
@@ -375,9 +375,9 @@ class IndexOpsMixin(object):
         sdf = self._internal.sdf.withColumn(idx_tmp, monotonically_increasing_id())
         window = Window.orderBy(sdf[idx_tmp]).rowsBetween(-1, -1)
         sdf = sdf.select(
-                  sdf[idx_tmp],
-                  F.when((col <= F.lag(col, 1).over(window)) & col.isNotNull(), True)
-                   .otherwise(False).alias('__temp__'))
+            sdf[idx_tmp],
+            F.when((col <= F.lag(col, 1).over(window)) & col.isNotNull(), True)
+             .otherwise(False).alias('__temp__'))
         return sdf.where(F.col('__temp__') == 'false').count() < 2
 
     def astype(self, dtype):

--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -308,19 +308,15 @@ class IndexOpsMixin(object):
         >>> ser.index.is_monotonic
         True
         """
-        from databricks.koalas.indexes import Index
-        if isinstance(self, Index):
-            from databricks.koalas.frame import DataFrame
-            from databricks.koalas.series import _col
-            index_scol = self._scol
-            sdf = self._internal.sdf.withColumn('id', monotonically_increasing_id())
-            window = Window.orderBy(sdf['id']).rowsBetween(-1, -1)
-            internal = _InternalFrame(sdf.select(index_scol >= F.lag(index_scol, 1).over(window)))
-            return _col(DataFrame(internal)).all()
-        else:
-            col = self._scol
-            window = Window.orderBy(self._kdf._internal.index_scols).rowsBetween(-1, -1)
-            return self._with_new_scol((col >= F.lag(col, 1).over(window)) & col.isNotNull()).all()
+        from databricks.koalas.frame import DataFrame
+        from databricks.koalas.series import _col
+        if self.hasnans:
+            return False
+        col = self._scol
+        sdf = self._internal.sdf.withColumn('id', monotonically_increasing_id())
+        window = Window.orderBy(sdf['id']).rowsBetween(-1, -1)
+        internal = _InternalFrame(sdf.select(col >= F.lag(col, 1).over(window)))
+        return _col(DataFrame(internal)).all()
 
     is_monotonic_increasing = is_monotonic
 
@@ -369,19 +365,15 @@ class IndexOpsMixin(object):
         >>> ser.index.is_monotonic_decreasing
         False
         """
-        from databricks.koalas.indexes import Index
-        if isinstance(self, Index):
-            from databricks.koalas.frame import DataFrame
-            from databricks.koalas.series import _col
-            index_scol = self._scol
-            sdf = self._internal.sdf.withColumn('id', monotonically_increasing_id())
-            window = Window.orderBy(sdf['id']).rowsBetween(-1, -1)
-            internal = _InternalFrame(sdf.select(index_scol <= F.lag(index_scol, 1).over(window)))
-            return _col(DataFrame(internal)).all()
-        else:
-            col = self._scol
-            window = Window.orderBy(self._kdf._internal.index_scols).rowsBetween(-1, -1)
-            return self._with_new_scol((col <= F.lag(col, 1).over(window)) & col.isNotNull()).all()
+        from databricks.koalas.frame import DataFrame
+        from databricks.koalas.series import _col
+        if self.hasnans:
+            return False
+        col = self._scol
+        sdf = self._internal.sdf.withColumn('id', monotonically_increasing_id())
+        window = Window.orderBy(sdf['id']).rowsBetween(-1, -1)
+        internal = _InternalFrame(sdf.select(col <= F.lag(col, 1).over(window)))
+        return _col(DataFrame(internal)).all()
 
     def astype(self, dtype):
         """

--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -27,13 +27,12 @@ from pandas.api.types import is_list_like
 from pyspark import sql as spark
 from pyspark.sql import functions as F, Window
 from pyspark.sql.types import DoubleType, FloatType, LongType, StringType, TimestampType
+from pyspark.sql.functions import monotonically_increasing_id
 
 from databricks import koalas as ks  # For running doctests and reference resolution in PyCharm.
 from databricks.koalas.internal import _InternalFrame
 from databricks.koalas.typedef import pandas_wraps, spark_type_to_pandas_dtype
 from databricks.koalas.utils import align_diff_series, scol_for
-from databricks.koalas.internal import SPARK_INDEX_NAME_FORMAT
-from pyspark.sql.functions import monotonically_increasing_id
 
 
 def _column_op(f):


### PR DESCRIPTION
Resolve #931 (The contents below is same as the contents of this issue)

When we use `is_monotonic_decreasing` or `is_monotonic_increasing` for index,

pandas works like below:

```python
>>> s = pd.Series([7, 6, 5, 4, 3, 2, 1], index=[7, 6, 5, 4, 3, 2, 1])
>>> s.index.is_monotonic_decreasing
True
```
Since the index order is literally motononic decreasing, they return `True`

But our case,

```python
>>> s = ks.Series([7, 6, 5, 4, 3, 2, 1], index=[7, 6, 5, 4, 3, 2, 1])
>>> s.index.is_monotonic_decreasing
False
```

as seen above, it returns `False`.

because our existing logic always order by index column before calculate the each rows increasing or decreasing.

So they always calculate result based on data column, not index column. (index column is always sorted since order by)

So i think maybe it is better to fix this logic to follow behavior of pandas one for index.