### PR TITLE
Add tests for MultiIndex column in Rolling/ExpandingGroupby

### DIFF
--- a/databricks/koalas/tests/test_expanding.py
+++ b/databricks/koalas/tests/test_expanding.py
@@ -94,14 +94,17 @@ class ExpandingTest(ReusedSQLTestCase, TestUtils):
             repr(getattr(kdf.groupby(kdf.a).expanding(2), f)().sort_index()),
             repr(getattr(pdf.groupby(pdf.a).expanding(2), f)()))
 
-        # TODO: restore below tests when issue #1032 is solved
         # Multiindex column
-        # kdf = ks.DataFrame({'a': [1, 2, 3, 2], 'b': [4.0, 2.0, 3.0, 1.0]})
-        # kdf.columns = pd.MultiIndex.from_tuples([('a', 'x'), ('a', 'y')])
-        # pdf = kdf.to_pandas()
-        # self.assert_eq(
-        #     repr(getattr(kdf.groupby(kdf.a).expanding(2), f)().sort_index()),
-        #     repr(getattr(pdf.groupby(pdf.a).expanding(2), f)()))
+        kdf = ks.DataFrame({'a': [1, 2, 3, 2], 'b': [4.0, 2.0, 3.0, 1.0]})
+        kdf.columns = pd.MultiIndex.from_tuples([('a', 'x'), ('a', 'y')])
+        pdf = kdf.to_pandas()
+        self.assert_eq(
+            repr(getattr(kdf.groupby(("a", "x")).expanding(2), f)().sort_index()),
+            repr(getattr(pdf.groupby(("a", "x")).expanding(2), f)()))
+
+        self.assert_eq(
+            repr(getattr(kdf.groupby([("a", "x"), ("a", "y")]).expanding(2), f)().sort_index()),
+            repr(getattr(pdf.groupby([("a", "x"), ("a", "y")]).expanding(2), f)()))
 
     def test_groupby_expanding_count(self):
         self._test_groupby_expanding_func("count")

--- a/databricks/koalas/tests/test_rolling.py
+++ b/databricks/koalas/tests/test_rolling.py
@@ -97,6 +97,18 @@ class RollingTest(ReusedSQLTestCase, TestUtils):
             repr(getattr(kdf.groupby(kdf.a).rolling(2), f)().sort_index()),
             repr(getattr(pdf.groupby(pdf.a).rolling(2), f)()))
 
+        # Multiindex column
+        kdf = ks.DataFrame({'a': [1, 2, 3, 2], 'b': [4.0, 2.0, 3.0, 1.0]})
+        kdf.columns = pd.MultiIndex.from_tuples([('a', 'x'), ('a', 'y')])
+        pdf = kdf.to_pandas()
+        self.assert_eq(
+            repr(getattr(kdf.groupby(("a", "x")).rolling(2), f)().sort_index()),
+            repr(getattr(pdf.groupby(("a", "x")).rolling(2), f)()))
+
+        self.assert_eq(
+            repr(getattr(kdf.groupby([("a", "x"), ("a", "y")]).rolling(2), f)().sort_index()),
+            repr(getattr(pdf.groupby([("a", "x"), ("a", "y")]).rolling(2), f)()))
+
     def test_groupby_rolling_count(self):
         self._test_groupby_rolling_func("count")
 


### PR DESCRIPTION
Add test case for MultiIndex column in Rolling/ExpandingGroupby

```python
# Multiindex column
kdf = ks.DataFrame({'a': [1, 2, 3, 2], 'b': [4.0, 2.0, 3.0, 1.0]})
kdf.columns = pd.MultiIndex.from_tuples([('a', 'x'), ('a', 'y')])
pdf = kdf.to_pandas()
self.assert_eq(
    repr(getattr(kdf.groupby(("a", "x")).rolling(2), f)().sort_index()),
    repr(getattr(pdf.groupby(("a", "x")).rolling(2), f)()))

self.assert_eq(
    repr(getattr(kdf.groupby([("a", "x"), ("a", "y")]).rolling(2), f)().sort_index()),
    repr(getattr(pdf.groupby([("a", "x"), ("a", "y")]).rolling(2), f)()))
```