### PR TITLE
DataFrameGroupBy.describe

### DIFF
--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -215,7 +215,8 @@ class GroupBy(object):
                 # Implement "quartiles" aggregate function for ``describe``.
                 elif aggfunc == "quartiles":
                     reordered.append(
-                        F.expr('percentile_approx(`{0}`, array(0.25, 0.5, 0.75)) as `{1}`'.format(name, data_col)))
+                        F.expr('percentile_approx(`{0}`, array(0.25, 0.5, 0.75)) as `{1}`'.format(
+                            name, data_col)))
 
                 else:
                     reordered.append(F.expr('{1}(`{0}`) as `{2}`'.format(name, aggfunc, data_col)))

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -22,6 +22,7 @@ import sys
 import inspect
 from collections import Callable, OrderedDict, namedtuple
 from functools import partial
+from itertools import product
 from typing import Any, List, Tuple, Union
 
 import numpy as np
@@ -245,7 +246,10 @@ class GroupBy(object):
         kdf.set_index([(key, "") for key in input_groupnames], inplace=True)
         kdf.index.names = input_groupnames
 
-        return kdf
+        # Reorder columns lexicographically by agg column followed by stats.
+        agg_cols = (col.name for col in self._agg_columns)
+        stats = ["count", "mean", "std", "min", "25%", "50%", "75%", "max"]
+        return kdf[list(product(agg_cols, stats))]
 
     def count(self):
         """

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -249,7 +249,11 @@ class GroupBy(object):
         # Reorder columns lexicographically by agg column followed by stats.
         agg_cols = (col.name for col in self._agg_columns)
         stats = ["count", "mean", "std", "min", "25%", "50%", "75%", "max"]
-        return kdf[list(product(agg_cols, stats))]
+        order = list(product(agg_cols, stats))
+        kdf = kdf[order]
+
+        # Cast columns to ``"float64"`` to match `pandas.DataFrame.groupby`.
+        return kdf.astype({col: "float64" for col in order})
 
     def count(self):
         """

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -249,11 +249,10 @@ class GroupBy(object):
         # Reorder columns lexicographically by agg column followed by stats.
         agg_cols = (col.name for col in self._agg_columns)
         stats = ["count", "mean", "std", "min", "25%", "50%", "75%", "max"]
-        order = list(product(agg_cols, stats))
-        kdf = kdf[order]
+        kdf = kdf[list(product(agg_cols, stats))]
 
         # Cast columns to ``"float64"`` to match `pandas.DataFrame.groupby`.
-        return kdf.astype({col: "float64" for col in order})
+        return kdf.astype("float64")
 
     def count(self):
         """

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -23,6 +23,7 @@ import inspect
 from collections import Callable, OrderedDict, namedtuple
 from functools import partial
 from itertools import product
+from operator import itemgetter
 from typing import Any, List, Tuple, Union
 
 import numpy as np
@@ -34,6 +35,7 @@ from pyspark.sql.types import FloatType, DoubleType, NumericType, StructField, S
 from pyspark.sql.functions import PandasUDFType, pandas_udf, Column
 
 from databricks import koalas as ks  # For running doctests and reference resolution in PyCharm.
+from databricks.koalas.base import _column_op
 from databricks.koalas.typedef import _infer_return_type
 from databricks.koalas.frame import DataFrame
 from databricks.koalas.internal import (_InternalFrame, HIDDEN_COLUMNS, NATURAL_ORDER_COLUMN_NAME,
@@ -1946,12 +1948,17 @@ class DataFrameGroupBy(GroupBy):
 
     def describe(self):
         kdf = self.agg(["count", "mean", "std", "min", "quartiles", "max"]).reset_index()
+        formatted_percentiles = ["25%", "50%", "75%"]
 
         # Split "quartiles" columns into first, second, and third quartiles.
         for label, content in kdf.iteritems():
             if label[1] == "quartiles":
-                exploded = ks.DataFrame(content.tolist())
-                exploded.columns = [(label[0], "25%"), (label[0], "50%"), (label[0], "75%")]
+                exploded = ks.DataFrame(
+                    {
+                        (label[0], x): _column_op(itemgetter(i))(content).to_numpy()
+                        for i, x in enumerate(formatted_percentiles)
+                    }
+                )
                 kdf = kdf.drop(label).join(exploded)
 
         # Reindex the DataFrame to reflect initial grouping and agg columns.
@@ -1961,7 +1968,7 @@ class DataFrameGroupBy(GroupBy):
 
         # Reorder columns lexicographically by agg column followed by stats.
         agg_cols = (col.name for col in self._agg_columns)
-        stats = ["count", "mean", "std", "min", "25%", "50%", "75%", "max"]
+        stats = ["count", "mean", "std", "min"] + formatted_percentiles + ["max"]
         kdf = kdf[list(product(agg_cols, stats))]
 
         # Cast columns to ``"float64"`` to match `pandas.DataFrame.groupby`.

--- a/databricks/koalas/missing/groupby.py
+++ b/databricks/koalas/missing/groupby.py
@@ -50,7 +50,6 @@ class _MissingPandasLikeDataFrameGroupBy(object):
     # Functions
     boxplot = unsupported_function('boxplot')
     cumcount = unsupported_function('cumcount')
-    describe = unsupported_function('describe')
     get_group = unsupported_function('get_group')
     median = unsupported_function('median')
     ngroup = unsupported_function('ngroup')

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -265,10 +265,19 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         describe_kdf = kdf.groupby("a").describe().sort_index()
 
         # Check that non-percentile columns are equal.
-        agg_cols = (col.name for col in kdf.groupby("a")._agg_columns)
+        agg_cols = [col.name for col in kdf.groupby("a")._agg_columns]
         formatted_percentiles = ["25%", "50%", "75%"]
         self.assert_eq(describe_kdf.drop(list(product(agg_cols, formatted_percentiles))),
                        describe_pdf.drop(columns=formatted_percentiles, level=1))
+
+        # Check that percentile columns are equal.
+        percentiles = [0.25, 0.5, 0.75]
+        # The interpolation argument is yet to be implemented in Koalas.
+        quantile_pdf = pdf.groupby("a").quantile(percentiles, interpolation="nearest")
+        quantile_pdf = quantile_pdf.unstack(level=1).astype(float)
+        non_percentile_stats = ["count", "mean", "std", "min", "max"]
+        self.assert_eq(describe_kdf.drop(list(product(agg_cols, non_percentile_stats))),
+                       quantile_pdf.rename(columns="{:.0%}".format, level=1))
 
     def test_all_any(self):
         pdf = pd.DataFrame({'A': [1, 1, 2, 2, 3, 3, 4, 4, 5, 5],


### PR DESCRIPTION
Close #1166 

Manual test:

```
>>> import databricks.koalas as ks
>>> df = ks.DataFrame({'a': [1, 1, 3], 'b': [4, 5, 6], 'c': [7, 8, 9]})
20/01/04 18:16:35 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
Using Spark's default log4j profile: org/apache/spark/log4j-defaults.properties
Setting default log level to "WARN".
To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).
>>> df.groupby('a').describe()
20/01/04 18:17:09 WARN WindowExec: No Partition Defined for Window operation! Moving all data to a single partition, this can cause serious performance degradation.
20/01/04 18:17:10 WARN WindowExec: No Partition Defined for Window operation! Moving all data to a single partition, this can cause serious performance degradation.
20/01/04 18:17:11 WARN WindowExec: No Partition Defined for Window operation! Moving all data to a single partition, this can cause serious performance degradation.
      b                                        c                                   
  count mean       std min 25% 50% 75% max count mean       std min 25% 50% 75% max
a                                                                                  
1     2  4.5  0.707107   4   4   4   5   5     2  7.5  0.707107   7   7   7   8   8
3     1  6.0       NaN   6   6   6   6   6     1  9.0       NaN   9   9   9   9   9
```

TODO:

- [x] Fix formatting (line length over 100, etc.)
- [ ] Add docstring
- [x] Add unit tests
- [x] Reorder percentiles