### PR TITLE
Add +ELLIPSIS to DataFrame.explain doctest

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -8177,11 +8177,11 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         Examples
         --------
         >>> df = ks.DataFrame({'id': range(10)})
-        >>> df.explain()
+        >>> df.explain()  # doctest: +ELLIPSIS
         == Physical Plan ==
         ...
 
-        >>> df.explain(True)
+        >>> df.explain(True)  # doctest: +ELLIPSIS
         == Parsed Logical Plan ==
         ...
         == Analyzed Logical Plan ==


### PR DESCRIPTION
It seems failing in my InteliJ env. This PR explicitly add `+ELLIPSIS` for `...`.

```
Expected:
    == Parsed Logical Plan ==
    ...
    == Analyzed Logical Plan ==
    ...
    == Optimized Logical Plan ==
    ...
    == Physical Plan ==
    ...
Got:
    == Parsed Logical Plan ==
    Project [__index_level_0__#0L, id#1L]
    +- Project [__index_level_0__#0L, id#1L, monotonically_increasing_id() AS __natural_order__#4L]
       +- LogicalRDD [__index_level_0__#0L, id#1L], false
    <BLANKLINE>
    == Analyzed Logical Plan ==
    __index_level_0__: bigint, id: bigint
    Project [__index_level_0__#0L, id#1L]
```