### PR TITLE
Implement std and var at rolling and expanding in Series, Frame, SeriesGroupBy, FrameGroupBy

### DIFF
--- a/databricks/koalas/missing/window.py
+++ b/databricks/koalas/missing/window.py
@@ -49,9 +49,7 @@ class _MissingPandasLikeExpanding(object):
     median = unsupported_function_expanding("median")
     quantile = unsupported_function_expanding("quantile")
     skew = unsupported_function_expanding("skew")
-    std = unsupported_function_expanding("std")
     validate = unsupported_function_expanding("validate")
-    var = unsupported_function_expanding("var")
 
     exclusions = unsupported_property_expanding("exclusions")
     is_datetimelike = unsupported_property_expanding("is_datetimelike")
@@ -69,9 +67,7 @@ class _MissingPandasLikeRolling(object):
     median = unsupported_function_rolling("median")
     quantile = unsupported_function_rolling("quantile")
     skew = unsupported_function_rolling("skew")
-    std = unsupported_function_rolling("std")
     validate = unsupported_function_rolling("validate")
-    var = unsupported_function_rolling("var")
 
     exclusions = unsupported_property_rolling("exclusions")
     is_datetimelike = unsupported_property_rolling("is_datetimelike")
@@ -89,9 +85,7 @@ class _MissingPandasLikeExpandingGroupby(object):
     median = unsupported_function_expanding("median")
     quantile = unsupported_function_expanding("quantile")
     skew = unsupported_function_expanding("skew")
-    std = unsupported_function_expanding("std")
     validate = unsupported_function_expanding("validate")
-    var = unsupported_function_expanding("var")
 
     exclusions = unsupported_property_expanding("exclusions")
     is_datetimelike = unsupported_property_expanding("is_datetimelike")
@@ -109,9 +103,7 @@ class _MissingPandasLikeRollingGroupby(object):
     median = unsupported_function_rolling("median")
     quantile = unsupported_function_rolling("quantile")
     skew = unsupported_function_rolling("skew")
-    std = unsupported_function_rolling("std")
     validate = unsupported_function_rolling("validate")
-    var = unsupported_function_rolling("var")
 
     exclusions = unsupported_property_rolling("exclusions")
     is_datetimelike = unsupported_property_rolling("is_datetimelike")

--- a/databricks/koalas/tests/test_expanding.py
+++ b/databricks/koalas/tests/test_expanding.py
@@ -72,6 +72,12 @@ class ExpandingTest(ReusedSQLTestCase, TestUtils):
     def test_expanding_sum(self):
         self._test_expanding_func("sum")
 
+    def test_expanding_std(self):
+        self._test_expanding_func("std")
+
+    def test_expanding_var(self):
+        self._test_expanding_func("var")
+
     def _test_groupby_expanding_func(self, f):
         kser = ks.Series([1, 2, 3])
         pser = kser.to_pandas()
@@ -117,3 +123,9 @@ class ExpandingTest(ReusedSQLTestCase, TestUtils):
 
     def test_groupby_expanding_sum(self):
         self._test_groupby_expanding_func("sum")
+
+    def test_groupby_expanding_std(self):
+        self._test_groupby_expanding_func("std")
+
+    def test_groupby_expanding_var(self):
+        self._test_groupby_expanding_func("var")

--- a/databricks/koalas/tests/test_rolling.py
+++ b/databricks/koalas/tests/test_rolling.py
@@ -75,6 +75,12 @@ class RollingTest(ReusedSQLTestCase, TestUtils):
     def test_rolling_count(self):
         self._test_rolling_func("count")
 
+    def test_rolling_std(self):
+        self._test_rolling_func("std")
+
+    def test_rolling_var(self):
+        self._test_rolling_func("var")
+
     def _test_groupby_rolling_func(self, f):
         kser = ks.Series([1, 2, 3])
         pser = kser.to_pandas()
@@ -111,3 +117,9 @@ class RollingTest(ReusedSQLTestCase, TestUtils):
 
     def test_groupby_rolling_sum(self):
         self._test_groupby_rolling_func("sum")
+
+    def test_groupby_rolling_std(self):
+        self._test_groupby_rolling_func("std")
+
+    def test_groupby_rolling_var(self):
+        self._test_groupby_rolling_func("var")

--- a/databricks/koalas/window.py
+++ b/databricks/koalas/window.py
@@ -87,6 +87,24 @@ class _RollingAndExpanding(object):
 
         return self._apply_as_series_or_frame(mean)
 
+    def std(self):
+        def std(scol):
+            return F.when(
+                F.row_number().over(self._unbounded_window) >= self._min_periods,
+                F.stddev(scol).over(self._window)
+            ).otherwise(F.lit(None))
+
+        return self._apply_as_series_or_frame(std)
+
+    def var(self):
+        def var(scol):
+            return F.when(
+                F.row_number().over(self._unbounded_window) >= self._min_periods,
+                F.variance(scol).over(self._window)
+            ).otherwise(F.lit(None))
+
+        return self._apply_as_series_or_frame(var)
+
 
 class Rolling(_RollingAndExpanding):
     def __init__(self, kdf_or_kser, window, min_periods=None):
@@ -201,7 +219,7 @@ class Rolling(_RollingAndExpanding):
 
     def sum(self):
         """
-        Calculate rolling sum of given DataFrame or Series.
+        Calculate rolling summation of given DataFrame or Series.
 
         .. note:: the current implementation of this API uses Spark's Window without
             specifying partition specification. This leads to move all data into
@@ -212,7 +230,7 @@ class Rolling(_RollingAndExpanding):
         -------
         Series or DataFrame
             Same type as the input, with the same index, containing the
-            rolling sum.
+            rolling summation.
 
         See Also
         --------
@@ -248,7 +266,7 @@ class Rolling(_RollingAndExpanding):
         4    13.0
         Name: 0, dtype: float64
 
-        For DataFrame, each rolling max is computed column-wise.
+        For DataFrame, each rolling summation is computed column-wise.
 
         >>> df = ks.DataFrame({"A": s.to_numpy(), "B": s.to_numpy() ** 2})
         >>> df
@@ -326,7 +344,7 @@ class Rolling(_RollingAndExpanding):
         4    2.0
         Name: 0, dtype: float64
 
-        For DataFrame, each rolling min is computed column-wise.
+        For DataFrame, each rolling minimum is computed column-wise.
 
         >>> df = ks.DataFrame({"A": s.to_numpy(), "B": s.to_numpy() ** 2})
         >>> df
@@ -403,7 +421,7 @@ class Rolling(_RollingAndExpanding):
         4    6.0
         Name: 0, dtype: float64
 
-        For DataFrame, each rolling max is computed column-wise.
+        For DataFrame, each rolling maximum is computed column-wise.
 
         >>> df = ks.DataFrame({"A": s.to_numpy(), "B": s.to_numpy() ** 2})
         >>> df
@@ -481,7 +499,7 @@ class Rolling(_RollingAndExpanding):
         4    4.333333
         Name: 0, dtype: float64
 
-        For DataFrame, each rolling max is computed column-wise.
+        For DataFrame, each rolling mean is computed column-wise.
 
         >>> df = ks.DataFrame({"A": s.to_numpy(), "B": s.to_numpy() ** 2})
         >>> df
@@ -509,6 +527,106 @@ class Rolling(_RollingAndExpanding):
         4  4.333333  21.666667
         """
         return super(Rolling, self).mean()
+
+    def std(self):
+        """
+        Calculate rolling standard deviation.
+
+        .. note:: the current implementation of this API uses Spark's Window without
+            specifying partition specification. This leads to move all data into
+            single partition in single machine and could cause serious
+            performance degradation. Avoid this method against very large dataset.
+
+        Returns
+        -------
+        Series or DataFrame
+            Returns the same object type as the caller of the rolling calculation.
+
+        See Also
+        --------
+        Series.rolling : Calling object with Series data.
+        DataFrame.rolling : Calling object with DataFrames.
+        Series.std : Equivalent method for Series.
+        DataFrame.std : Equivalent method for DataFrame.
+        numpy.std : Equivalent method for Numpy array.
+
+        Examples
+        --------
+        >>> s = ks.Series([5, 5, 6, 7, 5, 5, 5])
+        >>> s.rolling(3).std()
+        0         NaN
+        1         NaN
+        2    0.577350
+        3    1.000000
+        4    1.000000
+        5    1.154701
+        6    0.000000
+        Name: 0, dtype: float64
+
+        For DataFrame, each rolling standard deviation is computed column-wise.
+
+        >>> df = ks.DataFrame({"A": s.to_numpy(), "B": s.to_numpy() ** 2})
+        >>> df.rolling(2).std()
+                  A          B
+        0       NaN        NaN
+        1  0.000000   0.000000
+        2  0.707107   7.778175
+        3  0.707107   9.192388
+        4  1.414214  16.970563
+        5  0.000000   0.000000
+        6  0.000000   0.000000
+        """
+        return super(Rolling, self).std()
+
+    def var(self):
+        """
+        Calculate unbiased rolling variance.
+
+        .. note:: the current implementation of this API uses Spark's Window without
+            specifying partition specification. This leads to move all data into
+            single partition in single machine and could cause serious
+            performance degradation. Avoid this method against very large dataset.
+
+        Returns
+        -------
+        Series or DataFrame
+            Returns the same object type as the caller of the rolling calculation.
+
+        See Also
+        --------
+        Series.rolling : Calling object with Series data.
+        DataFrame.rolling : Calling object with DataFrames.
+        Series.var : Equivalent method for Series.
+        DataFrame.var : Equivalent method for DataFrame.
+        numpy.var : Equivalent method for Numpy array.
+
+        Examples
+        --------
+        >>> s = ks.Series([5, 5, 6, 7, 5, 5, 5])
+        >>> s.rolling(3).var()
+        0         NaN
+        1         NaN
+        2    0.333333
+        3    1.000000
+        4    1.000000
+        5    1.333333
+        6    0.000000
+        Name: 0, dtype: float64
+
+        For DataFrame, each unbiased rolling variance is computed column-wise.
+
+        >>> df = ks.DataFrame({"A": s.to_numpy(), "B": s.to_numpy() ** 2})
+        >>> df.rolling(2).var()
+             A      B
+        0  NaN    NaN
+        1  0.0    0.0
+        2  0.5   60.5
+        3  0.5   84.5
+        4  2.0  288.0
+        5  0.0    0.0
+        6  0.0    0.0
+        """
+        return super(Rolling, self).var()
 
 
 class RollingGroupby(Rolling):
@@ -668,7 +786,7 @@ class RollingGroupby(Rolling):
 
     def sum(self):
         """
-        The rolling sum of any non-NaN observations inside the window.
+        The rolling summation of any non-NaN observations inside the window.
 
         Returns
         -------
@@ -701,7 +819,7 @@ class RollingGroupby(Rolling):
            10     NaN
         Name: 0, dtype: float64
 
-        For DataFrame, each rolling sum is computed column-wise.
+        For DataFrame, each rolling summation is computed column-wise.
 
         >>> df = ks.DataFrame({"A": s.to_numpy(), "B": s.to_numpy() ** 2})
         >>> df.groupby(df.A).rolling(2).sum().sort_index()  # doctest: +NORMALIZE_WHITESPACE
@@ -723,7 +841,7 @@ class RollingGroupby(Rolling):
 
     def min(self):
         """
-        The rolling min of any non-NaN observations inside the window.
+        The rolling minimum of any non-NaN observations inside the window.
 
         Returns
         -------
@@ -756,7 +874,7 @@ class RollingGroupby(Rolling):
            10    NaN
         Name: 0, dtype: float64
 
-        For DataFrame, each rolling min is computed column-wise.
+        For DataFrame, each rolling minimum is computed column-wise.
 
         >>> df = ks.DataFrame({"A": s.to_numpy(), "B": s.to_numpy() ** 2})
         >>> df.groupby(df.A).rolling(2).min().sort_index()  # doctest: +NORMALIZE_WHITESPACE
@@ -778,7 +896,7 @@ class RollingGroupby(Rolling):
 
     def max(self):
         """
-        The rolling max of any non-NaN observations inside the window.
+        The rolling maximum of any non-NaN observations inside the window.
 
         Returns
         -------
@@ -811,7 +929,7 @@ class RollingGroupby(Rolling):
            10    NaN
         Name: 0, dtype: float64
 
-        For DataFrame, each rolling count is computed column-wise.
+        For DataFrame, each rolling maximum is computed column-wise.
 
         >>> df = ks.DataFrame({"A": s.to_numpy(), "B": s.to_numpy() ** 2})
         >>> df.groupby(df.A).rolling(2).max().sort_index()  # doctest: +NORMALIZE_WHITESPACE
@@ -885,6 +1003,44 @@ class RollingGroupby(Rolling):
           10  5.0  25.0
         """
         return super(RollingGroupby, self).mean()
+
+    def std(self):
+        """
+        Calculate rolling standard deviation.
+
+        Returns
+        -------
+        Series or DataFrame
+            Returns the same object type as the caller of the rolling calculation.
+
+        See Also
+        --------
+        Series.rolling : Calling object with Series data.
+        DataFrame.rolling : Calling object with DataFrames.
+        Series.std : Equivalent method for Series.
+        DataFrame.std : Equivalent method for DataFrame.
+        numpy.std : Equivalent method for Numpy array.
+        """
+        return super(RollingGroupby, self).std()
+
+    def var(self):
+        """
+        Calculate unbiased rolling variance.
+
+        Returns
+        -------
+        Series or DataFrame
+            Returns the same object type as the caller of the rolling calculation.
+
+        See Also
+        --------
+        Series.rolling : Calling object with Series data.
+        DataFrame.rolling : Calling object with DataFrames.
+        Series.var : Equivalent method for Series.
+        DataFrame.var : Equivalent method for DataFrame.
+        numpy.var : Equivalent method for Numpy array.
+        """
+        return super(RollingGroupby, self).var()
 
 
 class Expanding(_RollingAndExpanding):
@@ -985,7 +1141,7 @@ class Expanding(_RollingAndExpanding):
 
     def sum(self):
         """
-        Calculate expanding sum of given DataFrame or Series.
+        Calculate expanding summation of given DataFrame or Series.
 
         .. note:: the current implementation of this API uses Spark's Window without
             specifying partition specification. This leads to move all data into
@@ -996,7 +1152,7 @@ class Expanding(_RollingAndExpanding):
         -------
         Series or DataFrame
             Same type as the input, with the same index, containing the
-            expanding sum.
+            expanding summation.
 
         See Also
         --------
@@ -1024,7 +1180,7 @@ class Expanding(_RollingAndExpanding):
         4    15.0
         Name: 0, dtype: float64
 
-        For DataFrame, each expanding sum is computed column-wise.
+        For DataFrame, each expanding summation is computed column-wise.
 
         >>> df = ks.DataFrame({"A": s.to_numpy(), "B": s.to_numpy() ** 2})
         >>> df
@@ -1148,6 +1304,106 @@ class Expanding(_RollingAndExpanding):
         Name: 0, dtype: float64
         """
         return super(Expanding, self).mean()
+
+    def std(self):
+        """
+        Calculate expanding standard deviation.
+
+        .. note:: the current implementation of this API uses Spark's Window without
+            specifying partition specification. This leads to move all data into
+            single partition in single machine and could cause serious
+            performance degradation. Avoid this method against very large dataset.
+
+        Returns
+        -------
+        Series or DataFrame
+            Returns the same object type as the caller of the expanding calculation.
+
+        See Also
+        --------
+        Series.expanding : Calling object with Series data.
+        DataFrame.expanding : Calling object with DataFrames.
+        Series.std : Equivalent method for Series.
+        DataFrame.std : Equivalent method for DataFrame.
+        numpy.std : Equivalent method for Numpy array.
+
+        Examples
+        --------
+        >>> s = ks.Series([5, 5, 6, 7, 5, 5, 5])
+        >>> s.expanding(3).std()
+        0         NaN
+        1         NaN
+        2    0.577350
+        3    0.957427
+        4    0.894427
+        5    0.836660
+        6    0.786796
+        Name: 0, dtype: float64
+
+        For DataFrame, each expanding standard deviation variance is computed column-wise.
+
+        >>> df = ks.DataFrame({"A": s.to_numpy(), "B": s.to_numpy() ** 2})
+        >>> df.expanding(2).std()
+                  A          B
+        0       NaN        NaN
+        1  0.000000   0.000000
+        2  0.577350   6.350853
+        3  0.957427  11.412712
+        4  0.894427  10.630146
+        5  0.836660   9.928075
+        6  0.786796   9.327379
+        """
+        return super(Expanding, self).std()
+
+    def var(self):
+        """
+        Calculate unbiased expanding variance.
+
+        .. note:: the current implementation of this API uses Spark's Window without
+            specifying partition specification. This leads to move all data into
+            single partition in single machine and could cause serious
+            performance degradation. Avoid this method against very large dataset.
+
+        Returns
+        -------
+        Series or DataFrame
+            Returns the same object type as the caller of the expanding calculation.
+
+        See Also
+        --------
+        Series.expanding : Calling object with Series data.
+        DataFrame.expanding : Calling object with DataFrames.
+        Series.var : Equivalent method for Series.
+        DataFrame.var : Equivalent method for DataFrame.
+        numpy.var : Equivalent method for Numpy array.
+
+        Examples
+        --------
+        >>> s = ks.Series([5, 5, 6, 7, 5, 5, 5])
+        >>> s.expanding(3).var()
+        0         NaN
+        1         NaN
+        2    0.333333
+        3    0.916667
+        4    0.800000
+        5    0.700000
+        6    0.619048
+        Name: 0, dtype: float64
+
+        For DataFrame, each unbiased expanding variance is computed column-wise.
+
+        >>> df = ks.DataFrame({"A": s.to_numpy(), "B": s.to_numpy() ** 2})
+        >>> df.expanding(2).var()
+                  A           B
+        0       NaN         NaN
+        1  0.000000    0.000000
+        2  0.333333   40.333333
+        3  0.916667  130.250000
+        4  0.800000  113.000000
+        5  0.700000   98.566667
+        6  0.619048   87.000000
+        """
+        return super(Expanding, self).var()
 
 
 class ExpandingGroupby(Expanding):
@@ -1308,13 +1564,13 @@ class ExpandingGroupby(Expanding):
 
     def sum(self):
         """
-        Calculate expanding sum of given DataFrame or Series.
+        Calculate expanding summation of given DataFrame or Series.
 
         Returns
         -------
         Series or DataFrame
             Same type as the input, with the same index, containing the
-            expanding sum.
+            expanding summation.
 
         See Also
         --------
@@ -1341,7 +1597,7 @@ class ExpandingGroupby(Expanding):
            10     NaN
         Name: 0, dtype: float64
 
-        For DataFrame, each expanding sum is computed column-wise.
+        For DataFrame, each expanding summation is computed column-wise.
 
         >>> df = ks.DataFrame({"A": s.to_numpy(), "B": s.to_numpy() ** 2})
         >>> df.groupby(df.A).expanding(2).sum().sort_index()  # doctest: +NORMALIZE_WHITESPACE
@@ -1396,7 +1652,7 @@ class ExpandingGroupby(Expanding):
            10    NaN
         Name: 0, dtype: float64
 
-        For DataFrame, each expanding min is computed column-wise.
+        For DataFrame, each expanding minimum is computed column-wise.
 
         >>> df = ks.DataFrame({"A": s.to_numpy(), "B": s.to_numpy() ** 2})
         >>> df.groupby(df.A).expanding(2).min().sort_index()  # doctest: +NORMALIZE_WHITESPACE
@@ -1450,7 +1706,7 @@ class ExpandingGroupby(Expanding):
            10    NaN
         Name: 0, dtype: float64
 
-        For DataFrame, each expanding max is computed column-wise.
+        For DataFrame, each expanding maximum is computed column-wise.
 
         >>> df = ks.DataFrame({"A": s.to_numpy(), "B": s.to_numpy() ** 2})
         >>> df.groupby(df.A).expanding(2).max().sort_index()  # doctest: +NORMALIZE_WHITESPACE
@@ -1524,3 +1780,42 @@ class ExpandingGroupby(Expanding):
           10  5.0  25.0
         """
         return super(ExpandingGroupby, self).mean()
+
+    def std(self):
+        """
+        Calculate expanding standard deviation.
+
+
+        Returns
+        -------
+        Series or DataFrame
+            Returns the same object type as the caller of the expanding calculation.
+
+        See Also
+        --------
+        Series.expanding: Calling object with Series data.
+        DataFrame.expanding : Calling object with DataFrames.
+        Series.std : Equivalent method for Series.
+        DataFrame.std : Equivalent method for DataFrame.
+        numpy.std : Equivalent method for Numpy array.
+        """
+        return super(ExpandingGroupby, self).std()
+
+    def var(self):
+        """
+        Calculate unbiased expanding variance.
+
+        Returns
+        -------
+        Series or DataFrame
+            Returns the same object type as the caller of the expanding calculation.
+
+        See Also
+        --------
+        Series.expanding : Calling object with Series data.
+        DataFrame.expanding : Calling object with DataFrames.
+        Series.var : Equivalent method for Series.
+        DataFrame.var : Equivalent method for DataFrame.
+        numpy.var : Equivalent method for Numpy array.
+        """
+        return super(ExpandingGroupby, self).var()


### PR DESCRIPTION
This PR implements std and var at rolling and expanding in Series, Frame, SeriesGroupBy, FrameGroupBy.

```python
>>> s = ks.Series([5, 5, 6, 7, 5, 5, 5])
>>> s.rolling(3).std()
0         NaN
1         NaN
2    0.577350
3    1.000000
4    1.000000
5    1.154701
6    0.000000
Name: 0, dtype: float64
```

```python
>>> df = ks.DataFrame({"A": s.to_numpy(), "B": s.to_numpy() ** 2})
>>> df.rolling(2).std()
          A          B
0       NaN        NaN
1  0.000000   0.000000
2  0.707107   7.778175
3  0.707107   9.192388
4  1.414214  16.970563
5  0.000000   0.000000
6  0.000000   0.000000
```
