### PR TITLE
Fix output of print() matches with pandas of Series

### DIFF
--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -4292,10 +4292,6 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
                 return partial(property_or_func, self)
         return self.getField(item)
 
-    def __str__(self):
-        # TODO: figure out how to reuse the original one.
-        return 'Column<%s>' % self._scol._jc.toString().encode('utf8')
-
     def _to_internal_pandas(self):
         """
         Return a pandas Series directly from _internal to avoid overhead of copy.


### PR DESCRIPTION
Resolve https://github.com/databricks/koalas/issues/1248

Since the Python interpreter calls \_\_repr\_\_ if \_\_str\_\_ is not implemented, 
the output will be identical to pandas using the implemented \_\_repr\_\_ of __series.py__.

```python
>>> ks = ks.Series([1, 3, 5, np.nan, 6, 8])
>>> print(ks)
0    1.0
1    3.0
2    5.0
3    NaN
4    6.0
5    8.0
Name: 0, dtype: float64
>>> print(str(ks))
0    1.0
1    3.0
2    5.0
3    NaN
4    6.0
5    8.0
Name: 0, dtype: float64
>>> print(repr(ks))
0    1.0
1    3.0
2    5.0
3    NaN
4    6.0
5    8.0
Name: 0, dtype: float64
>>> ps = pd.Series([1, 3, 5, np.nan, 6, 8])
>>> print(ps)
0    1.0
1    3.0
2    5.0
3    NaN
4    6.0
5    8.0
dtype: float64
>>> print(str(ps))
0    1.0
1    3.0
2    5.0
3    NaN
4    6.0
5    8.0
dtype: float64
>>> print(repr(ps))
0    1.0
1    3.0
2    5.0
3    NaN
4    6.0
5    8.0
dtype: float64
```