### PR TITLE
Implement from_product() for MultiIndex

### DIFF
--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -1001,6 +1001,48 @@ class MultiIndex(Index):
             arrays=arrays, sortorder=sortorder, names=names
         )).index
 
+    @staticmethod
+    def from_product(iterables, sortorder=None, names=None):
+        """
+        Make a MultiIndex from the cartesian product of multiple iterables.
+
+        Parameters
+        ----------
+        iterables : list / sequence of iterables
+            Each iterable has unique labels for each level of the index.
+        sortorder : int or None
+            Level of sortedness (must be lexicographically sorted by that
+            level).
+        names : list / sequence of str, optional
+            Names for the levels in the index.
+
+        Returns
+        -------
+        index : MultiIndex
+
+        See Also
+        --------
+        MultiIndex.from_arrays : Convert list of arrays to MultiIndex.
+        MultiIndex.from_tuples : Convert list of tuples to MultiIndex.
+
+        Examples
+        --------
+        >>> numbers = [0, 1, 2]
+        >>> colors = ['green', 'purple']
+        >>> ks.MultiIndex.from_product([numbers, colors],
+        ...                            names=['number', 'color'])  # doctest: +SKIP
+        MultiIndex([(0,  'green'),
+                    (0, 'purple'),
+                    (1,  'green'),
+                    (1, 'purple'),
+                    (2,  'green'),
+                    (2, 'purple')],
+                   names=['number', 'color'])
+        """
+        return DataFrame(index=pd.MultiIndex.from_product(
+            iterables=iterables, sortorder=sortorder, names=names
+        )).index
+
     @property
     def name(self) -> str:
         raise PandasNotImplementedError(class_name='pd.MultiIndex', property_name='name')

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -405,3 +405,10 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         pidx = pidx.rename(['my', 'name', 'is'])
         kidx = kidx.rename(['my', 'name', 'is'])
         self.assert_eq(pidx, kidx)
+
+    def test_multiindex_from_product(self):
+        iterables = [[0, 1, 2], ['green', 'purple']]
+        pidx = pd.MultiIndex.from_product(iterables)
+        kidx = ks.MultiIndex.from_product(iterables)
+
+        self.assert_eq(pidx, kidx)

--- a/docs/source/reference/indexing.rst
+++ b/docs/source/reference/indexing.rst
@@ -113,6 +113,7 @@ MultiIndex Constructors
 
    MultiIndex.from_arrays
    MultiIndex.from_tuples
+   MultiIndex.from_product
 
 MultiIndex Properties
 ~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.MultiIndex.from_product.html#pandas.MultiIndex.from_product


```python
>>> numbers = [0, 1, 2]
>>> colors = ['green', 'purple']
>>> ks.MultiIndex.from_product([numbers, colors],
...                            names=['number', 'color'])
MultiIndex([(0,  'green'),
            (0, 'purple'),
            (1,  'green'),
            (1, 'purple'),
            (2,  'green'),
            (2, 'purple')],
           names=['number', 'color'])
```