### PR TITLE
Fix rename() for Index to support MultiIndex also

### DIFF
--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -311,7 +311,7 @@ class Index(IndexOpsMixin):
 
     def rename(self, name: Union[str, Tuple[str, ...]], inplace: bool = False):
         """
-        Alter Index name.
+        Alter Index or MultiIndex name.
         Able to set new names without level. Defaults to returning new index.
 
         Parameters
@@ -319,11 +319,11 @@ class Index(IndexOpsMixin):
         name : label or list of labels
             Name(s) to set.
         inplace : boolean, default False
-            Modifies the object directly, instead of creating a new Index.
+            Modifies the object directly, instead of creating a new Index or MultiIndex.
 
         Returns
         -------
-        Index
+        Index or MultiIndex
             The same type as the caller or None if inplace is True.
 
         Examples
@@ -346,19 +346,29 @@ class Index(IndexOpsMixin):
         e
         A  A
         C  B
+
+        Support for MultiIndex
+
+        >>> kidx = ks.MultiIndex.from_tuples([('a', 'x'), ('b', 'y')])
+        >>> kidx.names = ['hello', 'koalas']
+        >>> kidx  # doctest: +SKIP
+        MultiIndex([('a', 'x'),
+                    ('b', 'y'),
+                    ('c', 'z')],
+                   names=['hello', 'koalas'])
+
+        >>> kidx.rename(['aloha', 'databricks'])  # doctest: +SKIP
+        MultiIndex([('a', 'x'),
+                    ('b', 'y')],
+                   names=['aloha', 'databricks'])
         """
-        index_columns = self._kdf._internal.index_columns
-        assert len(index_columns) == 1
-
-        if isinstance(name, str):
-            name = (name,)
-        internal = self._kdf._internal.copy(index_map=[(index_columns[0], name)])
-
-        if inplace:
-            self._kdf._internal = internal
-            return self
+        if not inplace:
+            self = self.copy()
+        if isinstance(self, MultiIndex):
+            self.names = name
         else:
-            return Index(DataFrame(internal), scol=self._scol)
+            self.name = name
+        return self
 
     # TODO: add downcast parameter for fillna function
     def fillna(self, value):
@@ -1090,9 +1100,6 @@ class MultiIndex(Index):
             else:
                 return partial(property_or_func, self)
         raise AttributeError("'MultiIndex' object has no attribute '{}'".format(item))
-
-    def rename(self, name, inplace=False):
-        raise NotImplementedError()
 
     def __repr__(self):
         max_display_count = get_option("display.max_rows")

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -309,7 +309,7 @@ class Index(IndexOpsMixin):
         """
         return len(self._kdf._internal.index_columns)
 
-    def rename(self, name: Union[str, Tuple[str, ...]], inplace: bool = False):
+    def rename(self, name: Union[str, Tuple[str, ...], List[str]], inplace: bool = False):
         """
         Alter Index or MultiIndex name.
         Able to set new names without level. Defaults to returning new index.

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -353,8 +353,7 @@ class Index(IndexOpsMixin):
         >>> kidx.names = ['hello', 'koalas']
         >>> kidx  # doctest: +SKIP
         MultiIndex([('a', 'x'),
-                    ('b', 'y'),
-                    ('c', 'z')],
+                    ('b', 'y')],
                    names=['hello', 'koalas'])
 
         >>> kidx.rename(['aloha', 'databricks'])  # doctest: +SKIP

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -309,7 +309,7 @@ class Index(IndexOpsMixin):
         """
         return len(self._kdf._internal.index_columns)
 
-    def rename(self, name: Union[str, Tuple[str, ...], List[str]], inplace: bool = False):
+    def rename(self, name: Union[str, Tuple[str, ...]], inplace: bool = False):
         """
         Alter Index or MultiIndex name.
         Able to set new names without level. Defaults to returning new index.
@@ -364,7 +364,7 @@ class Index(IndexOpsMixin):
         if not inplace:
             self = self.copy()
         if isinstance(self, MultiIndex):
-            self.names = name
+            self.names = name  # type: ignore
         else:
             self.name = name
         return self

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -357,3 +357,15 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
                 NotImplementedError,
                 "notna is not defined for MultiIndex"):
             kidx.notnull()
+
+    def test_multiindex_rename(self):
+        pidx = pd.MultiIndex.from_tuples([('a', 'x', 1), ('b', 'y', 2), ('c', 'z', 3)])
+        kidx = ks.MultiIndex.from_tuples([('a', 'x', 1), ('b', 'y', 2), ('c', 'z', 3)])
+
+        pidx = pidx.rename(list('ABC'))
+        kidx = kidx.rename(list('ABC'))
+        self.assert_eq(pidx, kidx)
+
+        pidx = pidx.rename(['my', 'name', 'is'])
+        kidx = kidx.rename(['my', 'name', 'is'])
+        self.assert_eq(pidx, kidx)

--- a/docs/source/reference/indexing.rst
+++ b/docs/source/reference/indexing.rst
@@ -42,6 +42,7 @@ Modifying and computations
    Index.is_object
    Index.min
    Index.max
+   Index.rename
    Index.value_counts
 
 Missing Values
@@ -118,6 +119,7 @@ MultiIndex Modifying and computations
    :toctree: api/
 
    MultiIndex.copy
+   MultiIndex.rename
    MultiIndex.value_counts
 
 MultiIndex Combining / joining / set operations


### PR DESCRIPTION
the existing implementation can support only `Index`

so fix it to support `MultiIndex` also.

```python
>>> kidx = ks.MultiIndex.from_tuples([('a', 'x'), ('b', 'y')])
>>> kidx.names = ['hello', 'koalas']
>>> kidx
MultiIndex([('a', 'x'),
            ('b', 'y'),
            ('c', 'z')],
           names=['hello', 'koalas'])

>>> kidx.rename(['aloha', 'databricks'])
MultiIndex([('a', 'x'),
            ('b', 'y')],
           names=['aloha', 'databricks'])
```