### PR TITLE
Use Python 3.7 in Read the Docs build (with Conda)

### DIFF
--- a/dev/readthedocs-environment.yml
+++ b/dev/readthedocs-environment.yml
@@ -5,9 +5,11 @@
 channels:
   - conda-forge
 dependencies:
+  # In Read the Docs, seems whole pip-related installation is ignored when conda is used.
+  - python=3.7
   - openjdk=8
   - pip
   - pip:
-    # In Read the Docs, seems installing 'requirements-dev.txt' seems ignored when Conda is used.
+  # In Read the Docs, seems whole pip-related installation is ignored when conda is used.
     - -r ../requirements-dev.txt
 

--- a/dev/readthedocs-environment.yml
+++ b/dev/readthedocs-environment.yml
@@ -10,6 +10,8 @@ dependencies:
   - openjdk=8
   - pip
   - pip:
-  # In Read the Docs, seems whole pip-related installation is ignored when conda is used.
+    - --upgrade cython
+  - pip:
+    # In Read the Docs, seems whole pip-related installation is ignored when conda is used.
     - -r ../requirements-dev.txt
 


### PR DESCRIPTION
Many packages seem not supported with Python 3.8 yet. This PR aims to set the Python version to 3.7 for now in Read the Docs build.

Note that we should switch back to pip once Spark 3.0 is released because we use Conda only because of JDK 8.

Current pip configuration in `.readthedocs.yml` seems being ignored due to Conda configuration.

Related to https://github.com/readthedocs/readthedocs.org/issues/6350