### PR TITLE
[WIP] Support slice as `col_sel` for `loc` indexer

### DIFF
--- a/databricks/koalas/indexing.py
+++ b/databricks/koalas/indexing.py
@@ -520,6 +520,7 @@ class LocIndexer(_LocIndexerLike):
         :param key: the multi-index column keys represented by tuple
         :return: DataFrame or Series
         """
+        assert isinstance(key, tuple)
         if indexes is None:
             indexes = [(idx, idx) for idx in self._internal.column_index]
         for k in key:
@@ -529,8 +530,7 @@ class LocIndexer(_LocIndexerLike):
 
         if all(len(idx) > 0 and idx[0] == '' for _, idx in indexes):
             # If the head is '', drill down recursively.
-            indexes = [(col, tuple([str(key), *idx[1:]]))
-                       for i, (col, idx) in enumerate(indexes)]
+            indexes = [(col, tuple([str(key), *idx[1:]])) for i, (col, idx) in enumerate(indexes)]
             return self._get_from_multiindex_column((str(key),), indexes)
         else:
             returns_series = all(len(idx) == 0 for _, idx in indexes)

--- a/databricks/koalas/indexing.py
+++ b/databricks/koalas/indexing.py
@@ -520,31 +520,65 @@ class LocIndexer(_LocIndexerLike):
         :param key: the multi-index column keys represented by tuple
         :return: DataFrame or Series
         """
-        assert isinstance(key, tuple)
-        if indexes is None:
-            indexes = [(idx, idx) for idx in self._internal.column_index]
-        for k in key:
-            indexes = [(index, idx[1:]) for index, idx in indexes if idx[0] == k]
-            if len(indexes) == 0:
-                raise KeyError(k)
+        if isinstance(key, tuple):
+            if indexes is None:
+                indexes = [(idx, idx) for idx in self._internal.column_index]
+            for k in key:
+                indexes = [(index, idx[1:]) for index, idx in indexes if idx[0] == k]
+                if len(indexes) == 0:
+                    raise KeyError(k)
 
-        if all(len(idx) > 0 and idx[0] == '' for _, idx in indexes):
-            # If the head is '', drill down recursively.
-            indexes = [(col, tuple([str(key), *idx[1:]])) for i, (col, idx) in enumerate(indexes)]
-            return self._get_from_multiindex_column((str(key),), indexes)
-        else:
-            returns_series = all(len(idx) == 0 for _, idx in indexes)
-            if returns_series:
-                idxes = set(idx for idx, _ in indexes)
-                assert len(idxes) == 1
-                index = list(idxes)[0]
-                column_index = [index]
-                column_scols = [self._internal.scol_for(index)]
+            if all(len(idx) > 0 and idx[0] == '' for _, idx in indexes):
+                # If the head is '', drill down recursively.
+                indexes = [(col, tuple([str(key), *idx[1:]]))
+                           for i, (col, idx) in enumerate(indexes)]
+                return self._get_from_multiindex_column((str(key),), indexes)
             else:
-                column_index = [idx for _, idx in indexes]
-                column_scols = [self._internal.scol_for(idx) for idx, _ in indexes]
+                returns_series = all(len(idx) == 0 for _, idx in indexes)
+                if returns_series:
+                    idxes = set(idx for idx, _ in indexes)
+                    assert len(idxes) == 1
+                    index = list(idxes)[0]
+                    column_index = [index]
+                    column_scols = [self._internal.scol_for(index)]
+                else:
+                    column_index = [idx for _, idx in indexes]
+                    column_scols = [self._internal.scol_for(idx) for idx, _ in indexes]
 
-        return column_index, column_scols, returns_series
+            return column_index, column_scols, returns_series
+        elif isinstance(key, slice):
+            column_index = self._internal.column_index.copy()
+            first_column_index = ([tuple(idx[0]) for idx in column_index])
+            start = key.start
+            stop = key.stop
+
+            if not isinstance(start, (tuple, type(None))):
+                start = tuple(start)
+            if not isinstance(stop, (tuple, type(None))):
+                stop = tuple(stop)
+
+            if start in column_index:
+                start_index = column_index.index(start)
+            elif start in first_column_index:
+                start_index = first_column_index.index(start)
+            elif isinstance(key.start, type(None)):
+                start_index = 0
+
+            if stop in column_index:
+                stop_index = column_index.index(stop)
+            elif stop in first_column_index:
+                # if given `stop` is first_column_index, (e.g. 'a', not ('a', 'x'))
+                # should count whole columns belongs to it.
+                count = first_column_index.count(stop)
+                ext_len = count - 1
+                stop_index = first_column_index.index(stop) + ext_len
+            elif isinstance(key.stop, type(None)):
+                stop_index = len(column_index)
+
+            column_index = column_index[start_index:stop_index + 1]
+            column_scols = [self._internal.scol_for(idx) for idx in column_index]
+
+            return column_index, column_scols, False
 
     def _select_cols(self, cols_sel):
         from databricks.koalas.series import Series
@@ -555,8 +589,8 @@ class LocIndexer(_LocIndexerLike):
             if cols_sel == slice(None):
                 cols_sel = None
             else:
-                raise LocIndexer._raiseNotImplemented(
-                    "Can only select columns either by name or reference or all")
+                return self._get_from_multiindex_column(cols_sel)
+
         elif isinstance(cols_sel, (Series, spark.Column)):
             returns_series = True
             cols_sel = [cols_sel]

--- a/databricks/koalas/tests/test_indexing.py
+++ b/databricks/koalas/tests/test_indexing.py
@@ -375,6 +375,35 @@ class IndexingTest(ReusedSQLTestCase):
         self.assert_eq(kdf.loc['B':'B', 'bar'], pdf.loc['B':'B', 'bar'])
         self.assert_eq(kdf.loc['B':'B', ['bar']], pdf.loc['B':'B', ['bar']])
 
+        # slice as `col_sel`
+        self.assert_eq(
+            kdf.loc[:, 'bar':],
+            pdf.loc[:, 'bar':])
+
+        self.assert_eq(
+            kdf.loc[:, :'baz'],
+            pdf.loc[:, :'baz'])
+
+        self.assert_eq(
+            kdf.loc[:, ('bar', 'two'):],
+            pdf.loc[:, ('bar', 'two'):])
+
+        self.assert_eq(
+            kdf.loc[:, :('baz', 'one')],
+            pdf.loc[:, :('baz', 'one')])
+
+        self.assert_eq(
+            kdf.loc[:, ('bar', 'two'):('baz', 'one')],
+            pdf.loc[:, ('bar', 'two'):('baz', 'one')])
+
+        self.assert_eq(
+            kdf.loc[:, 'bar':('baz', 'one')],
+            pdf.loc[:, 'bar':('baz', 'one')])
+
+        self.assert_eq(
+            kdf.loc[:, ('bar', 'two'):'baz'],
+            pdf.loc[:, ('bar', 'two'):'baz'])
+
     def test_loc2d_with_known_divisions(self):
         pdf = pd.DataFrame(np.random.randn(20, 5),
                            index=list('abcdefghijklmnopqrst'),


### PR DESCRIPTION
Resolves #1176 

```python
>>> kdf
   x     y     z
   a  b  c  d  e
0  1  2  3  4  5

>>> kdf.loc[:, 'y':]
   y     z
   c  d  e
0  3  4  5

>>> kdf.loc[:, :'y']
   x     y
   a  b  c  d
0  1  2  3  4

>>> kdf.loc[:, ('x', 'b'):]
   x  y     z
   b  c  d  e
0  2  3  4  5

>>> kdf.loc[:, :('y', 'c')]
   x     y
   a  b  c
0  1  2  3

>>> kdf.loc[:, ('x', 'b'):('y', 'c')]
   x  y
   b  c
0  2  3

>>> kdf.loc[:, 'x':('y', 'c')]
   x     y
   a  b  c
0  1  2  3

>>> kdf.loc[:, ('x', 'b'):'y']
   x  y
   b  c  d
0  2  3  4
```