### PR TITLE
Reduce test time by lowering 'spark.sql.shuffle.partitions'

### DIFF
--- a/databricks/conftest.py
+++ b/databricks/conftest.py
@@ -32,15 +32,20 @@ from databricks import koalas
 from databricks.koalas import utils
 
 
+shared_conf = {
+    "spark.sql.shuffle.partitions": "5"
+}
 # Initialize Spark session that should be used in doctests or unittests.
 # Delta requires Spark 2.4.2+. See
 # https://github.com/delta-io/delta#compatibility-with-apache-spark-versions.
 if LooseVersion(__version__) >= LooseVersion("3.0.0"):
-    session = utils.default_session({"spark.jars.packages": "io.delta:delta-core_2.12:0.1.0"})
+    shared_conf["spark.jars.packages"] = "io.delta:delta-core_2.12:0.1.0"
+    session = utils.default_session(shared_conf)
 elif LooseVersion(__version__) >= LooseVersion("2.4.2"):
-    session = utils.default_session({"spark.jars.packages": "io.delta:delta-core_2.11:0.1.0"})
+    shared_conf["spark.jars.packages"] = "io.delta:delta-core_2.11:0.1.0"
+    session = utils.default_session(shared_conf)
 else:
-    session = utils.default_session()
+    session = utils.default_session(shared_conf)
 
 
 @pytest.fixture(scope='session', autouse=True)

--- a/databricks/conftest.py
+++ b/databricks/conftest.py
@@ -33,7 +33,7 @@ from databricks.koalas import utils
 
 
 shared_conf = {
-    "spark.sql.shuffle.partitions": "5"
+    "spark.sql.shuffle.partitions": "4"
 }
 # Initialize Spark session that should be used in doctests or unittests.
 # Delta requires Spark 2.4.2+. See

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -4581,48 +4581,48 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         >>> table = df.pivot_table(values='D', index=['A', 'B'],
         ...                        columns='C', aggfunc='sum')
-        >>> table  # doctest: +NORMALIZE_WHITESPACE
+        >>> table.sort_index()  # doctest: +NORMALIZE_WHITESPACE
         C        large  small
         A   B
+        bar one    4.0      5
+            two    7.0      6
         foo one    4.0      1
             two    NaN      6
-        bar two    7.0      6
-            one    4.0      5
 
         We can also fill missing values using the `fill_value` parameter.
 
         >>> table = df.pivot_table(values='D', index=['A', 'B'],
         ...                        columns='C', aggfunc='sum', fill_value=0)
-        >>> table  # doctest: +NORMALIZE_WHITESPACE
+        >>> table.sort_index()  # doctest: +NORMALIZE_WHITESPACE
         C        large  small
         A   B
+        bar one      4      5
+            two      7      6
         foo one      4      1
             two      0      6
-        bar two      7      6
-            one      4      5
 
         We can also calculate multiple types of aggregations for any given
         value column.
 
         >>> table = df.pivot_table(values=['D'], index =['C'],
         ...                        columns="A", aggfunc={'D': 'mean'})
-        >>> table  # doctest: +NORMALIZE_WHITESPACE
+        >>> table.sort_index()  # doctest: +NORMALIZE_WHITESPACE
                  D
         A      bar       foo
         C
-        small  5.5  2.333333
         large  5.5  2.000000
+        small  5.5  2.333333
 
         The next example aggregates on multiple values.
 
         >>> table = df.pivot_table(index=['C'], columns="A", values=['D', 'E'],
         ...                         aggfunc={'D': 'mean', 'E': 'sum'})
-        >>> table # doctest: +NORMALIZE_WHITESPACE
+        >>> table.sort_index() # doctest: +NORMALIZE_WHITESPACE
                  D             E
         A      bar       foo bar foo
         C
-        small  5.5  2.333333  17  13
         large  5.5  2.000000  15   9
+        small  5.5  2.333333  17  13
         """
         if not isinstance(columns, (str, tuple)):
             raise ValueError("columns should be string or tuple.")
@@ -5813,21 +5813,21 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         >>> left_kdf = ks.DataFrame({'A': [1, 2]})
         >>> right_kdf = ks.DataFrame({'B': ['x', 'y']}, index=[1, 2])
 
-        >>> left_kdf.merge(right_kdf, left_index=True, right_index=True)
+        >>> left_kdf.merge(right_kdf, left_index=True, right_index=True).sort_index()
            A  B
         1  2  x
 
-        >>> left_kdf.merge(right_kdf, left_index=True, right_index=True, how='left')
+        >>> left_kdf.merge(right_kdf, left_index=True, right_index=True, how='left').sort_index()
            A     B
         0  1  None
         1  2     x
 
-        >>> left_kdf.merge(right_kdf, left_index=True, right_index=True, how='right')
+        >>> left_kdf.merge(right_kdf, left_index=True, right_index=True, how='right').sort_index()
              A  B
         1  2.0  x
         2  NaN  y
 
-        >>> left_kdf.merge(right_kdf, left_index=True, right_index=True, how='outer')
+        >>> left_kdf.merge(right_kdf, left_index=True, right_index=True, how='outer').sort_index()
              A     B
         0  1.0  None
         1  2.0     x

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -5801,14 +5801,14 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         the default suffixes, _x and _y, appended.
 
         >>> merged = df1.merge(df2, left_on='lkey', right_on='rkey')
-        >>> merged.sort_values(by=['lkey', 'value_x', 'rkey', 'value_y'])
+        >>> merged.sort_values(by=['lkey', 'value_x', 'rkey', 'value_y'])  # doctest: +ELLIPSIS
           lkey  value_x rkey  value_y
-        0  bar        2  bar        6
-        5  baz        3  baz        7
-        1  foo        1  foo        5
-        2  foo        1  foo        8
-        3  foo        5  foo        5
-        4  foo        5  foo        8
+        ...bar        2  bar        6
+        ...baz        3  baz        7
+        ...foo        1  foo        5
+        ...foo        1  foo        8
+        ...foo        5  foo        5
+        ...foo        5  foo        8
 
         >>> left_kdf = ks.DataFrame({'A': [1, 2]})
         >>> right_kdf = ks.DataFrame({'B': ['x', 'y']}, index=[1, 2])
@@ -6078,12 +6078,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         original DataFrame’s index in the result.
 
         >>> join_kdf = kdf1.join(kdf2.set_index('key'), on='key')
-        >>> join_kdf.sort_index()
-          key   A     B
-        0  K3  A3  None
-        1  K0  A0    B0
-        2  K1  A1    B1
-        3  K2  A2    B2
+        >>> join_kdf.index
+        Int64Index([0, 1, 2, 3], dtype='int64')
         """
         if isinstance(right, ks.Series):
             common = list(self.columns.intersection([right.name]))
@@ -6195,7 +6191,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         >>> df = ks.DataFrame({'A': [1, 2, 3], 'B': [400, 500, 600]}, columns=['A', 'B'])
         >>> new_df = ks.DataFrame({'B': [4, 5, 6], 'C': [7, 8, 9]}, columns=['B', 'C'])
         >>> df.update(new_df)
-        >>> df
+        >>> df.sort_index()
            A  B
         0  1  4
         1  2  5
@@ -6207,7 +6203,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         >>> df = ks.DataFrame({'A': ['a', 'b', 'c'], 'B': ['x', 'y', 'z']}, columns=['A', 'B'])
         >>> new_df = ks.DataFrame({'B': ['d', 'e', 'f', 'g', 'h', 'i']}, columns=['B'])
         >>> df.update(new_df)
-        >>> df
+        >>> df.sort_index()
            A  B
         0  a  d
         1  b  e
@@ -6218,7 +6214,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         >>> df = ks.DataFrame({'A': ['a', 'b', 'c'], 'B': ['x', 'y', 'z']}, columns=['A', 'B'])
         >>> new_column = ks.Series(['d', 'e'], name='B', index=[0, 2])
         >>> df.update(new_column)
-        >>> df
+        >>> df.sort_index()
            A  B
         0  a  d
         1  b  y
@@ -6229,7 +6225,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         >>> df = ks.DataFrame({'A': [1, 2, 3], 'B': [400, 500, 600]}, columns=['A', 'B'])
         >>> new_df = ks.DataFrame({'B': [4, None, 6]}, columns=['B'])
         >>> df.update(new_df)
-        >>> df
+        >>> df.sort_index()
            A      B
         0  1    4.0
         1  2  500.0

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -1246,13 +1246,13 @@ class _Frame(object):
         2  Parrot       24.0
         3  Parrot       26.0
 
-        >>> df.groupby(['Animal']).mean()  # doctest: +NORMALIZE_WHITESPACE
+        >>> df.groupby(['Animal']).mean().sort_index()  # doctest: +NORMALIZE_WHITESPACE
                 Max Speed
         Animal
         Falcon      375.0
         Parrot       25.0
 
-        >>> df.groupby(['Animal'], as_index=False).mean()
+        >>> df.groupby(['Animal'], as_index=False).mean().sort_index()
            Animal  Max Speed
         0  Falcon      375.0
         1  Parrot       25.0

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -1252,10 +1252,11 @@ class _Frame(object):
         Falcon      375.0
         Parrot       25.0
 
-        >>> df.groupby(['Animal'], as_index=False).mean().sort_index()
+        >>> df.groupby(['Animal'], as_index=False).mean().sort_values('Animal')
+        ... # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
            Animal  Max Speed
-        0  Falcon      375.0
-        1  Parrot       25.0
+        ...Falcon      375.0
+        ...Parrot       25.0
         """
         from databricks.koalas.frame import DataFrame
         from databricks.koalas.series import Series

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -1294,14 +1294,14 @@ class GroupBy(object):
 
         We can also propagate non-null values forward or backward in group.
 
-        >>> df.groupby(['A'])['B'].fillna(method='ffill')
+        >>> df.groupby(['A'])['B'].fillna(method='ffill').sort_index()
         0    2.0
         1    4.0
         2    NaN
         3    3.0
         Name: B, dtype: float64
 
-        >>> df.groupby(['A']).fillna(method='bfill')
+        >>> df.groupby(['A']).fillna(method='bfill').sort_index()
              B    C  D
         0  2.0  NaN  0
         1  4.0  NaN  1

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -106,14 +106,14 @@ class GroupBy(object):
         Different aggregations per column
 
         >>> aggregated = df.groupby('A').agg({'B': 'min', 'C': 'sum'})
-        >>> aggregated[['B', 'C']]  # doctest: +NORMALIZE_WHITESPACE
+        >>> aggregated[['B', 'C']].sort_index()  # doctest: +NORMALIZE_WHITESPACE
            B      C
         A
         1  1  0.589
         2  3  0.705
 
         >>> aggregated = df.groupby('A').agg({'B': ['min', 'max']})
-        >>> aggregated  # doctest: +NORMALIZE_WHITESPACE
+        >>> aggregated.sort_index()  # doctest: +NORMALIZE_WHITESPACE
              B
            min  max
         A
@@ -121,14 +121,14 @@ class GroupBy(object):
         2    3    4
 
         >>> aggregated = df.groupby('A').agg('min')
-        >>> aggregated  # doctest: +NORMALIZE_WHITESPACE
+        >>> aggregated.sort_index()  # doctest: +NORMALIZE_WHITESPACE
              B      C
         A
         1    1  0.227
         2    3 -0.562
 
         >>> aggregated = df.groupby('A').agg(['min', 'max'])
-        >>> aggregated  # doctest: +NORMALIZE_WHITESPACE
+        >>> aggregated.sort_index()  # doctest: +NORMALIZE_WHITESPACE
              B           C
            min  max    min    max
         A
@@ -140,21 +140,21 @@ class GroupBy(object):
         used when applying multiple aggregation functions to specific columns.
 
         >>> aggregated = df.groupby('A').agg(b_max=ks.NamedAgg(column='B', aggfunc='max'))
-        >>> aggregated  # doctest: +NORMALIZE_WHITESPACE
+        >>> aggregated.sort_index()  # doctest: +NORMALIZE_WHITESPACE
              b_max
         A
         1        2
         2        4
 
         >>> aggregated = df.groupby('A').agg(b_max=('B', 'max'), b_min=('B', 'min'))
-        >>> aggregated  # doctest: +NORMALIZE_WHITESPACE
+        >>> aggregated.sort_index()  # doctest: +NORMALIZE_WHITESPACE
              b_max   b_min
         A
         1        2       1
         2        4       3
 
         >>> aggregated = df.groupby('A').agg(b_max=('B', 'max'), c_min=('C', 'min'))
-        >>> aggregated  # doctest: +NORMALIZE_WHITESPACE
+        >>> aggregated.sort_index()  # doctest: +NORMALIZE_WHITESPACE
              b_max   c_min
         A
         1        2   0.227
@@ -592,7 +592,7 @@ class GroupBy(object):
 
         By default, iterates over rows and finds the sum in each column.
 
-        >>> df.groupby("A").cummax()
+        >>> df.groupby("A").cummax().sort_index()
               B  C
         0   NaN  4
         1   0.1  4
@@ -601,7 +601,7 @@ class GroupBy(object):
 
         It works as below in Series.
 
-        >>> df.C.groupby(df.A).cummax()
+        >>> df.C.groupby(df.A).cummax().sort_index()
         0    4
         1    4
         2    4
@@ -639,7 +639,7 @@ class GroupBy(object):
 
         By default, iterates over rows and finds the sum in each column.
 
-        >>> df.groupby("A").cummin()
+        >>> df.groupby("A").cummin().sort_index()
               B  C
         0   NaN  4
         1   0.1  3
@@ -648,7 +648,7 @@ class GroupBy(object):
 
         It works as below in Series.
 
-        >>> df.B.groupby(df.A).cummin()
+        >>> df.B.groupby(df.A).cummin().sort_index()
         0     NaN
         1     0.1
         2     0.1
@@ -684,7 +684,7 @@ class GroupBy(object):
 
         By default, iterates over rows and finds the sum in each column.
 
-        >>> df.groupby("A").cumprod()
+        >>> df.groupby("A").cumprod().sort_index()
               B     C
         0   NaN   4.0
         1   0.1  12.0
@@ -693,7 +693,7 @@ class GroupBy(object):
 
         It works as below in Series.
 
-        >>> df.B.groupby(df.A).cumprod()
+        >>> df.B.groupby(df.A).cumprod().sort_index()
         0     NaN
         1     0.1
         2     2.0
@@ -750,7 +750,7 @@ class GroupBy(object):
 
         By default, iterates over rows and finds the sum in each column.
 
-        >>> df.groupby("A").cumsum()
+        >>> df.groupby("A").cumsum().sort_index()
               B  C
         0   NaN  4
         1   0.1  7
@@ -759,7 +759,7 @@ class GroupBy(object):
 
         It works as below in Series.
 
-        >>> df.B.groupby(df.A).cumsum()
+        >>> df.B.groupby(df.A).cumsum().sort_index()
         0     NaN
         1     0.1
         2    20.1
@@ -1350,7 +1350,7 @@ class GroupBy(object):
 
         Propagate non-null values backward.
 
-        >>> df.groupby(['A']).bfill()
+        >>> df.groupby(['A']).bfill().sort_index()
              B    C  D
         0  2.0  NaN  0
         1  4.0  NaN  1
@@ -1401,7 +1401,7 @@ class GroupBy(object):
 
         Propagate non-null values forward.
 
-        >>> df.groupby(['A']).ffill()
+        >>> df.groupby(['A']).ffill().sort_index()
              B    C  D
         0  2.0  NaN  0
         1  4.0  NaN  1
@@ -1440,22 +1440,22 @@ class GroupBy(object):
         5   3   7  3
         6   3   5  6
 
-        >>> df.groupby('a').head(2)
+        >>> df.groupby('a').head(2).sort_index()
             a   b  c
-        7   1   2  3
         2   1   3  5
-        10  3  10  4
-        5   3   7  3
         3   2   6  1
         4   2   9  2
+        5   3   7  3
+        7   1   2  3
+        10  3  10  4
 
-        >>> df.groupby('a')['b'].head(2)
-        7      2
+        >>> df.groupby('a')['b'].head(2).sort_index()
         2      3
-        10    10
-        5      7
         3      6
         4      9
+        5      7
+        7      2
+        10    10
         Name: b, dtype: int64
         """
         tmp_col = '__row_number__'
@@ -1965,7 +1965,7 @@ class DataFrameGroupBy(GroupBy):
         are returned.
 
         >>> described = df.groupby('a').describe()
-        >>> described  # doctest: +NORMALIZE_WHITESPACE
+        >>> described.sort_index()  # doctest: +NORMALIZE_WHITESPACE
               b                                        c
           count mean       std min 25% 50% 75% max count mean       std min 25% 50% 75% max
         a

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -832,11 +832,11 @@ class Index(IndexOpsMixin):
 
         Examples
         --------
-        >>> ks.DataFrame({'a': ['a', 'b', 'c']}, index=[1, 1, 3]).index.unique()
+        >>> ks.DataFrame({'a': ['a', 'b', 'c']}, index=[1, 1, 3]).index.unique().sort_values()
         Int64Index([1, 3], dtype='int64')
 
-        >>> ks.DataFrame({'a': ['a', 'b', 'c']}, index=['d', 'e', 'e']).index.unique()
-        Index(['e', 'd'], dtype='object')
+        >>> ks.DataFrame({'a': ['a', 'b', 'c']}, index=['d', 'e', 'e']).index.unique().sort_values()
+        Index(['d', 'e'], dtype='object')
         """
         if level is not None:
             self._validate_index_level(level)

--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -1823,14 +1823,14 @@ def merge(obj, right: 'DataFrame', how: str = 'inner',
     the default suffixes, _x and _y, appended.
 
     >>> merged = ks.merge(df1, df2, left_on='lkey', right_on='rkey')
-    >>> merged.sort_values(by=['lkey', 'value_x', 'rkey', 'value_y'])
+    >>> merged.sort_values(by=['lkey', 'value_x', 'rkey', 'value_y'])  # doctest: +ELLIPSIS
       lkey  value_x rkey  value_y
-    0  bar        2  bar        6
-    5  baz        3  baz        7
-    1  foo        1  foo        5
-    2  foo        1  foo        8
-    3  foo        5  foo        5
-    4  foo        5  foo        8
+    ...bar        2  bar        6
+    ...baz        3  baz        7
+    ...foo        1  foo        5
+    ...foo        1  foo        8
+    ...foo        5  foo        5
+    ...foo        5  foo        8
 
     >>> left_kdf = ks.DataFrame({'A': [1, 2]})
     >>> right_kdf = ks.DataFrame({'B': ['x', 'y']}, index=[1, 2])

--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -1835,21 +1835,21 @@ def merge(obj, right: 'DataFrame', how: str = 'inner',
     >>> left_kdf = ks.DataFrame({'A': [1, 2]})
     >>> right_kdf = ks.DataFrame({'B': ['x', 'y']}, index=[1, 2])
 
-    >>> ks.merge(left_kdf, right_kdf, left_index=True, right_index=True)
+    >>> ks.merge(left_kdf, right_kdf, left_index=True, right_index=True).sort_index()
        A  B
     1  2  x
 
-    >>> ks.merge(left_kdf, right_kdf, left_index=True, right_index=True, how='left')
+    >>> ks.merge(left_kdf, right_kdf, left_index=True, right_index=True, how='left').sort_index()
        A     B
     0  1  None
     1  2     x
 
-    >>> ks.merge(left_kdf, right_kdf, left_index=True, right_index=True, how='right')
+    >>> ks.merge(left_kdf, right_kdf, left_index=True, right_index=True, how='right').sort_index()
          A  B
     1  2.0  x
     2  NaN  y
 
-    >>> ks.merge(left_kdf, right_kdf, left_index=True, right_index=True, how='outer')
+    >>> ks.merge(left_kdf, right_kdf, left_index=True, right_index=True, how='outer').sort_index()
          A     B
     0  1.0  None
     1  2.0     x

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -1758,10 +1758,11 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         Examples
         --------
         >>> kser = ks.Series([2, 1, 3, 3], name='A')
-        >>> kser.unique().sort_index()
-        0    1
-        1    3
-        2    2
+        >>> kser.unique().sort_values()  # doctest: +NORMALIZE_WHITESPACE, +ELLIPSIS
+        <BLANKLINE>
+        ...  1
+        ...  2
+        ...  3
         Name: A, dtype: int64
 
         >>> ks.Series([pd.Timestamp('2016-01-01') for _ in range(3)]).unique()
@@ -1769,10 +1770,11 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         Name: 0, dtype: datetime64[ns]
 
         >>> kser.name = ('x', 'a')
-        >>> kser.unique().sort_index()
-        0    1
-        1    3
-        2    2
+        >>> kser.unique().sort_values()  # doctest: +NORMALIZE_WHITESPACE, +ELLIPSIS
+        <BLANKLINE>
+        ...  1
+        ...  2
+        ...  3
         Name: (x, a), dtype: int64
         """
         sdf = self._internal.sdf.select(self._scol).distinct()
@@ -3491,19 +3493,21 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         13    NaN
         Name: 0, dtype: float64
 
-        >>> s.mode()
-        0    1.0
-        1    3.0
-        2    2.0
+        >>> s.mode().sort_values()  # doctest: +NORMALIZE_WHITESPACE, +ELLIPSIS
+        <BLANKLINE>
+        ...  1.0
+        ...  2.0
+        ...  3.0
         Name: 0, dtype: float64
 
         With 'dropna' set to 'False', we can also see NaN in the result
 
-        >>> s.mode(False)
-        0    NaN
-        1    1.0
-        2    3.0
-        3    2.0
+        >>> s.mode(False).sort_values()  # doctest: +NORMALIZE_WHITESPACE, +ELLIPSIS
+        <BLANKLINE>
+        ...  1.0
+        ...  2.0
+        ...  3.0
+        ...  NaN
         Name: 0, dtype: float64
         """
         ser_count = self.value_counts(dropna=dropna, sort=False)

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -1318,7 +1318,7 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         Generate a Series with duplicated entries.
         >>> s = ks.Series(['lama', 'cow', 'lama', 'beetle', 'lama', 'hippo'],
         ...               name='animal')
-        >>> s
+        >>> s.sort_index()
         0      lama
         1       cow
         2      lama
@@ -1327,11 +1327,11 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         5     hippo
         Name: animal, dtype: object
 
-        >>> s.drop_duplicates()
-        1       cow
+        >>> s.drop_duplicates().sort_index()
         0      lama
-        5     hippo
+        1       cow
         3    beetle
+        5     hippo
         Name: animal, dtype: object
         """
         kseries = _col(self.to_frame().drop_duplicates())
@@ -1758,7 +1758,7 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         Examples
         --------
         >>> kser = ks.Series([2, 1, 3, 3], name='A')
-        >>> kser.unique()
+        >>> kser.unique().sort_index()
         0    1
         1    3
         2    2
@@ -1769,7 +1769,7 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         Name: 0, dtype: datetime64[ns]
 
         >>> kser.name = ('x', 'a')
-        >>> kser.unique()
+        >>> kser.unique().sort_index()
         0    1
         1    3
         2    2

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -1005,14 +1005,29 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         left_kdf = ks.from_pandas(left_pdf)
         right_kdf = ks.from_pandas(right_pdf)
 
-        self.assert_eq(left_kdf.merge(right_kdf, left_index=True, right_index=True),
-                       left_pdf.merge(right_pdf, left_index=True, right_index=True))
-        self.assert_eq(left_kdf.merge(right_kdf, left_index=True, right_index=True, how='left'),
-                       left_pdf.merge(right_pdf, left_index=True, right_index=True, how='left'))
-        self.assert_eq(left_kdf.merge(right_kdf, left_index=True, right_index=True, how='right'),
-                       left_pdf.merge(right_pdf, left_index=True, right_index=True, how='right'))
-        self.assert_eq(left_kdf.merge(right_kdf, left_index=True, right_index=True, how='outer'),
-                       left_pdf.merge(right_pdf, left_index=True, right_index=True, how='outer'))
+        kdf = left_kdf.merge(right_kdf, left_index=True, right_index=True)
+        pdf = left_pdf.merge(right_pdf, left_index=True, right_index=True)
+        self.assert_eq(
+            kdf.sort_values(by=list(kdf.columns)).reset_index(drop=True),
+            pdf.sort_values(by=list(pdf.columns)).reset_index(drop=True))
+
+        kdf = left_kdf.merge(right_kdf, left_index=True, right_index=True, how='left')
+        pdf = left_pdf.merge(right_pdf, left_index=True, right_index=True, how='left')
+        self.assert_eq(
+            kdf.sort_values(by=list(kdf.columns)).reset_index(drop=True),
+            pdf.sort_values(by=list(pdf.columns)).reset_index(drop=True))
+
+        kdf = left_kdf.merge(right_kdf, left_index=True, right_index=True, how='right')
+        pdf = left_pdf.merge(right_pdf, left_index=True, right_index=True, how='right')
+        self.assert_eq(
+            kdf.sort_values(by=list(kdf.columns)).reset_index(drop=True),
+            pdf.sort_values(by=list(pdf.columns)).reset_index(drop=True))
+
+        kdf = left_kdf.merge(right_kdf, left_index=True, right_index=True, how='outer')
+        pdf = left_pdf.merge(right_pdf, left_index=True, right_index=True, how='outer')
+        self.assert_eq(
+            kdf.sort_values(by=list(kdf.columns)).reset_index(drop=True),
+            pdf.sort_values(by=list(pdf.columns)).reset_index(drop=True))
 
     def test_merge_raises(self):
         left = ks.DataFrame({'value': [1, 2, 3, 5, 6],

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -188,17 +188,17 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
                 stats_kdf.sort_values(by=[('X', 'B'), ('Y', 'C')]).reset_index(drop=True),
                 stats_pdf.sort_values(by=[('X', 'B'), ('Y', 'C')]).reset_index(drop=True))
 
-            stats_kdf = kdf.groupby(
-                ('X', 'A')).agg({('X', 'B'): ['min', 'max'], ('Y', 'C'): 'sum'})
-            stats_pdf = pdf.groupby(
-                ('X', 'A')).agg({('X', 'B'): ['min', 'max'], ('Y', 'C'): 'sum'})
-            self.assert_eq(
-                stats_kdf.sort_values(
-                    by=[('X', 'B', 'min'), ('X', 'B', 'max'), ('Y', 'C', 'sum')]
-                ).reset_index(drop=True),
-                stats_pdf.sort_values(
-                    by=[('X', 'B', 'min'), ('X', 'B', 'max'), ('Y', 'C', 'sum')]
-                ).reset_index(drop=True))
+        stats_kdf = kdf.groupby(
+            ('X', 'A')).agg({('X', 'B'): ['min', 'max'], ('Y', 'C'): 'sum'})
+        stats_pdf = pdf.groupby(
+            ('X', 'A')).agg({('X', 'B'): ['min', 'max'], ('Y', 'C'): 'sum'})
+        self.assert_eq(
+            stats_kdf.sort_values(
+                by=[('X', 'B', 'min'), ('X', 'B', 'max'), ('Y', 'C', 'sum')]
+            ).reset_index(drop=True),
+            stats_pdf.sort_values(
+                by=[('X', 'B', 'min'), ('X', 'B', 'max'), ('Y', 'C', 'sum')]
+            ).reset_index(drop=True))
 
     def test_aggregate_func_str_list(self):
         # this is test for cases where only string or list is assigned

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -154,13 +154,20 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         kdf = ks.from_pandas(pdf)
 
         for as_index in [True, False]:
-            self.assert_eq(kdf.groupby('A', as_index=as_index).agg({'B': 'min', 'C': 'sum'}),
-                           pdf.groupby('A', as_index=as_index).agg({'B': 'min', 'C': 'sum'}))
+            stats_kdf = kdf.groupby('A', as_index=as_index).agg({'B': 'min', 'C': 'sum'})
+            stats_pdf = pdf.groupby('A', as_index=as_index).agg({'B': 'min', 'C': 'sum'})
+            self.assert_eq(stats_kdf.sort_values(by=['B', 'C']).reset_index(drop=True),
+                           stats_pdf.sort_values(by=['B', 'C']).reset_index(drop=True))
 
-            self.assert_eq(kdf.groupby('A', as_index=as_index).agg({'B': ['min', 'max'],
-                                                                    'C': 'sum'}),
-                           pdf.groupby('A', as_index=as_index).agg({'B': ['min', 'max'],
-                                                                    'C': 'sum'}))
+            stats_kdf = kdf.groupby('A', as_index=as_index).agg({'B': ['min', 'max'], 'C': 'sum'})
+            stats_pdf = pdf.groupby('A', as_index=as_index).agg({'B': ['min', 'max'], 'C': 'sum'})
+            self.assert_eq(
+                stats_kdf.sort_values(
+                    by=[('B', 'min'), ('B', 'max'), ('C', 'sum')]
+                ).reset_index(drop=True),
+                stats_pdf.sort_values(
+                    by=[('B', 'min'), ('B', 'max'), ('C', 'sum')]
+                ).reset_index(drop=True))
 
         expected_error_message = (r"aggs must be a dict mapping from column name \(string or "
                                   r"tuple\) to aggregate functions \(string or list of strings\).")
@@ -173,15 +180,25 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         kdf.columns = columns
 
         for as_index in [True, False]:
-            self.assert_eq(kdf.groupby(('X', 'A'), as_index=as_index)
-                           .agg({('X', 'B'): 'min', ('Y', 'C'): 'sum'}),
-                           pdf.groupby(('X', 'A'), as_index=as_index)
-                           .agg({('X', 'B'): 'min', ('Y', 'C'): 'sum'}))
+            stats_kdf = kdf.groupby(
+                ('X', 'A'), as_index=as_index).agg({('X', 'B'): 'min', ('Y', 'C'): 'sum'})
+            stats_pdf = pdf.groupby(
+                ('X', 'A'), as_index=as_index).agg({('X', 'B'): 'min', ('Y', 'C'): 'sum'})
+            self.assert_eq(
+                stats_kdf.sort_values(by=[('X', 'B'), ('Y', 'C')]).reset_index(drop=True),
+                stats_pdf.sort_values(by=[('X', 'B'), ('Y', 'C')]).reset_index(drop=True))
 
-        self.assert_eq(kdf.groupby(('X', 'A')).agg({('X', 'B'): ['min', 'max'],
-                                                    ('Y', 'C'): 'sum'}),
-                       pdf.groupby(('X', 'A')).agg({('X', 'B'): ['min', 'max'],
-                                                    ('Y', 'C'): 'sum'}))
+            stats_kdf = kdf.groupby(
+                ('X', 'A')).agg({('X', 'B'): ['min', 'max'], ('Y', 'C'): 'sum'})
+            stats_pdf = pdf.groupby(
+                ('X', 'A')).agg({('X', 'B'): ['min', 'max'], ('Y', 'C'): 'sum'})
+            self.assert_eq(
+                stats_kdf.sort_values(
+                    by=[('X', 'B', 'min'), ('X', 'B', 'max'), ('Y', 'C', 'sum')]
+                ).reset_index(drop=True),
+                stats_pdf.sort_values(
+                    by=[('X', 'B', 'min'), ('X', 'B', 'max'), ('Y', 'C', 'sum')]
+                ).reset_index(drop=True))
 
     def test_aggregate_func_str_list(self):
         # this is test for cases where only string or list is assigned

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -379,8 +379,8 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         pdf = pd.DataFrame({'a': [1, 1, 1, 1, 1, 0, 0, 0, 0, 0],
                             'b': [2, 2, 2, 3, 3, 4, 4, 5, 5, 5]})
         kdf = ks.from_pandas(pdf)
-        self.assert_eq(kdf.groupby("a").agg({"b": "nunique"}),
-                       pdf.groupby("a").agg({"b": "nunique"}))
+        self.assert_eq(kdf.groupby("a").agg({"b": "nunique"}).sort_index(),
+                       pdf.groupby("a").agg({"b": "nunique"}).sort_index())
         self.assert_eq(kdf.groupby("a").nunique().sort_index(),
                        pdf.groupby("a").nunique().sort_index())
         self.assert_eq(kdf.groupby("a").nunique(dropna=False).sort_index(),
@@ -391,8 +391,9 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
                        pdf.groupby("a")['b'].nunique(dropna=False).sort_index())
 
         for as_index in [True, False]:
-            self.assert_eq(kdf.groupby("a", as_index=as_index).agg({"b": "nunique"}),
-                           pdf.groupby("a", as_index=as_index).agg({"b": "nunique"}))
+            self.assert_eq(
+                kdf.groupby("a", as_index=as_index).agg({"b": "nunique"}).sort_index(),
+                pdf.groupby("a", as_index=as_index).agg({"b": "nunique"}).sort_index())
 
         # multi-index columns
         columns = pd.MultiIndex.from_tuples([('x', 'a'), ('y', 'b')])

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -390,10 +390,11 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         self.assert_eq(kdf.groupby("a")['b'].nunique(dropna=False).sort_index(),
                        pdf.groupby("a")['b'].nunique(dropna=False).sort_index())
 
-        for as_index in [True, False]:
-            self.assert_eq(
-                kdf.groupby("a", as_index=as_index).agg({"b": "nunique"}).sort_index(),
-                pdf.groupby("a", as_index=as_index).agg({"b": "nunique"}).sort_index())
+        nunique_kdf = kdf.groupby("a", as_index=False).agg({"b": "nunique"})
+        nunique_pdf = pdf.groupby("a", as_index=False).agg({"b": "nunique"})
+        self.assert_eq(
+            nunique_kdf.sort_values(['a', 'b']).reset_index(drop=True),
+            nunique_pdf.sort_values(['a', 'b']).reset_index(drop=True))
 
         # multi-index columns
         columns = pd.MultiIndex.from_tuples([('x', 'a'), ('y', 'b')])

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -475,11 +475,11 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
     def test_index_drop_duplicates(self):
         pidx = pd.Index([1, 1, 2])
         kidx = ks.Index([1, 1, 2])
-        self.assert_eq(pidx.drop_duplicates(), kidx.drop_duplicates())
+        self.assert_eq(pidx.drop_duplicates().sort_values(), kidx.drop_duplicates().sort_values())
 
         pidx = pd.MultiIndex.from_tuples([(1, 1), (1, 1), (2, 2)], names=['level1', 'level2'])
         kidx = ks.MultiIndex.from_tuples([(1, 1), (1, 1), (2, 2)], names=['level1', 'level2'])
-        self.assert_eq(pidx.drop_duplicates(), kidx.drop_duplicates())
+        self.assert_eq(pidx.drop_duplicates().sort_values(), kidx.drop_duplicates().sort_values())
 
     def test_index_sort(self):
         idx = ks.Index([1, 2, 3, 4, 5])


### PR DESCRIPTION
This PR targets to reduce the elapsed time in tests by using less partitions in shuffle.

Seems it can decrease roughly around 15 ~ 20 mins.