### PR TITLE
Implement first_valid_index for DataFrame & Integrate with Series

### DIFF
--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -21,6 +21,7 @@ import warnings
 from collections import Counter
 from collections.abc import Iterable
 from distutils.version import LooseVersion
+from functools import reduce
 
 import numpy as np
 import pandas as pd
@@ -1327,6 +1328,97 @@ class _Frame(object):
             raise TypeError('bool() expects DataFrame or Series; however, '
                             'got [%s]' % (self,))
         return df.head(2)._to_internal_pandas().bool()
+
+    def first_valid_index(self):
+        """
+        Retrieves the index of the first valid value.
+
+        Returns
+        -------
+        idx_first_valid : type of index
+
+        Examples
+        --------
+
+        Support for DataFrame
+
+        >>> kdf = ks.DataFrame({'a': [None, 2, 3, 2],
+        ...                     'b': [None, 2.0, 3.0, 1.0],
+        ...                     'c': [None, 200, 400, 200]},
+        ...                     index=['Q', 'W', 'E', 'R'])
+        >>> kdf
+             a    b      c
+        Q  NaN  NaN    NaN
+        W  2.0  2.0  200.0
+        E  3.0  3.0  400.0
+        R  2.0  1.0  200.0
+
+        >>> kdf.first_valid_index()
+        'W'
+
+        Support for MultiIndex columns
+
+        >>> kdf.columns = pd.MultiIndex.from_tuples([('a', 'x'), ('b', 'y'), ('c', 'z')])
+        >>> kdf
+             a    b      c
+             x    y      z
+        Q  NaN  NaN    NaN
+        W  2.0  2.0  200.0
+        E  3.0  3.0  400.0
+        R  2.0  1.0  200.0
+
+        >>> kdf.first_valid_index()
+        'W'
+
+        Support for Series.
+
+        >>> s = ks.Series([None, None, 3, 4, 5], index=[100, 200, 300, 400, 500])
+        >>> s
+        100    NaN
+        200    NaN
+        300    3.0
+        400    4.0
+        500    5.0
+        Name: 0, dtype: float64
+
+        >>> s.first_valid_index()
+        300
+
+        Support for MultiIndex
+
+        >>> midx = pd.MultiIndex([['lama', 'cow', 'falcon'],
+        ...                       ['speed', 'weight', 'length']],
+        ...                      [[0, 0, 0, 1, 1, 1, 2, 2, 2],
+        ...                       [0, 1, 2, 0, 1, 2, 0, 1, 2]])
+        >>> s = ks.Series([None, None, None, None, 250, 1.5, 320, 1, 0.3], index=midx)
+        >>> s
+        lama    speed       NaN
+                weight      NaN
+                length      NaN
+        cow     speed       NaN
+                weight    250.0
+                length      1.5
+        falcon  speed     320.0
+                weight      1.0
+                length      0.3
+        Name: 0, dtype: float64
+
+        >>> s.first_valid_index()
+        ('cow', 'weight')
+        """
+        sdf = self._internal.sdf
+        column_scols = self._internal.column_scols
+        cond = reduce(lambda x, y: x & y,
+                      map(lambda x: x.isNotNull(), column_scols))
+
+        first_valid_row = sdf.where(cond).first()
+        first_valid_idx = tuple(first_valid_row[idx_col]
+                                for idx_col in self._internal.index_columns)
+
+        if len(first_valid_idx) == 1:
+            first_valid_idx = first_valid_idx[0]
+
+        return first_valid_idx
 
     def median(self, accuracy=10000):
         """

--- a/databricks/koalas/missing/frame.py
+++ b/databricks/koalas/missing/frame.py
@@ -56,7 +56,6 @@ class _MissingPandasLikeDataFrame(object):
     eval = unsupported_function('eval')
     ewm = unsupported_function('ewm')
     first = unsupported_function('first')
-    first_valid_index = unsupported_function('first_valid_index')
     idxmax = unsupported_function('idxmax')
     idxmin = unsupported_function('idxmin')
     infer_objects = unsupported_function('infer_objects')

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -3630,62 +3630,6 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
 
         return result
 
-    def first_valid_index(self):
-        """
-        Retrieves the index of the first valid value.
-
-        Returns
-        -------
-        idx_first_valid : type of index
-
-        Examples
-        --------
-        >>> s = ks.Series([None, None, 3, 4, 5], index=[100, 200, 300, 400, 500])
-        >>> s
-        100    NaN
-        200    NaN
-        300    3.0
-        400    4.0
-        500    5.0
-        Name: 0, dtype: float64
-
-        >>> s.first_valid_index()
-        300
-
-        Support for MultiIndex
-
-        >>> midx = pd.MultiIndex([['lama', 'cow', 'falcon'],
-        ...                       ['speed', 'weight', 'length']],
-        ...                      [[0, 0, 0, 1, 1, 1, 2, 2, 2],
-        ...                       [0, 1, 2, 0, 1, 2, 0, 1, 2]])
-        >>> s = ks.Series([None, None, None, None, 250, 1.5, 320, 1, 0.3], index=midx)
-        >>> s
-        lama    speed       NaN
-                weight      NaN
-                length      NaN
-        cow     speed       NaN
-                weight    250.0
-                length      1.5
-        falcon  speed     320.0
-                weight      1.0
-                length      0.3
-        Name: 0, dtype: float64
-
-        >>> s.first_valid_index()
-        ('cow', 'weight')
-        """
-        sdf = self._internal.sdf
-        data_scol = self._internal.scol
-
-        first_valid_row = sdf.where(data_scol.isNotNull()).first()
-        first_valid_idx = tuple(first_valid_row[idx_col]
-                                for idx_col in self._internal.index_columns)
-
-        if len(first_valid_idx) == 1:
-            first_valid_idx = first_valid_idx[0]
-
-        return first_valid_idx
-
     def keys(self):
         """
         Return alias for index.

--- a/docs/source/reference/frame.rst
+++ b/docs/source/reference/frame.rst
@@ -197,6 +197,7 @@ Time series-related
    :toctree: api/
 
    DataFrame.shift
+   DataFrame.first_valid_index
 
 Cache
 -------------------------------


### PR DESCRIPTION
Implement DataFrame.first_valid_index


```python
>>> kdf = ks.DataFrame({'a': [None, 2, 3, 2],
...                     'b': [None, 2.0, 3.0, 1.0],
...                     'c': [None, 200, 400, 200]},
...                     index=['Q', 'W', 'E', 'R'])
>>> kdf
     a    b      c
Q  NaN  NaN    NaN
W  2.0  2.0  200.0
E  3.0  3.0  400.0
R  2.0  1.0  200.0

>>> kdf.first_valid_index()
'W'
```

Support for MultiIndex columns

```
>>> kdf.columns = pd.MultiIndex.from_tuples([('a', 'x'), ('b', 'y'), ('c', 'z')])
>>> kdf
     a    b      c
     x    y      z
Q  NaN  NaN    NaN
W  2.0  2.0  200.0
E  3.0  3.0  400.0
R  2.0  1.0  200.0

>>> kdf.first_valid_index()
'W'
```

and integrate with `Series.first_valid_index()` into `generic.py` since they can share same implementation.