### PR TITLE
Implement Dataframe.iterrows using spark.dataframe.toLocalIterator

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -1111,6 +1111,8 @@ class DataFrame(_Frame, Generic[T]):
         data : pandas.Series
             The data of the row as a Series.
 
+        Returns
+        -------
         it : generator
             A generator that iterates over the rows of the frame.
 

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -1111,8 +1111,6 @@ class DataFrame(_Frame, Generic[T]):
         data : pandas.Series
             The data of the row as a Series.
 
-        Returns
-        -------
         it : generator
             A generator that iterates over the rows of the frame.
 

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -1101,13 +1101,48 @@ class DataFrame(_Frame, Generic[T]):
         return list((col_name, self[col_name]) for col_name in cols)
 
     def iterrows(self):
-        # TODO: document
+        """
+        Iterate over DataFrame rows as (index, Series) pairs.
+        Yields
+        ------
+        index : label or tuple of label
+            The index of the row. A tuple for a `MultiIndex`.
+        data : pandas.Series
+            The data of the row as a Series.
+        it : generator
+            A generator that iterates over the rows of the frame.
+
+        Notes
+        -----
+        1. Because ``iterrows`` returns a Series for each row,
+           it does **not** preserve dtypes across the rows (dtypes are
+           preserved across columns for DataFrames). For example,
+           >>> df = pd.DataFrame([[1, 1.5]], columns=['int', 'float'])
+           >>> row = next(df.iterrows())[1]
+           >>> row
+           int      1.0
+           float    1.5
+           Name: 0, dtype: float64
+           >>> print(row['int'].dtype)
+           float64
+           >>> print(df['int'].dtype)
+           int64
+           To preserve dtypes while iterating over the rows, it is better
+           to use :meth:`itertuples` which returns namedtuples of the values
+           and which is generally faster than ``iterrows``.
+        2. You should **never modify** something you are iterating over.
+           This is not guaranteed to work in all cases. Depending on the
+           data types, the iterator returns a copy and not a view, and writing
+           to it will have no effect.
+        """
+
         columns = self.columns
         internal_index_columns = self._internal.index_columns
         internal_data_columns = self._internal.data_columns
 
         def extract_kv_from_spark_row(row):
-            k = tuple(row[c] for c in internal_index_columns)
+            k = row[internal_index_columns[0]] if len(internal_index_columns) == 1 else tuple(
+                row[c] for c in internal_index_columns)
             v = [row[c] for c in internal_data_columns]
             return k, v
 

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -1110,6 +1110,7 @@ class DataFrame(_Frame, Generic[T]):
             The index of the row. A tuple for a `MultiIndex`.
         data : pandas.Series
             The data of the row as a Series.
+
         it : generator
             A generator that iterates over the rows of the frame.
 
@@ -1119,7 +1120,8 @@ class DataFrame(_Frame, Generic[T]):
         1. Because ``iterrows`` returns a Series for each row,
            it does **not** preserve dtypes across the rows (dtypes are
            preserved across columns for DataFrames). For example,
-           >>> df = pd.DataFrame([[1, 1.5]], columns=['int', 'float'])
+
+           >>> df = ks.DataFrame([[1, 1.5]], columns=['int', 'float'])
            >>> row = next(df.iterrows())[1]
            >>> row
            int      1.0
@@ -1129,6 +1131,7 @@ class DataFrame(_Frame, Generic[T]):
            float64
            >>> print(df['int'].dtype)
            int64
+
            To preserve dtypes while iterating over the rows, it is better
            to use :meth:`itertuples` which returns namedtuples of the values
            and which is generally faster than ``iterrows``.

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -1103,6 +1103,7 @@ class DataFrame(_Frame, Generic[T]):
     def iterrows(self):
         """
         Iterate over DataFrame rows as (index, Series) pairs.
+
         Yields
         ------
         index : label or tuple of label
@@ -1114,6 +1115,7 @@ class DataFrame(_Frame, Generic[T]):
 
         Notes
         -----
+
         1. Because ``iterrows`` returns a Series for each row,
            it does **not** preserve dtypes across the rows (dtypes are
            preserved across columns for DataFrames). For example,
@@ -1130,6 +1132,7 @@ class DataFrame(_Frame, Generic[T]):
            To preserve dtypes while iterating over the rows, it is better
            to use :meth:`itertuples` which returns namedtuples of the values
            and which is generally faster than ``iterrows``.
+
         2. You should **never modify** something you are iterating over.
            This is not guaranteed to work in all cases. Depending on the
            data types, the iterator returns a copy and not a view, and writing

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -1100,6 +1100,21 @@ class DataFrame(_Frame, Generic[T]):
         cols = list(self.columns)
         return list((col_name, self[col_name]) for col_name in cols)
 
+    def iterrows(self):
+        # TODO: document
+        columns = self.columns
+        internal_index_columns = self._internal.index_columns
+        internal_data_columns = self._internal.data_columns
+
+        def extract_kv_from_spark_row(row):
+            k = tuple(row[c] for c in internal_index_columns)
+            v = [row[c] for c in internal_data_columns]
+            return k, v
+
+        for k, v in map(extract_kv_from_spark_row, self._sdf.toLocalIterator()):
+            s = pd.Series(v, index=columns, name=k)
+            yield k, s
+
     def items(self) -> Iterable:
         """This is an alias of ``iteritems``."""
         return self.iteritems()

--- a/databricks/koalas/missing/frame.py
+++ b/databricks/koalas/missing/frame.py
@@ -63,7 +63,6 @@ class _MissingPandasLikeDataFrame(object):
     info = unsupported_function('info')
     insert = unsupported_function('insert')
     interpolate = unsupported_function('interpolate')
-    iterrows = unsupported_function('iterrows')
     itertuples = unsupported_function('itertuples')
     last = unsupported_function('last')
     last_valid_index = unsupported_function('last_valid_index')

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -143,6 +143,20 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(kdf[('X', 'A')].to_pandas().columns.names, pdf[('X', 'A')].columns.names)
         self.assert_eq(kdf[('X', 'A', 'Z')], pdf[('X', 'A', 'Z')])
 
+    def test_iterrows(self):
+        pdf = pd.DataFrame({
+            ('x', 'a', '1'): [1, 2, 3],
+            ('x', 'b', '2'): [4, 5, 6],
+            ('y.z', 'c.d', '3'): [7, 8, 9],
+            ('x', 'b', '4'): [10, 11, 12],
+        },
+            index=[[0, 0, 1], [0, 1, 2]])
+        kdf = ks.from_pandas(pdf)
+
+        for (pdf_k, pdf_v), (kdf_k, kdf_v) in zip(pdf.iterrows(), kdf.iterrows()):
+            self.assert_eq(pdf_k, kdf_k)
+            self.assert_eq(pdf_v, kdf_v)
+
     def test_reset_index_with_multiindex_columns(self):
         index = pd.MultiIndex.from_tuples([('bird', 'falcon'),
                                            ('bird', 'parrot'),

--- a/docs/source/reference/frame.rst
+++ b/docs/source/reference/frame.rst
@@ -55,6 +55,7 @@ Indexing, iteration
    DataFrame.iloc
    DataFrame.items
    DataFrame.iteritems
+   DataFrame.iterrows
    DataFrame.keys
    DataFrame.xs
    DataFrame.get


### PR DESCRIPTION
#885 
Inspired by https://github.com/databricks/koalas/issues/1003#issuecomment-556908359

the data type yield from iterator is `pd.Series`. I assume each row is small enough.