### PR TITLE
Implement DataFrame.info

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -8088,7 +8088,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Prints information of all columns:
 
-        >>> df.info(verbose=True)
+        >>> df.info(verbose=True)  # doctest: +SKIP
         <class 'databricks.koalas.frame.DataFrame'>
         Index: 5 entries, 0 to 4
         Data columns (total 3 columns):
@@ -8100,7 +8100,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         Prints a summary of columns count and its dtypes but not per column
         information:
 
-        >>> df.info(verbose=False)
+        >>> df.info(verbose=False)  # doctest: +SKIP
         <class 'databricks.koalas.frame.DataFrame'>
         Index: 5 entries, 0 to 4
         Columns: 3 entries, int_col to float_col

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -8116,6 +8116,15 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         >>> with open('%s/info.txt' % path, "w",
         ...           encoding="utf-8") as f:
         ...     _ = f.write(s)
+        >>> with open('%s/info.txt' % path) as f:
+        ...     f.readlines()  # doctest: +NORMALIZE_WHITESPACE, +ELLIPSIS
+        [...databricks.koalas.frame.DataFrame...,
+        'Index: 5 entries, 0 to 4\\n',
+        'Data columns (total 3 columns):\\n',
+        'int_col      5 non-null int64\\n',
+        'text_col     5 non-null object\\n',
+        'float_col    5 non-null float64\\n',
+        'dtypes: float64(1), int64(1), object(1)']
         """
         # To avoid pandas' existing config affects Koalas.
         # TODO: should we have corresponding Koalas configs?

--- a/databricks/koalas/missing/frame.py
+++ b/databricks/koalas/missing/frame.py
@@ -57,7 +57,6 @@ class _MissingPandasLikeDataFrame(object):
     ewm = unsupported_function('ewm')
     first = unsupported_function('first')
     infer_objects = unsupported_function('infer_objects')
-    info = unsupported_function('info')
     insert = unsupported_function('insert')
     interpolate = unsupported_function('interpolate')
     itertuples = unsupported_function('itertuples')

--- a/docs/source/reference/frame.rst
+++ b/docs/source/reference/frame.rst
@@ -216,6 +216,7 @@ Serialization / IO / Conversion
    :toctree: api/
 
    DataFrame.from_records
+   DataFrame.info
    DataFrame.to_table
    DataFrame.to_delta
    DataFrame.to_parquet


### PR DESCRIPTION
This PR proposes `DataFrame.info`.

```python
>>> import databricks.koalas as ks
>>> ks.range(100).info()
<class 'databricks.koalas.frame.DataFrame'>
Index: 100 entries, 0 to 99
Data columns (total 1 columns):
id    100 non-null int64
```

Resolves #872