### PR TITLE
disable 'str' for 'SeriesGroupBy', disable 'DataFrame' for 'GroupBy'

### DIFF
--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -1279,6 +1279,8 @@ class _Frame(object):
             col_by = [_resolve_col(df, col_or_s) for col_or_s in by]
             return DataFrameGroupBy(df_or_s, col_by, as_index=as_index)
         if isinstance(df_or_s, Series):
+            if not isinstance(by[0], Series):
+                raise KeyError(by[0])
             col = df_or_s  # type: Series
             anchor = df_or_s._kdf
             col_by = [_resolve_col(anchor, col_or_s) for col_or_s in by]

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -1262,16 +1262,31 @@ class _Frame(object):
         from databricks.koalas.groupby import DataFrameGroupBy, SeriesGroupBy
 
         df_or_s = self
-        if isinstance(by, str):
+        if isinstance(by, DataFrame):
+            raise ValueError("Grouper for '{}' not 1-dimensional".format(type(by)))
+        elif isinstance(by, str):
+            if isinstance(df_or_s, Series):
+                raise KeyError(by)
             by = [(by,)]
         elif isinstance(by, tuple):
+            if isinstance(df_or_s, Series):
+                for key in by:
+                    if isinstance(key, str):
+                        raise KeyError(key)
+            for key in by:
+                if isinstance(key, DataFrame):
+                    raise ValueError("Grouper for '{}' not 1-dimensional".format(type(key)))
             by = [by]
         elif isinstance(by, Series):
             by = [by]
         elif isinstance(by, Iterable):
+            if isinstance(df_or_s, Series):
+                for key in by:
+                    if isinstance(key, str):
+                        raise KeyError(key)
             by = [key if isinstance(key, (tuple, Series)) else (key,) for key in by]
         else:
-            raise ValueError('Not a valid index: TODO')
+            raise ValueError("Grouper for '{}' not 1-dimensional".format(type(by)))
         if not len(by):
             raise ValueError('No group keys passed!')
         if isinstance(df_or_s, DataFrame):
@@ -1279,8 +1294,6 @@ class _Frame(object):
             col_by = [_resolve_col(df, col_or_s) for col_or_s in by]
             return DataFrameGroupBy(df_or_s, col_by, as_index=as_index)
         if isinstance(df_or_s, Series):
-            if not isinstance(by[0], Series):
-                raise KeyError(by[0])
             col = df_or_s  # type: Series
             anchor = df_or_s._kdf
             col_by = [_resolve_col(anchor, col_or_s) for col_or_s in by]

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -71,10 +71,12 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         # we can't use column name/names as a parameter `by` for `SeriesGroupBy`.
         self.assertRaises(KeyError, lambda: kdf.a.groupby(by='a'))
         self.assertRaises(KeyError, lambda: kdf.a.groupby(by=['a', 'b']))
+        self.assertRaises(KeyError, lambda: kdf.a.groupby(by=('a', 'b')))
 
         # we can't use DataFrame as a parameter `by` for `DataFrameGroupBy`/`SeriesGroupBy`.
         self.assertRaises(ValueError, lambda: kdf.groupby(kdf))
         self.assertRaises(ValueError, lambda: kdf.a.groupby(kdf))
+        self.assertRaises(ValueError, lambda: kdf.a.groupby((kdf,)))
 
     def test_groupby_multiindex_columns(self):
         pdf = pd.DataFrame({('x', 'a'): [1, 2, 6, 4, 4, 6, 4, 3, 7],

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -72,6 +72,10 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         self.assertRaises(KeyError, lambda: kdf.a.groupby(by='a'))
         self.assertRaises(KeyError, lambda: kdf.a.groupby(by=['a', 'b']))
 
+        # we can't use DataFrame as a parameter `by` for `DataFrameGroupBy`/`SeriesGroupBy`.
+        self.assertRaises(ValueError, lambda: kdf.groupby(kdf))
+        self.assertRaises(ValueError, lambda: kdf.a.groupby(kdf))
+
     def test_groupby_multiindex_columns(self):
         pdf = pd.DataFrame({('x', 'a'): [1, 2, 6, 4, 4, 6, 4, 3, 7],
                             ('x', 'b'): [4, 2, 7, 3, 3, 1, 1, 1, 2],

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -68,6 +68,10 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
 
         self.assertRaises(TypeError, lambda: kdf.a.groupby(kdf.b, as_index=False))
 
+        # we can't use column name/names as a parameter `by` for `SeriesGroupBy`.
+        self.assertRaises(KeyError, lambda: kdf.a.groupby(by='a'))
+        self.assertRaises(KeyError, lambda: kdf.a.groupby(by=['a', 'b']))
+
     def test_groupby_multiindex_columns(self):
         pdf = pd.DataFrame({('x', 'a'): [1, 2, 6, 4, 4, 6, 4, 3, 7],
                             ('x', 'b'): [4, 2, 7, 3, 3, 1, 1, 1, 2],
@@ -838,7 +842,7 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             with self.assertRaisesRegex(
                     PandasNotImplementedError,
                     "method.*GroupBy.*{}.*not implemented( yet\\.|\\. .+)".format(name)):
-                getattr(kdf.a.groupby('a'), name)()
+                getattr(kdf.a.groupby(kdf.a), name)()
 
         deprecated_functions = [name for (name, type_) in missing_functions
                                 if type_.__name__ == 'deprecated_function']
@@ -846,7 +850,7 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             with self.assertRaisesRegex(PandasNotImplementedError,
                                         "method.*GroupBy.*{}.*is deprecated"
                                         .format(name)):
-                getattr(kdf.a.groupby('a'), name)()
+                getattr(kdf.a.groupby(kdf.a), name)()
 
         # DataFrameGroupBy properties
         missing_properties = inspect.getmembers(_MissingPandasLikeDataFrameGroupBy,
@@ -875,14 +879,14 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             with self.assertRaisesRegex(
                     PandasNotImplementedError,
                     "property.*GroupBy.*{}.*not implemented( yet\\.|\\. .+)".format(name)):
-                getattr(kdf.a.groupby('a'), name)
+                getattr(kdf.a.groupby(kdf.a), name)
         deprecated_properties = [name for (name, type_) in missing_properties
                                  if type_.fget.__name__ == 'deprecated_property']
         for name in deprecated_properties:
             with self.assertRaisesRegex(PandasNotImplementedError,
                                         "property.*GroupBy.*{}.*is deprecated"
                                         .format(name)):
-                getattr(kdf.a.groupby('a'), name)
+                getattr(kdf.a.groupby(kdf.a), name)
 
     @staticmethod
     def test_is_multi_agg_with_relabel():


### PR DESCRIPTION
Resolve #1095 

```python
>>> kser = ks.Series([1, 2, 3, 4, 5], name='x')
>>> kser.groupby('x').head(2)
Traceback (most recent call last):
...
KeyError: ('x',)
```
```python
>>> pdf = pd.DataFrame({'a': [1, 2, 6, 4, 4, 6, 4, 3, 7],
...                             'b': [4, 2, 7, 3, 3, 1, 1, 1, 2],
...                             'c': [4, 2, 7, 3, None, 1, 1, 1, 2],
...                             'd': list('abcdefght')},
...                            index=[0, 1, 3, 5, 6, 8, 9, 9, 9])
>>> pdf.groupby(pdf)
Traceback (most recent call last):
...
ValueError: Grouper for '<class 'pandas.core.frame.DataFrame'>' not 1-dimensional

>>> pdf.a.groupby(pdf)
Traceback (most recent call last):
...
ValueError: Grouper for '<class 'pandas.core.frame.DataFrame'>' not 1-dimensional
```