### PR TITLE
Implements Top-level function to_numeric()

### DIFF
--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -1915,7 +1915,7 @@ def to_numeric(arg):
     3   -3.0
     Name: 0, dtype: float32
 
-    Also support for list, tuple, np.array, or a single numeric type
+    Also support for list, tuple, np.array, or a scalar
 
     >>> ks.to_numeric(['1.0', '2', '-3'])
     array([ 1.,  2., -3.])
@@ -1926,7 +1926,7 @@ def to_numeric(arg):
     >>> ks.to_numeric(np.array(['1.0', '2', '-3']))
     array([ 1.,  2., -3.])
 
-    >>> ks.to_numeric(1.0)
+    >>> ks.to_numeric('1.0')
     1.0
     """
     if isinstance(arg, Series):

--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -1942,9 +1942,9 @@ def to_numeric(arg):
     """
     if isinstance(arg, Series):
         sdf = arg._internal.sdf
-        name = arg.name
+        name = arg._internal.data_columns[0]
         sdf = sdf.withColumn(name, sdf[name].cast('float'))
-        column_scols = [sdf[name]]
+        column_scols = [scol_for(sdf, name)]
         return Series(arg._internal.copy(
             sdf=sdf,
             column_scols=column_scols,

--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -1867,17 +1867,6 @@ def to_numeric(arg):
     """
     Convert argument to a numeric type.
 
-    .. note:: this API executes the function once to infer the type which is
-         potentially expensive, for instance, when the dataset is created after
-         aggregations or sorting.
-
-         To avoid this, specify return type in ``func``, for instance, as below:
-
-         >>> def square(x) -> np.int32:
-         ...     return x ** 2
-
-         Koalas uses return type hint and does not try to infer the type.
-
     Parameters
     ----------
     arg : scalar, list, tuple, 1-d array, or Series
@@ -1941,14 +1930,7 @@ def to_numeric(arg):
     1.0
     """
     if isinstance(arg, Series):
-        sdf = arg._internal.sdf
-        name = arg._internal.data_columns[0]
-        sdf = sdf.withColumn(name, sdf[name].cast('float'))
-        column_scols = [scol_for(sdf, name)]
-        return Series(arg._internal.copy(
-            sdf=sdf,
-            column_scols=column_scols,
-            scol=column_scols[0]))
+        return arg._with_new_scol(arg._internal.scol.cast('float'))
     else:
         return pd.to_numeric(arg)
 

--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -1867,18 +1867,6 @@ def to_numeric(arg):
     """
     Convert argument to a numeric type.
 
-    The default return dtype is `float64` or `int64`
-    depending on the data supplied. Use the `downcast` parameter
-    to obtain other dtypes.
-
-    Please note that precision loss may occur if really large numbers
-    are passed in. Due to the internal limitations of `ndarray`, if
-    numbers smaller than `-9223372036854775808` (np.iinfo(np.int64).min)
-    or larger than `18446744073709551615` (np.iinfo(np.uint64).max) are
-    passed in, it is very likely they will be converted to float so that
-    they can stored in an `ndarray`. These warnings apply similarly to
-    `Series` since it internally leverages `ndarray`.
-
     Parameters
     ----------
     arg : scalar, list, tuple, 1-d array, or Series
@@ -1886,7 +1874,6 @@ def to_numeric(arg):
     Returns
     -------
     ret : numeric if parsing succeeded.
-        Return type depends on input.  Series if Series, otherwise ndarray.
 
     See Also
     --------

--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -1867,6 +1867,17 @@ def to_numeric(arg):
     """
     Convert argument to a numeric type.
 
+    .. note:: this API executes the function once to infer the type which is
+         potentially expensive, for instance, when the dataset is created after
+         aggregations or sorting.
+
+         To avoid this, specify return type in ``func``, for instance, as below:
+
+         >>> def square(x) -> np.int32:
+         ...     return x ** 2
+
+         Koalas uses return type hint and does not try to infer the type.
+
     Parameters
     ----------
     arg : scalar, list, tuple, 1-d array, or Series

--- a/docs/source/reference/general_functions.rst
+++ b/docs/source/reference/general_functions.rst
@@ -32,6 +32,7 @@ Top-level missing data
 .. autosummary::
    :toctree: api/
 
+   to_numeric
    isna
    isnull
    notna


### PR DESCRIPTION
Resolves #1044 
(https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.to_numeric.html#pandas.to_numeric)

i think we can directly use pandas one, except the case of `Series`

```python
>>> kser = ks.Series(['1.0', '2', '-3'])
>>> kser
0    1.0
1      2
2     -3
Name: 0, dtype: object

>>> ks.to_numeric(kser)
0    1.0
1    2.0
2   -3.0
Name: 0, dtype: float32

If given Series contains invalid value to cast float, just cast it to `np.nan`

>>> kser = ks.Series(['apple', '1.0', '2', '-3'])
>>> kser
0    apple
1      1.0
2        2
3       -3
Name: 0, dtype: object

>>> ks.to_numeric(kser)
0    NaN
1    1.0
2    2.0
3   -3.0
Name: 0, dtype: float32

Also support for list, tuple, np.array, or a single numeric type

>>> ks.to_numeric(['1.0', '2', '-3'])
array([ 1.,  2., -3.])

>>> ks.to_numeric(('1.0', '2', '-3'))
array([ 1.,  2., -3.])

>>> ks.to_numeric(np.array(['1.0', '2', '-3']))
array([ 1.,  2., -3.])

>>> ks.to_numeric(1.0)
1.0
```