### PR TITLE
Fix bug when  assign None to name as Index

### DIFF
--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -172,10 +172,11 @@ class Index(IndexOpsMixin):
             raise ValueError('Names must be a list-like')
         internal = self._kdf._internal
         if len(internal.index_map) != len(names):
+
             raise ValueError('Length of new names must be {}, got {}'
                              .format(len(internal.index_map), len(names)))
-        if None not in names:
-            names = [name if isinstance(name, tuple) else (name,) for name in names]
+
+        names = [name if isinstance(name, (tuple, type(None))) else (name,) for name in names]
         self._kdf._internal = internal.copy(index_map=list(zip(internal.index_columns, names)))
 
     @property

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -172,7 +172,6 @@ class Index(IndexOpsMixin):
             raise ValueError('Names must be a list-like')
         internal = self._kdf._internal
         if len(internal.index_map) != len(names):
-
             raise ValueError('Length of new names must be {}, got {}'
                              .format(len(internal.index_map), len(names)))
 

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -174,7 +174,8 @@ class Index(IndexOpsMixin):
         if len(internal.index_map) != len(names):
             raise ValueError('Length of new names must be {}, got {}'
                              .format(len(internal.index_map), len(names)))
-        names = [name if isinstance(name, tuple) else (name,) for name in names]
+        if None not in names:
+            names = [name if isinstance(name, tuple) else (name,) for name in names]
         self._kdf._internal = internal.copy(index_map=list(zip(internal.index_columns, names)))
 
     @property

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -107,6 +107,12 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         self.assertEqual(kidx.names, pidx.names)
         self.assert_eq(kidx, pidx)
 
+        pidx.name = None
+        kidx.name = None
+        self.assertEqual(kidx.name, pidx.name)
+        self.assertEqual(kidx.names, pidx.names)
+        self.assert_eq(kidx, pidx)
+
         with self.assertRaisesRegex(ValueError, "Names must be a list-like"):
             kidx.names = 'hi'
 

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -134,6 +134,10 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         pidx.names = ['renamed_number', 'renamed_color']
         kidx.names = ['renamed_number', 'renamed_color']
         self.assertEqual(kidx.names, pidx.names)
+
+        pidx.names = ['renamed_number', None]
+        kidx.names = ['renamed_number', None]
+        self.assertEqual(kidx.names, pidx.names)
         if LooseVersion(pyspark.__version__) < LooseVersion('2.4'):
             # PySpark < 2.4 does not support struct type with arrow enabled.
             with self.sql_conf({'spark.sql.execution.arrow.enabled': False}):


### PR DESCRIPTION
Resolves #971 

```python
>>> kidx
Int64Index([1, 2, 3], dtype='int64', name='a')
>>> kidx.name = None
>>> kidx
Int64Index([1, 2, 3], dtype='int64')
```