### PR TITLE
[WIP] Support MultiIndex for `loc` indexer with slice as `row_sel`.

### DIFF
--- a/databricks/koalas/indexing.py
+++ b/databricks/koalas/indexing.py
@@ -562,7 +562,6 @@ class LocIndexer(_LocIndexerLike):
             else:
                 LocIndexer._raiseNotImplemented("Cannot select with MultiIndex with Spark.")
         else:
-            # TODO: 아마 여기가 rows_sel이 slice가 아닐때의 처리인듯?
             if not isinstance(rows_sel, tuple):
                 rows_sel = (rows_sel,)
             if len(rows_sel) > len(self._internal.index_map):

--- a/databricks/koalas/tests/test_indexing.py
+++ b/databricks/koalas/tests/test_indexing.py
@@ -313,7 +313,7 @@ class IndexingTest(ReusedSQLTestCase):
         pdf = pdf.set_index('b', append=True)
 
         self.assert_eq(kdf.loc[:], pdf.loc[:])
-        self.assertRaises(NotImplementedError, lambda: kdf.loc[5:5])
+        self.assert_eq(kdf.loc[5:5], pdf.loc[5:5])
 
         self.assert_eq(kdf.loc[5], pdf.loc[5])
         self.assert_eq(kdf.loc[9], pdf.loc[9])
@@ -324,6 +324,40 @@ class IndexingTest(ReusedSQLTestCase):
         self.assertTrue((kdf.a.loc[(5, 3)] == pdf.a.loc[(5, 3)]).all())
         self.assert_eq(kdf.a.loc[(9, 0)], pdf.a.loc[(9, 0)])
 
+        # MultiIndex with slice as `row_sel`
+        data = [('x', 'a'), ('x', 'b'), ('y', 'c'), ('y', 'd'), ('z', 'e')]
+        pser = pd.Series([1, 2, 3, 4, 5],
+                         index=pd.MultiIndex.from_tuples(data))
+        kser = ks.from_pandas(pser)
+
+        self.assert_eq(
+            pser.loc['y':],
+            kser.loc['y':])
+
+        self.assert_eq(
+            pser.loc[:'y'],
+            kser.loc[:'y'])
+
+        self.assert_eq(
+            pser.loc[('x', 'b'):],
+            kser.loc[('x', 'b'):])
+
+        self.assert_eq(
+            pser.loc[:('y', 'c')],
+            kser.loc[:('y', 'c')])
+
+        self.assert_eq(
+            pser.loc[('x', 'b'):('y', 'c')],
+            kser.loc[('x', 'b'):('y', 'c')])
+
+        self.assert_eq(
+            pser.loc['x':('y', 'c')],
+            kser.loc['x':('y', 'c')])
+
+        self.assert_eq(
+            pser.loc[('x', 'b'):'y'],
+            kser.loc[('x', 'b'):'y'])
+
     def test_loc2d_multiindex(self):
         kdf = self.kdf
         kdf = kdf.set_index('b', append=True)
@@ -332,7 +366,7 @@ class IndexingTest(ReusedSQLTestCase):
 
         self.assert_eq(kdf.loc[:, :], pdf.loc[:, :])
         self.assert_eq(kdf.loc[:, 'a'], pdf.loc[:, 'a'])
-        self.assertRaises(NotImplementedError, lambda: kdf.loc[5:5, 'a'])
+        self.assert_eq(kdf.loc[5:5, 'a'], pdf.loc[5:5, 'a'])
 
     def test_loc2d(self):
         kdf = self.kdf


### PR DESCRIPTION
Resolves #1175 

```python
>>> kser
x  a    1
   b    2
y  c    3
   d    4
z  e    5
Name: 0, dtype: int64

>>> kser.loc['y':]
y  c    3
   d    4
z  e    5
Name: 0, dtype: int64

>>> kser.loc[:'y']
x  a    1
   b    2
y  c    3
   d    4
Name: 0, dtype: int64

>>> kser.loc[('x', 'b'):]
x  b    2
y  c    3
   d    4
z  e    5
Name: 0, dtype: int64

>>> kser.loc[:('y', 'c')]
x  a    1
   b    2
y  c    3
Name: 0, dtype: int64

>>> kser.loc[('x', 'b'):('y', 'c')]
x  b    2
y  c    3
Name: 0, dtype: int64

>>> kser.loc['x':('y', 'c')]
x  a    1
   b    2
y  c    3
Name: 0, dtype: int64

>>> kser.loc[('x', 'b'):'y']
x  b    2
y  c    3
   d    4
Name: 0, dtype: int64
```