### PR TITLE
Fix DataFrame.__setitem__ with tuple-named Series.

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -8206,21 +8206,16 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         if (isinstance(value, Series) and value._kdf is not self) or \
                 (isinstance(value, DataFrame) and value is not self):
             # Different Series or DataFrames
-            level = self._internal.column_index_level
             if isinstance(value, Series):
                 value = value.to_frame()
-                value.columns = pd.MultiIndex.from_tuples(
-                    [tuple(list(value._internal.column_index[0]) + ([''] * (level - 1)))])
             else:
-                assert isinstance(value, DataFrame)
-                value_level = value._internal.column_index_level
-                if value_level > level:
-                    value.columns = pd.MultiIndex.from_tuples(
-                        [idx[level:] for idx in value._internal.column_index])
-                elif value_level < level:
-                    value.columns = pd.MultiIndex.from_tuples(
-                        [tuple(list(idx) + ([''] * (level - value_level)))
-                         for idx in value._internal.column_index])
+                assert isinstance(value, DataFrame), type(value)
+                value = value.copy()
+            level = self._internal.column_index_level
+
+            value.columns = pd.MultiIndex.from_tuples(
+                [tuple([name_like_string(idx)] + ([''] * (level - 1)))
+                 for idx in value._internal.column_index])
 
             if isinstance(key, str):
                 key = [(key,)]
@@ -8229,7 +8224,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             else:
                 key = [k if isinstance(k, tuple) else (k,) for k in key]
 
-            level = self._internal.column_index_level
+            if any(len(idx) > level for idx in key):
+                raise KeyError('Key length ({}) exceeds index depth ({})'
+                               .format(max(len(idx) for idx in key), level))
             key = [tuple(list(idx) + ([''] * (level - len(idx)))) for idx in key]
 
             def assign_columns(kdf, this_column_index, that_column_index):

--- a/databricks/koalas/tests/test_ops_on_diff_frames.py
+++ b/databricks/koalas/tests/test_ops_on_diff_frames.py
@@ -592,9 +592,28 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
         pdf = pd.DataFrame({'a': [1, 2, 3, 2], 'b': [4.0, 2.0, 3.0, 1.0]})
         pdf.columns = pd.MultiIndex.from_tuples([('a', 'x'), ('a', 'y')])
         kdf = ks.DataFrame(pdf)
-        kdf["c"] = 1
-        pdf["c"] = 1
-        self.assert_eq(repr(kdf), repr(pdf))
+
+        kdf['c'] = ks.Series([10, 20, 30, 20])
+        pdf['c'] = pd.Series([10, 20, 30, 20])
+
+        kdf[('d', 'x')] = ks.Series([100, 200, 300, 200], name='1')
+        pdf[('d', 'x')] = pd.Series([100, 200, 300, 200], name='1')
+
+        kdf[('d', 'y')] = ks.Series([1000, 2000, 3000, 2000], name=('1', '2'))
+        pdf[('d', 'y')] = pd.Series([1000, 2000, 3000, 2000], name=('1', '2'))
+
+        kdf['e'] = ks.Series([10000, 20000, 30000, 20000], name=('1', '2', '3'))
+        pdf['e'] = pd.Series([10000, 20000, 30000, 20000], name=('1', '2', '3'))
+
+        kdf[[('f', 'x'), ('f', 'y')]] = ks.DataFrame({'1': [100000, 200000, 300000, 200000],
+                                                      '2': [1000000, 2000000, 3000000, 2000000]})
+        pdf[[('f', 'x'), ('f', 'y')]] = pd.DataFrame({'1': [100000, 200000, 300000, 200000],
+                                                      '2': [1000000, 2000000, 3000000, 2000000]})
+
+        self.assert_eq(repr(kdf.sort_index()), repr(pdf))
+
+        with self.assertRaisesRegex(KeyError, 'Key length \\(3\\) exceeds index depth \\(2\\)'):
+            kdf[('1', '2', '3')] = ks.Series([100, 200, 300, 200])
 
 
 class OpsOnDiffFramesDisabledTest(ReusedSQLTestCase, SQLTestUtils):


### PR DESCRIPTION
Fix `DataFrame.__setitem__` with tuple-named Series derived from a different DataFrame.

e.g.,:

```py
>>> import databricks.koalas as ks
>>> ks.set_option("compute.ops_on_diff_frames", True)
>>> kdf = ks.DataFrame({'a': [1, 2, 3, 2], 'b': [4.0, 2.0, 3.0, 1.0]})
>>> kdf['c'] = ks.Series([10, 20, 30, 20], name=('1', '2'))
>>> kdf
    c
  NaN  a    b
0  10  1  4.0
1  20  2  2.0
3  20  2  1.0
2  30  3  3.0
```

The result should be:

```py
>>> kdf
   a    b   c
0  1  4.0  10
1  2  2.0  20
3  2  1.0  20
2  3  3.0  30
```