### PR TITLE
Fix median to support multi-index columns.

### DIFF
--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -1422,7 +1422,7 @@ class _Frame(object):
             .withColumn('__DUMMY__', F.monotonically_increasing_id())
         # This is expected to be small so it's fine to transpose.
         return DataFrame(kdf._internal.copy(sdf=sdf, index_map=[('__DUMMY__', None)])) \
-                   ._to_internal_pandas().transpose().iloc[:, 0]
+            ._to_internal_pandas().transpose().iloc[:, 0]
 
     def rolling(self, *args, **kwargs):
         return Rolling(self)

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -1369,19 +1369,48 @@ class _Frame(object):
 
         >>> df['a'].median()
         25.0
+        >>> (df['a'] + 100).median()
+        125.0
+
+        For multi-index columns,
+
+        >>> df.columns = pd.MultiIndex.from_tuples([('x', 'a'), ('y', 'b')])
+        >>> df
+              x  y
+              a  b
+        0  24.0  1
+        1  21.0  2
+        2  25.0  3
+        3  33.0  4
+        4  26.0  5
+
+        On a DataFrame:
+
+        >>> df.median()
+        x  a    25.0
+        y  b     3.0
+        Name: 0, dtype: float64
+
+        On a Series:
+
+        >>> df[('x', 'a')].median()
+        25.0
+        >>> (df[('x', 'a')] + 100).median()
+        125.0
         """
         if not isinstance(accuracy, int):
             raise ValueError("accuracy must be an integer; however, got [%s]" % type(accuracy))
 
         from databricks.koalas.frame import DataFrame
-        from databricks.koalas.series import Series
+        from databricks.koalas.series import Series, _col
 
         kdf_or_ks = self
         if isinstance(kdf_or_ks, Series):
-            ks = kdf_or_ks
-            return self._reduce_for_stat_function(
+            ks = _col(kdf_or_ks.to_frame())
+            return ks._reduce_for_stat_function(
                 lambda _: F.expr(
-                    "approx_percentile(`%s`, 0.5, %s)" % (ks.name, accuracy)), name="median")
+                    "approx_percentile(`%s`, 0.5, %s)" % (ks._internal.data_columns[0], accuracy)),
+                name="median")
         assert isinstance(kdf_or_ks, DataFrame)
 
         # This code path cannot reuse `_reduce_for_stat_function` since there looks no proper way
@@ -1389,9 +1418,11 @@ class _Frame(object):
         kdf = kdf_or_ks
         sdf = kdf._sdf
         median = lambda name: F.expr("approx_percentile(`%s`, 0.5, %s)" % (name, accuracy))
-        sdf = sdf.select([median(col).alias(col) for col in kdf.columns])
+        sdf = sdf.select([median(col).alias(col) for col in kdf._internal.data_columns]) \
+            .withColumn('__DUMMY__', F.monotonically_increasing_id())
         # This is expected to be small so it's fine to transpose.
-        return DataFrame(sdf)._to_internal_pandas().transpose().iloc[:, 0]
+        return DataFrame(kdf._internal.copy(sdf=sdf, index_map=[('__DUMMY__', None)])) \
+                   ._to_internal_pandas().transpose().iloc[:, 0]
 
     def rolling(self, *args, **kwargs):
         return Rolling(self)

--- a/databricks/koalas/tests/test_stats.py
+++ b/databricks/koalas/tests/test_stats.py
@@ -35,9 +35,9 @@ class StatsTest(ReusedSQLTestCase, SQLTestUtils):
             self.assert_eq(getattr(kdf.A, funcname)(), getattr(pdf.A, funcname)(), almost=True)
             self.assert_eq(getattr(kdf, funcname)(), getattr(pdf, funcname)(), almost=True)
 
-        # NOTE: To test skew and kurt, just make sure they run.
+        # NOTE: To test skew, kurt, and median, just make sure they run.
         #       The numbers are different in spark and pandas.
-        functions = ['skew', 'kurt']
+        functions = ['skew', 'kurt', 'median']
         for funcname in functions:
             getattr(kdf.A, funcname)()
             getattr(kdf, funcname)()


### PR DESCRIPTION
This PR fixes `_Frame.median()` to:

- follow `_scol` for `Series`.
- support multi-index columns.
- avoid attaching default index for `DataFrame`.