### PR TITLE
Fix column name as a tuple in multi column index

### DIFF
--- a/databricks/koalas/internal.py
+++ b/databricks/koalas/internal.py
@@ -742,9 +742,10 @@ class _InternalFrame(object):
                 index_map = [(SPARK_INDEX_NAME_FORMAT(i), None)
                              for i in range(len(index.levels))]
             else:
-                index_map = [(SPARK_INDEX_NAME_FORMAT(i) if name is None else name,
-                              name if name is None or isinstance(name, tuple) else (name,))
-                             for i, name in enumerate(index.names)]
+                index_map = [
+                    (SPARK_INDEX_NAME_FORMAT(i) if name is None else name_like_string(name),
+                     name if name is None or isinstance(name, tuple) else (name,))
+                    for i, name in enumerate(index.names)]
         else:
             name = index.name
             index_map = [(name_like_string(name)

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -517,6 +517,13 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
 
         self.assert_eq(pidx, kidx)
 
+    def test_multiindex_tuple_column_name(self):
+        column_index = pd.MultiIndex.from_tuples([('a', 'x'), ('a', 'y'), ('b', 'z')])
+        pdf = pd.DataFrame([[1, 2, 3], [4, 5, 6], [7, 8, 9]], columns=column_index)
+        pdf.set_index(('a', 'x'), append=True, inplace=True)
+        kdf = ks.from_pandas(pdf)
+        self.assert_eq(pdf, kdf)
+
     def test_len(self):
         pidx = pd.Index(range(10000))
         kidx = ks.Index(range(10000))


### PR DESCRIPTION
```python
import pandas as pd
import databricks.koalas as ks
column_index = pd.MultiIndex.from_tuples([('a', 'x'), ('a', 'y'), ('b', 'z')])
pdf = pd.DataFrame([[1, 2, 3], [4, 5, 6], [7, 8, 9]], columns=column_index)
pdf.set_index(('a', 'x'), append=True, inplace=True)
ks.from_pandas(pdf)
```

Before:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/.../koalas/databricks/koalas/namespace.py", line 70, in from_pandas
    return DataFrame(pobj)
  File "/.../koalas/databricks/koalas/frame.py", line 380, in __init__
    super(DataFrame, self).__init__(_InternalFrame.from_pandas(pdf))
  File "/.../koalas/databricks/koalas/internal.py", line 771, in from_pandas
    column_index_names=column_index_names)
  File "/.../koalas/databricks/koalas/internal.py", line 431, in __init__
    for index_field, index_name in index_map), index_map
AssertionError: [('__index_level_0__', None), (('a', 'x'), ('a', 'x'))]
```

After:

```
          a  b
          y  z
  (a, x)
0 1       2  3
1 4       5  6
2 7       8  9
```