### PR TITLE
Fix reindex when all the given columns are included the existing columns

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -6692,19 +6692,16 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 raise ValueError("shape (1,{}) doesn't match the shape (1,{})"
                                  .format(len(col), level))
         scols, columns, idx = [], [], []
-        null_columns = False
         for label in label_columns:
             if label in self._internal.column_index:
                 scols.append(self._internal.scol_for(label))
                 columns.append(self._internal.column_name_for(label))
             else:
-                scols.append(F.lit(np.nan).alias(str(label)))
-                columns.append(str(label))
-                null_columns = True
+                scols.append(F.lit(np.nan).alias(name_like_string(label)))
+                columns.append(name_like_string(label))
             idx.append(label)
 
-        if null_columns:
-            sdf = self._sdf.select(self._internal.index_scols + list(scols))
+        sdf = self._sdf.select(self._internal.index_scols + scols)
 
         return self._internal.copy(sdf=sdf, data_columns=columns, column_index=idx)
 

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -1732,8 +1732,16 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             kdf.reindex(['A', 'B', 'C'], index=['numbers', '2', '3']).sort_index())
 
         self.assert_eq(
-            pdf.reindex(index=['numbers', '2', '3']).sort_index(),
-            kdf.reindex(index=['numbers', '2', '3']).sort_index())
+            pdf.reindex(index=['A', 'B']).sort_index(),
+            kdf.reindex(index=['A', 'B']).sort_index())
+
+        self.assert_eq(
+            pdf.reindex(index=['A', 'B', '2', '3']).sort_index(),
+            kdf.reindex(index=['A', 'B', '2', '3']).sort_index())
+
+        self.assert_eq(
+            pdf.reindex(columns=['numbers']).sort_index(),
+            kdf.reindex(columns=['numbers']).sort_index())
 
         self.assert_eq(
             pdf.reindex(columns=['numbers', '2', '3']).sort_index(),


### PR DESCRIPTION
When `kdf.reindex()`, all the given columns are included the existing columns, the following error is raised.

```
Traceback (most recent call last):

...

  File "/Users/ueshin/workspace/databricks-koalas/master/databricks/koalas/frame.py", line 6641, in reindex
    df = DataFrame(df._reindex_columns(columns))
  File "/Users/ueshin/workspace/databricks-koalas/master/databricks/koalas/frame.py", line 6709, in _reindex_columns
    return self._internal.copy(sdf=sdf, data_columns=columns, column_index=idx)
UnboundLocalError: local variable 'sdf' referenced before assignment
```
