### PR TITLE
Add __doc__ for replaced property when logging is enabled.

### DIFF
--- a/databricks/koalas/usage_logging/__init__.py
+++ b/databricks/koalas/usage_logging/__init__.py
@@ -173,6 +173,8 @@ def _wrap_property(class_name, property_name, prop, logger):
         finally:
             _local.logging = False
 
+    wrapper.__doc__ = prop.__doc__
+
     if prop.fset is not None:
         wrapper = wrapper.setter(_wrap_function(class_name, prop.fset.__name__, prop.fset, logger))
 


### PR DESCRIPTION
When logging is enabled, docs for replaced properties didn't exist, and as a side-effect, doctests for the properties were not run.