### PR TITLE
Add a config to perform natural ordering when head.

### DIFF
--- a/databricks/koalas/config.py
+++ b/databricks/koalas/config.py
@@ -174,7 +174,7 @@ _options = [
         key='compute.ordered_head',
         doc=(
             "'compute.ordered_head' sets whether or not to operate head with natural ordering. "
-            "Koalas doesn't guarantee the row ordering so `head` could return some rows from "
+            "Koalas does not guarantee the row ordering so `head` could return some rows from "
             "distributed partitions. If 'compute.ordered_head' is set to True, Koalas performs "
             "natural ordering beforehand, but it will cause a performance overhead."),
         default=False,

--- a/databricks/koalas/config.py
+++ b/databricks/koalas/config.py
@@ -171,6 +171,16 @@ _options = [
             "Index type should be one of 'sequence', 'distributed', 'distributed-sequence'.")),
 
     Option(
+        key='compute.ordered_head',
+        doc=(
+            "'compute.ordered_head' sets whether or not to operate head with natural ordering. "
+            "Koalas doesn't guarantee the row ordering so `head` could return some rows from "
+            "distributed partitions. If 'compute.ordered_head' is set to True, Koalas performs "
+            "natural ordering beforehand, but it will cause a performance overhead."),
+        default=False,
+        types=bool),
+
+    Option(
         key='plotting.max_rows',
         doc=(
             "'plotting.max_rows' sets the visual limit on top-n-based plots such as `plot.bar` "

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -4510,8 +4510,11 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         1        bee
         2     falcon
         """
-
-        return DataFrame(self._internal.copy(sdf=self._sdf.limit(n)))
+        if get_option('compute.ordered_head'):
+            sdf = self._sdf.orderBy(NATURAL_ORDER_COLUMN_NAME)
+        else:
+            sdf = self._sdf
+        return DataFrame(self._internal.copy(sdf=sdf.limit(n)))
 
     def pivot_table(self, values=None, index=None, columns=None,
                     aggfunc='mean', fill_value=None):
@@ -5298,7 +5301,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             (False, 'last'): lambda x: Column(getattr(x._jc, "desc_nulls_last")()),
         }
         by = [mapper[(asc, na_position)](scol) for scol, asc in zip(by, ascending)]
-        sdf = self._sdf.drop(NATURAL_ORDER_COLUMN_NAME).sort(*by)
+        sdf = self._sdf.sort(*(by + [NATURAL_ORDER_COLUMN_NAME])).drop(NATURAL_ORDER_COLUMN_NAME)
         kdf = DataFrame(self._internal.copy(sdf=sdf))  # type: ks.DataFrame
         if inplace:
             self._internal = kdf._internal

--- a/docs/source/user_guide/options.rst
+++ b/docs/source/user_guide/options.rst
@@ -248,6 +248,13 @@ compute.ops_on_diff_frames      False          This determines whether or not to
                                                that method throws an exception.
 compute.default_index_type      'sequence'     This sets the default index type: sequence,
                                                distributed and distributed-sequence.
+compute.ordered_head            False          'compute.ordered_head' sets whether or not to operate
+                                               head with natural ordering. Koalas does not guarantee
+                                               the row ordering so `head` could return some rows
+                                               from distributed partitions. If
+                                               'compute.ordered_head' is set to True, Koalas
+                                               performs natural ordering beforehand, but it will
+                                               cause a performance overhead.
 plotting.max_rows               1000           'plotting.max_rows' sets the visual limit on top-n-
                                                based plots such as `plot.bar` and `plot.pie`. If it
                                                is set to 1000, the first 1000 data points will be
@@ -257,4 +264,3 @@ plotting.sample_ratio           None           'plotting.sample_ratio' sets the 
                                                `plot.line` and `plot.area`. This option defaults to
                                                'plotting.max_rows' option.
 =============================== ============== =====================================================
-


### PR DESCRIPTION
Koalas doesn't guarantee the row ordering, so `head` could return some rows from distributed partitions and the result is not deterministic, which might confuse users. (See #411, #1064, or #1219)

```py
>>> import databricks.koalas as ks
>>> spark = ks.utils.default_session({'spark.master': 'local-cluster[4, 2, 1024]'})
>>> spark.conf.set('spark.sql.execution.arrow.enabled', True)
>>> kdf = ks.DataFrame({'a': range(10)})
>>> pdf = kdf.to_pandas().head(3)
```

```py
>>> for _ in range(100):
...     assert kdf.head(3).to_pandas().equals(pdf), 'NOT equals.'
... else:
...     print('equals.')
...
Traceback (most recent call last):
  File "<stdin>", line 2, in <module>
AssertionError: NOT equals.
```

If `compute.ordered_head` is set to True, Koalas performs natural ordering beforehand, but it will cause a performance overhead.

```py
>>> ks.options.compute.ordered_head = True
>>>
>>> for _ in range(100):
...     assert kdf.head(3).to_pandas().equals(pdf), 'NOT equals.'
... else:
...     print('equals.')
...
equals.
```

I don't think we should enable it by default due to the overhead, but it will help users debug.