### PR TITLE
Produce correct output against multiIndex when 'compute.ops_on_diff_frames' is enabled

### DIFF
--- a/databricks/koalas/tests/test_ops_on_diff_frames.py
+++ b/databricks/koalas/tests/test_ops_on_diff_frames.py
@@ -78,6 +78,30 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
         }, index=list(range(9))).set_index(['a', 'b'])
 
     @property
+    def pser1(self):
+        midx = pd.MultiIndex([['lama', 'cow', 'falcon', 'koala'],
+                              ['speed', 'weight', 'length', 'power']],
+                             [[0, 3, 1, 1, 1, 2, 2, 2],
+                              [0, 2, 0, 3, 2, 0, 1, 3]])
+        return pd.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1], index=midx)
+
+    @property
+    def pser2(self):
+        midx = pd.MultiIndex([['lama', 'cow', 'falcon'],
+                              ['speed', 'weight', 'length']],
+                             [[0, 0, 0, 1, 1, 1, 2, 2, 2],
+                              [0, 1, 2, 0, 1, 2, 0, 1, 2]])
+        return pd.Series([-45, 200, -1.2, 30, -250, 1.5, 320, 1, -0.3], index=midx)
+
+    @property
+    def pser3(self):
+        midx = pd.MultiIndex([['koalas', 'cow', 'falcon'],
+                              ['speed', 'weight', 'length']],
+                             [[0, 0, 0, 1, 1, 1, 2, 2, 2],
+                              [1, 1, 2, 0, 0, 2, 2, 2, 1]])
+        return pd.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3], index=midx)
+
+    @property
     def kdf1(self):
         return ks.from_pandas(self.pdf1)
 
@@ -101,6 +125,18 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
     def kdf6(self):
         return ks.from_pandas(self.pdf6)
 
+    @property
+    def kser1(self):
+        return ks.from_pandas(self.pser1)
+
+    @property
+    def kser2(self):
+        return ks.from_pandas(self.pser2)
+
+    @property
+    def kser3(self):
+        return ks.from_pandas(self.pser3)
+
     def test_ranges(self):
         self.assert_eq(
             (ks.range(10) + ks.range(10)).sort_index(),
@@ -117,6 +153,10 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
         kdf2 = self.kdf2
         pdf1 = self.pdf1
         pdf2 = self.pdf2
+        kser1 = self.kser1
+        pser1 = self.pser1
+        kser2 = self.kser2
+        pser2 = self.pser2
 
         # Series
         self.assert_eq(
@@ -161,6 +201,23 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
             (kdf1 + kdf2).sort_index(),
             (pdf1 + pdf2).sort_index(), almost=True)
 
+        # MultiIndex Series
+        self.assert_eq(
+            (kser1 + kser2).sort_index(),
+            (pser1 + pser2).sort_index(), almost=True)
+
+        self.assert_eq(
+            (kser1 - kser2).sort_index(),
+            (pser1 - pser2).sort_index(), almost=True)
+
+        self.assert_eq(
+            (kser1 * kser2).sort_index(),
+            (pser1 * pser2).sort_index(), almost=True)
+
+        self.assert_eq(
+            (kser1 / kser2).sort_index(),
+            (pser1 / pser2).sort_index(), almost=True)
+
     def test_arithmetic_chain(self):
         kdf1 = self.kdf1
         kdf2 = self.kdf2
@@ -168,6 +225,12 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
         pdf1 = self.pdf1
         pdf2 = self.pdf2
         pdf3 = self.pdf3
+        kser1 = self.kser1
+        pser1 = self.pser1
+        kser2 = self.kser2
+        pser2 = self.pser2
+        kser3 = self.kser3
+        pser3 = self.pser3
 
         # Series
         self.assert_eq(
@@ -215,6 +278,23 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(
             (kdf1 + kdf2 - kdf3).sort_index(),
             (pdf1 + pdf2 - pdf3).sort_index(), almost=True)
+
+        # MultiIndex Series
+        self.assert_eq(
+            (kser1 + kser2 - kser3).sort_index(),
+            (pser1 + pser2 - pser3).sort_index(), almost=True)
+
+        self.assert_eq(
+            (kser1 * kser2 * kser3).sort_index(),
+            (pser1 * pser2 * pser3).sort_index(), almost=True)
+
+        self.assert_eq(
+            (kser1 - kser2 / kser3).sort_index(),
+            (pser1 - pser2 / pser3).sort_index(), almost=True)
+
+        self.assert_eq(
+            (kser1 + kser2 * kser3).sort_index(),
+            (pser1 + pser2 * pser3).sort_index(), almost=True)
 
     def test_different_columns(self):
         kdf1 = self.kdf1

--- a/databricks/koalas/utils.py
+++ b/databricks/koalas/utils.py
@@ -75,7 +75,7 @@ def combine_frames(this, *args, how="full"):
         # If the same named index is found, that's used.
         for this_column, this_name in this_index_map:
             for that_col, that_name in that_index_map:
-                if this_name == that_name:
+                if (this_column == that_col) and (this_name == that_name):
                     # We should merge the Spark columns into one
                     # to mimic pandas' behavior.
                     this_scol = this._internal.scol_for(this_column)

--- a/databricks/koalas/utils.py
+++ b/databricks/koalas/utils.py
@@ -74,12 +74,12 @@ def combine_frames(this, *args, how="full"):
 
         # If the same named index is found, that's used.
         for this_column, this_name in this_index_map:
-            for that_col, that_name in that_index_map:
-                if (this_column == that_col) and (this_name == that_name):
+            for that_column, that_name in that_index_map:
+                if (this_column == that_column) and (this_name == that_name):
                     # We should merge the Spark columns into one
                     # to mimic pandas' behavior.
                     this_scol = this._internal.scol_for(this_column)
-                    that_scol = that._internal.scol_for(that_col)
+                    that_scol = that._internal.scol_for(that_column)
                     join_scol = this_scol == that_scol
                     join_scols.append(join_scol)
                     merged_index_scols.append(


### PR DESCRIPTION
Resolves #1088 

```python
>>> kser1
lama    speed      45.0
koalas  length    200.0
cow     speed       1.2
        power      30.0
        length    250.0
falcon  speed       1.5
        weight    320.0
        power       1.0
Name: 0, dtype: float64

>>> kser2
lama    speed     -45.0
        weight    200.0
        length     -1.2
cow     speed      30.0
        weight   -250.0
        length      1.5
falcon  speed     320.0
        weight      1.0
        length     -0.3
Name: 0, dtype: float64
```

existing `kser1 + kser2`  works like below which was not correct.

```python
>>> kser1 + kser2
cow     length    None
falcon  weight    None
cow     speed     None
falcon  speed     None
koalas  length    None
lama    speed     None
cow     power     None
falcon  power     None
        falcon    None
        falcon    None
        falcon    None
lama    lama      None
        lama      None
        lama      None
cow     cow       None
        cow       None
        cow       None
Name: 0, dtype: object
```

now it works same with pandas

```python
>>> kser1 + kser2
cow     weight      NaN
        length    251.5
lama    weight      NaN
falcon  weight    321.0
cow     speed      31.2
lama    length      NaN
falcon  speed     321.5
koalas  length      NaN
lama    speed       0.0
cow     power       NaN
falcon  power       NaN
        length      NaN
Name: 0, dtype: float64
```