### PR TITLE
Add attach_distributed_sequence_column with SPARK_DEFAULT_INDEX_NAME in InternalFrame

### DIFF
--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -31,7 +31,7 @@ from pyspark.sql.types import DoubleType, FloatType, LongType, StringType, Times
 from databricks import koalas as ks  # For running doctests and reference resolution in PyCharm.
 from databricks.koalas import numpy_compat
 from databricks.koalas.internal import (_InternalFrame, NATURAL_ORDER_COLUMN_NAME,
-                                        SPARK_INDEX_NAME_FORMAT)
+                                        SPARK_DEFAULT_INDEX_NAME)
 from databricks.koalas.typedef import pandas_wraps, spark_type_to_pandas_dtype
 from databricks.koalas.utils import align_diff_series, scol_for, validate_axis
 from databricks.koalas.frame import DataFrame
@@ -1013,7 +1013,7 @@ class IndexOpsMixin(object):
             sdf_dropna = self._internal._sdf.select(self._scol).dropna()
         else:
             sdf_dropna = self._internal._sdf.select(self._scol)
-        index_name = SPARK_INDEX_NAME_FORMAT(0)
+        index_name = SPARK_DEFAULT_INDEX_NAME
         column_name = self._internal.data_columns[0]
         sdf = sdf_dropna.groupby(scol_for(sdf_dropna, column_name).alias(index_name)).count()
         if sort:

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -48,7 +48,7 @@ from databricks import koalas as ks  # For running doctests and reference resolu
 from databricks.koalas.utils import validate_arguments_and_invoke_function, align_diff_frames
 from databricks.koalas.generic import _Frame
 from databricks.koalas.internal import (_InternalFrame, HIDDEN_COLUMNS, NATURAL_ORDER_COLUMN_NAME,
-                                        SPARK_INDEX_NAME_FORMAT)
+                                        SPARK_INDEX_NAME_FORMAT, SPARK_DEFAULT_INDEX_NAME)
 from databricks.koalas.missing.frame import _MissingPandasLikeDataFrame
 from databricks.koalas.ml import corr
 from databricks.koalas.utils import column_index_level, name_like_string, scol_for, validate_axis
@@ -2696,8 +2696,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             # Now, new internal Spark columns are named as same as index name.
             new_index_map = [(column, name) for column, name in new_index_map]
 
-            sdf, index_column = _InternalFrame.attach_default_index(sdf)
-            index_map = [(index_column, None)]
+            sdf = _InternalFrame.attach_default_index(sdf)
+            index_map = [(SPARK_DEFAULT_INDEX_NAME, None)]
 
         if drop:
             new_index_map = []
@@ -3149,7 +3149,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         sdf = self._sdf
         if column == index_column:
-            index_column = SPARK_INDEX_NAME_FORMAT(0)
+            index_column = SPARK_DEFAULT_INDEX_NAME
             sdf = sdf.select([self._internal.index_scols[0].alias(index_column)]
                              + self._internal.data_scols)
 
@@ -8137,7 +8137,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             for i in range(len(quantiles)):
                 cols_dict[column].append(scol_for(sdf, column).getItem(i).alias(column))
 
-        internal_index_column = SPARK_INDEX_NAME_FORMAT(0)
+        internal_index_column = SPARK_DEFAULT_INDEX_NAME
         cols = []
         for i, col in enumerate(zip(*cols_dict.values())):
             cols.append(F.struct(

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -23,7 +23,6 @@ import inspect
 from collections import Callable, OrderedDict, namedtuple
 from functools import partial
 from itertools import product
-from operator import itemgetter
 from typing import Any, List, Tuple, Union
 
 import numpy as np
@@ -39,7 +38,7 @@ from databricks import koalas as ks  # For running doctests and reference resolu
 from databricks.koalas.typedef import _infer_return_type
 from databricks.koalas.frame import DataFrame
 from databricks.koalas.internal import (_InternalFrame, HIDDEN_COLUMNS, NATURAL_ORDER_COLUMN_NAME,
-                                        SPARK_INDEX_NAME_FORMAT)
+                                        SPARK_INDEX_NAME_FORMAT, SPARK_DEFAULT_INDEX_NAME)
 from databricks.koalas.missing.groupby import _MissingPandasLikeDataFrameGroupBy, \
     _MissingPandasLikeSeriesGroupBy
 from databricks.koalas.series import Series, _col
@@ -1016,7 +1015,7 @@ class GroupBy(object):
                 else:
                     index_map = [(
                         index.name
-                        if index.name is not None else SPARK_INDEX_NAME_FORMAT(0), index.name)]
+                        if index.name is not None else SPARK_DEFAULT_INDEX_NAME, index.name)]
 
                 new_index_columns = [index_column for index_column, _ in index_map]
                 new_data_columns = [str(col) for col in columns]

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -1218,11 +1218,10 @@ class Index(IndexOpsMixin):
         >>> kidx.argmax()
         4
         """
-        sdf = self._internal.sdf
-        sdf = sdf.select(self._scol.alias('__index_value__'))
+        sdf = self._internal.sdf.select(self._scol)
 
-        sdf, index_column = _InternalFrame.attach_default_index(
-            sdf, default_index_type='distributed-sequence')
+        sequence_col = "__distributed_sequence_column__"
+        sdf = _InternalFrame.attach_distributed_sequence_column(sdf, column_name=sequence_col)
         # sdf here looks like below
         # +-----------------+---------------+
         # |__index_level_0__|__index_value__|
@@ -1238,9 +1237,7 @@ class Index(IndexOpsMixin):
         # |                1|              9|
         # +-----------------+---------------+
 
-        return sdf.orderBy(
-            F.col('__index_value__').desc(),
-            F.col(index_column).asc()).first()[0]
+        return sdf.orderBy(self._scol.desc(), F.col(sequence_col).asc()).first()[0]
 
     def argmin(self):
         """
@@ -1263,14 +1260,13 @@ class Index(IndexOpsMixin):
         >>> kidx.argmin()
         7
         """
-        sdf = self._internal.sdf
-        sdf = sdf.select(self._scol.alias('__index_value__'))
-        sdf, index_column = _InternalFrame.attach_default_index(
-            sdf, default_index_type='distributed-sequence')
+        sdf = self._internal.sdf.select(self._scol)
 
-        return sdf.orderBy(
-            F.col('__index_value__').asc(),
-            F.col(index_column).asc()).first()[0]
+        # This is a workaround to perform an operation based on natural order.
+        sequence_col = "__distributed_sequence_column__"
+        sdf = _InternalFrame.attach_distributed_sequence_column(sdf, column_name=sequence_col)
+
+        return sdf.orderBy(self._scol.asc(), F.col(sequence_col).asc()).first()[0]
 
     def set_names(self, names, level=None, inplace=False):
         """

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -1219,7 +1219,6 @@ class Index(IndexOpsMixin):
         4
         """
         sdf = self._internal.sdf.select(self._scol)
-
         sequence_col = "__distributed_sequence_column__"
         sdf = _InternalFrame.attach_distributed_sequence_column(sdf, column_name=sequence_col)
         # sdf here looks like below
@@ -1261,8 +1260,6 @@ class Index(IndexOpsMixin):
         7
         """
         sdf = self._internal.sdf.select(self._scol)
-
-        # This is a workaround to perform an operation based on natural order.
         sequence_col = "__distributed_sequence_column__"
         sdf = _InternalFrame.attach_distributed_sequence_column(sdf, column_name=sequence_col)
 

--- a/databricks/koalas/indexing.py
+++ b/databricks/koalas/indexing.py
@@ -196,8 +196,6 @@ class iAtIndexer(_IndexerLike):
             col_sel = (self._internal.data_columns[col_sel],)
 
         sdf = self._internal.sdf.select(self._internal.data_columns)
-
-        # This is a workaround to perform an operation based on natural order.
         sequence_col = "__distributed_sequence_column__"
         sdf = _InternalFrame.attach_distributed_sequence_column(sdf, column_name=sequence_col)
         cond = F.col(sequence_col) == row_sel

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -41,7 +41,7 @@ from databricks.koalas.exceptions import SparkPandasIndexingError
 from databricks.koalas.frame import DataFrame
 from databricks.koalas.generic import _Frame
 from databricks.koalas.internal import (_InternalFrame, NATURAL_ORDER_COLUMN_NAME,
-                                        SPARK_INDEX_NAME_FORMAT)
+                                        SPARK_DEFAULT_INDEX_NAME)
 from databricks.koalas.missing.series import _MissingPandasLikeSeries
 from databricks.koalas.plot import KoalasSeriesPlotMethods
 from databricks.koalas.ml import corr
@@ -2721,7 +2721,7 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
                 "approx_percentile(`%s`, array(%s), %s)" % (self.name, args, accuracy))
             sdf = sdf.select(percentile_col.alias("percentiles"))
 
-            internal_index_column = SPARK_INDEX_NAME_FORMAT(0)
+            internal_index_column = SPARK_DEFAULT_INDEX_NAME
             value_column = "value"
             cols = []
             for i, quantile in enumerate(quantiles):
@@ -3319,8 +3319,8 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
 
             self._internal = self.drop(item)._internal
             item_string = name_like_string(item)
-            sdf = sdf.withColumn(SPARK_INDEX_NAME_FORMAT(0), F.lit(str(item_string)))
-            internal = _InternalFrame(sdf=sdf, index_map=[(SPARK_INDEX_NAME_FORMAT(0), None)])
+            sdf = sdf.withColumn(SPARK_DEFAULT_INDEX_NAME, F.lit(str(item_string)))
+            internal = _InternalFrame(sdf=sdf, index_map=[(SPARK_DEFAULT_INDEX_NAME, None)])
             return _col(DataFrame(internal))
 
         internal = self._internal.copy(
@@ -3510,8 +3510,7 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         sdf_count = ser_count._internal.sdf
         most_value = ser_count.max()
         sdf_most_value = sdf_count.filter("count == {}".format(most_value))
-        sdf = sdf_most_value.select(
-            F.col(SPARK_INDEX_NAME_FORMAT(0)).alias('0'))
+        sdf = sdf_most_value.select(F.col(SPARK_DEFAULT_INDEX_NAME).alias('0'))
         internal = _InternalFrame(sdf=sdf, index_map=None)
 
         result = _col(DataFrame(internal))

--- a/databricks/koalas/tests/test_internal.py
+++ b/databricks/koalas/tests/test_internal.py
@@ -16,7 +16,7 @@
 
 import pandas as pd
 
-from databricks.koalas.internal import _InternalFrame, SPARK_INDEX_NAME_FORMAT
+from databricks.koalas.internal import _InternalFrame, SPARK_DEFAULT_INDEX_NAME
 from databricks.koalas.testing.utils import ReusedSQLTestCase, SQLTestUtils
 
 
@@ -28,7 +28,7 @@ class InternalFrameTest(ReusedSQLTestCase, SQLTestUtils):
         internal = _InternalFrame.from_pandas(pdf)
         sdf = internal.sdf
 
-        self.assert_eq(internal.index_map, [(SPARK_INDEX_NAME_FORMAT(0), None)])
+        self.assert_eq(internal.index_map, [(SPARK_DEFAULT_INDEX_NAME, None)])
         self.assert_eq(internal.column_index, [('a', ), ('b', )])
         self.assert_eq(internal.data_columns, ['a', 'b'])
         self.assertTrue(internal.scol_for(('a',))._jc.equals(sdf['a']._jc))
@@ -42,7 +42,7 @@ class InternalFrameTest(ReusedSQLTestCase, SQLTestUtils):
         internal = _InternalFrame.from_pandas(pdf)
         sdf = internal.sdf
 
-        self.assert_eq(internal.index_map, [(SPARK_INDEX_NAME_FORMAT(0), None), ('a', ('a',))])
+        self.assert_eq(internal.index_map, [(SPARK_DEFAULT_INDEX_NAME, None), ('a', ('a',))])
         self.assert_eq(internal.column_index, [('b', )])
         self.assert_eq(internal.data_columns, ['b'])
         self.assertTrue(internal.scol_for(('b',))._jc.equals(sdf['b']._jc))
@@ -55,7 +55,7 @@ class InternalFrameTest(ReusedSQLTestCase, SQLTestUtils):
         internal = _InternalFrame.from_pandas(pdf)
         sdf = internal.sdf
 
-        self.assert_eq(internal.index_map, [(SPARK_INDEX_NAME_FORMAT(0), None), ('a', ('a',))])
+        self.assert_eq(internal.index_map, [(SPARK_DEFAULT_INDEX_NAME, None), ('a', ('a',))])
         self.assert_eq(internal.column_index, [('x', 'b')])
         self.assert_eq(internal.data_columns, ['(x, b)'])
         self.assertTrue(internal.scol_for(('x', 'b'))._jc.equals(sdf['(x, b)']._jc))


### PR DESCRIPTION
This PR adds:

- `attach_distributed_sequence_column` for the case when we need a sequence in an API.
- Use `SPARK_DEFAULT_INDEX_NAME` instead of `SPARK_INDEX_NAME_FORMAT(0)` for default column name.