### PR TITLE
Support arithmetic and comparison APIs on itself in DataFrame

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -109,6 +109,12 @@ circle          1      361
 triangle        4      181
 rectangle       5      361
 
+>>> df.add(df)
+           angles  degrees
+circle          0      720
+triangle        6      360
+rectangle       8      720
+
 >>> df.radd(1)
            angles  degrees
 circle          1      361
@@ -500,7 +506,11 @@ class DataFrame(_Frame, Generic[T]):
             # DataFrame and Series
             applied = []
             for idx in self._internal.column_index:
-                applied.append(getattr(self[idx], op)(other))
+                if isinstance(other, DataFrame):
+                    argument = other[idx]
+                else:
+                    argument = other
+                applied.append(getattr(self[idx], op)(argument))
 
             sdf = self._sdf.select(
                 self._internal.index_scols + [c._scol for c in applied])


### PR DESCRIPTION
This PR fixes the existing DataFrame's arithmetic and comparison APIs to take the same DataFrame as its argument. See below:

```python
>>> import databricks.koalas as ks
>>> kdf = ks.range(10)
>>> kdf + kdf
   id
0   0
1   2
2   4
3   6
4   8
5  10
6  12
7  14
8  16
9  18
```