### PR TITLE
Throw a better exception in DataFrame.sort_values when multi-index column is used

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -5385,8 +5385,17 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             by = [by]  # type: ignore
         else:
             by = [b if isinstance(b, tuple) else (b,) for b in by]  # type: ignore
-        by = [self[colname]._scol for colname in by]
-        return self._sort(by=by, ascending=ascending,
+
+        new_by = []
+        for colname in by:
+            ser = self[colname]
+            if not isinstance(ser, ks.Series):
+                raise ValueError(
+                    "The column %s is not unique. For a multi-index, the label must "
+                    "be a tuple with elements corresponding to each level." % colname)
+            new_by.append(ser._scol)
+
+        return self._sort(by=new_by, ascending=ascending,
                           inplace=inplace, na_position=na_position)
 
     def sort_index(self, axis: int = 0,

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -5391,8 +5391,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             ser = self[colname]
             if not isinstance(ser, ks.Series):
                 raise ValueError(
-                    "The column %s is not unique. For a multi-index, the label must "
-                    "be a tuple with elements corresponding to each level." % colname)
+                    "The column %s is not unique. For a multi-index, the label must be a tuple "
+                    "with elements corresponding to each level." % name_like_string(colname))
             new_by.append(ser._scol)
 
         return self._sort(by=new_by, ascending=ascending,

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -729,6 +729,13 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(kdf.sort_values('b', inplace=True), pdf.sort_values('b', inplace=True))
         self.assert_eq(repr(kdf), repr(pdf))
 
+        columns = pd.MultiIndex.from_tuples([('X', 'A'), ('X', 'B')])
+        kdf.columns = columns
+        self.assertRaisesRegex(
+            ValueError,
+            "For a multi-index, the label must be a tuple with elements",
+            lambda: kdf.sort_values(['X']))
+
     def test_sort_index(self):
         pdf = pd.DataFrame({'A': [2, 1, np.nan], 'B': [np.nan, 0, np.nan]},
                            index=['b', 'a', np.nan])


### PR DESCRIPTION
Previously, it threw the exception as below:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/.../koalas/databricks/koalas/frame.py", line 5398, in sort_values
    by = [self[colname]._scol for colname in by]
  File "/.../koalas/databricks/koalas/frame.py", line 5398, in <listcomp>
    by = [self[colname]._scol for colname in by]
  File "/.../koalas/databricks/koalas/frame.py", line 8334, in __getattr__
    "'%s' object has no attribute '%s'" % (self.__class__.__name__, key))
AttributeError: 'DataFrame' object has no attribute '_scol'
```

Can be tested as below:

```python
import pandas as pd
import databricks.koalas as ks

mi = pd.MultiIndex.from_tuples([('a', 'b')])
kdf = ks.range(10)
kdf.columns = mi
kdf.sort_values("a")
```