### PR TITLE
Add PyArrow 0.15 support back, and test PyArrow 0.16 in CI

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -19,7 +19,7 @@ jobs:
           - python-version: 3.5
             spark-version: 2.3.4
             pandas-version: 0.23.4
-            pyarrow-version: 0.10.0
+            pyarrow-version: 0.16.0
           - python-version: 3.5
             spark-version: 2.3.4
             pandas-version: 0.24.2
@@ -103,7 +103,7 @@ jobs:
           - python-version: 3.7
             spark-version: 2.4.5
             pandas-version: 1.0.3
-            pyarrow-version: 0.14.1
+            pyarrow-version: 0.15.1
     env:
       PYTHON_VERSION: ${{ matrix.python-version }}
       SPARK_VERSION: ${{ matrix.spark-version }}

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ dbutils.library.restartPython()
 
 Note that Koalas requires Databricks Runtime 5.x or above. In the future, we will package Koalas out-of-the-box in both the regular Databricks Runtime and Databricks Runtime for Machine Learning.
 
+Lastly, note that if your PyArrow version is 0.15+, it is best for you to set `ARROW_PRE_0_15_IPC_FORMAT` environment variable to `1` manually.
+Koalas will try its best to set it for you but it is impossible to set it if there is a Spark context already launched.
+
 Now you can turn a pandas DataFrame into a Koalas DataFrame that is API-compliant with the former:
 
 ```python

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ dbutils.library.restartPython()
 
 Note that Koalas requires Databricks Runtime 5.x or above. In the future, we will package Koalas out-of-the-box in both the regular Databricks Runtime and Databricks Runtime for Machine Learning.
 
-Lastly, note that if your PyArrow version is 0.15+, it is best for you to set `ARROW_PRE_0_15_IPC_FORMAT` environment variable to `1` manually.
+Lastly, note that if your PyArrow version is 0.15+ and your PySpark version is lower than 3.0, it is best for you to set `ARROW_PRE_0_15_IPC_FORMAT` environment variable to `1` manually.
 Koalas will try its best to set it for you but it is impossible to set it if there is a Spark context already launched.
 
 Now you can turn a pandas DataFrame into a Koalas DataFrame that is API-compliant with the former:

--- a/databricks/koalas/__init__.py
+++ b/databricks/koalas/__init__.py
@@ -45,16 +45,17 @@ assert_pyspark_version()
 import pyspark
 import pyarrow
 
-if LooseVersion(pyarrow.__version__) >= LooseVersion("0.15") and LooseVersion(
-    pyspark.__version__
-) < LooseVersion("3.0"):
-    if "ARROW_PRE_0_15_IPC_FORMAT" not in os.environ:
+if LooseVersion(pyspark.__version__) < LooseVersion("3.0"):
+    if (
+        LooseVersion(pyarrow.__version__) >= LooseVersion("0.15")
+        and "ARROW_PRE_0_15_IPC_FORMAT" not in os.environ
+    ):
         import logging
 
         logging.warning(
             "'ARROW_PRE_0_15_IPC_FORMAT' environment variable was not set. It is required to "
             "set this environment variable to '1' in both driver and executor sides if you use "
-            "pyarrow>=0.15 and pyspark<=3.0. "
+            "pyarrow>=0.15 and pyspark<3.0. "
             "Koalas will set it for you but it does not work if there is a Spark context already "
             "launched."
         )
@@ -65,7 +66,7 @@ elif "ARROW_PRE_0_15_IPC_FORMAT" in os.environ:
     raise RuntimeError(
         "Please explicitly unset 'ARROW_PRE_0_15_IPC_FORMAT' environment variable in both "
         "driver and executor sides. It is required to set this environment variable only "
-        "when you use pyarrow>=0.15 and pyspark<=3.0."
+        "when you use pyarrow>=0.15 and pyspark<3.0."
     )
 
 

--- a/databricks/koalas/__init__.py
+++ b/databricks/koalas/__init__.py
@@ -48,9 +48,26 @@ import pyarrow
 if LooseVersion(pyarrow.__version__) >= LooseVersion("0.15") and LooseVersion(
     pyspark.__version__
 ) < LooseVersion("3.0"):
-    # This is required to support PyArrow 0.15 in PySpark versions lower than 3.0.
-    # See SPARK-29367.
-    os.environ["ARROW_PRE_0_15_IPC_FORMAT"] = "1"
+    if "ARROW_PRE_0_15_IPC_FORMAT" not in os.environ:
+        import logging
+
+        logging.warning(
+            "'ARROW_PRE_0_15_IPC_FORMAT' environment variable was not set. It is required to "
+            "set this environment variable to '1' in both driver and executor sides if you use "
+            "pyarrow>=0.15 and pyspark<=3.0. "
+            "Koalas will set it for you but it does not work if there is a Spark context already "
+            "launched."
+        )
+        # This is required to support PyArrow 0.15 in PySpark versions lower than 3.0.
+        # See SPARK-29367.
+        os.environ["ARROW_PRE_0_15_IPC_FORMAT"] = "1"
+elif "ARROW_PRE_0_15_IPC_FORMAT" in os.environ:
+    raise RuntimeError(
+        "Please explicitly unset 'ARROW_PRE_0_15_IPC_FORMAT' environment variable in both "
+        "driver and executor sides. It is required to set this environment variable only "
+        "when you use pyarrow>=0.15 and pyspark<=3.0."
+    )
+
 
 from databricks.koalas.frame import DataFrame
 from databricks.koalas.indexes import Index, MultiIndex

--- a/databricks/koalas/utils.py
+++ b/databricks/koalas/utils.py
@@ -18,7 +18,6 @@ Commonly used utils in Koalas.
 """
 
 import functools
-import os
 from collections import OrderedDict
 from distutils.version import LooseVersion
 from typing import Callable, Dict, List, Tuple, Union
@@ -331,7 +330,7 @@ def default_session(conf=None):
                 "both driver and executor sides. Check your spark.executorEnv.*, "
                 "spark.yarn.appMasterEnv.*, spark.mesos.driverEnv.* and "
                 "spark.kubernetes.driverEnv.* configurations. It is required to set this "
-                "environment variable only when you use pyarrow>=0.15 and pyspark<=3.0."
+                "environment variable only when you use pyarrow>=0.15 and pyspark<3.0."
             )
     return session
 

--- a/databricks/koalas/utils.py
+++ b/databricks/koalas/utils.py
@@ -18,6 +18,7 @@ Commonly used utils in Koalas.
 """
 
 import functools
+import os
 from collections import OrderedDict
 from distutils.version import LooseVersion
 from typing import Callable, Dict, List, Tuple, Union
@@ -296,6 +297,7 @@ def align_diff_series(func, this_series, *args, how="full"):
 def default_session(conf=None):
     if conf is None:
         conf = dict()
+    should_use_legacy_ipc = False
     if LooseVersion(pyarrow.__version__) >= LooseVersion("0.15") and LooseVersion(
         pyspark.__version__
     ) < LooseVersion("3.0"):
@@ -303,13 +305,35 @@ def default_session(conf=None):
         conf["spark.yarn.appMasterEnv.ARROW_PRE_0_15_IPC_FORMAT"] = "1"
         conf["spark.mesos.driverEnv.ARROW_PRE_0_15_IPC_FORMAT"] = "1"
         conf["spark.kubernetes.driverEnv.ARROW_PRE_0_15_IPC_FORMAT"] = "1"
+        should_use_legacy_ipc = True
+
     builder = spark.SparkSession.builder.appName("Koalas")
     for key, value in conf.items():
         builder = builder.config(key, value)
     # Currently, Koalas is dependent on such join due to 'compute.ops_on_diff_frames'
     # configuration. This is needed with Spark 3.0+.
     builder.config("spark.sql.analyzer.failAmbiguousSelfJoin.enabled", False)
-    return builder.getOrCreate()
+    session = builder.getOrCreate()
+
+    if not should_use_legacy_ipc:
+        is_legacy_ipc_set = any(
+            v == "1"
+            for v in [
+                session.conf.get("spark.executorEnv.ARROW_PRE_0_15_IPC_FORMAT", None),
+                session.conf.get("spark.yarn.appMasterEnv.ARROW_PRE_0_15_IPC_FORMAT", None),
+                session.conf.get("spark.mesos.driverEnv.ARROW_PRE_0_15_IPC_FORMAT", None),
+                session.conf.get("spark.kubernetes.driverEnv.ARROW_PRE_0_15_IPC_FORMAT", None),
+            ]
+        )
+        if is_legacy_ipc_set:
+            raise RuntimeError(
+                "Please explicitly unset 'ARROW_PRE_0_15_IPC_FORMAT' environment variable in "
+                "both driver and executor sides. Check your spark.executorEnv.*, "
+                "spark.yarn.appMasterEnv.*, spark.mesos.driverEnv.* and "
+                "spark.kubernetes.driverEnv.* configurations. It is required to set this "
+                "environment variable only when you use pyarrow>=0.15 and pyspark<=3.0."
+            )
+    return session
 
 
 def validate_arguments_and_invoke_function(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 # Dependencies in Koalas. When you update don't forget to update setup.py and install.rst in docs.
 pandas>=0.23.2
-pyarrow>=0.10,<0.15
+pyarrow>=0.10
 matplotlib>=3.0.0
 numpy>=1.14
 

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     python_requires='>=3.5',
     install_requires=[
         'pandas>=0.23.2',
-        'pyarrow>=0.10,<0.15',
+        'pyarrow>=0.10',
         'numpy>=1.14',
         'matplotlib>=3.0.0',
     ],


### PR DESCRIPTION
This PR adds PyArrow 0.15 support back with a better documentation and error message.
Error message will look as below:

Warning when pyarrow>=0.15 and pyspark<3.0 but `ARROW_PRE_0_15_IPC_FORMAT` not set.

```
WARNING:root:'ARROW_PRE_0_15_IPC_FORMAT' environment variable was not set. It is required 
to set this environment variable to '1' if you use pyarrow>=0.15 and pyspark<3.0. Koalas will 
set it for you but it does not work if there is a Spark context already launched.
```

Exceptions when `ARROW_PRE_0_15_IPC_FORMAT` is set in valid cases:

```
RuntimeError: Please explicitly unset 'ARROW_PRE_0_15_IPC_FORMAT' environment variable 
in both driver and executor sides. Check your spark.executorEnv.*, spark.yarn.appMasterEnv.*, 
spark.mesos.driverEnv.* and spark.kubernetes.driverEnv.* configurations. It is required to set 
this environment variable only when you use pyarrow>=0.15 and pyspark<3.0.
```

```
RuntimeError: Please explicitly unset 'ARROW_PRE_0_15_IPC_FORMAT' environment variable in 
both driver and executor sides. It is required to set this environment variable only when you use 
pyarrow>=0.15 and pyspark<3.0.
```

Resolves #1109