### PR TITLE
Fix Series.idxmax() & idxmin() to make result properly

### DIFF
--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -3165,9 +3165,9 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         # desc_nulls_(last|first) is used via Py4J directly because
         # it's not supported in Spark 2.3.
         if skipna:
-            sdf = sdf.orderBy(Column(scol._jc.desc_nulls_last()))
+            sdf = sdf.orderBy(Column(scol._jc.desc_nulls_last()), *index_scols)
         else:
-            sdf = sdf.orderBy(Column(scol._jc.desc_nulls_first()))
+            sdf = sdf.orderBy(Column(scol._jc.desc_nulls_first()), *index_scols)
         results = sdf.select([scol] + index_scols).take(1)
         if len(results) == 0:
             raise ValueError("attempt to get idxmin of an empty sequence")
@@ -3254,7 +3254,7 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         sdf = self._internal._sdf
         scol = self._scol
         index_scols = self._internal.index_scols
-        # asc_nulls_(list|first)is used via Py4J directly because
+        # asc_nulls_(last|first)is used via Py4J directly because
         # it's not supported in Spark 2.3.
         if skipna:
             sdf = sdf.orderBy(Column(scol._jc.asc_nulls_last()))

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -3158,6 +3158,22 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
 
         >>> s.idxmax()
         ('b', 'f')
+
+        If multiple values equal the maximum, the first row label with that
+        value is returned.
+
+        >>> s = ks.Series([1, 100, 1, 100, 1, 100])
+        >>> s
+        0      1
+        1    100
+        2      1
+        3    100
+        4      1
+        5    100
+        Name: 0, dtype: int64
+
+        >>> s.idxmax()
+        1
         """
         sdf = self._internal._sdf
         scol = self._scol
@@ -3250,6 +3266,22 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
 
         >>> s.idxmin()
         ('b', 'f')
+
+        If multiple values equal the minimum, the first row label with that
+        value is returned.
+
+        >>> s = ks.Series([1, 100, 1, 100, 1, 100])
+        >>> s
+        0      1
+        1    100
+        2      1
+        3    100
+        4      1
+        5    100
+        Name: 0, dtype: int64
+
+        >>> s.idxmin()
+        0
         """
         sdf = self._internal._sdf
         scol = self._scol
@@ -3257,9 +3289,9 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         # asc_nulls_(last|first)is used via Py4J directly because
         # it's not supported in Spark 2.3.
         if skipna:
-            sdf = sdf.orderBy(Column(scol._jc.asc_nulls_last()))
+            sdf = sdf.orderBy(Column(scol._jc.asc_nulls_last()), *index_scols)
         else:
-            sdf = sdf.orderBy(Column(scol._jc.asc_nulls_first()))
+            sdf = sdf.orderBy(Column(scol._jc.asc_nulls_first()), *index_scols)
         results = sdf.select([scol] + index_scols).take(1)
         if len(results) == 0:
             raise ValueError("attempt to get idxmin of an empty sequence")

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -3098,7 +3098,7 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         """
         Return the row label of the maximum value.
 
-        If multiple values equal the maximum, the row label with that
+        If multiple values equal the maximum, the first row label with that
         value is returned.
 
         Parameters
@@ -3185,7 +3185,7 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         """
         Return the row label of the minimum value.
 
-        If multiple values equal the minimum, the row label with that
+        If multiple values equal the minimum, the first row label with that
         value is returned.
 
         Parameters


### PR DESCRIPTION
if given series like below,

```python
>>> kser = ks.Series([1, 100, 1, 100, 1, 100])
>>> kser
0      1
1    100
2      1
3    100
4      1
5    100
```

And if we want to get an index of maximum value, we can use `idxmax()`

the pandas doc says, "If multiple values equal the maximum, the 'first' row label with that value is returned",  (Actually, our doc have missed the part, 'first')

<img width="799" alt="스크린샷 2019-11-22 오후 12 09 16" src="https://user-images.githubusercontent.com/44108233/69394997-ec223200-0d20-11ea-97fa-5f3cddcc9e1f.png">


So in this case, it should returns '1' which is the first row label of those maximum values.

but the existing behavior returns random label like this.

```python
>>> kser.idxmax()
5
>>> kser.idxmax()
5
>>> kser.idxmax()
1
>>> kser.idxmax()
5
>>> kser.idxmax()
3
>>> kser.idxmax()
3
>>> kser.idxmax()
1
```

so i think it should be better fixed.

(those descriptions above are also applied to `idxmin()` exactly same)