### PR TITLE
Explicitly don't use Series.ravel()

### DIFF
--- a/databricks/koalas/missing/series.py
+++ b/databricks/koalas/missing/series.py
@@ -79,7 +79,6 @@ class _MissingPandasLikeSeries(object):
     pct_change = unsupported_function('pct_change')
     prod = unsupported_function('prod')
     product = unsupported_function('product')
-    ravel = unsupported_function('ravel')
     rdivmod = unsupported_function('rdivmod')
     reindex = unsupported_function('reindex')
     reindex_like = unsupported_function('reindex_like')
@@ -142,6 +141,10 @@ class _MissingPandasLikeSeries(object):
         reason="'nbytes' requires to compute whole dataset. You can calculate manually it, "
                "with its 'itemsize', by explicitly executing its count. Use Spark's web UI "
                "to monitor disk and memory usage of your application in general.")
+    ravel = unsupported_property(
+        'ravel',
+        reason="If you want to collect your flattened underlying data as an NumPy array, "
+               "use 'to_numpy().ravel()' instead.")
 
     # Functions we won't support.
     memory_usage = common.memory_usage(unsupported_function)

--- a/databricks/koalas/missing/series.py
+++ b/databricks/koalas/missing/series.py
@@ -141,13 +141,13 @@ class _MissingPandasLikeSeries(object):
         reason="'nbytes' requires to compute whole dataset. You can calculate manually it, "
                "with its 'itemsize', by explicitly executing its count. Use Spark's web UI "
                "to monitor disk and memory usage of your application in general.")
-    ravel = unsupported_property(
-        'ravel',
-        reason="If you want to collect your flattened underlying data as an NumPy array, "
-               "use 'to_numpy().ravel()' instead.")
 
     # Functions we won't support.
     memory_usage = common.memory_usage(unsupported_function)
     to_pickle = common.to_pickle(unsupported_function)
     to_xarray = common.to_xarray(unsupported_function)
     __iter__ = common.__iter__(unsupported_function)
+    ravel = unsupported_function(
+        'ravel',
+        reason="If you want to collect your flattened underlying data as an NumPy array, "
+               "use 'to_numpy().ravel()' instead.")


### PR DESCRIPTION
I tried to implement Series.ravel(),

But i think it seems that it requires to compute whole dataset that has potentially raises out of memory.

So i think that we better don't support this function explicitly and let users know alternative. (`to_numpy().ravel()`)

```python
>>> ks.Series([1, 2, 3]).ravel()
Traceback (most recent call last):
databricks.koalas.exceptions.PandasNotImplementedError: The method `ks.Series.ravel()` is not implemented. If you want to collect your flattened underlying data as an NumPy array, use 'to_numpy().ravel()' instead.
```