### PR TITLE
'isna' type functions should return proper message for MultiIndex

### DIFF
--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -604,7 +604,7 @@ class IndexOpsMixin(object):
         """
         from databricks.koalas.indexes import MultiIndex
         if isinstance(self, MultiIndex):
-            raise NotImplementedError("isna is not defined for MultiIndex")
+            raise NotImplementedError("notna is not defined for MultiIndex")
         return (~self.isnull()).rename(self.name)
 
     notna = notnull

--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -558,6 +558,9 @@ class IndexOpsMixin(object):
         >>> ser.rename("a").to_frame().set_index("a").index.isna()
         Index([False, False, True], dtype='object', name='a')
         """
+        from databricks.koalas.indexes import MultiIndex
+        if isinstance(self, MultiIndex):
+            raise NotImplementedError("isna is not defined for MultiIndex")
         if isinstance(self.spark_type, (FloatType, DoubleType)):
             return self._with_new_scol(self._scol.isNull() | F.isnan(self._scol)).rename(self.name)
         else:
@@ -599,6 +602,9 @@ class IndexOpsMixin(object):
         >>> ser.rename("a").to_frame().set_index("a").index.notna()
         Index([True, True, False], dtype='object', name='a')
         """
+        from databricks.koalas.indexes import MultiIndex
+        if isinstance(self, MultiIndex):
+            raise NotImplementedError("isna is not defined for MultiIndex")
         return (~self.isnull()).rename(self.name)
 
     notna = notnull

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -350,10 +350,10 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
 
         with self.assertRaisesRegex(
                 NotImplementedError,
-                "isna is not defined for MultiIndex"):
+                "notna is not defined for MultiIndex"):
             kidx.notna()
 
         with self.assertRaisesRegex(
                 NotImplementedError,
-                "isna is not defined for MultiIndex"):
+                "notna is not defined for MultiIndex"):
             kidx.notnull()

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -334,3 +334,26 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
 
         with self.assertRaisesRegex(TypeError, "Unsupported type <class 'list'>"):
             kidx.fillna([1, 2])
+
+    def test_multiindex_isna(self):
+        kidx = ks.MultiIndex.from_tuples([('a', 'x', 1), ('b', 'y', 2), ('c', 'z', 3)])
+
+        with self.assertRaisesRegex(
+                NotImplementedError,
+                "isna is not defined for MultiIndex"):
+            kidx.isna()
+
+        with self.assertRaisesRegex(
+                NotImplementedError,
+                "isna is not defined for MultiIndex"):
+            kidx.isnull()
+
+        with self.assertRaisesRegex(
+                NotImplementedError,
+                "isna is not defined for MultiIndex"):
+            kidx.notna()
+
+        with self.assertRaisesRegex(
+                NotImplementedError,
+                "isna is not defined for MultiIndex"):
+            kidx.notnull()


### PR DESCRIPTION
In pandas, `pd.MultiIndex.isna()`, `pd.MultiIndex.isnull()`, `pd.MultiIndex.notna()`, `pd.MultiIndex.notnull()` return same error message that `isna is not defined for MultiIndex` like below.

```python
>>> pidx = pd.MultiIndex.from_tuples([('a', 'x', 1), ('b', 'y', 2)])

>>> pidx.isna()
Traceback (most recent call last):
...
NotImplementedError: isna is not defined for MultiIndex

>>> pidx.isnull()
Traceback (most recent call last):
...
NotImplementedError: isna is not defined for MultiIndex

>>> pidx.notna()
Traceback (most recent call last):
...
NotImplementedError: isna is not defined for MultiIndex

>>> pidx.notnull()
Traceback (most recent call last):
...
NotImplementedError: isna is not defined for MultiIndex
```

i think we'd better mimic them for our functions.