### PR TITLE
Add repr for Expanding

### DIFF
--- a/databricks/koalas/tests/test_expanding.py
+++ b/databricks/koalas/tests/test_expanding.py
@@ -39,3 +39,6 @@ class ExpandingTests(ReusedSQLTestCase, TestUtils):
                 TypeError,
                 "kdf_or_kser must be a series or dataframe; however, got:.*int"):
             Expanding(1, 2)
+
+    def test_expanding_repr(self):
+        self.assertEqual(repr(ks.range(10).expanding(5)), "Expanding [min_periods=5]")

--- a/databricks/koalas/window.py
+++ b/databricks/koalas/window.py
@@ -80,6 +80,10 @@ class Expanding(_RollingAndExpanding):
                 return partial(property_or_func, self)
         raise AttributeError(item)
 
+    # TODO: when add 'center' and 'axis' parameter, should add to here too.
+    def __repr__(self):
+        return "Expanding [min_periods={}]".format(self._min_periods)
+
     def count(self):
         """
         The expanding count of any non-NaN observations inside the window.


### PR DESCRIPTION
i'm not pretty sure whether this is necessary or not,

but i think maybe is it better to have `__repr__` for `Expanding` like pandas?


```python
>>> pd.Series([1, 2, 3]).expanding(2)
Expanding [min_periods=2,center=False,axis=0]

>>> ks.Series([1, 2, 3]).expanding(2)
Expanding [min_periods=2]
```

the results slightly different since now we have only `min_periods` parameter