### PR TITLE
Reduce memory consumption in Read the Docs build

### DIFF
--- a/dev/readthedocs-environment.yml
+++ b/dev/readthedocs-environment.yml
@@ -9,5 +9,5 @@ dependencies:
   - pip
   - pip:
     # In Read the Docs, seems installing 'requirements-dev.txt' seems ignored when Conda is used.
-    - -r ../requirements-dev.txt
+    - --no-cache-dir -r ../requirements-dev.txt
 


### PR DESCRIPTION
Currently Read the Docs build is being failed:

```
Collecting package metadata (repodata.json): ...working... Killed


Command killed due to excessive memory consumption
Command time: 44s Return: 1
```

This PR tries to use no-cache in `pip` to reduce memory consumption.