### PR TITLE
Implement Index.copy & MultiIndex.copy

### DIFF
--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -460,6 +460,62 @@ class MultiIndex(Index):
 
     toPandas = to_pandas
 
+    # TODO: add 'name' parameter after pd.MultiIndex.name is implemented
+    def copy(self):
+        """
+        Make a copy of this object. name sets those attributes on the new object.
+
+        Examples
+        --------
+        >>> midx = pd.MultiIndex([['a', 'b', 'c'],
+        ...                       ['lama', 'cow', 'falcon'],
+        ...                       ['speed', 'weight', 'length']],
+        ...                      [[0, 0, 0, 0, 0, 0, 1, 1, 1],
+        ...                       [0, 0, 0, 1, 1, 1, 2, 2, 2],
+        ...                       [0, 0, 0, 0, 1, 2, 0, 1, 2]]
+        ...  )
+        >>> s = ks.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3],
+        ...              index=midx)
+        >>> s
+        a  lama    speed      45.0
+                   speed     200.0
+                   speed       1.2
+           cow     speed      30.0
+                   weight    250.0
+                   length      1.5
+        b  falcon  speed     320.0
+                   weight      1.0
+                   length      0.3
+        Name: 0, dtype: float64
+
+        >>> s.index
+        MultiIndex([('a',   'lama',  'speed'),
+                    ('a',   'lama',  'speed'),
+                    ('a',   'lama',  'speed'),
+                    ('a',    'cow',  'speed'),
+                    ('a',    'cow', 'weight'),
+                    ('a',    'cow', 'length'),
+                    ('b', 'falcon',  'speed'),
+                    ('b', 'falcon', 'weight'),
+                    ('b', 'falcon', 'length')],
+                   )
+
+        >>> s.index.copy()
+        MultiIndex([('a',   'lama',  'speed'),
+                    ('a',   'lama',  'speed'),
+                    ('a',   'lama',  'speed'),
+                    ('a',    'cow',  'speed'),
+                    ('a',    'cow', 'weight'),
+                    ('a',    'cow', 'length'),
+                    ('b', 'falcon',  'speed'),
+                    ('b', 'falcon', 'weight'),
+                    ('b', 'falcon', 'length')],
+                   )
+        """
+        internal = self._kdf._internal.copy()
+        result = MultiIndex(ks.DataFrame(internal))
+        return result
+
     def __getattr__(self, item: str) -> Any:
         if hasattr(_MissingPandasLikeMultiIndex, item):
             property_or_func = getattr(_MissingPandasLikeMultiIndex, item)

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -316,6 +316,44 @@ class Index(IndexOpsMixin):
         """
         return is_object_dtype(self.dtype)
 
+    def copy(self, name=None):
+        """
+        Make a copy of this object. name sets those attributes on the new object.
+
+        Parameters
+        ----------
+        name : string, optional
+            to set name of index
+
+        Examples
+        --------
+        >>> df = ks.DataFrame([[1, 2], [4, 5], [7, 8]],
+        ...                   index=['cobra', 'viper', 'sidewinder'],
+        ...                   columns=['max_speed', 'shield'])
+        >>> df
+                    max_speed  shield
+        cobra               1       2
+        viper               4       5
+        sidewinder          7       8
+        >>> df.index
+        Index(['cobra', 'viper', 'sidewinder'], dtype='object')
+
+        Copy index
+
+        >>> df.index.copy()
+        Index(['cobra', 'viper', 'sidewinder'], dtype='object')
+
+        Copy index with name
+
+        >>> df.index.copy(name='snake')
+        Index(['cobra', 'viper', 'sidewinder'], dtype='object', name='snake')
+        """
+        internal = self._kdf._internal.copy()
+        result = Index(ks.DataFrame(internal), self._scol)
+        if name:
+            result.name = name
+        return result
+
     def __getattr__(self, item: str) -> Any:
         if hasattr(_MissingPandasLikeIndex, item):
             property_or_func = getattr(_MissingPandasLikeIndex, item)

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -463,54 +463,7 @@ class MultiIndex(Index):
     # TODO: add 'name' parameter after pd.MultiIndex.name is implemented
     def copy(self):
         """
-        Make a copy of this object. name sets those attributes on the new object.
-
-        Examples
-        --------
-        >>> midx = pd.MultiIndex([['a', 'b', 'c'],
-        ...                       ['lama', 'cow', 'falcon'],
-        ...                       ['speed', 'weight', 'length']],
-        ...                      [[0, 0, 0, 0, 0, 0, 1, 1, 1],
-        ...                       [0, 0, 0, 1, 1, 1, 2, 2, 2],
-        ...                       [0, 0, 0, 0, 1, 2, 0, 1, 2]]
-        ...  )
-        >>> s = ks.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3],
-        ...              index=midx)
-        >>> s
-        a  lama    speed      45.0
-                   speed     200.0
-                   speed       1.2
-           cow     speed      30.0
-                   weight    250.0
-                   length      1.5
-        b  falcon  speed     320.0
-                   weight      1.0
-                   length      0.3
-        Name: 0, dtype: float64
-
-        >>> s.index
-        MultiIndex([('a',   'lama',  'speed'),
-                    ('a',   'lama',  'speed'),
-                    ('a',   'lama',  'speed'),
-                    ('a',    'cow',  'speed'),
-                    ('a',    'cow', 'weight'),
-                    ('a',    'cow', 'length'),
-                    ('b', 'falcon',  'speed'),
-                    ('b', 'falcon', 'weight'),
-                    ('b', 'falcon', 'length')],
-                   )
-
-        >>> s.index.copy()
-        MultiIndex([('a',   'lama',  'speed'),
-                    ('a',   'lama',  'speed'),
-                    ('a',   'lama',  'speed'),
-                    ('a',    'cow',  'speed'),
-                    ('a',    'cow', 'weight'),
-                    ('a',    'cow', 'length'),
-                    ('b', 'falcon',  'speed'),
-                    ('b', 'falcon', 'weight'),
-                    ('b', 'falcon', 'length')],
-                   )
+        Make a copy of this object.
         """
         internal = self._kdf._internal.copy()
         result = MultiIndex(ks.DataFrame(internal))

--- a/databricks/koalas/missing/indexes.py
+++ b/databricks/koalas/missing/indexes.py
@@ -154,7 +154,6 @@ class _MissingPandasLikeMultiIndex(object):
     argsort = unsupported_function('argsort')
     asof = unsupported_function('asof')
     asof_locs = unsupported_function('asof_locs')
-    copy = unsupported_function('copy')
     delete = unsupported_function('delete')
     difference = unsupported_function('difference')
     drop = unsupported_function('drop')

--- a/databricks/koalas/missing/indexes.py
+++ b/databricks/koalas/missing/indexes.py
@@ -51,7 +51,6 @@ class _MissingPandasLikeIndex(object):
     argsort = unsupported_function('argsort')
     asof = unsupported_function('asof')
     asof_locs = unsupported_function('asof_locs')
-    copy = unsupported_function('copy')
     delete = unsupported_function('delete')
     difference = unsupported_function('difference')
     drop = unsupported_function('drop')

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -140,6 +140,14 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         with self.assertRaises(PandasNotImplementedError):
             kidx.name = 'renamed'
 
+    def test_multi_index_copy(self):
+        arrays = [[1, 1, 2, 2], ['red', 'blue', 'red', 'blue']]
+        idx = pd.MultiIndex.from_arrays(arrays, names=('number', 'color'))
+        pdf = pd.DataFrame(np.random.randn(4, 5), idx)
+        kdf = ks.from_pandas(pdf)
+
+        self.assert_eq(kdf.index.copy(), pdf.index.copy())
+
     def test_missing(self):
         kdf = ks.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6], 'c': [7, 8, 9]})
 

--- a/docs/source/reference/indexing.rst
+++ b/docs/source/reference/indexing.rst
@@ -29,6 +29,7 @@ Modifying and computations
 .. autosummary::
    :toctree: api/
 
+   Index.copy
    Index.is_boolean
    Index.is_categorical
    Index.is_floating

--- a/docs/source/reference/indexing.rst
+++ b/docs/source/reference/indexing.rst
@@ -78,7 +78,7 @@ MultiIndex Properties
    MultiIndex.names
 
 MultiIndex Modifying and computations
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. autosummary::
    :toctree: api/
 

--- a/docs/source/reference/indexing.rst
+++ b/docs/source/reference/indexing.rst
@@ -76,3 +76,10 @@ MultiIndex Properties
    :toctree: api/
 
    MultiIndex.names
+
+MultiIndex Modifying and computations
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. autosummary::
+   :toctree: api/
+
+   Index.copy


### PR DESCRIPTION
like pandas (https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Index.copy.html#pandas.Index.copy)

implement function `copy` for Index

```python
>>> df = ks.DataFrame([[1, 2], [4, 5], [7, 8]],
...                   index=['cobra', 'viper', 'sidewinder'],
...                   columns=['max_speed', 'shield'])
>>> df
            max_speed  shield
cobra               1       2
viper               4       5
sidewinder          7       8
>>> df.index
Index(['cobra', 'viper', 'sidewinder'], dtype='object')

>>> df.index.copy()
Index(['cobra', 'viper', 'sidewinder'], dtype='object')

>>> df.index.copy(name='snake')
Index(['cobra', 'viper', 'sidewinder'], dtype='object', name='snake')
```