### PR TITLE
Fix `_InternalFrame.with_new_columns` not to rename columns.

### DIFF
--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -2018,8 +2018,8 @@ class SeriesGroupBy(GroupBy):
         #   `SeriesGroupBy` creates another DataFrame and
         #   internal IDs of the columns become different. Maybe we should refactor the whole
         #   class in the future.
-        self._groupkeys_scols = [F.col(name_like_string(s.name)) for s in self._groupkeys]
-        self._agg_columns_scols = [F.col(name_like_string(s.name)) for s in self._agg_columns]
+        self._groupkeys_scols = [F.col(s._internal.data_columns[0]) for s in self._groupkeys]
+        self._agg_columns_scols = [F.col(s._internal.data_columns[0]) for s in self._agg_columns]
 
         if not as_index:
             raise TypeError('as_index=False only valid with DataFrame')

--- a/databricks/koalas/internal.py
+++ b/databricks/koalas/internal.py
@@ -811,7 +811,7 @@ class _InternalFrame(object):
                 scol = scol_or_kser._internal.scol
             else:
                 scol = scol_or_kser
-            column_scols.append(scol.alias(name_like_string(idx)))  # type: ignore
+            column_scols.append(scol)
 
         hidden_columns = []
         if keep_order:
@@ -822,7 +822,7 @@ class _InternalFrame(object):
         return self.copy(
             sdf=sdf,
             column_index=column_index,
-            column_scols=[scol_for(sdf, name_like_string(idx)) for idx in column_index],
+            column_scols=[scol_for(sdf, col) for col in self._sdf.select(column_scols).columns],
             scol=None)
 
     def with_filter(self, pred: Union[spark.Column, 'Series']):


### PR DESCRIPTION
We should not have renamed the columns in `_InternalFrame.with_new_columns`, otherwise the new column names could be unexpectable.