### PR TITLE
Suggesting add parameter default_index_type to attach_default_index()

### DIFF
--- a/databricks/koalas/internal.py
+++ b/databricks/koalas/internal.py
@@ -467,13 +467,14 @@ class _InternalFrame(object):
             self._column_index_names = column_index_names
 
     @staticmethod
-    def attach_default_index(sdf):
+    def attach_default_index(sdf, default_index_type=None):
         """
         This method attaches a default index to Spark DataFrame. Spark does not have the index
         notion so corresponding column should be generated.
         There are several types of default index can be configured by `compute.default_index_type`.
         """
-        default_index_type = get_option("compute.default_index_type")
+        if default_index_type is None:
+            default_index_type = get_option("compute.default_index_type")
         if default_index_type == "sequence":
             sequential_index = F.row_number().over(
                 Window.orderBy(NATURAL_ORDER_COLUMN_NAME)) - 1


### PR DESCRIPTION
when i want to make default index column for spark dataframe,

i usually use `_InternalFrame.attach_default_index()` like below

```python
>>> from databricks.koalas.config import set_option, get_option
>>> origin_option = get_option("compute.default_index_type")
>>> set_option("compute.default_index_type", "distributed-sequence")
>>> try:
...     _InternalFrame.attach_default_index(sdf)
... finally:
...     set_option("compute.default_index_type", origin_option)
```

and i felt annoying and thought that it harms code readability also.

so i suggest a parameter `default_index_type` for `_InternalFrame.attach_default_index()`,

so that we can simply use like below if this parameter will be added.

```python
>>> _InternalFrame.attach_default_index(sdf, default_index_type="distributed-sequence")
```