### PR TITLE
Fix value_counts() to work properly when dropna is True

### DIFF
--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -943,7 +943,8 @@ class IndexOpsMixin(object):
         from databricks.koalas.series import Series, _col
         if bins is not None:
             raise NotImplementedError("value_counts currently does not support bins")
-        # if Series from DataFrame, we should've specified a proper subset.
+
+        # if given Series is a subset of DataFrame, we should've specified a proper subset.
         if self._kdf._internal is not self._internal:
             self = _col(self.to_frame())
         if dropna:

--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -947,10 +947,10 @@ class IndexOpsMixin(object):
         if dropna:
             sdf_dropna = self._internal._sdf.select(self._scol).dropna()
         else:
-            sdf_dropna = self._internal._sdf
+            sdf_dropna = self._internal._sdf.select(self._scol)
         index_name = SPARK_INDEX_NAME_FORMAT(0)
         column_name = self._internal.data_columns[0]
-        sdf = sdf_dropna.groupby(sdf_dropna[column_name].alias(index_name)).count()
+        sdf = sdf_dropna.groupby(scol_for(sdf_dropna, column_name).alias(index_name)).count()
         if sort:
             if ascending:
                 sdf = sdf.orderBy(F.col('count'))

--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -949,7 +949,8 @@ class IndexOpsMixin(object):
         else:
             sdf_dropna = self._internal._sdf
         index_name = SPARK_INDEX_NAME_FORMAT(0)
-        sdf = sdf_dropna.groupby(sdf_dropna[self.name].alias(index_name)).count()
+        column_name = self._internal.data_columns[0]
+        sdf = sdf_dropna.groupby(sdf_dropna[column_name].alias(index_name)).count()
         if sort:
             if ascending:
                 sdf = sdf.orderBy(F.col('count'))

--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -944,15 +944,12 @@ class IndexOpsMixin(object):
         if bins is not None:
             raise NotImplementedError("value_counts currently does not support bins")
 
-        # if given Series is a subset of DataFrame, we should've specified a proper subset.
-        if self._kdf._internal is not self._internal:
-            self = _col(self.to_frame())
         if dropna:
-            sdf_dropna = self._internal._sdf.dropna()
+            sdf_dropna = self._internal._sdf.select(self._scol).dropna()
         else:
             sdf_dropna = self._internal._sdf
         index_name = SPARK_INDEX_NAME_FORMAT(0)
-        sdf = sdf_dropna.groupby(self._scol.alias(index_name)).count()
+        sdf = sdf_dropna.groupby(sdf_dropna[self.name].alias(index_name)).count()
         if sort:
             if ascending:
                 sdf = sdf.orderBy(F.col('count'))

--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -20,7 +20,9 @@ Base and utility classes for Koalas objects.
 
 from functools import wraps
 from typing import Union, Callable, Any
+from distutils.version import LooseVersion
 
+import pyspark
 import numpy as np
 import pandas as pd
 from pandas.api.types import is_list_like
@@ -33,7 +35,7 @@ from databricks import koalas as ks  # For running doctests and reference resolu
 from databricks.koalas import numpy_compat
 from databricks.koalas.internal import _InternalFrame, SPARK_INDEX_NAME_FORMAT
 from databricks.koalas.typedef import pandas_wraps, spark_type_to_pandas_dtype
-from databricks.koalas.utils import align_diff_series, scol_for, validate_axis
+from databricks.koalas.utils import align_diff_series, scol_for, validate_axis, default_session
 from databricks.koalas.frame import DataFrame
 
 
@@ -941,6 +943,11 @@ class IndexOpsMixin(object):
         Name: koalas, dtype: int64
         """
         from databricks.koalas.series import Series, _col
+        if LooseVersion(pyspark.__version__) < LooseVersion("2.4") and \
+                default_session().conf.get("spark.sql.execution.arrow.enabled") == "true":
+            raise RuntimeError("if you're using pyspark < 2.4, set conf "
+                               "'spark.sql.execution.arrow.enabled' to 'false' "
+                               "for using this function")
         if bins is not None:
             raise NotImplementedError("value_counts currently does not support bins")
 

--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -943,11 +943,13 @@ class IndexOpsMixin(object):
         Name: koalas, dtype: int64
         """
         from databricks.koalas.series import Series, _col
+        from databricks.koalas.indexes import MultiIndex
         if LooseVersion(pyspark.__version__) < LooseVersion("2.4") and \
-                default_session().conf.get("spark.sql.execution.arrow.enabled") == "true":
+                default_session().conf.get("spark.sql.execution.arrow.enabled") == "true" and \
+                isinstance(self, MultiIndex):
             raise RuntimeError("if you're using pyspark < 2.4, set conf "
                                "'spark.sql.execution.arrow.enabled' to 'false' "
-                               "for using this function")
+                               "for using this function with MultiIndex")
         if bins is not None:
             raise NotImplementedError("value_counts currently does not support bins")
 

--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -943,7 +943,9 @@ class IndexOpsMixin(object):
         from databricks.koalas.series import Series, _col
         if bins is not None:
             raise NotImplementedError("value_counts currently does not support bins")
-
+        # if Series from DataFrame, we should've specified a proper subset.
+        if self._kdf._internal is not self._internal:
+            self = _col(self.to_frame())
         if dropna:
             sdf_dropna = self._internal._sdf.dropna()
         else:

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -244,6 +244,7 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         self.assertEqual(ks.Series(range(100)).nunique(approx=True, rsd=0.01), 100)
 
     def test_value_counts(self):
+        # this is also containing test for Index & MultiIndex
         pser = pd.Series([1, 2, 1, 3, 3, np.nan, 1, 4], name="x")
         kser = ks.from_pandas(pser)
 
@@ -260,6 +261,15 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
                        pser.value_counts(normalize=True, dropna=False), almost=True)
         self.assert_eq(kser.value_counts(ascending=True, dropna=False),
                        pser.value_counts(ascending=True, dropna=False), almost=True)
+
+        self.assert_eq(kser.index.value_counts(normalize=True),
+                       pser.index.value_counts(normalize=True), almost=True)
+        self.assert_eq(kser.index.value_counts(ascending=True),
+                       pser.index.value_counts(ascending=True), almost=True)
+        self.assert_eq(kser.index.value_counts(normalize=True, dropna=False),
+                       pser.index.value_counts(normalize=True, dropna=False), almost=True)
+        self.assert_eq(kser.index.value_counts(ascending=True, dropna=False),
+                       pser.index.value_counts(ascending=True, dropna=False), almost=True)
 
         with self.assertRaisesRegex(NotImplementedError,
                                     "value_counts currently does not support bins"):
@@ -282,6 +292,15 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(kdf.a.value_counts(ascending=True, dropna=False),
                        pdf.a.value_counts(ascending=True, dropna=False), almost=True)
 
+        self.assert_eq(kser.index.value_counts(normalize=True),
+                       pser.index.value_counts(normalize=True), almost=True)
+        self.assert_eq(kser.index.value_counts(ascending=True),
+                       pser.index.value_counts(ascending=True), almost=True)
+        self.assert_eq(kser.index.value_counts(normalize=True, dropna=False),
+                       pser.index.value_counts(normalize=True, dropna=False), almost=True)
+        self.assert_eq(kser.index.value_counts(ascending=True, dropna=False),
+                       pser.index.value_counts(ascending=True, dropna=False), almost=True)
+
         # Series with NaN index
         pser = pd.Series([1, 2, 3], index=[2, None, 5])
         kser = ks.from_pandas(pser)
@@ -294,6 +313,81 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
                        pser.value_counts(normalize=True, dropna=False), almost=True)
         self.assert_eq(kser.value_counts(ascending=True, dropna=False),
                        pser.value_counts(ascending=True, dropna=False), almost=True)
+
+        self.assert_eq(kser.index.value_counts(normalize=True),
+                       pser.index.value_counts(normalize=True), almost=True)
+        self.assert_eq(kser.index.value_counts(ascending=True),
+                       pser.index.value_counts(ascending=True), almost=True)
+        self.assert_eq(kser.index.value_counts(normalize=True, dropna=False),
+                       pser.index.value_counts(normalize=True, dropna=False), almost=True)
+        self.assert_eq(kser.index.value_counts(ascending=True, dropna=False),
+                       pser.index.value_counts(ascending=True, dropna=False), almost=True)
+
+        # Series with MultiIndex
+        pser.index = pd.MultiIndex.from_tuples([('x', 'a'), ('x', 'b'), ('y', 'c')])
+        kser = ks.from_pandas(pser)
+
+        self.assert_eq(kser.value_counts(normalize=True),
+                       pser.value_counts(normalize=True), almost=True)
+        self.assert_eq(kser.value_counts(ascending=True),
+                       pser.value_counts(ascending=True), almost=True)
+        self.assert_eq(kser.value_counts(normalize=True, dropna=False),
+                       pser.value_counts(normalize=True, dropna=False), almost=True)
+        self.assert_eq(kser.value_counts(ascending=True, dropna=False),
+                       pser.value_counts(ascending=True, dropna=False), almost=True)
+
+        self.assert_eq(kser.index.value_counts(normalize=True),
+                       pser.index.value_counts(normalize=True), almost=True)
+        self.assert_eq(kser.index.value_counts(ascending=True),
+                       pser.index.value_counts(ascending=True), almost=True)
+        self.assert_eq(kser.index.value_counts(normalize=True, dropna=False),
+                       pser.index.value_counts(normalize=True, dropna=False), almost=True)
+        self.assert_eq(kser.index.value_counts(ascending=True, dropna=False),
+                       pser.index.value_counts(ascending=True, dropna=False), almost=True)
+
+        # Series with MultiIndex some of index has NaN
+        pser.index = pd.MultiIndex.from_tuples([('x', 'a'), ('x', None), ('y', 'c')])
+        kser = ks.from_pandas(pser)
+
+        self.assert_eq(kser.value_counts(normalize=True),
+                       pser.value_counts(normalize=True), almost=True)
+        self.assert_eq(kser.value_counts(ascending=True),
+                       pser.value_counts(ascending=True), almost=True)
+        self.assert_eq(kser.value_counts(normalize=True, dropna=False),
+                       pser.value_counts(normalize=True, dropna=False), almost=True)
+        self.assert_eq(kser.value_counts(ascending=True, dropna=False),
+                       pser.value_counts(ascending=True, dropna=False), almost=True)
+
+        self.assert_eq(kser.index.value_counts(normalize=True),
+                       pser.index.value_counts(normalize=True), almost=True)
+        self.assert_eq(kser.index.value_counts(ascending=True),
+                       pser.index.value_counts(ascending=True), almost=True)
+        self.assert_eq(kser.index.value_counts(normalize=True, dropna=False),
+                       pser.index.value_counts(normalize=True, dropna=False), almost=True)
+        self.assert_eq(kser.index.value_counts(ascending=True, dropna=False),
+                       pser.index.value_counts(ascending=True, dropna=False), almost=True)
+
+        # Series with MultiIndex some of index is NaN
+        pser.index = pd.MultiIndex.from_tuples([('x', 'a'), None, ('y', 'c')])
+        kser = ks.from_pandas(pser)
+
+        self.assert_eq(kser.value_counts(normalize=True),
+                       pser.value_counts(normalize=True), almost=True)
+        self.assert_eq(kser.value_counts(ascending=True),
+                       pser.value_counts(ascending=True), almost=True)
+        self.assert_eq(kser.value_counts(normalize=True, dropna=False),
+                       pser.value_counts(normalize=True, dropna=False), almost=True)
+        self.assert_eq(kser.value_counts(ascending=True, dropna=False),
+                       pser.value_counts(ascending=True, dropna=False), almost=True)
+
+        self.assert_eq(kser.index.value_counts(normalize=True),
+                       pser.index.value_counts(normalize=True), almost=True)
+        self.assert_eq(kser.index.value_counts(ascending=True),
+                       pser.index.value_counts(ascending=True), almost=True)
+        self.assert_eq(kser.index.value_counts(normalize=True, dropna=False),
+                       pser.index.value_counts(normalize=True, dropna=False), almost=True)
+        self.assert_eq(kser.index.value_counts(ascending=True, dropna=False),
+                       pser.index.value_counts(ascending=True, dropna=False), almost=True)
 
     def test_nsmallest(self):
         sample_lst = [1, 2, 3, 4, np.nan, 6]

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -282,6 +282,19 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(kdf.a.value_counts(ascending=True, dropna=False),
                        pdf.a.value_counts(ascending=True, dropna=False), almost=True)
 
+        # Series with NaN index
+        pser = pd.Series([1, 2, 3], index=[2, None, 5])
+        kser = ks.from_pandas(pser)
+
+        self.assert_eq(kser.value_counts(normalize=True),
+                       pser.value_counts(normalize=True), almost=True)
+        self.assert_eq(kser.value_counts(ascending=True),
+                       pser.value_counts(ascending=True), almost=True)
+        self.assert_eq(kser.value_counts(normalize=True, dropna=False),
+                       pser.value_counts(normalize=True, dropna=False), almost=True)
+        self.assert_eq(kser.value_counts(ascending=True, dropna=False),
+                       pser.value_counts(ascending=True, dropna=False), almost=True)
+
     def test_nsmallest(self):
         sample_lst = [1, 2, 3, 4, np.nan, 6]
         pser = pd.Series(sample_lst, name='x')

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -255,10 +255,6 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         self.assertEqual(res.name, exp.name)
         self.assert_eq(res, exp, almost=True)
 
-        if LooseVersion(pyspark.__version__) < LooseVersion("2.4") and \
-                default_session().conf.get("spark.sql.execution.arrow.enabled") == "true":
-            self.assertRaises(RuntimeError, lambda: kser.value_counts())
-
         self.assert_eq(kser.value_counts(normalize=True),
                        pser.value_counts(normalize=True), almost=True)
         self.assert_eq(kser.value_counts(ascending=True),
@@ -405,6 +401,9 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
                 self._test_value_counts()
             finally:
                 default_session().conf.set("spark.sql.execution.arrow.enabled", "true")
+            self.assertRaises(
+                RuntimeError,
+                lambda: ks.MultiIndex.from_tuples([('x', 'a'), ('x', 'b')]).value_counts())
         else:
             self._test_value_counts()
 

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -375,27 +375,29 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(kser.index.value_counts(ascending=True, dropna=False),
                        pser.index.value_counts(ascending=True, dropna=False), almost=True)
 
-        # Series with MultiIndex some of index is NaN
-        pser.index = pd.MultiIndex.from_tuples([('x', 'a'), None, ('y', 'c')])
-        kser = ks.from_pandas(pser)
+        # Series with MultiIndex some of index is NaN.
+        # This test only available for pandas >= 0.24.
+        if LooseVersion(pd.__version__) < LooseVersion("0.24"):
+            pser.index = pd.MultiIndex.from_tuples([('x', 'a'), None, ('y', 'c')])
+            kser = ks.from_pandas(pser)
 
-        self.assert_eq(kser.value_counts(normalize=True),
-                       pser.value_counts(normalize=True), almost=True)
-        self.assert_eq(kser.value_counts(ascending=True),
-                       pser.value_counts(ascending=True), almost=True)
-        self.assert_eq(kser.value_counts(normalize=True, dropna=False),
-                       pser.value_counts(normalize=True, dropna=False), almost=True)
-        self.assert_eq(kser.value_counts(ascending=True, dropna=False),
-                       pser.value_counts(ascending=True, dropna=False), almost=True)
+            self.assert_eq(kser.value_counts(normalize=True),
+                           pser.value_counts(normalize=True), almost=True)
+            self.assert_eq(kser.value_counts(ascending=True),
+                           pser.value_counts(ascending=True), almost=True)
+            self.assert_eq(kser.value_counts(normalize=True, dropna=False),
+                           pser.value_counts(normalize=True, dropna=False), almost=True)
+            self.assert_eq(kser.value_counts(ascending=True, dropna=False),
+                           pser.value_counts(ascending=True, dropna=False), almost=True)
 
-        self.assert_eq(kser.index.value_counts(normalize=True),
-                       pser.index.value_counts(normalize=True), almost=True)
-        self.assert_eq(kser.index.value_counts(ascending=True),
-                       pser.index.value_counts(ascending=True), almost=True)
-        self.assert_eq(kser.index.value_counts(normalize=True, dropna=False),
-                       pser.index.value_counts(normalize=True, dropna=False), almost=True)
-        self.assert_eq(kser.index.value_counts(ascending=True, dropna=False),
-                       pser.index.value_counts(ascending=True, dropna=False), almost=True)
+            self.assert_eq(kser.index.value_counts(normalize=True),
+                           pser.index.value_counts(normalize=True), almost=True)
+            self.assert_eq(kser.index.value_counts(ascending=True),
+                           pser.index.value_counts(ascending=True), almost=True)
+            self.assert_eq(kser.index.value_counts(normalize=True, dropna=False),
+                           pser.index.value_counts(normalize=True, dropna=False), almost=True)
+            self.assert_eq(kser.index.value_counts(ascending=True, dropna=False),
+                           pser.index.value_counts(ascending=True, dropna=False), almost=True)
 
         if set_arrow_conf:
             default_session().conf.set("spark.sql.execution.arrow.enabled", "true")

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -269,6 +269,19 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         kser.name = 'index'
         self.assert_eq(kser.value_counts(), pser.value_counts(), almost=True)
 
+        # Series from DataFrame
+        pdf = pd.DataFrame({'a': [1, 2, 3], 'b': [None, 1, None]})
+        kdf = ks.from_pandas(pdf)
+
+        self.assert_eq(kdf.a.value_counts(normalize=True),
+                       pdf.a.value_counts(normalize=True), almost=True)
+        self.assert_eq(kdf.a.value_counts(ascending=True),
+                       pdf.a.value_counts(ascending=True), almost=True)
+        self.assert_eq(kdf.a.value_counts(normalize=True, dropna=False),
+                       pdf.a.value_counts(normalize=True, dropna=False), almost=True)
+        self.assert_eq(kdf.a.value_counts(ascending=True, dropna=False),
+                       pdf.a.value_counts(ascending=True, dropna=False), almost=True)
+
     def test_nsmallest(self):
         sample_lst = [1, 2, 3, 4, np.nan, 6]
         pser = pd.Series(sample_lst, name='x')

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -377,7 +377,7 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
 
         # Series with MultiIndex some of index is NaN.
         # This test only available for pandas >= 0.24.
-        if LooseVersion(pd.__version__) < LooseVersion("0.24"):
+        if LooseVersion(pd.__version__) >= LooseVersion("0.24"):
             pser.index = pd.MultiIndex.from_tuples([('x', 'a'), None, ('y', 'c')])
             kser = ks.from_pandas(pser)
 


### PR DESCRIPTION
This PR Resolves comment https://github.com/databricks/koalas/pull/949#discussion_r356364770

```python
>>> kdf
   a    b
0  1  NaN
1  2  1.0
2  3  NaN

>>> kdf.a
0    1
1    2
2    3
Name: a, dtype: int64

>>> kdf.a.value_counts()
2    1
3    1
1    1
Name: a, dtype: int64
```