### PR TITLE
Set the pyarrow version upper bound again.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ matrix:
         - JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
         - SPARK_VERSION=2.4.4
         - PANDAS_VERSION=0.25.3
-        - PYARROW_VERSION=0.15.1
+        - PYARROW_VERSION=0.14.1
 
 before_install:
   - ./dev/download_travis_dependencies.sh

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 # Dependencies in Koalas. When you update don't forget to update setup.py and install.rst in docs.
 pandas>=0.23.2
-pyarrow>=0.10
+pyarrow>=0.10,<0.15
 matplotlib>=3.0.0
 numpy>=1.14
 

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     python_requires='>=3.5',
     install_requires=[
         'pandas>=0.23.2',
-        'pyarrow>=0.10',
+        'pyarrow>=0.10,<0.15',
         'numpy>=1.14',
         'matplotlib>=3.0.0',
     ],


### PR DESCRIPTION
Seems still unstable with PyArrow 0.15. Let me set the upper bound again for now.