### PR TITLE
Add len() for Index & MultiIndex

### DIFF
--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -988,6 +988,9 @@ class Index(IndexOpsMixin):
     def __xor__(self, other):
         return self.symmetric_difference(other)
 
+    def __len__(self):
+        return self.size
+
 
 class MultiIndex(Index):
     """

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -451,3 +451,14 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         kidx = ks.MultiIndex.from_product(iterables)
 
         self.assert_eq(pidx, kidx)
+
+    def test_len(self):
+        pidx = pd.Index(range(10000))
+        kidx = ks.Index(range(10000))
+
+        self.assert_eq(len(pidx), len(kidx))
+
+        pidx = pd.MultiIndex.from_tuples([('a', 'x', 1), ('b', 'y', 2), ('c', 'z', 3)])
+        kidx = ks.MultiIndex.from_tuples([('a', 'x', 1), ('b', 'y', 2), ('c', 'z', 3)])
+
+        self.assert_eq(len(pidx), len(kidx))


### PR DESCRIPTION
an alias for `size`

```python
>>> pidx = pd.Index(range(1000))
>>> kidx = ks.Index(range(1000))
>>> len(pidx)
1000
>>> len(kidx)
1000
```

for MultiIndex

```python
>>> pidx = pd.MultiIndex.from_tuples([('a', 'x', 1), ('b', 'y', 2), ('c', 'z', 3)])
>>> kidx = ks.MultiIndex.from_tuples([('a', 'x', 1), ('b', 'y', 2), ('c', 'z', 3)])
>>> len(pidx)
3
>>> len(kidx)
3
```