### PR TITLE
Enable creating Index from list like 'Index([1, 2, 3])'

### DIFF
--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -49,6 +49,14 @@ class Index(IndexOpsMixin):
     :ivar _scol: Spark Column instance
     :type _scol: pyspark.Column
 
+    Parameters
+    ----------
+    data : DataFrame or list
+        Index can be created by DataFrame or list
+    dtype : dtype, default None
+        Data type to force. Only a single dtype is allowed. If None, infer
+    name : name of index, hashable
+
     See Also
     --------
     MultiIndex : A multi-level, or hierarchical, Index.
@@ -68,9 +76,15 @@ class Index(IndexOpsMixin):
     Index(['a', 'b', 'c'], dtype='object')
     """
 
-    def __init__(self, kdf_or_names: Union[DataFrame, list],
-                 scol: Optional[spark.Column] = None) -> None:
-        kdf = DataFrame(index=kdf_or_names) if isinstance(kdf_or_names, list) else kdf_or_names
+    def __init__(self, data: Union[DataFrame, list],
+                 scol: Optional[spark.Column] = None, dtype=None, name=None) -> None:
+        if isinstance(data, DataFrame):
+            assert dtype is None
+            assert name is None
+            kdf = data
+        else:
+            assert scol is None
+            kdf = DataFrame(index=pd.Index(data=data, dtype=dtype, name=name))
         if scol is None:
             scol = kdf._internal.index_scols[0]
         internal = kdf._internal.copy(scol=scol,

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -77,7 +77,6 @@ class Index(IndexOpsMixin):
                                       data_columns=kdf._internal.index_columns,
                                       column_index=kdf._internal.index_names,
                                       column_index_names=None)
-
         IndexOpsMixin.__init__(self, internal, kdf)
 
     def _with_new_scol(self, scol: spark.Column) -> 'Index':

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -60,15 +60,24 @@ class Index(IndexOpsMixin):
 
     >>> ks.DataFrame({'a': [1, 2, 3]}, index=list('abc')).index
     Index(['a', 'b', 'c'], dtype='object')
+
+    >>> Index([1, 2, 3])
+    Int64Index([1, 2, 3], dtype='int64')
+
+    >>> Index(list('abc'))
+    Index(['a', 'b', 'c'], dtype='object')
     """
 
-    def __init__(self, kdf: DataFrame, scol: Optional[spark.Column] = None) -> None:
+    def __init__(self, kdf_or_names: Union[DataFrame, list],
+                 scol: Optional[spark.Column] = None) -> None:
+        kdf = DataFrame(index=kdf_or_names) if isinstance(kdf_or_names, list) else kdf_or_names
         if scol is None:
             scol = kdf._internal.index_scols[0]
         internal = kdf._internal.copy(scol=scol,
                                       data_columns=kdf._internal.index_columns,
                                       column_index=kdf._internal.index_names,
                                       column_index_names=None)
+
         IndexOpsMixin.__init__(self, internal, kdf)
 
     def _with_new_scol(self, scol: spark.Column) -> 'Index':

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -76,8 +76,8 @@ class Index(IndexOpsMixin):
     Index(['a', 'b', 'c'], dtype='object')
     """
 
-    def __init__(self, data: Union[DataFrame, list],
-                 scol: Optional[spark.Column] = None, dtype=None, name=None) -> None:
+    def __init__(self, data: Union[DataFrame, list], dtype=None, name=None,
+                 scol: Optional[spark.Column] = None) -> None:
         if isinstance(data, DataFrame):
             assert dtype is None
             assert name is None
@@ -100,7 +100,7 @@ class Index(IndexOpsMixin):
         :param scol: the new Spark Column
         :return: the copied Index
         """
-        return Index(self._kdf, scol)
+        return Index(self._kdf, scol=scol)
 
     @property
     def size(self) -> int:
@@ -266,7 +266,7 @@ class Index(IndexOpsMixin):
             self._kdf._internal = internal
             return self
         else:
-            return Index(DataFrame(internal), self._scol)
+            return Index(DataFrame(internal), scol=self._scol)
 
     def to_series(self, name: Union[str, Tuple[str, ...]] = None) -> Series:
         """
@@ -459,7 +459,7 @@ class Index(IndexOpsMixin):
         Index(['cobra', 'viper', 'sidewinder'], dtype='object', name='snake')
         """
         internal = self._kdf._internal.copy()
-        result = Index(ks.DataFrame(internal), self._scol)
+        result = Index(ks.DataFrame(internal), scol=self._scol)
         if name:
             result.name = name
         return result


### PR DESCRIPTION
Resolves #948

```python
>>> Index([1, 2, 3])
Int64Index([1, 2, 3], dtype='int64')

>>> Index(list('abc'))
Index(['a', 'b', 'c'], dtype='object')
```