### PR TITLE
Avoid to return a different DataFrame from Series where (and multiple small bug fixes)

### DIFF
--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -3916,8 +3916,10 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
 
         assert isinstance(cond, Series)
 
-        should_try_ops_on_diff_frame = \
-            cond._kdf is not self._kdf or isinstance(other, Series) and other._kdf is not self._kdf
+        # We should check the DataFrame from both `cond` and `other`.
+        should_try_ops_on_diff_frame = (
+                cond._kdf is not self._kdf or
+                (isinstance(other, Series) and other._kdf is not self._kdf))
 
         if should_try_ops_on_diff_frame:
             # Try to perform it with 'compute.ops_on_diff_frame' option.

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -3918,8 +3918,8 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
 
         # We should check the DataFrame from both `cond` and `other`.
         should_try_ops_on_diff_frame = (
-                cond._kdf is not self._kdf or
-                (isinstance(other, Series) and other._kdf is not self._kdf))
+            cond._kdf is not self._kdf or
+            (isinstance(other, Series) and other._kdf is not self._kdf))
 
         if should_try_ops_on_diff_frame:
             # Try to perform it with 'compute.ops_on_diff_frame' option.

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -4235,14 +4235,19 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
 
     def __getitem__(self, key):
         if isinstance(key, Series) and isinstance(key.spark_type, BooleanType):
-            kdf = self.to_frame()
-            kdf["__temp_col__"] = key
-            sdf = kdf._sdf.filter(F.col("__temp_col__")).drop("__temp_col__")
-            return _col(ks.DataFrame(_InternalFrame(
-                sdf=sdf,
-                index_map=self._internal.index_map,
-                column_index=self._internal.column_index,
-                column_index_names=self._internal.column_index_names)))
+            should_try_ops_on_diff_frame = key._kdf is not self._kdf
+
+            if should_try_ops_on_diff_frame:
+                kdf = self.to_frame()
+                kdf["__temp_col__"] = key
+                sdf = kdf._sdf.filter(F.col("__temp_col__")).drop("__temp_col__")
+                return _col(ks.DataFrame(_InternalFrame(
+                    sdf=sdf,
+                    index_map=self._internal.index_map,
+                    column_index=self._internal.column_index,
+                    column_index_names=self._internal.column_index_names)))
+            else:
+                return _col(DataFrame(self._internal.copy(sdf=self._kdf._sdf.filter(key._scol))))
 
         if not isinstance(key, tuple):
             key = (key,)

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -3912,28 +3912,47 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
 
         >>> reset_option("compute.ops_on_diff_frames")
         """
-        kdf = self.to_frame()
-        kdf['__tmp_cond_col__'] = cond
-        kdf['__tmp_other_col__'] = other
-        sdf = kdf._sdf
-        # above logic make spark dataframe looks like below:
-        # +-----------------+---+----------------+-----------------+
-        # |__index_level_0__|  0|__tmp_cond_col__|__tmp_other_col__|
-        # +-----------------+---+----------------+-----------------+
-        # |                0|  0|           false|              100|
-        # |                1|  1|           false|              200|
-        # |                3|  3|            true|              400|
-        # |                2|  2|            true|              300|
-        # |                4|  4|            true|              500|
-        # +-----------------+---+----------------+-----------------+
         data_col_name = self._internal.column_name_for(self._internal.column_index[0])
-        index_column = self._internal.index_columns[0]
-        condition = F.when(sdf['__tmp_cond_col__'], sdf[data_col_name]) \
-                     .otherwise(sdf['__tmp_other_col__']).alias(data_col_name)
-        sdf = sdf.select(index_column, condition)
-        result = _col(ks.DataFrame(_InternalFrame(sdf=sdf, index_map=self._internal.index_map)))
 
-        return result
+        assert isinstance(cond, Series)
+
+        should_try_ops_on_diff_frame = \
+            cond._kdf is not self._kdf or isinstance(other, Series) and other._kdf is not self._kdf
+
+        if should_try_ops_on_diff_frame:
+            # Try to perform it with 'compute.ops_on_diff_frame' option.
+            kdf = self.to_frame()
+            kdf['__tmp_cond_col__'] = cond
+            kdf['__tmp_other_col__'] = other
+
+            sdf = kdf._sdf
+            # above logic makes a Spark DataFrame looks like below:
+            # +-----------------+---+----------------+-----------------+
+            # |__index_level_0__|  0|__tmp_cond_col__|__tmp_other_col__|
+            # +-----------------+---+----------------+-----------------+
+            # |                0|  0|           false|              100|
+            # |                1|  1|           false|              200|
+            # |                3|  3|            true|              400|
+            # |                2|  2|            true|              300|
+            # |                4|  4|            true|              500|
+            # +-----------------+---+----------------+-----------------+
+            condition = F.when(
+                sdf['__tmp_cond_col__'], sdf[data_col_name]
+            ).otherwise(sdf['__tmp_other_col__']).alias(data_col_name)
+
+            sdf = sdf.select(*self._internal.index_columns + [condition])
+            return _col(ks.DataFrame(_InternalFrame(
+                sdf=sdf,
+                index_map=self._internal.index_map,
+                column_index=self._internal.column_index,
+                column_index_names=self._internal.column_index_names)))
+        else:
+            if isinstance(other, Series):
+                other = other._scol
+            condition = F.when(
+                cond._scol, self._scol
+            ).otherwise(other).alias(data_col_name)
+            return self._with_new_scol(condition)
 
     def mask(self, cond, other=np.nan):
         """
@@ -4216,9 +4235,14 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
 
     def __getitem__(self, key):
         if isinstance(key, Series) and isinstance(key.spark_type, BooleanType):
-            self._kdf["__temp_col__"] = key
-            sdf = self._kdf._sdf.filter(F.col("__temp_col__")).drop("__temp_col__")
-            return _col(DataFrame(_InternalFrame(sdf=sdf, index_map=self._internal.index_map)))
+            kdf = self.to_frame()
+            kdf["__temp_col__"] = key
+            sdf = kdf._sdf.filter(F.col("__temp_col__")).drop("__temp_col__")
+            return _col(ks.DataFrame(_InternalFrame(
+                sdf=sdf,
+                index_map=self._internal.index_map,
+                column_index=self._internal.column_index,
+                column_index_names=self._internal.column_index_names)))
 
         if not isinstance(key, tuple):
             key = (key,)

--- a/databricks/koalas/tests/test_ops_on_diff_frames.py
+++ b/databricks/koalas/tests/test_ops_on_diff_frames.py
@@ -226,6 +226,9 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(pdf1.A[pdf2.A > 100],
                        kdf1.A[kdf2.A > 100].sort_index())
 
+        self.assert_eq((pdf1.A + 1)[pdf2.A > 100],
+                       (kdf1.A + 1)[kdf2.A > 100].sort_index())
+
     def test_bitwise(self):
         pser1 = pd.Series([True, False, True, False, np.nan, np.nan, True, False, np.nan])
         pser2 = pd.Series([True, False, False, True, True, False, np.nan, np.nan, np.nan])

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -37,16 +37,6 @@ from databricks.koalas.config import set_option, reset_option
 
 class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
 
-    @classmethod
-    def setUpClass(cls):
-        super(SeriesTest, cls).setUpClass()
-        set_option("compute.ops_on_diff_frames", True)
-
-    @classmethod
-    def tearDownClass(cls):
-        reset_option("compute.ops_on_diff_frames")
-        super(SeriesTest, cls).tearDownClass()
-
     @property
     def pser(self):
         return pd.Series([1, 2, 3, 4, 5, 6, 7], name='x')
@@ -819,37 +809,17 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
 
     def test_where(self):
         pser1 = pd.Series([0, 1, 2, 3, 4], name=0)
-        pser2 = pd.Series([100, 200, 300, 400, 500], name=0)
         kser1 = ks.from_pandas(pser1)
-        kser2 = ks.from_pandas(pser2)
 
-        self.assert_eq(repr(pser1.where(pser2 > 100)),
-                       repr(kser1.where(kser2 > 100).sort_index()))
-
-        pser1 = pd.Series([-1, -2, -3, -4, -5], name=0)
-        pser2 = pd.Series([-100, -200, -300, -400, -500], name=0)
-        kser1 = ks.from_pandas(pser1)
-        kser2 = ks.from_pandas(pser2)
-
-        self.assert_eq(repr(pser1.where(pser2 < -250)),
-                       repr(kser1.where(kser2 < -250).sort_index()))
+        self.assert_eq(repr(pser1.where(pser1 > 3)),
+                       repr(kser1.where(kser1 > 3).sort_index()))
 
     def test_mask(self):
         pser1 = pd.Series([0, 1, 2, 3, 4], name=0)
-        pser2 = pd.Series([100, 200, 300, 400, 500], name=0)
         kser1 = ks.from_pandas(pser1)
-        kser2 = ks.from_pandas(pser2)
 
-        self.assert_eq(repr(pser1.mask(pser2 > 100)),
-                       repr(kser1.mask(kser2 > 100).sort_index()))
-
-        pser1 = pd.Series([-1, -2, -3, -4, -5], name=0)
-        pser2 = pd.Series([-100, -200, -300, -400, -500], name=0)
-        kser1 = ks.from_pandas(pser1)
-        kser2 = ks.from_pandas(pser2)
-
-        self.assert_eq(repr(pser1.mask(pser2 < -250)),
-                       repr(kser1.mask(kser2 < -250).sort_index()))
+        self.assert_eq(repr(pser1.mask(pser1 > 3)),
+                       repr(kser1.mask(kser1 > 3).sort_index()))
 
     def test_truncate(self):
         pser1 = pd.Series([10, 20, 30, 40, 50, 60, 70], index=[1, 2, 3, 4, 5, 6, 7])


### PR DESCRIPTION
**1..** We can avoid operations on different DataFrames. See below:

```python
>>> import databricks.koalas as ks
>>> kdf = ks.DataFrame({'a': [1,2,3]})
>>> kdf.a.where(kdf.a > 1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/.../koalas/databricks/koalas/series.py", line 3916, in where
    kdf['__tmp_cond_col__'] = cond
  File "/.../koalas/databricks/koalas/frame.py", line 8089, in __setitem__
    kdf = align_diff_frames(assign_columns, self, value, fillna=False, how="left")
  File "/.../koalas/databricks/koalas/utils.py", line 187, in align_diff_frames
    combined = combine_frames(this, that, how=how)
  File "/.../koalas/databricks/koalas/utils.py", line 122, in combine_frames
    "Cannot combine the series or dataframe because it comes from a different dataframe. "
ValueError: Cannot combine the series or dataframe because it comes from a different dataframe. In order to allow this operation, enable 'compute.ops_on_diff_frames' option.
```

`kdf.a` is from the same DataFrame but currently it requires `compute.ops_on_diff_frames` to be enabled.

This is because `self.to_frame()` creates another DataFrame and it loses it's anchor DataFrame; therefore, it became a different DataFrame.


**2..** We should set `column_index` and `column_index_names`. Otherwise, output DataFrames will lose column indexes (e.g., multi-index columns).

**3..** When we should use `self._kdf` in `Series` API implementation, we should keep check if it matters at output data column because, if we apply some APIs that do not need to create another DataFrame (which is preferred), it will ignore the applied column. See the example below:

```python
ser = df.a.round()  # `kdf` is as is but it only replaces `scol`.
ser._kdf.filter(...).show()  # `scol` is missing in the output
```

**4..** Currently, `compute.ops_on_diff_frames` should only be enabled in `OpsOnDiffFramesEnabledTest`. This option is disabled by default and discouraged due to performance issue.

It was mistakenly enabled at `SeriesTest`. I removed it back.