### PR TITLE
Implement Index/MultiIndex.equals

### DIFF
--- a/databricks/koalas/missing/indexes.py
+++ b/databricks/koalas/missing/indexes.py
@@ -46,7 +46,6 @@ class _MissingPandasLikeIndex(object):
     delete = unsupported_function('delete')
     difference = unsupported_function('difference')
     droplevel = unsupported_function('droplevel')
-    equals = unsupported_function('equals')
     factorize = unsupported_function('factorize')
     format = unsupported_function('format')
     get_indexer = unsupported_function('get_indexer')

--- a/databricks/koalas/missing/indexes.py
+++ b/databricks/koalas/missing/indexes.py
@@ -119,7 +119,6 @@ class _MissingPandasLikeMultiIndex(object):
     difference = unsupported_function('difference')
     droplevel = unsupported_function('droplevel')
     equal_levels = unsupported_function('equal_levels')
-    equals = unsupported_function('equals')
     factorize = unsupported_function('factorize')
     format = unsupported_function('format')
     get_indexer = unsupported_function('get_indexer')

--- a/docs/source/reference/indexing.rst
+++ b/docs/source/reference/indexing.rst
@@ -45,6 +45,7 @@ Modifying and computations
    Index.argmin
    Index.argmax
    Index.copy
+   Index.equals
    Index.identical
    Index.is_boolean
    Index.is_categorical
@@ -174,6 +175,7 @@ MultiIndex Modifying and computations
 .. autosummary::
    :toctree: api/
 
+   MultiIndex.equals
    MultiIndex.identical
    MultiIndex.drop
    MultiIndex.copy


### PR DESCRIPTION
```python
import databricks.koalas as ks
idx = ks.Index(['a', 'b', 'c'])
midx = ks.MultiIndex.from_tuples([('a', 'x'), ('b', 'y'), ('c', 'z')])
idx.equals(idx)
midx.equals(idx)
from databricks.koalas.config import option_context
with option_context('compute.ops_on_diff_frames', True):
    idx.equals(ks.Index(['a', 'b', 'c']))
```