### PR TITLE
Use one Spark session across all tests

### DIFF
--- a/databricks/conftest.py
+++ b/databricks/conftest.py
@@ -46,8 +46,8 @@ else:
 @pytest.fixture(scope='session', autouse=True)
 def session_termination():
     yield
-    # Share one session across all the tests. Repeating starting and stopping session and contexts
-    # seems causing a memory leak for an unknown reason.
+    # Share one session across all the tests. Repeating starting and stopping sessions and contexts
+    # seems causing a memory leak for an unknown reason in PySpark.
     session.stop()
 
 

--- a/databricks/conftest.py
+++ b/databricks/conftest.py
@@ -43,6 +43,14 @@ else:
     session = utils.default_session()
 
 
+@pytest.fixture(scope='session', autouse=True)
+def session_termination():
+    yield
+    # Share one session across all the tests. Repeating starting and stopping session and contexts
+    # seems causing a memory leak for an unknown reason.
+    session.stop()
+
+
 @pytest.fixture(autouse=True)
 def add_ks(doctest_namespace):
     doctest_namespace['ks'] = koalas

--- a/databricks/koalas/testing/utils.py
+++ b/databricks/koalas/testing/utils.py
@@ -121,7 +121,8 @@ class ReusedSQLTestCase(unittest.TestCase, SQLTestUtils):
 
     @classmethod
     def setUpClass(cls):
-        cls.spark = default_session({'spark.sql.execution.arrow.enabled': True})
+        cls.spark = default_session()
+        cls.spark.conf("spark.sql.execution.arrow.enabled", True)
 
     @classmethod
     def tearDownClass(cls):

--- a/databricks/koalas/testing/utils.py
+++ b/databricks/koalas/testing/utils.py
@@ -126,7 +126,7 @@ class ReusedSQLTestCase(unittest.TestCase, SQLTestUtils):
     @classmethod
     def tearDownClass(cls):
         # We don't stop Spark session to reuse across all tests.
-        # The session will be started and stopped at session level.
+        # The Spark session will be started and stopped at PyTest session level.
         # Please see databricks/koalas/conftest.py.
         pass
 


### PR DESCRIPTION
For some reasons, the tests started to suddenly fail as below:

```
databricks/koalas/tests/test_series_string.py::SeriesStringTest::test_string_wrap PASSED [ 97%]
databricks/koalas/tests/test_series_string.py::SeriesStringTest::test_string_zfill PASSED [ 97%]
databricks/koalas/tests/test_sql.py::SQLTest::test_error_bad_sql PASSED  [ 97%]
databricks/koalas/tests/test_sql.py::SQLTest::test_error_unsupported_type PASSED [ 98%]
databricks/koalas/tests/test_sql.py::SQLTest::test_error_variable_not_exist PASSED [ 98%]
databricks/koalas/tests/test_stats.py::StatsTest::test_abs FAILED        [ 98%]
databricks/koalas/tests/test_stats.py::StatsTest::test_axis_on_dataframe FAILED [ 98%]
databricks/koalas/tests/test_stats.py::StatsTest::test_corr FAILED       [ 98%]
databricks/koalas/tests/test_stats.py::StatsTest::test_cov_corr_meta FAILED [ 98%]
databricks/koalas/tests/test_stats.py::StatsTest::test_some_stats_functions_should_discard_non_numeric_columns_by_default FAILED [ 98%]
databricks/koalas/tests/test_stats.py::StatsTest::test_stat_functions FAILED [ 98%]
databricks/koalas/tests/test_stats.py::StatsTest::test_stat_functions_multiindex_column FAILED [ 99%]
databricks/koalas/tests/test_stats.py::StatsTest::test_stats_on_boolean_dataframe FAILED [ 99%]
databricks/koalas/tests/test_stats.py::StatsTest::test_stats_on_boolean_series FAILED [ 99%]
databricks/koalas/tests/test_stats.py::StatsTest::test_stats_on_non_numeric_columns_should_be_discarded_if_numeric_only_is_true FAILED [ 99%]
databricks/koalas/tests/test_stats.py::StatsTest::test_stats_on_non_numeric_columns_should_not_be_discarded_if_numeric_only_is_false FAILED [ 99%]
databricks/koalas/tests/test_utils.py::UtilsTest::test_lazy_property PASSED [ 99%]
databricks/koalas/tests/test_utils.py::UtilsTest::test_validate_arguments_and_invoke_function PASSED [ 99%]
databricks/koalas/tests/test_window.py::ExpandingRollingTests::test_missing PASSED [ 99%]
databricks/koalas/tests/test_window.py::ExpandingRollingTests::test_missing_groupby PASSED [100%]
```

```
            Caused by: org.apache.spark.SparkException: Job aborted due to stage failure: Task 0 in stage 0.0 failed 1 times, most recent failure: Lost task 0.0 in stage 0.0 (TID 0, localhost, executor driver): java.io.IOException: Failed to send RPC /jars/io.delta_delta-core_2.11-0.1.0.jar to travis-job-15a5165f-f0ad-4d6d-a590-d067abf61931.c.travis-ci-prod-3.internal/10.30.1.109:39783: io.netty.util.internal.OutOfDirectMemoryError: failed to allocate 16777216 byte(s) of direct memory (used: 939524096, max: 954728448)
E                   	at org.apache.spark.network.client.TransportClient$2.handleFailure(TransportClient.java:163)
E                   	at org.apache.spark.network.client.TransportClient$StdChannelListener.operationComplete(TransportClient.java:339)
E                   	at io.netty.util.concurrent.DefaultPromise.notifyListener0(DefaultPromise.java:507)
E                   	at io.netty.util.concurrent.DefaultPromise.notifyListenersNow(DefaultPromise.java:481)
E                   	at io.netty.util.concurrent.DefaultPromise.notifyListeners(DefaultPromise.java:420)
E                   	at io.netty.util.concurrent.DefaultPromise.tryFailure(DefaultPromise.java:122)
E                   	at io.netty.channel.AbstractChannel$AbstractUnsafe.safeSetFailure(AbstractChannel.java:987)
E                   	at io.netty.channel.AbstractChannel$AbstractUnsafe.write(AbstractChannel.java:883)
E                   	at io.netty.channel.DefaultChannelPipeline$HeadContext.write(DefaultChannelPipeline.java:1316)
E                   	at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:738)
E                   	at io.netty.channel.AbstractChannelHandlerContext.invokeWrite(AbstractChannelHandlerContext.java:730)
E                   	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:816)
E                   	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:723)
E                   	at io.netty.handler.codec.MessageToMessageEncoder.write(MessageToMessageEncoder.java:111)
E                   	at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:738)
E                   	at io.netty.channel.AbstractChannelHandlerContext.invokeWrite(AbstractChannelHandlerContext.java:730)
E                   	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:816)
E                   	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:723)
E                   	at io.netty.handler.timeout.IdleStateHandler.write(IdleStateHandler.java:302)
E                   	at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:738)
E                   	at io.netty.channel.AbstractChannelHandlerContext.invokeWrite(AbstractChannelHandlerContext.java:730)
E                   	at io.netty.channel.AbstractChannelHandlerContext.access$1900(AbstractChannelHandlerContext.java:38)
E                   	at io.netty.channel.AbstractChannelHandlerContext$AbstractWriteTask.write(AbstractChannelHandlerContext.java:1081)
E                   	at io.netty.channel.AbstractChannelHandlerContext$WriteAndFlushTask.write(AbstractChannelHandlerContext.java:1128)
E                   	at io.netty.channel.AbstractChannelHandlerContext$AbstractWriteTask.run(AbstractChannelHandlerContext.java:1070)
E                   	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:163)
E                   	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:403)
E                   	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:463)
E                   	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:858)
E                   	at io.netty.util.concurrent.DefaultThreadFactory$DefaultRunnableDecorator.run(DefaultThreadFactory.java:138)
E                   	at java.lang.Thread.run(Thread.java:748)
E                   Caused by: io.netty.util.internal.OutOfDirectMemoryError: failed to allocate 16777216 byte(s) of direct memory (used: 939524096, max: 954728448)
E                   	at io.netty.util.internal.PlatformDependent.incrementMemoryCounter(PlatformDependent.java:640)
E                   	at io.netty.util.internal.PlatformDependent.allocateDirectNoCleaner(PlatformDependent.java:594)
E                   	at io.netty.buffer.PoolArena$DirectArena.allocateDirect(PoolArena.java:764)
E                   	at io.netty.buffer.PoolArena$DirectArena.newChunk(PoolArena.java:740)
E                   	at io.netty.buffer.PoolArena.allocateNormal(PoolArena.java:244)
E                   	at io.netty.buffer.PoolArena.allocate(PoolArena.java:214)
E                   	at io.netty.buffer.PoolArena.allocate(PoolArena.java:146)
E                   	at io.netty.buffer.PooledByteBufAllocator.newDirectBuffer(PooledByteBufAllocator.java:324)
E                   	at io.netty.buffer.AbstractByteBufAllocator.directBuffer(AbstractByteBufAllocator.java:185)
E                   	at io.netty.buffer.AbstractByteBufAllocator.directBuffer(AbstractByteBufAllocator.java:176)
E                   	at io.netty.channel.nio.AbstractNioChannel.newDirectBuffer(AbstractNioChannel.java:449)
E                   	at io.netty.channel.nio.AbstractNioByteChannel.filterOutboundMessage(AbstractNioByteChannel.java:262)
E                   	at io.netty.channel.AbstractChannel$AbstractUnsafe.write(AbstractChannel.java:877)
E                   	... 23 more
E                   
E                   Driver stacktrace:
E                   	at org.apache.spark.scheduler.DAGScheduler.org$apache$spark$scheduler$DAGScheduler$$failJobAndIndependentStages(DAGScheduler.scala:1889)
E                   	at org.apache.spark.scheduler.DAGScheduler$$anonfun$abortStage$1.apply(DAGScheduler.scala:1877)
E                   	at org.apache.spark.scheduler.DAGScheduler$$anonfun$abortStage$1.apply(DAGScheduler.scala:1876)
E                   	at scala.collection.mutable.ResizableArray$class.foreach(ResizableArray.scala:59)
E                   	at scala.collection.mutable.ArrayBuffer.foreach(ArrayBuffer.scala:48)
E                   	at org.apache.spark.scheduler.DAGScheduler.abortStage(DAGScheduler.scala:1876)
E                   	at org.apache.spark.scheduler.DAGScheduler$$anonfun$handleTaskSetFailed$1.apply(DAGScheduler.scala:926)
E                   	at org.apache.spark.scheduler.DAGScheduler$$anonfun$handleTaskSetFailed$1.apply(DAGScheduler.scala:926)
E                   	at scala.Option.foreach(Option.scala:257)
E                   	at org.apache.spark.scheduler.DAGScheduler.handleTaskSetFailed(DAGScheduler.scala:926)
E                   	at org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.doOnReceive(DAGScheduler.scala:2110)
E                   	at org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.onReceive(DAGScheduler.scala:2059)
E                   	at org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.onReceive(DAGScheduler.scala:2048)
E                   	at org.apache.spark.util.EventLoop$$anon$1.run(EventLoop.scala:49)
E                   	at org.apache.spark.scheduler.DAGScheduler.runJob(DAGScheduler.scala:737)
E                   	at org.apache.spark.SparkContext.runJob(SparkContext.scala:2061)
E                   	at org.apache.spark.sql.Dataset$$anonfun$collectAsArrowToPython$1$$anonfun$apply$17.apply(Dataset.scala:3318)
E                   	at org.apache.spark.sql.Dataset$$anonfun$collectAsArrowToPython$1$$anonfun$apply$17.apply(Dataset.scala:3287)
E                   	at org.apache.spark.api.python.PythonRDD$$anonfun$7$$anonfun$apply$3.apply$mcV$sp(PythonRDD.scala:456)
E                   	at org.apache.spark.api.python.PythonRDD$$anonfun$7$$anonfun$apply$3.apply(PythonRDD.scala:456)
E                   	at org.apache.spark.api.python.PythonRDD$$anonfun$7$$anonfun$apply$3.apply(PythonRDD.scala:456)
E                   	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1360)
E                   	at org.apache.spark.api.python.PythonRDD$$anonfun$7.apply(PythonRDD.scala:457)
E                   	at org.apache.spark.api.python.PythonRDD$$anonfun$7.apply(PythonRDD.scala:453)
E                   	at org.apache.spark.api.python.SocketFuncServer.handleConnection(PythonRDD.scala:994)
E                   	at org.apache.spark.api.python.SocketFuncServer.handleConnection(PythonRDD.scala:988)
E                   	at org.apache.spark.api.python.PythonServer$$anonfun$11$$anonfun$apply$9.apply(PythonRDD.scala:853)
E                   	at scala.util.Try$.apply(Try.scala:192)
E                   	at org.apache.spark.api.python.PythonServer$$anonfun$11.apply(PythonRDD.scala:853)
E                   	at org.apache.spark.api.python.PythonServer$$anonfun$11.apply(PythonRDD.scala:852)
E                   	at org.apache.spark.api.python.PythonServer$$anon$1.run(PythonRDD.scala:908)
```

Seems like repeating starting and stopping session and contexts seems causing a memory leak for an unknown reason.

Although we should figure out the root cause in PySpark, we should also find the workaround to avoid this issue.

This PR proposes the workaround by sharing single Spark session across tests first.