### PR TITLE
Fix some typos in install.rst & best_practices.rst

### DIFF
--- a/docs/source/getting_started/install.rst
+++ b/docs/source/getting_started/install.rst
@@ -74,7 +74,7 @@ Installing with the official release channel
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can install PySpark by downloading a release in `the official release channel <https://spark.apache.org/downloads.html>`__.
-Once you download the release, un-ter it first as below::
+Once you download the release, un-tar it first as below::
 
     tar xzvf spark-2.4.4-bin-hadoop2.7.tgz
 

--- a/docs/source/user_guide/best_practices.rst
+++ b/docs/source/user_guide/best_practices.rst
@@ -11,7 +11,7 @@ in Koalas as well. Leverage and combine those cutting-edge features with Koalas.
 Existing Spark context and Spark sessions are used out of the box in Koalas. If you already have your own
 configured Spark context or sessions running, Koalas uses them.
 
-If there is no Spark context or session running in your environment (e.g., ordinary Python interpretor),
+If there is no Spark context or session running in your environment (e.g., ordinary Python interpreter),
 such configurations can be set to ``SparkContext`` and/or ``SparkSession``.
 Once Spark context and/or session is created, Koalas can use this context and/or session automatically.
 For example, if you want to configure the executor memory in Spark, you can do as below:


### PR DESCRIPTION
It's nothing special.
I found a few typos, check it out please.

- in docs/source/getting_started/install.rst
    - un-ter -> un-tar

- in docs/source/user_guide/best_practices.rst 
    - interpretor -> interpreter

Thank you.