### PR TITLE
Add Series.between to the documentation

### DIFF
--- a/docs/source/reference/series.rst
+++ b/docs/source/reference/series.rst
@@ -104,6 +104,7 @@ Computations / Descriptive Stats
    Series.abs
    Series.all
    Series.any
+   Series.between
    Series.clip
    Series.corr
    Series.count


### PR DESCRIPTION
I forgot to add `Series.between` to the doc in #997.