### PR TITLE
Implement DataFrame.where() & DataFrame.mask()

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -2270,18 +2270,19 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         >>> reset_option("compute.ops_on_diff_frames")
         """
+        from databricks.koalas.series import Series
+        if not isinstance(cond, (DataFrame, Series)):
+            raise ValueError("type of cond must be a DataFrame or Series")
+
         sdf = cond._internal.sdf
         for col in cond._internal.data_columns:
             sdf = sdf.withColumn(col, ~F.col(col))
 
-        internal = cond._internal.copy(
+        internal = self._internal.copy(
             sdf=sdf,
-            index_map=cond._internal.index_map,
-            column_index=cond._internal.column_index,
-            column_scols=[scol_for(sdf, col) for col in cond._internal.data_columns],
-            column_index_names=None)
-
+            column_scols=[scol_for(sdf, column) for column in self._internal.data_columns])
         cond_inversed = DataFrame(internal)
+
         return self.where(cond_inversed, other)
 
     @property

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -2145,12 +2145,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         index_columns = self._internal.index_columns
         sdf = sdf.select(*index_columns, *conditions)
-        internal = self._internal.copy(
-            sdf=sdf,
-            index_map=self._internal.index_map,
-            column_index=self._internal.column_index,
-            column_scols=[scol_for(sdf, col) for col in self._internal.data_columns],
-            column_index_names=None)
+        internal = self._internal.copy(sdf=sdf)
 
         return DataFrame(_InternalFrame(sdf=sdf, index_map=self._internal.index_map))
 

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -2141,8 +2141,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 F.when(sdf[tmp_cond_col_name.format(column)], sdf[data_col_name])
                  .otherwise(sdf[tmp_other_col_name.format(column)]).alias(data_col_name))
 
-        index_column = self._internal.index_columns[0]
-        sdf = sdf.select(index_column, *conditions)
+        index_columns = self._internal.index_columns
+        sdf = sdf.select(*index_columns, *conditions)
         internal = self._internal.copy(
             sdf=sdf,
             index_map=self._internal.index_map,
@@ -2226,7 +2226,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         """
         sdf = cond._internal.sdf
         for col in cond._internal.data_columns:
-           sdf = sdf.withColumn(col, ~F.col(col))
+            sdf = sdf.withColumn(col, ~F.col(col))
 
         internal = cond._internal.copy(
             sdf=sdf,

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -2113,6 +2113,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         4  4  500
 
         When the column name of cond is different from self, it treats all values are False
+
         >>> cond = ks.DataFrame({'C': [0, -1, -2, -3, -4], 'D':[4, 3, 2, 1, 0]}) % 3 == 0
         >>> cond
                C      D

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -2115,7 +2115,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         tmp_cond_col_name = '__tmp_cond_col_{}__'
         tmp_other_col_name = '__tmp_other_col_{}__'
         kdf = self.copy()
-        for column in self._internal._data_columns:
+        for column in self._internal.data_columns:
             kdf[tmp_cond_col_name.format(column)] = cond[column]
             if isinstance(other, DataFrame):
                 kdf[tmp_other_col_name.format(column)] = other[column]
@@ -2135,7 +2135,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         sdf = kdf._sdf
         conditions = []
-        for column in self._internal._data_columns:
+        for column in self._internal.data_columns:
             data_col_name = self._internal.column_name_for(column)
             conditions.append(
                 F.when(sdf[tmp_cond_col_name.format(column)], sdf[data_col_name])
@@ -2146,8 +2146,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         internal = self._internal.copy(
             sdf=sdf,
             index_map=self._internal.index_map,
-            data_columns=self._internal._data_columns,
             column_index=self._internal.column_index,
+            column_scols=[scol_for(sdf, col) for col in self._internal.data_columns],
             column_index_names=None)
 
         return DataFrame(_InternalFrame(sdf=sdf, index_map=self._internal.index_map))
@@ -2224,45 +2224,19 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         >>> reset_option("compute.ops_on_diff_frames")
         """
-        tmp_cond_col_name = '__tmp_cond_col_{}__'
-        tmp_other_col_name = '__tmp_other_col_{}__'
-        kdf = self.copy()
-        for column in self._internal._data_columns:
-            kdf[tmp_cond_col_name.format(column)] = ~cond[column]
-            if isinstance(other, DataFrame):
-                kdf[tmp_other_col_name.format(column)] = other[column]
-            else:
-                kdf[tmp_other_col_name.format(column)] = other
+        sdf = cond._internal.sdf
+        for col in cond._internal.data_columns:
+           sdf = sdf.withColumn(col, ~F.col(col))
 
-        # above logic make spark dataframe looks like below:
-        # +-----------------+---+---+------------------+-------------------+------------------+--...
-        # |__index_level_0__|  A|  B|__tmp_cond_col_A__|__tmp_other_col_A__|__tmp_cond_col_B__|__...
-        # +-----------------+---+---+------------------+-------------------+------------------+--...
-        # |                0|  0|100|              true|                  0|             false|  ...
-        # |                1|  1|200|             false|                 -1|             false|  ...
-        # |                3|  3|400|              true|                 -3|             false|  ...
-        # |                2|  2|300|             false|                 -2|              true|  ...
-        # |                4|  4|500|             false|                 -4|             false|  ...
-        # +-----------------+---+---+------------------+-------------------+------------------+--...
-
-        sdf = kdf._sdf
-        conditions = []
-        for column in self._internal._data_columns:
-            data_col_name = self._internal.column_name_for(column)
-            conditions.append(
-                F.when(sdf[tmp_cond_col_name.format(column)], sdf[data_col_name])
-                 .otherwise(sdf[tmp_other_col_name.format(column)]).alias(data_col_name))
-
-        index_column = self._internal.index_columns[0]
-        sdf = sdf.select(index_column, *conditions)
-        internal = self._internal.copy(
+        internal = cond._internal.copy(
             sdf=sdf,
-            index_map=self._internal.index_map,
-            data_columns=self._internal._data_columns,
-            column_index=self._internal.column_index,
+            index_map=cond._internal.index_map,
+            column_index=cond._internal.column_index,
+            column_scols=[scol_for(sdf, col) for col in cond._internal.data_columns],
             column_index_names=None)
 
-        return DataFrame(_InternalFrame(sdf=sdf, index_map=self._internal.index_map))
+        cond_inversed = DataFrame(internal)
+        return self.where(cond_inversed, other)
 
     @property
     def index(self):

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -2038,6 +2038,118 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         return result
 
+    def where(self, cond, other=np.nan):
+        """
+        Replace values where the condition is False.
+
+        Parameters
+        ----------
+        cond : boolean DataFrame
+            Where cond is True, keep the original value. Where False,
+            replace with corresponding value from other.
+        other : scalar, DataFrame
+            Entries where cond is False are replaced with corresponding value from other.
+
+        Returns
+        -------
+        DataFrame
+
+        Examples
+        --------
+
+        >>> from databricks.koalas.config import set_option, reset_option
+        >>> set_option("compute.ops_on_diff_frames", True)
+        >>> df1 = ks.DataFrame({'A': [0, 1, 2, 3, 4], 'B':[100, 200, 300, 400, 500]})
+        >>> df2 = ks.DataFrame({'A': [0, -1, -2, -3, -4], 'B':[-100, -200, -300, -400, -500]})
+        >>> df1
+           A    B
+        0  0  100
+        1  1  200
+        2  2  300
+        3  3  400
+        4  4  500
+        >>> df2
+           A    B
+        0  0 -100
+        1 -1 -200
+        2 -2 -300
+        3 -3 -400
+        4 -4 -500
+
+        >>> df1.where(df1 > 0).sort_index()
+             A      B
+        0  NaN  100.0
+        1  1.0  200.0
+        2  2.0  300.0
+        3  3.0  400.0
+        4  4.0  500.0
+
+        >>> df1.where(df1 > 1, 10).sort_index()
+            A    B
+        0  10  100
+        1  10  200
+        2   2  300
+        3   3  400
+        4   4  500
+
+        >>> df1.where(df1 > 1, df1 + 100).sort_index()
+             A    B
+        0  100  100
+        1  101  200
+        2    2  300
+        3    3  400
+        4    4  500
+
+        >>> df1.where(df1 > 1, df2).sort_index()
+           A    B
+        0  0  100
+        1 -1  200
+        2  2  300
+        3  3  400
+        4  4  500
+
+        >>> reset_option("compute.ops_on_diff_frames")
+        """
+        tmp_cond_col_name = '__tmp_cond_col_{}__'
+        tmp_other_col_name = '__tmp_other_col_{}__'
+        kdf = self.copy()
+        for column in self._internal._data_columns:
+            kdf[tmp_cond_col_name.format(column)] = cond[column]
+            if isinstance(other, DataFrame):
+                kdf[tmp_other_col_name.format(column)] = other[column]
+            else:
+                kdf[tmp_other_col_name.format(column)] = other
+
+        # above logic make spark dataframe looks like below:
+        # +-----------------+---+---+------------------+-------------------+------------------+--...
+        # |__index_level_0__|  A|  B|__tmp_cond_col_A__|__tmp_other_col_A__|__tmp_cond_col_B__|__...
+        # +-----------------+---+---+------------------+-------------------+------------------+--...
+        # |                0|  0|100|              true|                  0|             false|  ...
+        # |                1|  1|200|             false|                 -1|             false|  ...
+        # |                3|  3|400|              true|                 -3|             false|  ...
+        # |                2|  2|300|             false|                 -2|              true|  ...
+        # |                4|  4|500|             false|                 -4|             false|  ...
+        # +-----------------+---+---+------------------+-------------------+------------------+--...
+
+        sdf = kdf._sdf
+        conditions = []
+        for column in self._internal._data_columns:
+            data_col_name = self._internal.column_name_for(column)
+            conditions.append(
+                F.when(sdf[tmp_cond_col_name.format(column)], sdf[data_col_name])
+                 .otherwise(sdf[tmp_other_col_name.format(column)]).alias(data_col_name))
+
+        index_column = self._internal.index_columns[0]
+        sdf = sdf.select(index_column, *conditions)
+        internal = self._internal.copy(
+            sdf=sdf,
+            index_map=self._internal.index_map,
+            data_columns=self._internal._data_columns,
+            column_index=self._internal.column_index,
+            column_index_names=None)
+
+        return DataFrame(_InternalFrame(sdf=sdf, index_map=self._internal.index_map))
+
     @property
     def index(self):
         """The index (row labels) Column of the DataFrame.

--- a/databricks/koalas/missing/frame.py
+++ b/databricks/koalas/missing/frame.py
@@ -69,7 +69,6 @@ class _MissingPandasLikeDataFrame(object):
     last_valid_index = unsupported_function('last_valid_index')
     lookup = unsupported_function('lookup')
     mad = unsupported_function('mad')
-    mask = unsupported_function('mask')
     mode = unsupported_function('mode')
     pct_change = unsupported_function('pct_change')
     prod = unsupported_function('prod')

--- a/databricks/koalas/missing/frame.py
+++ b/databricks/koalas/missing/frame.py
@@ -101,7 +101,6 @@ class _MissingPandasLikeDataFrame(object):
     tz_convert = unsupported_function('tz_convert')
     tz_localize = unsupported_function('tz_localize')
     unstack = unsupported_function('unstack')
-    where = unsupported_function('where')
 
     # Deprecated functions
     as_blocks = unsupported_function('as_blocks', deprecated=True)

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -30,16 +30,6 @@ from databricks.koalas.missing.frame import _MissingPandasLikeDataFrame
 
 class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
-    @classmethod
-    def setUpClass(cls):
-        super(DataFrameTest, cls).setUpClass()
-        set_option("compute.ops_on_diff_frames", True)
-
-    @classmethod
-    def tearDownClass(cls):
-        reset_option("compute.ops_on_diff_frames")
-        super(DataFrameTest, cls).tearDownClass()
-
     @property
     def pdf(self):
         return pd.DataFrame({
@@ -776,16 +766,24 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         kdf1 = ks.from_pandas(pdf1)
         kdf2 = ks.from_pandas(pdf2)
 
-        self.assert_eq(repr(pdf1.where(pdf2 > 100)),
-                       repr(kdf1.where(kdf2 > 100).sort_index()))
+        set_option("compute.ops_on_diff_frames", True)
+        try:
+            self.assert_eq(repr(pdf1.where(pdf2 > 100)),
+                           repr(kdf1.where(kdf2 > 100).sort_index()))
+        finally:
+            reset_option("compute.ops_on_diff_frames")
 
         pdf1 = pd.DataFrame({'A': [-1, -2, -3, -4, -5], 'B': [-100, -200, -300, -400, -500]})
         pdf2 = pd.DataFrame({'A': [-10, -20, -30, -40, -50], 'B': [-5, -4, -3, -2, -1]})
         kdf1 = ks.from_pandas(pdf1)
         kdf2 = ks.from_pandas(pdf2)
 
-        self.assert_eq(repr(pdf1.where(pdf2 < -250)),
-                       repr(kdf1.where(kdf2 < -250).sort_index()))
+        set_option("compute.ops_on_diff_frames", True)
+        try:
+            self.assert_eq(repr(pdf1.where(pdf2 < -250)),
+                           repr(kdf1.where(kdf2 < -250).sort_index()))
+        finally:
+            reset_option("compute.ops_on_diff_frames")
 
     def test_missing(self):
         kdf = self.kdf

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -2227,3 +2227,9 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         with self.assertRaisesRegex(ValueError, "quantile currently doesn't supports numeric_only"):
             kdf.quantile(.5, numeric_only=False)
+
+    def test_where(self):
+        kdf = ks.from_pandas(self.pdf)
+
+        with self.assertRaisesRegex(ValueError, 'type of cond must be a DataFrame or Series'):
+            kdf.where(1)

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -760,56 +760,6 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         with self.assertRaisesRegex(KeyError, msg):
             kdf.xs(('mammal', 'dog', 'walks', 'foo'))
 
-    def test_where(self):
-        pdf1 = pd.DataFrame({'A': [0, 1, 2, 3, 4], 'B': [100, 200, 300, 400, 500]})
-        pdf2 = pd.DataFrame({'A': [0, -1, -2, -3, -4], 'B': [-100, -200, -300, -400, -500]})
-        kdf1 = ks.from_pandas(pdf1)
-        kdf2 = ks.from_pandas(pdf2)
-
-        set_option("compute.ops_on_diff_frames", True)
-        try:
-            self.assert_eq(repr(pdf1.where(pdf2 > 100)),
-                           repr(kdf1.where(kdf2 > 100).sort_index()))
-        finally:
-            reset_option("compute.ops_on_diff_frames")
-
-        pdf1 = pd.DataFrame({'A': [-1, -2, -3, -4, -5], 'B': [-100, -200, -300, -400, -500]})
-        pdf2 = pd.DataFrame({'A': [-10, -20, -30, -40, -50], 'B': [-5, -4, -3, -2, -1]})
-        kdf1 = ks.from_pandas(pdf1)
-        kdf2 = ks.from_pandas(pdf2)
-
-        set_option("compute.ops_on_diff_frames", True)
-        try:
-            self.assert_eq(repr(pdf1.where(pdf2 < -250)),
-                           repr(kdf1.where(kdf2 < -250).sort_index()))
-        finally:
-            reset_option("compute.ops_on_diff_frames")
-
-    def test_mask(self):
-        pdf1 = pd.DataFrame({'A': [0, 1, 2, 3, 4], 'B': [100, 200, 300, 400, 500]})
-        pdf2 = pd.DataFrame({'A': [0, -1, -2, -3, -4], 'B': [-100, -200, -300, -400, -500]})
-        kdf1 = ks.from_pandas(pdf1)
-        kdf2 = ks.from_pandas(pdf2)
-
-        set_option("compute.ops_on_diff_frames", True)
-        try:
-            self.assert_eq(repr(pdf1.mask(pdf2 < 100)),
-                           repr(kdf1.mask(kdf2 < 100).sort_index()))
-        finally:
-            reset_option("compute.ops_on_diff_frames")
-
-        pdf1 = pd.DataFrame({'A': [-1, -2, -3, -4, -5], 'B': [-100, -200, -300, -400, -500]})
-        pdf2 = pd.DataFrame({'A': [-10, -20, -30, -40, -50], 'B': [-5, -4, -3, -2, -1]})
-        kdf1 = ks.from_pandas(pdf1)
-        kdf2 = ks.from_pandas(pdf2)
-
-        set_option("compute.ops_on_diff_frames", True)
-        try:
-            self.assert_eq(repr(pdf1.mask(pdf2 > -250)),
-                           repr(kdf1.mask(kdf2 > -250).sort_index()))
-        finally:
-            reset_option("compute.ops_on_diff_frames")
-
     def test_missing(self):
         kdf = self.kdf
 

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -785,6 +785,31 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         finally:
             reset_option("compute.ops_on_diff_frames")
 
+    def test_mask(self):
+        pdf1 = pd.DataFrame({'A': [0, 1, 2, 3, 4], 'B': [100, 200, 300, 400, 500]})
+        pdf2 = pd.DataFrame({'A': [0, -1, -2, -3, -4], 'B': [-100, -200, -300, -400, -500]})
+        kdf1 = ks.from_pandas(pdf1)
+        kdf2 = ks.from_pandas(pdf2)
+
+        set_option("compute.ops_on_diff_frames", True)
+        try:
+            self.assert_eq(repr(pdf1.mask(pdf2 < 100)),
+                           repr(kdf1.mask(kdf2 < 100).sort_index()))
+        finally:
+            reset_option("compute.ops_on_diff_frames")
+
+        pdf1 = pd.DataFrame({'A': [-1, -2, -3, -4, -5], 'B': [-100, -200, -300, -400, -500]})
+        pdf2 = pd.DataFrame({'A': [-10, -20, -30, -40, -50], 'B': [-5, -4, -3, -2, -1]})
+        kdf1 = ks.from_pandas(pdf1)
+        kdf2 = ks.from_pandas(pdf2)
+
+        set_option("compute.ops_on_diff_frames", True)
+        try:
+            self.assert_eq(repr(pdf1.mask(pdf2 > -250)),
+                           repr(kdf1.mask(kdf2 > -250).sort_index()))
+        finally:
+            reset_option("compute.ops_on_diff_frames")
+
     def test_missing(self):
         kdf = self.kdf
 

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -2233,3 +2233,9 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         with self.assertRaisesRegex(ValueError, 'type of cond must be a DataFrame or Series'):
             kdf.where(1)
+
+    def test_mask(self):
+        kdf = ks.from_pandas(self.pdf)
+
+        with self.assertRaisesRegex(ValueError, 'type of cond must be a DataFrame or Series'):
+            kdf.mask(1)

--- a/databricks/koalas/tests/test_ops_on_diff_frames.py
+++ b/databricks/koalas/tests/test_ops_on_diff_frames.py
@@ -422,6 +422,39 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
 
         self.assert_eq(kdf.sort_index(), pdf.sort_index())
 
+    def test_where(self):
+        pdf1 = pd.DataFrame({'A': [0, 1, 2, 3, 4], 'B': [100, 200, 300, 400, 500]})
+        pdf2 = pd.DataFrame({'A': [0, -1, -2, -3, -4], 'B': [-100, -200, -300, -400, -500]})
+        kdf1 = ks.from_pandas(pdf1)
+        kdf2 = ks.from_pandas(pdf2)
+
+        self.assert_eq(repr(pdf1.where(pdf2 > 100)),
+                       repr(kdf1.where(kdf2 > 100).sort_index()))
+
+        pdf1 = pd.DataFrame({'A': [-1, -2, -3, -4, -5], 'B': [-100, -200, -300, -400, -500]})
+        pdf2 = pd.DataFrame({'A': [-10, -20, -30, -40, -50], 'B': [-5, -4, -3, -2, -1]})
+        kdf1 = ks.from_pandas(pdf1)
+        kdf2 = ks.from_pandas(pdf2)
+
+        self.assert_eq(repr(pdf1.where(pdf2 < -250)),
+                       repr(kdf1.where(kdf2 < -250).sort_index()))
+
+    def test_mask(self):
+        pdf1 = pd.DataFrame({'A': [0, 1, 2, 3, 4], 'B': [100, 200, 300, 400, 500]})
+        pdf2 = pd.DataFrame({'A': [0, -1, -2, -3, -4], 'B': [-100, -200, -300, -400, -500]})
+        kdf1 = ks.from_pandas(pdf1)
+        kdf2 = ks.from_pandas(pdf2)
+
+        self.assert_eq(repr(pdf1.mask(pdf2 < 100)),
+                       repr(kdf1.mask(kdf2 < 100).sort_index()))
+
+        pdf1 = pd.DataFrame({'A': [-1, -2, -3, -4, -5], 'B': [-100, -200, -300, -400, -500]})
+        pdf2 = pd.DataFrame({'A': [-10, -20, -30, -40, -50], 'B': [-5, -4, -3, -2, -1]})
+        kdf1 = ks.from_pandas(pdf1)
+        kdf2 = ks.from_pandas(pdf2)
+
+        self.assert_eq(repr(pdf1.mask(pdf2 > -250)),
+                       repr(kdf1.mask(kdf2 > -250).sort_index()))
 
 class OpsOnDiffFramesDisabledTest(ReusedSQLTestCase, SQLTestUtils):
 
@@ -485,3 +518,41 @@ class OpsOnDiffFramesDisabledTest(ReusedSQLTestCase, SQLTestUtils):
 
         with self.assertRaisesRegex(ValueError, "Cannot combine the series or dataframe"):
             kdf.loc[['viper', 'sidewinder'], ['shield']] = another_kdf.max_speed
+
+    def test_where(self):
+        pdf1 = pd.DataFrame({'A': [0, 1, 2, 3, 4], 'B': [100, 200, 300, 400, 500]})
+        pdf2 = pd.DataFrame({'A': [0, -1, -2, -3, -4], 'B': [-100, -200, -300, -400, -500]})
+        kdf1 = ks.from_pandas(pdf1)
+        kdf2 = ks.from_pandas(pdf2)
+
+        with self.assertRaisesRegex(ValueError, "Cannot combine the series or dataframe"):
+            self.assert_eq(repr(pdf1.where(pdf2 > 100)),
+                           repr(kdf1.where(kdf2 > 100).sort_index()))
+
+        pdf1 = pd.DataFrame({'A': [-1, -2, -3, -4, -5], 'B': [-100, -200, -300, -400, -500]})
+        pdf2 = pd.DataFrame({'A': [-10, -20, -30, -40, -50], 'B': [-5, -4, -3, -2, -1]})
+        kdf1 = ks.from_pandas(pdf1)
+        kdf2 = ks.from_pandas(pdf2)
+
+        with self.assertRaisesRegex(ValueError, "Cannot combine the series or dataframe"):
+            self.assert_eq(repr(pdf1.where(pdf2 < -250)),
+                           repr(kdf1.where(kdf2 < -250).sort_index()))
+
+    def test_mask(self):
+        pdf1 = pd.DataFrame({'A': [0, 1, 2, 3, 4], 'B': [100, 200, 300, 400, 500]})
+        pdf2 = pd.DataFrame({'A': [0, -1, -2, -3, -4], 'B': [-100, -200, -300, -400, -500]})
+        kdf1 = ks.from_pandas(pdf1)
+        kdf2 = ks.from_pandas(pdf2)
+
+        with self.assertRaisesRegex(ValueError, "Cannot combine the series or dataframe"):
+            self.assert_eq(repr(pdf1.mask(pdf2 < 100)),
+                           repr(kdf1.mask(kdf2 < 100).sort_index()))
+
+        pdf1 = pd.DataFrame({'A': [-1, -2, -3, -4, -5], 'B': [-100, -200, -300, -400, -500]})
+        pdf2 = pd.DataFrame({'A': [-10, -20, -30, -40, -50], 'B': [-5, -4, -3, -2, -1]})
+        kdf1 = ks.from_pandas(pdf1)
+        kdf2 = ks.from_pandas(pdf2)
+
+        with self.assertRaisesRegex(ValueError, "Cannot combine the series or dataframe"):
+            self.assert_eq(repr(pdf1.mask(pdf2 > -250)),
+                           repr(kdf1.mask(kdf2 > -250).sort_index()))

--- a/databricks/koalas/tests/test_ops_on_diff_frames.py
+++ b/databricks/koalas/tests/test_ops_on_diff_frames.py
@@ -456,6 +456,7 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(repr(pdf1.mask(pdf2 > -250)),
                        repr(kdf1.mask(kdf2 > -250).sort_index()))
 
+
 class OpsOnDiffFramesDisabledTest(ReusedSQLTestCase, SQLTestUtils):
 
     @classmethod

--- a/docs/source/reference/frame.rst
+++ b/docs/source/reference/frame.rst
@@ -59,6 +59,7 @@ Indexing, iteration
    DataFrame.xs
    DataFrame.get
    DataFrame.where
+   DataFrame.mask
 
 Binary operator functions
 -------------------------

--- a/docs/source/reference/frame.rst
+++ b/docs/source/reference/frame.rst
@@ -58,6 +58,7 @@ Indexing, iteration
    DataFrame.keys
    DataFrame.xs
    DataFrame.get
+   DataFrame.where
 
 Binary operator functions
 -------------------------


### PR DESCRIPTION
Resolves #884 

This PR implement `where` of `DataFrame` 
(https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.where.html#pandas.DataFrame.where)
and `mask` of `DataFrame` (same as where except for the opposite cond)
(https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.mask.html#pandas.DataFrame.mask)

```python
>>> df1 = ks.DataFrame({'A': [0, 1, 2, 3, 4], 'B':[100, 200, 300, 400, 500]})
>>> df2 = ks.DataFrame({'A': [0, -1, -2, -3, -4], 'B':[-100, -200, -300, -400, -500]})
>>> df1
   A    B
0  0  100
1  1  200
2  2  300
3  3  400
4  4  500
>>> df2
   A    B
0  0 -100
1 -1 -200
2 -2 -300
3 -3 -400
4 -4 -500

>>> df1.where(df1 > 0).sort_index()
     A      B
0  NaN  100.0
1  1.0  200.0
2  2.0  300.0
3  3.0  400.0
4  4.0  500.0

>>> df1.where(df1 > 1, 10).sort_index()
    A    B
0  10  100
1  10  200
2   2  300
3   3  400
4   4  500

>>> df1.where(df1 > 1, df1 + 100).sort_index()
     A    B
0  100  100
1  101  200
2    2  300
3    3  400
4    4  500

>>> df1.where(df1 > 1, df2).sort_index()
   A    B
0  0  100
1 -1  200
2  2  300
3  3  400
4  4  500
```