### PR TITLE
Force to enable Arrow execution mode.

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -8260,8 +8260,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = ks.DataFrame({'id': range(10)})  # doctest: +SKIP
-        >>> df.explain()
+        >>> df = ks.DataFrame({'id': range(10)})
+        >>> df.explain()  # doctest: +SKIP
         == Physical Plan ==
         Scan ExistingRDD arrow[__index_level_0__#...,id#...]
 

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -8260,12 +8260,12 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = ks.DataFrame({'id': range(10)})
+        >>> df = ks.DataFrame({'id': range(10)})  # doctest: +SKIP
         >>> df.explain()
         == Physical Plan ==
         Scan ExistingRDD arrow[__index_level_0__#...,id#...]
 
-        >>> df.explain(True)
+        >>> df.explain(True)  # doctest: +SKIP
         == Parsed Logical Plan ==
         ...
         == Analyzed Logical Plan ==

--- a/databricks/koalas/ml.py
+++ b/databricks/koalas/ml.py
@@ -23,6 +23,8 @@ import pyspark
 from pyspark.ml.feature import VectorAssembler
 from pyspark.ml.stat import Correlation
 
+from databricks.koalas.utils import arrow_enabled
+
 
 if TYPE_CHECKING:
     import databricks.koalas as ks
@@ -51,7 +53,8 @@ def corr(kdf: 'ks.DataFrame', method: str = 'pearson') -> pd.DataFrame:
     assert method in ('pearson', 'spearman')
     ndf, fields = to_numeric_df(kdf)
     corr = Correlation.corr(ndf, CORRELATION_OUTPUT_COLUMN, method)
-    pcorr = corr.toPandas()
+    with arrow_enabled():
+        pcorr = corr.toPandas()
     arr = pcorr.iloc[0, 0].toArray()
     arr = pd.DataFrame(arr)
     arr.columns = fields

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -45,8 +45,8 @@ from databricks.koalas.internal import (_InternalFrame, NATURAL_ORDER_COLUMN_NAM
 from databricks.koalas.missing.series import _MissingPandasLikeSeries
 from databricks.koalas.plot import KoalasSeriesPlotMethods
 from databricks.koalas.ml import corr
-from databricks.koalas.utils import (validate_arguments_and_invoke_function, scol_for,
-                                     combine_frames, name_like_string, validate_axis)
+from databricks.koalas.utils import (arrow_enabled, validate_arguments_and_invoke_function,
+                                     scol_for, combine_frames, name_like_string, validate_axis)
 from databricks.koalas.datetimes import DatetimeMethods
 from databricks.koalas.strings import StringMethods
 
@@ -3319,7 +3319,8 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
 
         if len(self._internal._index_map) == len(item):
             # if sdf has one column and one data, return data only without frame
-            pdf = sdf.limit(2).toPandas()
+            with arrow_enabled():
+                pdf = sdf.limit(2).toPandas()
             length = len(pdf)
             if length == 1:
                 self._internal = self.drop(item)._internal
@@ -4075,7 +4076,8 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
 
         if len(self._internal._index_map) == len(key):
             # if sdf has one column and one data, return data only without frame
-            pdf = sdf.limit(2).toPandas()
+            with arrow_enabled():
+                pdf = sdf.limit(2).toPandas()
             length = len(pdf)
             if length == 1:
                 return pdf[self.name].iloc[0]

--- a/databricks/koalas/utils.py
+++ b/databricks/koalas/utils.py
@@ -19,6 +19,7 @@ Commonly used utils in Koalas.
 
 import functools
 from collections import OrderedDict
+from contextlib import contextmanager
 from distutils.version import LooseVersion
 from typing import Callable, Dict, List, Tuple, Union
 
@@ -286,6 +287,28 @@ def default_session(conf=None):
     for key, value in conf.items():
         builder = builder.config(key, value)
     return builder.getOrCreate()
+
+
+@contextmanager
+def arrow_enabled():
+    """
+    Context manager to temporarily enable arrow execution in the `with` statement context.
+    """
+    session = default_session()
+    try:
+        conf = 'spark.sql.execution.arrow.pyspark.enabled'
+        orig = session.conf.get(conf, None)
+    except Exception:
+        conf = 'spark.sql.execution.arrow.enabled'
+        orig = session.conf.get(conf, None)
+    try:
+        session.conf.set(conf, True)
+        yield
+    finally:
+        if orig is None:
+            session.conf.unset(conf)
+        else:
+            session.conf.set(conf, orig)
 
 
 def validate_arguments_and_invoke_function(pobj: Union[pd.DataFrame, pd.Series],


### PR DESCRIPTION
This is part of #1200.

Currently we don't care about whether arrow execution mode is enabled or not, but it might cause the behavior difference between enabled or not. We should always use arrow execution mode.