### PR TITLE
Add Null handling for different frames

### DIFF
--- a/databricks/koalas/tests/test_ops_on_diff_frames.py
+++ b/databricks/koalas/tests/test_ops_on_diff_frames.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 import pandas as pd
+import numpy as np
 
 from databricks import koalas as ks
 from databricks.koalas.config import set_option, reset_option
@@ -215,6 +216,23 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(
             (kdf1 + kdf2 - kdf3).sort_index(),
             (pdf1 + pdf2 - pdf3).sort_index(), almost=True)
+
+    def test_bitwise(self):
+        pser1 = pd.Series([True, False, True, False, np.nan, np.nan, True, False, np.nan])
+        pser2 = pd.Series([True, False, False, True, True, False, np.nan, np.nan, np.nan])
+        kser1 = ks.from_pandas(pser1)
+        kser2 = ks.from_pandas(pser2)
+
+        self.assert_eq(pser1 | pser2, (kser1 | kser2).sort_index())
+        self.assert_eq(pser1 & pser2, (kser1 & kser2).sort_index())
+
+        pser1 = pd.Series([True, False, np.nan], index=list('ABC'))
+        pser2 = pd.Series([False, True, np.nan], index=list('DEF'))
+        kser1 = ks.from_pandas(pser1)
+        kser2 = ks.from_pandas(pser2)
+
+        self.assert_eq(pser1 | pser2, (kser1 | kser2).sort_index())
+        self.assert_eq(pser1 & pser2, (kser1 & kser2).sort_index())
 
     def test_different_columns(self):
         kdf1 = self.kdf1


### PR DESCRIPTION
As @ueshin pointed out in https://github.com/databricks/koalas/pull/1029#discussion_r350422624, the fix #1029 didn't cover the case below. This PR fixes it.

```python
>>> ks.options.compute.ops_on_diff_frames = True
>>> s1 = pd.Series([True, False, True], index=list("ABC"), name="x")
>>> s2 = pd.Series([True, True, False], index=list("ABD"), name="x")
>>> s1
A     True
B    False
C     True
Name: x, dtype: bool
>>> s2
A     True
B     True
D    False
Name: x, dtype: bool
>>> s1 | s2
A     True
B     True
C     True
D    False
Name: x, dtype: bool
>>> (ks.from_pandas(s1) | ks.from_pandas(s2)).sort_index()
A    True
B    True
C    True
D    None
Name: x, dtype: object
```
