### PR TITLE
Fix idxmax() / idxmin() for Series work properly

### DIFF
--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -3165,9 +3165,9 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         # desc_nulls_(last|first) is used via Py4J directly because
         # it's not supported in Spark 2.3.
         if skipna:
-            sdf = sdf.orderBy(Column(scol._jc.desc_nulls_last()))
+            sdf = sdf.orderBy(Column(scol._jc.desc_nulls_last()), *index_scols)
         else:
-            sdf = sdf.orderBy(Column(scol._jc.desc_nulls_first()))
+            sdf = sdf.orderBy(Column(scol._jc.desc_nulls_first()), *index_scols)
         results = sdf.select([scol] + index_scols).take(1)
         if len(results) == 0:
             raise ValueError("attempt to get idxmin of an empty sequence")
@@ -3254,7 +3254,7 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         sdf = self._internal._sdf
         scol = self._scol
         index_scols = self._internal.index_scols
-        # asc_nulls_(list|first)is used via Py4J directly because
+        # asc_nulls_(last|first)is used via Py4J directly because
         # it's not supported in Spark 2.3.
         if skipna:
             sdf = sdf.orderBy(Column(scol._jc.asc_nulls_last()))

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -3158,6 +3158,22 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
 
         >>> s.idxmax()
         ('b', 'f')
+
+        If multiple values equal the maximum, the first row label with that
+        value is returned.
+
+        >>> s = ks.Series([1, 100, 1, 100, 1, 100])
+        >>> s
+        0      1
+        1    100
+        2      1
+        3    100
+        4      1
+        5    100
+        Name: 0, dtype: int64
+
+        >>> s.idxmax()
+        1
         """
         sdf = self._internal._sdf
         scol = self._scol
@@ -3250,6 +3266,22 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
 
         >>> s.idxmin()
         ('b', 'f')
+
+        If multiple values equal the minimum, the first row label with that
+        value is returned.
+
+        >>> s = ks.Series([1, 100, 1, 100, 1, 100])
+        >>> s
+        0      1
+        1    100
+        2      1
+        3    100
+        4      1
+        5    100
+        Name: 0, dtype: int64
+
+        >>> s.idxmin()
+        0
         """
         sdf = self._internal._sdf
         scol = self._scol
@@ -3257,9 +3289,9 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         # asc_nulls_(last|first)is used via Py4J directly because
         # it's not supported in Spark 2.3.
         if skipna:
-            sdf = sdf.orderBy(Column(scol._jc.asc_nulls_last()))
+            sdf = sdf.orderBy(Column(scol._jc.asc_nulls_last()), *index_scols)
         else:
-            sdf = sdf.orderBy(Column(scol._jc.asc_nulls_first()))
+            sdf = sdf.orderBy(Column(scol._jc.asc_nulls_first()), *index_scols)
         results = sdf.select([scol] + index_scols).take(1)
         if len(results) == 0:
             raise ValueError("attempt to get idxmin of an empty sequence")

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -3098,7 +3098,7 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         """
         Return the row label of the maximum value.
 
-        If multiple values equal the maximum, the row label with that
+        If multiple values equal the maximum, the first row label with that
         value is returned.
 
         Parameters
@@ -3185,7 +3185,7 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         """
         Return the row label of the minimum value.
 
-        If multiple values equal the minimum, the row label with that
+        If multiple values equal the minimum, the first row label with that
         value is returned.
 
         Parameters

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -3175,16 +3175,18 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         >>> s.idxmax()
         3
         """
-        if len(self) == 0:
-            raise ValueError("attempt to get idxmin of an empty sequence")
-
         sdf = self._internal._sdf
         scol = self._scol
         index_scols = self._internal.index_scols
         if skipna:
-            max_value = sdf.orderBy(scol.desc_nulls_last()).select([scol]).first()[0]
+            max_row = sdf.orderBy(scol.desc_nulls_last()).select([scol]).first()
         else:
-            max_value = sdf.orderBy(scol.desc_nulls_first()).select([scol]).first()[0]
+            max_row = sdf.orderBy(scol.desc_nulls_first()).select([scol]).first()
+
+        if max_row is None:
+            raise ValueError("attempt to get idxmax of an empty sequence")
+
+        max_value = max_row[0]
 
         if max_value is None:
             return np.nan
@@ -3280,16 +3282,18 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         >>> s.idxmin()
         10
         """
-        if len(self) == 0:
-            raise ValueError("attempt to get idxmin of an empty sequence")
-
         sdf = self._internal._sdf
         scol = self._scol
         index_scols = self._internal.index_scols
         if skipna:
-            min_value = sdf.orderBy(scol.asc_nulls_last()).select([scol]).first()[0]
+            min_row = sdf.orderBy(scol.asc_nulls_last()).select([scol]).first()
         else:
-            min_value = sdf.orderBy(scol.asc_nulls_first()).select([scol]).first()[0]
+            min_row = sdf.orderBy(scol.asc_nulls_first()).select([scol]).first()
+
+        if min_row is None:
+            raise ValueError("attempt to get idxmin of an empty sequence")
+
+        min_value = min_row[0]
 
         if min_value is None:
             return np.nan

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -660,6 +660,12 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         with self.assertRaisesRegex(ValueError, "an empty sequence"):
             kser.idxmax()
 
+        pser = pd.Series([1, 100, None, 100, 1, 100], index=[10, 3, 5, 2, 1, 8])
+        kser = ks.Series(pser)
+
+        self.assertEqual(kser.idxmax(), pser.idxmax())
+        self.assertEqual(repr(kser.idxmax(skipna=False)), repr(pser.idxmax(skipna=False)))
+
     def test_idxmin(self):
         pser = pd.Series(data=[1, 4, 5], index=['A', 'B', 'C'])
         kser = ks.Series(pser)
@@ -678,6 +684,12 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         kser = ks.Series([])
         with self.assertRaisesRegex(ValueError, "an empty sequence"):
             kser.idxmin()
+
+        pser = pd.Series([1, 100, None, 100, 1, 100], index=[10, 3, 5, 2, 1, 8])
+        kser = ks.Series(pser)
+
+        self.assertEqual(kser.idxmin(), pser.idxmin())
+        self.assertEqual(repr(kser.idxmin(skipna=False)), repr(pser.idxmin(skipna=False)))
 
     def test_shift(self):
         pser = pd.Series([10, 20, 15, 30, 45], name='x')


### PR DESCRIPTION
Reopen of #1065

fix more properly with considering of more examples commented at https://github.com/databricks/koalas/pull/1065#issuecomment-558303388

```python
>>> pser = pd.Series([1, 100, None, 100, 1, 100], index=[10, 3, 5, 2, 1, 8])
>>> kser = ks.from_pandas(pser)
>>>
>>> pser.idxmax()
3
>>> kser.idxmax()
3
>>> pser.idxmin()
10
>>> kser.idxmin()
10
```