### PR TITLE
Fix fillna not to change index values.

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -4091,8 +4091,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 for v in value.values():
                     if not isinstance(v, (float, int, str, bool)):
                         raise TypeError("Unsupported type %s" % type(v))
-                value = {k if isinstance(k, tuple) else (k,): v for k, v in v.items()}
-                value = {self._internal.column_name_for(k): v for k, v in v.items()
+                value = {k if isinstance(k, tuple) else (k,): v for k, v in value.items()}
+                value = {self._internal.column_name_for(k): v for k, v in value.items()
                          if k in self._internal.column_index}
             if limit is not None:
                 raise ValueError('limit parameter for value is not support now')

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -4091,10 +4091,14 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 for v in value.values():
                     if not isinstance(v, (float, int, str, bool)):
                         raise TypeError("Unsupported type %s" % type(v))
-                value = {self._internal.column_name_for(key): value for key, value in value.items()}
+                value = {key if isinstance(key, tuple) else (key,): value
+                         for key, value in value.items()}
+                value = {self._internal.column_name_for(idx): value
+                         for idx, value in value.items()
+                         if idx in self._internal.column_index}
             if limit is not None:
                 raise ValueError('limit parameter for value is not support now')
-            sdf = self._sdf.fillna(value)
+            sdf = self._sdf.fillna(value, subset=self._internal.data_columns)
             kdf = DataFrame(self._internal.copy(
                 sdf=sdf,
                 column_scols=[scol_for(sdf, col) for col in self._internal.data_columns]))

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -4091,11 +4091,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 for v in value.values():
                     if not isinstance(v, (float, int, str, bool)):
                         raise TypeError("Unsupported type %s" % type(v))
-                value = {key if isinstance(key, tuple) else (key,): value
-                         for key, value in value.items()}
-                value = {self._internal.column_name_for(idx): value
-                         for idx, value in value.items()
-                         if idx in self._internal.column_index}
+                value = {k if isinstance(k, tuple) else (k,): v for k, v in v.items()}
+                value = {self._internal.column_name_for(k): v for k, v in v.items()
+                         if k in self._internal.column_index}
             if limit is not None:
                 raise ValueError('limit parameter for value is not support now')
             sdf = self._sdf.fillna(value, subset=self._internal.data_columns)

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -609,11 +609,10 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(pdf.fillna(method='bfill'), kdf.fillna(method='bfill'))
         self.assert_eq(pdf.fillna(method='bfill', limit=2), kdf.fillna(method='bfill', limit=2))
 
-        pdf = pd.DataFrame({'x': np.random.rand(6),
-                            'y': np.random.rand(6),
-                            'z': [1, 2, 3, 4, np.nan, np.nan]}).set_index(['x', 'y'])
+        pdf = pdf.set_index(['x', 'y'])
         kdf = ks.from_pandas(pdf)
         # check multi index
+        self.assert_eq(kdf.fillna(-1), pdf.fillna(-1))
         self.assert_eq(pdf.fillna(method='bfill'), kdf.fillna(method='bfill'))
         self.assert_eq(pdf.fillna(method='ffill'), kdf.fillna(method='ffill'))
 
@@ -655,6 +654,13 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(pdf.fillna(method='ffill', limit=2), kdf.fillna(method='ffill', limit=2))
         self.assert_eq(pdf.fillna(method='bfill'), kdf.fillna(method='bfill'))
         self.assert_eq(pdf.fillna(method='bfill', limit=2), kdf.fillna(method='bfill', limit=2))
+
+        # check multi index
+        pdf = pdf.set_index([('x', 'a'), ('x', 'b')])
+        kdf = ks.from_pandas(pdf)
+        self.assert_eq(kdf.fillna(-1), pdf.fillna(-1))
+        self.assert_eq(kdf.fillna({('x', 'a'): -1, ('x', 'b'): -2, ('y', 'c'): -5}),
+                       pdf.fillna({('x', 'a'): -1, ('x', 'b'): -2, ('y', 'c'): -5}))
 
     def test_isnull(self):
         pdf = pd.DataFrame({'x': [1, 2, 3, 4, None, 6], 'y': list('abdabd')},


### PR DESCRIPTION
`DataFrame.fillna()` should not change the index values.

```py
>>> import pandas as pd
>>> import numpy as np
>>> pdf = pd.DataFrame({'x': [np.nan, 2, 3, 4, np.nan, 6],
...                     'y': [1, 2, np.nan, 4, np.nan, np.nan],
...                     'z': [1, 2, 3, 4, np.nan, np.nan]}).set_index(['x', 'y'])
>>>
>>> pdf.fillna(-1)
           z
x   y
NaN 1.0  1.0
2.0 2.0  2.0
3.0 NaN  3.0
4.0 4.0  4.0
NaN NaN -1.0
6.0 NaN -1.0
>>> pdf.fillna({'x': -1, 'y': -2, 'z': -5})
           z
x   y
NaN 1.0  1.0
2.0 2.0  2.0
3.0 NaN  3.0
4.0 4.0  4.0
NaN NaN -5.0
6.0 NaN -5.0
```

whereas:

```py
>>> ks.from_pandas(pdf).fillna(-1)
             z
x    y
-1.0  1.0  1.0
 2.0  2.0  2.0
 3.0 -1.0  3.0
 4.0  4.0  4.0
-1.0 -1.0 -1.0
 6.0 -1.0 -1.0
>>> ks.from_pandas(pdf).fillna({'x': -1, 'y': -2, 'z': -5})
             z
x    y
-1.0  1.0  1.0
 2.0  2.0  2.0
 3.0 -2.0  3.0
 4.0  4.0  4.0
-1.0 -2.0 -5.0
 6.0 -2.0 -5.0
```