### PR TITLE
Implement Series.keys

### DIFF
--- a/databricks/koalas/missing/series.py
+++ b/databricks/koalas/missing/series.py
@@ -75,7 +75,6 @@ class _MissingPandasLikeSeries(object):
     interpolate = unsupported_function('interpolate')
     items = unsupported_function('items')
     iteritems = unsupported_function('iteritems')
-    keys = unsupported_function('keys')
     last = unsupported_function('last')
     last_valid_index = unsupported_function('last_valid_index')
     mad = unsupported_function('mad')

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -3240,7 +3240,7 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         ...                       [0, 1, 2, 0, 1, 2, 0, 1, 2]])
         >>> kser = ks.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3], index=midx)
 
-        >>> kser.keys()
+        >>> kser.keys()  # doctest: +SKIP
         MultiIndex([(  'lama',  'speed'),
                     (  'lama', 'weight'),
                     (  'lama', 'length'),

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -3231,6 +3231,26 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         -------
         Index
             Index of the Series.
+
+        Examples
+        --------
+        >>> midx = pd.MultiIndex([['lama', 'cow', 'falcon'],
+        ...                       ['speed', 'weight', 'length']],
+        ...                      [[0, 0, 0, 1, 1, 1, 2, 2, 2],
+        ...                       [0, 1, 2, 0, 1, 2, 0, 1, 2]])
+        >>> kser = ks.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3], index=midx)
+
+        >>> kser.keys()
+        MultiIndex([(  'lama',  'speed'),
+                    (  'lama', 'weight'),
+                    (  'lama', 'length'),
+                    (   'cow',  'speed'),
+                    (   'cow', 'weight'),
+                    (   'cow', 'length'),
+                    ('falcon',  'speed'),
+                    ('falcon', 'weight'),
+                    ('falcon', 'length')],
+                   )
         """
         return self.index
 

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -3223,6 +3223,17 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         """
         return _col(DataFrame(self._internal.copy()))
 
+    def keys(self):
+        """
+        Return alias for index.
+
+        Returns
+        -------
+        Index
+            Index of the Series.
+        """
+        return self.index
+
     # TODO: 'regex', 'method' parameter
     def replace(self, to_replace=None, value=None, regex=False) -> 'Series':
         """

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -728,3 +728,13 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
 
         self.assert_eq(pser.drop_duplicates().sort_values(),
                        kser.drop_duplicates().sort_values())
+
+    def test_keys(self):
+        midx = pd.MultiIndex([['lama', 'cow', 'falcon'],
+                              ['speed', 'weight', 'length']],
+                             [[0, 0, 0, 1, 1, 1, 2, 2, 2],
+                              [0, 1, 2, 0, 1, 2, 0, 1, 2]])
+        kser = ks.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3], index=midx)
+        pser = kser.to_pandas()
+
+        self.assert_eq(kser.keys(), pser.keys())

--- a/docs/source/reference/series.rst
+++ b/docs/source/reference/series.rst
@@ -50,6 +50,7 @@ Indexing, iteration
    Series.at
    Series.loc
    Series.iloc
+   Series.keys
 
 Binary operator functions
 -------------------------


### PR DESCRIPTION
An alias for index.

```python
>>> midx = pd.MultiIndex([['lama', 'cow', 'falcon'],
...                       ['speed', 'weight', 'length']],
...                      [[0, 0, 0, 1, 1, 1, 2, 2, 2],
...                       [0, 1, 2, 0, 1, 2, 0, 1, 2]])
>>> kser = ks.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3], index=midx)
>>> pser = kser.to_pandas()

>>> pser.keys()
MultiIndex([(  'lama',  'speed'),
            (  'lama', 'weight'),
            (  'lama', 'length'),
            (   'cow',  'speed'),
            (   'cow', 'weight'),
            (   'cow', 'length'),
            ('falcon',  'speed'),
            ('falcon', 'weight'),
            ('falcon', 'length')],
           )

>>> kser.keys()
MultiIndex([(  'lama',  'speed'),
            (  'lama', 'weight'),
            (  'lama', 'length'),
            (   'cow',  'speed'),
            (   'cow', 'weight'),
            (   'cow', 'length'),
            ('falcon',  'speed'),
            ('falcon', 'weight'),
            ('falcon', 'length')],
           )
```