### PR TITLE
Set the upper-bound for pandas.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 # Dependencies in Koalas. When you update don't forget to update setup.py and install.rst in docs.
-pandas>=0.23.2
+pandas>=0.23.2,<1.0
 pyarrow>=0.10,<0.15
 matplotlib>=3.0.0
 numpy>=1.14

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     },
     python_requires='>=3.5',
     install_requires=[
-        'pandas>=0.23.2',
+        'pandas>=0.23.2,<1.0',
         'pyarrow>=0.10,<0.15',
         'numpy>=1.14',
         'matplotlib>=3.0.0',


### PR DESCRIPTION
Pandas 1.0.0 will be released soon and it says it will only support Python 3.6.1 and higher, and also it might contain behavior changes.
We will still support Python 3.5 for a while, we should set the upper-bound for pandas for now to confirm Koalas works with it.