### PR TITLE
Fix Index.to_frame() to work properly when it has renamed

### DIFF
--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -547,11 +547,12 @@ class Index(IndexOpsMixin):
         Bear    Bear
         Cow      Cow
         """
+        index_name = self.names[0]
         if name is None:
-            if self._internal.index_names[0] is None:
+            if index_name is None:
                 name = ('0',)
             else:
-                name = self._internal.index_names[0]
+                name = (index_name,)
         elif isinstance(name, str):
                 name = (name,)
         scol = self._scol.alias(name_like_string(name))
@@ -559,7 +560,10 @@ class Index(IndexOpsMixin):
         sdf = self._internal.sdf.select(scol, NATURAL_ORDER_COLUMN_NAME)
 
         if index:
-            index_map = [(name_like_string(name), self._internal.index_names[0])]
+            if index_name is not None:
+                index_map = [(name_like_string(name), (index_name,))]
+            else:
+                index_map = [(name_like_string(name), None)]
         else:
             index_map = None  # type: ignore
 

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -567,7 +567,7 @@ class Index(IndexOpsMixin):
         else:
             index_map = None  # type: ignore
 
-        internal = _InternalFrame(sdf=sdf,
+        internal = _InternalFrame(sdf=sdf,  # type: ignore
                                   index_map=index_map,
                                   column_index=[name],
                                   column_scols=[scol_for(sdf, name_like_string(name))])

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -102,6 +102,7 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         kidx.name = 'a'
 
         self.assert_eq(repr(kidx.to_frame()), repr(pidx.to_frame()))
+        self.assert_eq(repr(kidx.to_frame(index=False)), repr(pidx.to_frame(index=False)))
 
         if LooseVersion(pd.__version__) >= LooseVersion('0.24'):
             # The `name` argument is added in pandas 0.24.

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -98,6 +98,11 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         self.assert_eq(repr(kidx.to_frame()), repr(pidx.to_frame()))
         self.assert_eq(repr(kidx.to_frame(index=False)), repr(pidx.to_frame(index=False)))
 
+        pidx.name = 'a'
+        kidx.name = 'a'
+
+        self.assert_eq(repr(kidx.to_frame()), repr(pidx.to_frame()))
+
         if LooseVersion(pd.__version__) >= LooseVersion('0.24'):
             # The `name` argument is added in pandas 0.24.
             self.assert_eq(repr(kidx.to_frame(name='x')), repr(pidx.to_frame(name='x')))


### PR DESCRIPTION
Resolves #1206 


- before fix
```python
>>> idx = ks.Index(['Ant', 'Bear', 'Cow'])
>>> idx.name = 'animal'
>>> idx.to_frame()  # 'animal' is not shown in created frame.
         0
Ant    Ant
Bear  Bear
Cow    Cow

>>> idx.to_pandas().to_frame()  # we have to fix like this
       animal
animal
Ant       Ant
Bear     Bear
Cow       Cow
```

- after fix
```python
>>> idx = ks.Index(['Ant', 'Bear', 'Cow'])
>>> idx.name = 'animal'
>>> idx.to_frame()  # 'animal' is shown in created frame like pandas
       animal
animal
Ant       Ant
Bear     Bear
Cow       Cow
```