### PR TITLE
[HOTFIX] Don't use data_columns in DataFrame.quantile

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -7588,7 +7588,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         internal = self._internal.copy(
             sdf=sdf,
-            data_columns=self._internal.data_columns,
+            column_scols=[scol_for(sdf, col) for col in self._internal.data_columns],
             index_map=[(internal_index_column, None)],
             column_index=self._internal.column_index,
             column_index_names=None)

--- a/databricks/koalas/internal.py
+++ b/databricks/koalas/internal.py
@@ -382,7 +382,7 @@ class _InternalFrame(object):
     def __init__(self, sdf: spark.DataFrame,
                  index_map: Optional[List[IndexMap]] = None,
                  column_index: Optional[List[Tuple[str, ...]]] = None,
-                 column_scols: Optional[spark.Column] = None,
+                 column_scols: Optional[List[spark.Column]] = None,
                  column_index_names: Optional[List[str]] = None,
                  scol: Optional[spark.Column] = None) -> None:
         """
@@ -676,7 +676,7 @@ class _InternalFrame(object):
              index_map: Union[List[IndexMap], _NoValueType] = _NoValue,
              column_index: Union[List[Tuple[str, ...]], _NoValueType] = _NoValue,
              column_scols: Union[List[spark.Column], _NoValueType] = _NoValue,
-             column_index_names: Union[List[str], _NoValueType] = _NoValue,
+             column_index_names: Optional[Union[List[str], _NoValueType]] = _NoValue,
              scol: Union[spark.Column, _NoValueType] = _NoValue) -> '_InternalFrame':
         """ Copy the immutable DataFrame.
 

--- a/databricks/koalas/testing/utils.py
+++ b/databricks/koalas/testing/utils.py
@@ -122,7 +122,7 @@ class ReusedSQLTestCase(unittest.TestCase, SQLTestUtils):
     @classmethod
     def setUpClass(cls):
         cls.spark = default_session()
-        cls.spark.conf("spark.sql.execution.arrow.enabled", True)
+        cls.spark.conf.set('spark.sql.execution.arrow.enabled', True)
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
There was a conflict between https://github.com/databricks/koalas/commit/11f8f3902ff779b0786ef46f1e28adde0b20be7e and https://github.com/databricks/koalas/commit/1cb4ba04183b1f4f3d333525e8b10f6142c87d26.

