### PR TITLE
Keep consistency of Test Class Names: *Tests -> *Test

### DIFF
--- a/databricks/koalas/tests/test_expanding.py
+++ b/databricks/koalas/tests/test_expanding.py
@@ -21,7 +21,7 @@ from databricks.koalas.testing.utils import ReusedSQLTestCase, TestUtils
 from databricks.koalas.window import Expanding
 
 
-class ExpandingTests(ReusedSQLTestCase, TestUtils):
+class ExpandingTest(ReusedSQLTestCase, TestUtils):
 
     def _test_expanding_func(self, f):
         kser = ks.Series([1, 2, 3])

--- a/databricks/koalas/tests/test_repr.py
+++ b/databricks/koalas/tests/test_repr.py
@@ -18,78 +18,78 @@ from databricks.koalas.config import set_option, reset_option
 from databricks.koalas.testing.utils import ReusedSQLTestCase
 
 
-class ReprTests(ReusedSQLTestCase):
+class ReprTest(ReusedSQLTestCase):
     max_display_count = 23
 
     @classmethod
     def setUpClass(cls):
-        super(ReprTests, cls).setUpClass()
-        set_option("display.max_rows", ReprTests.max_display_count)
+        super(ReprTest, cls).setUpClass()
+        set_option("display.max_rows", ReprTest.max_display_count)
 
     @classmethod
     def tearDownClass(cls):
         reset_option("display.max_rows")
-        super(ReprTests, cls).tearDownClass()
+        super(ReprTest, cls).tearDownClass()
 
     def test_repr_dataframe(self):
-        kdf = ks.range(ReprTests.max_display_count)
+        kdf = ks.range(ReprTest.max_display_count)
         self.assertTrue("Showing only the first" not in repr(kdf))
         self.assert_eq(repr(kdf), repr(kdf.to_pandas()))
 
-        kdf = ks.range(ReprTests.max_display_count + 1)
+        kdf = ks.range(ReprTest.max_display_count + 1)
         self.assertTrue("Showing only the first" in repr(kdf))
 
         set_option("display.max_rows", None)
         try:
-            kdf = ks.range(ReprTests.max_display_count + 1)
+            kdf = ks.range(ReprTest.max_display_count + 1)
             self.assert_eq(repr(kdf), repr(kdf.to_pandas()))
         finally:
-            set_option("display.max_rows", ReprTests.max_display_count)
+            set_option("display.max_rows", ReprTest.max_display_count)
 
     def test_repr_series(self):
-        kser = ks.range(ReprTests.max_display_count).id
+        kser = ks.range(ReprTest.max_display_count).id
         self.assertTrue("Showing only the first" not in repr(kser))
         self.assert_eq(repr(kser), repr(kser.to_pandas()))
 
-        kser = ks.range(ReprTests.max_display_count + 1).id
+        kser = ks.range(ReprTest.max_display_count + 1).id
         self.assertTrue("Showing only the first" in repr(kser))
 
         set_option("display.max_rows", None)
         try:
-            kser = ks.range(ReprTests.max_display_count + 1).id
+            kser = ks.range(ReprTest.max_display_count + 1).id
             self.assert_eq(repr(kser), repr(kser.to_pandas()))
         finally:
-            set_option("display.max_rows", ReprTests.max_display_count)
+            set_option("display.max_rows", ReprTest.max_display_count)
 
     def test_repr_indexes(self):
-        kdf = ks.range(ReprTests.max_display_count)
+        kdf = ks.range(ReprTest.max_display_count)
         kidx = kdf.index
         self.assertTrue("Showing only the first" not in repr(kidx))
         self.assert_eq(repr(kidx), repr(kidx.to_pandas()))
 
-        kdf = ks.range(ReprTests.max_display_count + 1)
+        kdf = ks.range(ReprTest.max_display_count + 1)
         kidx = kdf.index
         self.assertTrue("Showing only the first" in repr(kidx))
 
         set_option("display.max_rows", None)
         try:
-            kdf = ks.range(ReprTests.max_display_count + 1)
+            kdf = ks.range(ReprTest.max_display_count + 1)
             kidx = kdf.index
             self.assert_eq(repr(kidx), repr(kidx.to_pandas()))
         finally:
-            set_option("display.max_rows", ReprTests.max_display_count)
+            set_option("display.max_rows", ReprTest.max_display_count)
 
     def test_html_repr(self):
-        kdf = ks.range(ReprTests.max_display_count)
+        kdf = ks.range(ReprTest.max_display_count)
         self.assertTrue("Showing only the first" not in kdf._repr_html_())
         self.assertEqual(kdf._repr_html_(), kdf.to_pandas()._repr_html_())
 
-        kdf = ks.range(ReprTests.max_display_count + 1)
+        kdf = ks.range(ReprTest.max_display_count + 1)
         self.assertTrue("Showing only the first" in kdf._repr_html_())
 
         set_option("display.max_rows", None)
         try:
-            kdf = ks.range(ReprTests.max_display_count + 1)
+            kdf = ks.range(ReprTest.max_display_count + 1)
             self.assertEqual(kdf._repr_html_(), kdf.to_pandas()._repr_html_())
         finally:
-            set_option("display.max_rows", ReprTests.max_display_count)
+            set_option("display.max_rows", ReprTest.max_display_count)

--- a/databricks/koalas/tests/test_rolling.py
+++ b/databricks/koalas/tests/test_rolling.py
@@ -21,7 +21,7 @@ from databricks.koalas.testing.utils import ReusedSQLTestCase, TestUtils
 from databricks.koalas.window import Rolling
 
 
-class RollingTests(ReusedSQLTestCase, TestUtils):
+class RollingTest(ReusedSQLTestCase, TestUtils):
 
     def test_rolling_error(self):
         with self.assertRaisesRegex(ValueError, "window must be >= 0"):

--- a/databricks/koalas/tests/test_window.py
+++ b/databricks/koalas/tests/test_window.py
@@ -24,7 +24,7 @@ from databricks.koalas.missing.window import _MissingPandasLikeExpanding, \
 from databricks.koalas.testing.utils import ReusedSQLTestCase, TestUtils
 
 
-class ExpandingRollingTests(ReusedSQLTestCase, TestUtils):
+class ExpandingRollingTest(ReusedSQLTestCase, TestUtils):
     def test_missing(self):
         kdf = ks.DataFrame({'a': [1, 2, 3, 4, 5, 6, 7, 8, 9]})
 


### PR DESCRIPTION
Maybe this is not so necessary, but sometimes i got confused when i did some test.

For example, if i'd like to test `groupby.rolling.sum`, i was confused which is the correct test class name of this function `pytest tests/test_rolling.py::RollingTests::test_groupby_rolling_sum.py` or `pytest tests/test_rolling.py::RollingTest::test_groupby_rolling_sum.py`.

since some of test classes are named by `*Tests` and the others are `*Test`.

so i think it should be better to use unified rule when naming test class to keep consistency.