### PR TITLE
[MINOR] Fix typos from 'Koala' to 'Koalas' in Series and DataFrame

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -270,7 +270,7 @@ if (3, 5) <= sys.version_info < (3, 7):
 
 class DataFrame(_Frame, Generic[T]):
     """
-    Koala DataFrame that corresponds to Pandas DataFrame logically. This holds Spark DataFrame
+    Koalas DataFrame that corresponds to Pandas DataFrame logically. This holds Spark DataFrame
     internally.
 
     :ivar _internal: an internal immutable Frame to manage metadata.

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -278,7 +278,7 @@ str_type = str
 
 class Series(_Frame, IndexOpsMixin, Generic[T]):
     """
-    Koala Series that corresponds to Pandas Series logically. This holds Spark Column
+    Koalas Series that corresponds to Pandas Series logically. This holds Spark Column
     internally.
 
     :ivar _internal: an internal immutable Frame to manage metadata.


### PR DESCRIPTION
DataFrame:

<img width="1016" alt="スクリーンショット 2019-11-06 1 35 22" src="https://user-images.githubusercontent.com/52075027/68226797-05936080-0036-11ea-9871-f60af89d4701.png">

Series:

<img width="1011" alt="スクリーンショット 2019-11-06 10 54 29" src="https://user-images.githubusercontent.com/52075027/68261586-f1765000-0083-11ea-91d6-b83b5c55c605.png">
