### PR TITLE
Fix GroupBy.rank documentation to render properly

### DIFF
--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -1052,7 +1052,7 @@ class GroupBy(object):
         DataFrame with ranking of values within each group
 
         Examples
-        -------
+        --------
 
         >>> df = ks.DataFrame({
         ...     'a': [1, 1, 1, 2, 2, 2, 3, 3, 3],


### PR DESCRIPTION
Before:

![Screen Shot 2019-11-12 at 10 10 28 PM](https://user-images.githubusercontent.com/6477701/68674550-6d4b2d80-0599-11ea-9286-45696dd34c29.png)

After:

<img width="812" alt="Screen Shot 2019-11-12 at 10 13 22 PM" src="https://user-images.githubusercontent.com/6477701/68677977-5cea8100-05a0-11ea-9564-1581729b553f.png">

