### PR TITLE
Move iat implementation to iloc.

### DIFF
--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -32,7 +32,7 @@ from pyspark.sql.readwriter import OptionUtils
 from pyspark.sql.types import DataType, DoubleType, FloatType
 
 from databricks import koalas as ks  # For running doctests and reference resolution in PyCharm.
-from databricks.koalas.indexing import AtIndexer, iAtIndexer, ILocIndexer, LocIndexer
+from databricks.koalas.indexing import AtIndexer, iAtIndexer, iLocIndexer, LocIndexer
 from databricks.koalas.internal import _InternalFrame, NATURAL_ORDER_COLUMN_NAME
 from databricks.koalas.utils import validate_arguments_and_invoke_function, scol_for
 from databricks.koalas.window import Rolling, Expanding
@@ -1652,9 +1652,9 @@ class _Frame(object):
 
     @property
     def iloc(self):
-        return ILocIndexer(self)
+        return iLocIndexer(self)
 
-    iloc.__doc__ = ILocIndexer.__doc__
+    iloc.__doc__ = iLocIndexer.__doc__
 
     @property
     def loc(self):

--- a/databricks/koalas/indexing.py
+++ b/databricks/koalas/indexing.py
@@ -25,10 +25,9 @@ from pyspark.sql import functions as F
 from pyspark.sql.types import BooleanType, LongType
 from pyspark.sql.utils import AnalysisException
 
-from databricks.koalas.internal import (_InternalFrame, HIDDEN_COLUMNS, NATURAL_ORDER_COLUMN_NAME,
-                                        SPARK_INDEX_NAME_FORMAT)
+from databricks.koalas.internal import _InternalFrame, NATURAL_ORDER_COLUMN_NAME
 from databricks.koalas.exceptions import SparkPandasIndexingError, SparkPandasNotImplementedError
-from databricks.koalas.utils import column_index_level, name_like_string, scol_for
+from databricks.koalas.utils import column_index_level, lazy_property, name_like_string
 
 
 class _IndexerLike(object):
@@ -178,35 +177,16 @@ class iAtIndexer(_IndexerLike):
                 raise TypeError(
                     "Use DataFrame.iat like .iat[row_integer_position, column_integer_position]")
             row_sel, col_sel = key
+            if not isinstance(row_sel, int) or not isinstance(col_sel, int):
+                raise ValueError('iAt based indexing can only have integer indexers')
+            return self._kdf_or_kser.iloc[row_sel, col_sel]
         else:
             assert self._is_series, type(self._kdf_or_kser)
             if not isinstance(key, int) and len(key) != 1:
                 raise TypeError("Use Series.iat like .iat[row_integer_position]")
-            row_sel = key
-            col_sel = 0
-
-        if len(self._internal.index_map) == 1:
-            if is_list_like(row_sel):
-                raise ValueError(
-                    'iAt based indexing can only have integer indexers')
-        if not isinstance(col_sel, int):
-            raise ValueError('iat based indexing on multi-index can only have integer values')
-        if isinstance(col_sel, int):
-            if col_sel > len(self._internal.data_columns):
-                raise KeyError(name_like_string(col_sel))
-            col_sel = (self._internal.data_columns[col_sel],)
-
-        sdf = self._internal.sdf.select(self._internal.data_columns)
-
-        sdf, index_column = \
-            _InternalFrame.attach_default_index(sdf, default_index_type="distributed-sequence")
-        cond = F.col(index_column) == row_sel
-        pdf = sdf.where(cond).select(*col_sel).toPandas()
-
-        if len(pdf) < 1:
-            raise KeyError(name_like_string(row_sel))
-
-        return pdf.iloc[0, 0]
+            if not isinstance(key, int):
+                raise ValueError('iAt based indexing can only have integer indexers')
+            return self._kdf_or_kser.iloc[key]
 
 
 class _LocIndexerLike(_IndexerLike):
@@ -220,10 +200,6 @@ class _LocIndexerLike(_IndexerLike):
                 kdf = self._kdf_or_kser.to_frame()
                 kdf['__temp_col__'] = key
                 return type(self)(kdf[self._kdf_or_kser.name])[kdf['__temp_col__']]
-            elif isinstance(key, int) and isinstance(self, ILocIndexer):
-                # if type of item in given `key` for ILocIndexer is integer,
-                # directly use `iat` since they work the same
-                return self._kdf_or_kser.iat[key]
 
             cond, limit, remaining_index = self._select_rows(key)
             if cond is None and limit is None:
@@ -237,10 +213,6 @@ class _LocIndexerLike(_IndexerLike):
             if isinstance(key, tuple):
                 if len(key) != 2:
                     raise SparkPandasIndexingError("Only accepts pairs of candidates")
-                elif all((isinstance(item, int) for item in key)) and isinstance(self, ILocIndexer):
-                    # if all type of item in given `key` for ILocIndexer are integer,
-                    # directly use `iat` since they work the same
-                    return self._kdf_or_kser.iat[key]
                 rows_sel, cols_sel = key
             else:
                 rows_sel = key
@@ -743,7 +715,7 @@ class LocIndexer(_LocIndexerLike):
                     self._kdf_or_kser[col_sel] = value
 
 
-class ILocIndexer(_LocIndexerLike):
+class iLocIndexer(_LocIndexerLike):
     """
     Purely integer-location based indexing for selection by position.
 
@@ -794,12 +766,14 @@ class ILocIndexer(_LocIndexerLike):
 
     **Indexing just the rows**
 
-    A scalar integer for row selection is not allowed.
+    A scalar integer for row selection.
 
     >>> df.iloc[0]
-    Traceback (most recent call last):
-     ...
-    databricks.koalas.exceptions.SparkPandasNotImplementedError: ...
+    a    1
+    b    2
+    c    3
+    d    4
+    Name: 0, dtype: int64
 
     A list of integers for row selection is not allowed.
 
@@ -864,6 +838,15 @@ class ILocIndexer(_LocIndexerLike):
             pandas_function=".iloc[..., ...]",
             spark_target_function="select, where")
 
+    @lazy_property
+    def _internal(self):
+        internal = super(iLocIndexer, self)._internal
+        sdf, index_column = \
+            _InternalFrame.attach_default_index(internal.sdf,
+                                                default_index_type='distributed-sequence')
+        self._index_column = index_column
+        return internal.copy(sdf=sdf.orderBy(NATURAL_ORDER_COLUMN_NAME))
+
     def _select_rows(self, rows_sel):
         from databricks.koalas.indexes import Index
 
@@ -877,14 +860,17 @@ class ILocIndexer(_LocIndexerLike):
                 # If slice is None - select everything, so nothing to do
                 return None, None, None
             elif (rows_sel.start is not None) or (rows_sel.step is not None):
-                ILocIndexer._raiseNotImplemented("Cannot use start or step with Spark.")
+                iLocIndexer._raiseNotImplemented("Cannot use start or step with Spark.")
             elif not isinstance(rows_sel.stop, int):
                 raise TypeError("cannot do slice indexing with these indexers [{}] of {}"
                                 .format(rows_sel.stop, type(rows_sel.stop)))
             else:
                 return None, rows_sel.stop, None
+        elif isinstance(rows_sel, int):
+            sdf = self._internal.sdf
+            return (sdf[self._index_column] == rows_sel), None, 0
         else:
-            ILocIndexer._raiseNotImplemented(".iloc requires numeric slice or conditional "
+            iLocIndexer._raiseNotImplemented(".iloc requires numeric slice or conditional "
                                              "boolean Index, got {}".format(type(rows_sel)))
 
     def _select_cols(self, cols_sel):
@@ -897,6 +883,8 @@ class ILocIndexer(_LocIndexerLike):
             column_index = cols_sel._internal.column_index
             column_scols = cols_sel._internal.column_scols
         elif isinstance(cols_sel, int):
+            if cols_sel > len(self._internal.column_index):
+                raise KeyError(cols_sel)
             column_index = [self._internal.column_index[cols_sel]]
             column_scols = [self._internal.column_scols[cols_sel]]
         elif cols_sel is None or cols_sel == slice(None):


### PR DESCRIPTION
This moves `iat `implementation to `iloc` and adds the infrastructure to support other types of access via `iloc`.