### PR TITLE
Add test of drop_duplicates with inplace parameter

### DIFF
--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -1699,6 +1699,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         pdf = pd.DataFrame({'a': [1, 2, 2, 2, 3], 'b': ['a', 'a', 'a', 'c', 'd']})
         kdf = ks.from_pandas(pdf)
 
+        # inplace is False
         self.assert_eq(pdf.drop_duplicates().sort_index(),
                        kdf.drop_duplicates().sort_index())
         self.assert_eq(pdf.drop_duplicates('a').sort_index(),
@@ -1706,7 +1707,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(pdf.drop_duplicates(['a', 'b']).sort_index(),
                        kdf.drop_duplicates(['a', 'b']).sort_index())
 
-        # multi-index columns
+        # multi-index columns, inplace is False
         columns = pd.MultiIndex.from_tuples([('x', 'a'), ('y', 'b')])
         pdf.columns = columns
         kdf.columns = columns
@@ -1717,6 +1718,29 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
                        kdf.drop_duplicates(('x', 'a')).sort_index())
         self.assert_eq(pdf.drop_duplicates([('x', 'a'), ('y', 'b')]).sort_index(),
                        kdf.drop_duplicates([('x', 'a'), ('y', 'b')]).sort_index())
+
+        # inplace is True
+        subset_list = [None, 'a', ['a', 'b']]
+        for subset in subset_list:
+            pdf = pd.DataFrame({'a': [1, 2, 2, 2, 3], 'b': ['a', 'a', 'a', 'c', 'd']})
+            kdf = ks.from_pandas(pdf)
+            pdf.drop_duplicates(subset=subset, inplace=True)
+            kdf.drop_duplicates(subset=subset, inplace=True)
+            self.assert_eq(pdf.sort_index(),
+                           kdf.sort_index())
+
+        # multi-index columns, inplace is True
+        subset_list = [None, ('x', 'a'), [('x', 'a'), ('y', 'b')]]
+        for subset in subset_list:
+            pdf = pd.DataFrame({'a': [1, 2, 2, 2, 3], 'b': ['a', 'a', 'a', 'c', 'd']})
+            kdf = ks.from_pandas(pdf)
+            columns = pd.MultiIndex.from_tuples([('x', 'a'), ('y', 'b')])
+            pdf.columns = columns
+            kdf.columns = columns
+            pdf.drop_duplicates(subset=subset, inplace=True)
+            kdf.drop_duplicates(subset=subset, inplace=True)
+            self.assert_eq(pdf.sort_index(),
+                           kdf.sort_index())
 
     def test_reindex(self):
         index = ['A', 'B', 'C', 'D', 'E']


### PR DESCRIPTION
There is no test that tested with `inplace=True` parameter at drop_duplicates function.
So I update test case that is `drop_duplicates(inplace=True)`.

![image](https://user-images.githubusercontent.com/29699834/67914119-8e437400-fbd2-11e9-82d7-72674468823f.png)

Now the `test_drop_duplicates()` check 4 stages. (`single-index columns with/without inplace`, `multi-index columns with/without inplace`)