### PR TITLE
Make attach_default_index generate the index column name.

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -2696,8 +2696,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             # Now, new internal Spark columns are named as same as index name.
             new_index_map = [(column, name) for column, name in new_index_map]
 
-            index_map = [(SPARK_INDEX_NAME_FORMAT(0), None)]
-            sdf = _InternalFrame.attach_default_index(sdf)
+            sdf, index_column = _InternalFrame.attach_default_index(sdf)
+            index_map = [(index_column, None)]
 
         if drop:
             new_index_map = []

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -1220,7 +1220,7 @@ class Index(IndexOpsMixin):
         sdf = self._internal.sdf
         sdf = sdf.select(self._scol.alias('__index_value__'))
 
-        sdf = _InternalFrame.attach_default_index(
+        sdf, index_column = _InternalFrame.attach_default_index(
             sdf, default_index_type='distributed-sequence')
         # sdf here looks like below
         # +-----------------+---------------+
@@ -1239,7 +1239,7 @@ class Index(IndexOpsMixin):
 
         return sdf.orderBy(
             F.col('__index_value__').desc(),
-            F.col('__index_level_0__').asc()).first()[0]
+            F.col(index_column).asc()).first()[0]
 
     def argmin(self):
         """
@@ -1264,12 +1264,12 @@ class Index(IndexOpsMixin):
         """
         sdf = self._internal.sdf
         sdf = sdf.select(self._scol.alias('__index_value__'))
-        sdf = _InternalFrame.attach_default_index(
+        sdf, index_column = _InternalFrame.attach_default_index(
             sdf, default_index_type='distributed-sequence')
 
         return sdf.orderBy(
             F.col('__index_value__').asc(),
-            F.col('__index_level_0__').asc()).first()[0]
+            F.col(index_column).asc()).first()[0]
 
     def set_names(self, names, level=None, inplace=False):
         """

--- a/databricks/koalas/indexing.py
+++ b/databricks/koalas/indexing.py
@@ -198,8 +198,9 @@ class iAtIndexer(_IndexerLike):
 
         sdf = self._internal.sdf.select(self._internal.data_columns)
 
-        sdf = _InternalFrame.attach_default_index(sdf, default_index_type="distributed-sequence")
-        cond = F.col(SPARK_INDEX_NAME_FORMAT(0)) == row_sel
+        sdf, index_column = \
+            _InternalFrame.attach_default_index(sdf, default_index_type="distributed-sequence")
+        cond = F.col(index_column) == row_sel
         pdf = sdf.where(cond).select(*col_sel).toPandas()
 
         if len(pdf) < 1:


### PR DESCRIPTION
The usage of `_InternalFrame.attach_default_index` is spreading out of `_InternalFrame`, and we might not be able to control the index column name.
We should make the function generate the index column name instead of the fixed name.