### PR TITLE
Remove fillna from Series.between

### DIFF
--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -741,7 +741,7 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
             lmask = self > left
             rmask = self < right
 
-        return (lmask & rmask).fillna(False)
+        return (lmask & rmask)
 
     # TODO: arg should support Series
     # TODO: NaN and None


### PR DESCRIPTION
Remove `fillna` from `Series.between` because comparison operators fill `NULL` with a boolean value (#1029).

https://github.com/databricks/koalas/blob/fe93ac1e6247d5f1ee658d90a887eacbb5ffe655/databricks/koalas/series.py#L740-L744