### PR TITLE
Fix circular reference between Series and _InternalFrame in type hint for old Python 3.5.x

### DIFF
--- a/databricks/koalas/internal.py
+++ b/databricks/koalas/internal.py
@@ -18,7 +18,7 @@
 An internal immutable DataFrame with some metadata to manage indexes.
 """
 import re
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union, TYPE_CHECKING
 from itertools import accumulate
 
 import numpy as np
@@ -35,6 +35,9 @@ except ImportError:
     from pyspark.sql.pandas.types import to_arrow_type
 
 from databricks import koalas as ks  # For running doctests and reference resolution in PyCharm.
+if TYPE_CHECKING:
+    # This is required in old Python 3.5 to prevent circular reference.
+    from databricks.koalas.series import Series
 from databricks.koalas.config import get_option
 from databricks.koalas.typedef import infer_pd_series_spark_type, spark_type_to_pandas_dtype
 from databricks.koalas.utils import (column_index_level, default_session, lazy_property,
@@ -726,7 +729,7 @@ class _InternalFrame(object):
                                for name in index_names]
         return pdf
 
-    def with_new_columns(self, scols_or_ksers: List[Union[spark.Column, 'ks.Series']],
+    def with_new_columns(self, scols_or_ksers: List[Union[spark.Column, 'Series']],
                          column_index: Optional[List[Tuple[str, ...]]] = None,
                          keep_order: bool = True) -> '_InternalFrame':
         """ Copy the immutable DataFrame with the updates by the specified Spark Columns or Series.
@@ -775,7 +778,7 @@ class _InternalFrame(object):
             column_scols=[scol_for(sdf, name_like_string(idx)) for idx in column_index],
             scol=None)
 
-    def with_filter(self, pred: Union[spark.Column, 'ks.Series']):
+    def with_filter(self, pred: Union[spark.Column, 'Series']):
         """ Copy the immutable DataFrame with the updates by the predicate.
 
         :param pred: the predicate to filter.


### PR DESCRIPTION

```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<command-3232250281008415> in <module>()
      1 import pandas as pd
      2 import numpy as np
----> 3 import databricks.koalas as ks
      4 from pyspark.sql import SparkSession

/databricks/python/lib/python3.5/site-packages/databricks/koalas/__init__.py in <module>()
     47     os.environ["ARROW_PRE_0_15_IPC_FORMAT"] = "1"
     48 
---> 49 from databricks.koalas.frame import DataFrame
     50 from databricks.koalas.indexes import Index, MultiIndex
     51 from databricks.koalas.series import Series

/databricks/python/lib/python3.5/site-packages/databricks/koalas/frame.py in <module>()
     47 from databricks import koalas as ks  # For running doctests and reference resolution in PyCharm.
     48 from databricks.koalas.utils import validate_arguments_and_invoke_function, align_diff_frames
---> 49 from databricks.koalas.generic import _Frame
     50 from databricks.koalas.internal import (_InternalFrame, HIDDEN_COLUMNS, NATURAL_ORDER_COLUMN_NAME,
     51                                         SPARK_INDEX_NAME_FORMAT)

/databricks/python/lib/python3.5/site-packages/databricks/koalas/generic.py in <module>()
     33 
     34 from databricks import koalas as ks  # For running doctests and reference resolution in PyCharm.
---> 35 from databricks.koalas.indexing import AtIndexer, iAtIndexer, ILocIndexer, LocIndexer
     36 from databricks.koalas.internal import _InternalFrame, NATURAL_ORDER_COLUMN_NAME
     37 from databricks.koalas.utils import validate_arguments_and_invoke_function, scol_for

/databricks/python/lib/python3.5/site-packages/databricks/koalas/indexing.py in <module>()
     26 from pyspark.sql.utils import AnalysisException
     27 
---> 28 from databricks.koalas.internal import (_InternalFrame, HIDDEN_COLUMNS, NATURAL_ORDER_COLUMN_NAME,
     29                                         SPARK_INDEX_NAME_FORMAT)
     30 from databricks.koalas.exceptions import SparkPandasIndexingError, SparkPandasNotImplementedError

/databricks/python/lib/python3.5/site-packages/databricks/koalas/internal.py in <module>()
     54 
     55 
---> 56 class _InternalFrame(object):
     57     """
     58     The internal immutable DataFrame which manages Spark DataFrame and column names and index

/databricks/python/lib/python3.5/site-packages/databricks/koalas/internal.py in _InternalFrame()
    729     def with_new_columns(self, scols_or_ksers: List[Union[spark.Column, 'ks.Series']],
    730                          column_index: Optional[List[Tuple[str, ...]]] = None,
--> 731                          keep_order: bool = True) -> '_InternalFrame':
    732         """ Copy the immutable DataFrame with the updates by the specified Spark Columns or Series.
    733 

/usr/lib/python3.5/typing.py in __getitem__(self, parameters)
    550             parameters = (parameters,)
    551         return self.__class__(self.__name__, self.__bases__,
--> 552                               dict(self.__dict__), parameters, _root=True)
    553 
    554     def __eq__(self, other):

/usr/lib/python3.5/typing.py in __new__(cls, name, bases, namespace, parameters, _root)
    510                 continue
    511             if any(isinstance(t2, type) and issubclass(t1, t2)
--> 512                    for t2 in all_params - {t1} if not isinstance(t2, TypeVar)):
    513                 all_params.remove(t1)
    514         # It's not a union if there's only one type left.

/usr/lib/python3.5/typing.py in <genexpr>(.0)
    510                 continue
    511             if any(isinstance(t2, type) and issubclass(t1, t2)
--> 512                    for t2 in all_params - {t1} if not isinstance(t2, TypeVar)):
    513                 all_params.remove(t1)
    514         # It's not a union if there's only one type left.

/usr/lib/python3.5/typing.py in __subclasscheck__(self, cls)
    188             localns = self.__forward_frame__.f_locals
    189             try:
--> 190                 self._eval_type(globalns, localns)
    191             except NameError:
    192                 return False  # Too early.

/usr/lib/python3.5/typing.py in _eval_type(self, globalns, localns)
    175                 localns = globalns
    176             self.__forward_value__ = _type_check(
--> 177                 eval(self.__forward_code__, globalns, localns),
    178                 "Forward references must evaluate to types.")
    179             self.__forward_evaluated__ = True

/databricks/python/lib/python3.5/site-packages/databricks/koalas/internal.py in <module>()

AttributeError: module 'databricks.koalas' has no attribute 'Series'
```
