### PR TITLE
Setting index name / names for Series

### DIFF
--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -141,8 +141,6 @@ class IndexOpsMixin(object):
         assert kdf is not None and isinstance(kdf, DataFrame)
         self._internal = internal  # type: _InternalFrame
         self._kdf = kdf
-        if isinstance(self, Series):
-            self._index = kdf.index
 
     @property
     def _scol(self):

--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -136,7 +136,6 @@ class IndexOpsMixin(object):
         Creates new object with the new column
     """
     def __init__(self, internal: _InternalFrame, kdf):
-        from databricks.koalas.series import Series
         assert internal is not None
         assert kdf is not None and isinstance(kdf, DataFrame)
         self._internal = internal  # type: _InternalFrame

--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -135,8 +135,11 @@ class IndexOpsMixin(object):
         Creates new object with the new column
     """
     def __init__(self, internal: _InternalFrame, kdf):
+        from databricks.koalas.series import Series
         self._internal = internal  # type: _InternalFrame
         self._kdf = kdf
+        if isinstance(self, Series):
+            self._index = kdf.index
 
     @property
     def _scol(self):

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -958,8 +958,6 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
     def index(self):
         """The index (axis labels) Column of the Series.
 
-        Currently not supported when the DataFrame has no index.
-
         See Also
         --------
         Index

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -964,7 +964,7 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         --------
         Index
         """
-        return self.to_frame().index
+        return self._index
 
     @property
     def is_unique(self):

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -962,7 +962,7 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         --------
         Index
         """
-        return self._index
+        return self._kdf.index
 
     @property
     def is_unique(self):

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -909,3 +909,25 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         pser = kser.to_pandas()
 
         self.assert_eq(kser.keys(), pser.keys())
+
+    def test_index(self):
+        # to check setting name of Index properly.
+        idx = pd.Index([1, 2, 3, 4, 5, 6, 7, 8, 9])
+        kser = ks.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3], index=idx)
+        pser = kser.to_pandas()
+
+        kser.name = 'koalas'
+        pser.name = 'koalas'
+        self.assert_eq(kser.index.name, pser.index.name)
+
+        # for check setting names of MultiIndex properly.
+        midx = pd.MultiIndex([['lama', 'cow', 'falcon'],
+                              ['speed', 'weight', 'length']],
+                             [[0, 0, 0, 1, 1, 1, 2, 2, 2],
+                              [0, 1, 2, 0, 1, 2, 0, 1, 2]])
+        kser = ks.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3], index=midx)
+        pser = kser.to_pandas()
+
+        kser.names = ['hello', 'koalas']
+        pser.names = ['hello', 'koalas']
+        self.assert_eq(kser.index.names, pser.index.names)


### PR DESCRIPTION
Unlike pandas, `koalas.Series` can't set the index name like below.

```python
>>> pser = pd.Series([1, 2, 3, 4, 5])
>>> pser.index.name = 'koalas'
>>> pser.index.name
'koalas'

>>> kser = ks.Series([1, 2, 3, 4, 5])
>>> kser.index.name = 'koalas'
>>> kser.index.name
```

For MultiIndex also

```python
>>> midx = pd.MultiIndex([['lama', 'cow', 'falcon'],
...                       ['speed', 'weight', 'length']],
...                      [[0, 0, 0, 1, 1, 1, 2, 2, 2],
...                       [0, 1, 2, 0, 1, 2, 0, 1, 2]])
>>> pser = pd.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3], index=midx)
>>> pser.index.names
FrozenList([None, None])
>>> pser.index.names = ['hello', 'koalas']
>>> pser.index.names
FrozenList(['hello', 'koalas'])

>>> midx = pd.MultiIndex([['lama', 'cow', 'falcon'],
...                       ['speed', 'weight', 'length']],
...                      [[0, 0, 0, 1, 1, 1, 2, 2, 2],
...                       [0, 1, 2, 0, 1, 2, 0, 1, 2]])
>>> kser = ks.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3], index=midx)
>>> kser.index.names
[None, None]
>>> kser.index.names = ['hello', 'koalas']
>>> kser.index.names
[None, None]
```

So, this PR suggests that make ours possible also.

```python
>>> kser = ks.Series([1, 2, 3, 4, 5])
>>> kser.index.name = 'koalas'
>>> kser.index.name
'koalas'

>>> midx = pd.MultiIndex([['lama', 'cow', 'falcon'],
...                       ['speed', 'weight', 'length']],
...                      [[0, 0, 0, 1, 1, 1, 2, 2, 2],
...                       [0, 1, 2, 0, 1, 2, 0, 1, 2]])
>>> kser = ks.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3], index=midx)
>>> kser.index.names
[None, None]
>>> kser.index.names = ['hello', 'koalas']
>>> kser.index.names
['hello', 'koalas']
```