### PR TITLE
Sync with PySpark upstream in Apache Spark

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -8176,7 +8176,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         >>> df = ks.DataFrame({'id': range(10)})
         >>> df.explain()
         == Physical Plan ==
-        Scan ExistingRDD[__index_level_0__#...,id#...]
+        ...
 
         >>> df.explain(True)
         == Parsed Logical Plan ==
@@ -8186,7 +8186,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         == Optimized Logical Plan ==
         ...
         == Physical Plan ==
-        Scan ExistingRDD[__index_level_0__#...,id#...]
+        ...
         """
         self._internal.spark_internal_df.explain(extended)
 

--- a/databricks/koalas/plot.py
+++ b/databricks/koalas/plot.py
@@ -325,7 +325,7 @@ class KoalasBoxPlot(BoxPlot):
         # Computes mean, median, Q1 and Q3 with approx_percentile and precision
         pdf = (data._kdf._sdf
                .agg(*[F.expr('approx_percentile({}, {}, {})'.format(colname, q,
-                                                                    1. / precision))
+                                                                    int(1. / precision)))
                       .alias('{}_{}%'.format(colname, int(q * 100)))
                       for q in [.25, .50, .75]],
                     F.mean(colname).alias('{}_mean'.format(colname))).toPandas())

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -82,12 +82,7 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         pidx = self.pdf.set_index('b', append=True).index
         kidx = self.kdf.set_index('b', append=True).index
 
-        if LooseVersion(pyspark.__version__) < LooseVersion('2.4'):
-            # PySpark < 2.4 does not support struct type with arrow enabled.
-            with self.sql_conf({'spark.sql.execution.arrow.enabled': False}):
-                self.assert_eq(kidx.to_series(), pidx.to_series())
-                self.assert_eq(kidx.to_series(name='a'), pidx.to_series(name='a'))
-        else:
+        with self.sql_conf({'spark.sql.execution.arrow.enabled': False}):
             self.assert_eq(kidx.to_series(), pidx.to_series())
             self.assert_eq(kidx.to_series(name='a'), pidx.to_series(name='a'))
 

--- a/databricks/koalas/utils.py
+++ b/databricks/koalas/utils.py
@@ -285,6 +285,9 @@ def default_session(conf=None):
     builder = spark.SparkSession.builder.appName("Koalas")
     for key, value in conf.items():
         builder = builder.config(key, value)
+    # Currently, Koalas is dependent on such join due to 'compute.ops_on_diff_frames'
+    # configuration. This is needed with Spark 3.0+.
+    builder.config("spark.sql.analyzer.failAmbiguousSelfJoin.enabled", False)
     return builder.getOrCreate()
 
 


### PR DESCRIPTION
This PR syncs Koalas to support PySpark 3.0. It's development purpose mainly.