### PR TITLE
Add as_index check logic to groupby parameter

### DIFF
--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -1282,7 +1282,7 @@ class _Frame(object):
         if not len(by):
             raise ValueError('No group keys passed!')
         if not isinstance(as_index, bool):
-            raise TypeError('as_index must be an boolean; however, '
+            raise TypeError('as_index must be a boolean; however, '
                             'got [%s]' % type(as_index))
         if isinstance(df_or_s, DataFrame):
             df = df_or_s  # type: DataFrame

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -1285,7 +1285,7 @@ class _Frame(object):
             raise ValueError('No group keys passed!')
         axis = validate_axis(axis)
         if axis != 0:
-            raise ValueError('axis should be either 0 or "index" currently.')
+            raise NotImplementedError('axis should be either 0 or "index" currently.')
         if isinstance(df_or_s, DataFrame):
             df = df_or_s  # type: DataFrame
             col_by = [_resolve_col(df, col_or_s) for col_or_s in by]

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -170,8 +170,7 @@ class _Frame(object):
     # TODO: add 'axis' parameter
     def cumsum(self, skipna: bool = True):
         """
-        Return cumulative sum over a DataFrame or Series  axis=0,
-   axis.
+        Return cumulative sum over a DataFrame or Series axis.
 
         Returns a DataFrame or Series of the same size containing the cumulative sum.
 

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -34,7 +34,7 @@ from pyspark.sql.types import DataType, DoubleType, FloatType
 from databricks import koalas as ks  # For running doctests and reference resolution in PyCharm.
 from databricks.koalas.indexing import AtIndexer, iAtIndexer, iLocIndexer, LocIndexer
 from databricks.koalas.internal import _InternalFrame, NATURAL_ORDER_COLUMN_NAME
-from databricks.koalas.utils import validate_arguments_and_invoke_function, scol_for
+from databricks.koalas.utils import validate_arguments_and_invoke_function, scol_for, validate_axis
 from databricks.koalas.window import Rolling, Expanding
 
 
@@ -1209,6 +1209,8 @@ class _Frame(object):
             If Series is passed, the Series or dict VALUES
             will be used to determine the groups. A label or list of
             labels may be passed to group by the columns in ``self``.
+        axis : int, default 0 or 'index'
+            Can only be set to 0 at the moment.
         as_index : bool, default True
             For aggregated output, return object with group labels as the
             index. Only relevant for DataFrame input. as_index=False is
@@ -1281,6 +1283,7 @@ class _Frame(object):
             raise ValueError("Grouper for '{}' not 1-dimensional".format(type(by)))
         if not len(by):
             raise ValueError('No group keys passed!')
+        axis = validate_axis(axis)
         if axis != 0:
             raise ValueError('axis should be either 0 or "index" currently.')
         if isinstance(df_or_s, DataFrame):

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -170,7 +170,8 @@ class _Frame(object):
     # TODO: add 'axis' parameter
     def cumsum(self, skipna: bool = True):
         """
-        Return cumulative sum over a DataFrame or Series axis.
+        Return cumulative sum over a DataFrame or Series  axis=0,
+   axis.
 
         Returns a DataFrame or Series of the same size containing the cumulative sum.
 
@@ -1193,7 +1194,7 @@ class _Frame(object):
 
     # TODO: by argument only support the grouping name and as_index only for now. Documentation
     # should be updated when it's supported.
-    def groupby(self, by, as_index: bool = True):
+    def groupby(self, by, axis=0, as_index: bool = True):
         """
         Group DataFrame or Series using a Series of columns.
 
@@ -1281,6 +1282,8 @@ class _Frame(object):
             raise ValueError("Grouper for '{}' not 1-dimensional".format(type(by)))
         if not len(by):
             raise ValueError('No group keys passed!')
+        if axis != 0:
+            raise ValueError('axis sould be either 0 or "index" currently.')
         if not isinstance(as_index, bool):
             raise TypeError('as_index must be a boolean; however, '
                             'got [%s]' % type(as_index))

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -1282,7 +1282,7 @@ class _Frame(object):
         if not len(by):
             raise ValueError('No group keys passed!')
         if axis != 0:
-            raise ValueError('axis sould be either 0 or "index" currently.')
+            raise ValueError('axis should be either 0 or "index" currently.')
         if isinstance(df_or_s, DataFrame):
             df = df_or_s  # type: DataFrame
             col_by = [_resolve_col(df, col_or_s) for col_or_s in by]

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -1281,6 +1281,9 @@ class _Frame(object):
             raise ValueError("Grouper for '{}' not 1-dimensional".format(type(by)))
         if not len(by):
             raise ValueError('No group keys passed!')
+        if not isinstance(as_index, bool):
+            raise TypeError('as_index must be an boolean; however, '
+                            'got [%s]' % type(as_index))
         if isinstance(df_or_s, DataFrame):
             df = df_or_s  # type: DataFrame
             col_by = [_resolve_col(df, col_or_s) for col_or_s in by]

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -1284,9 +1284,6 @@ class _Frame(object):
             raise ValueError('No group keys passed!')
         if axis != 0:
             raise ValueError('axis sould be either 0 or "index" currently.')
-        if not isinstance(as_index, bool):
-            raise TypeError('as_index must be a boolean; however, '
-                            'got [%s]' % type(as_index))
         if isinstance(df_or_s, DataFrame):
             df = df_or_s  # type: DataFrame
             col_by = [_resolve_col(df, col_or_s) for col_or_s in by]

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -80,10 +80,10 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
 
         self.assertRaises(TypeError, lambda: kdf.a.groupby(kdf.b, as_index=False))
 
+        self.assertRaises(ValueError, lambda: kdf.groupby('a', 'b'))
+        self.assertRaises(ValueError, lambda: kdf.a.groupby(kdf.a, kdf.b))
         self.assertRaises(TypeError, lambda: kdf.groupby('a', as_index='b'))
-        self.assertRaises(TypeError, lambda: kdf.groupby('a', 'b'))
         self.assertRaises(TypeError, lambda: kdf.a.groupby(kdf.a, as_index=kdf.b))
-        self.assertRaises(TypeError, lambda: kdf.a.groupby(kdf.a, kdf.b))
 
         # we can't use column name/names as a parameter `by` for `SeriesGroupBy`.
         self.assertRaises(KeyError, lambda: kdf.a.groupby(by='a'))

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -80,6 +80,11 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
 
         self.assertRaises(TypeError, lambda: kdf.a.groupby(kdf.b, as_index=False))
 
+        self.assertRaises(TypeError, lambda: kdf.groupby('a', as_index='b'))
+        self.assertRaises(TypeError, lambda: kdf.groupby('a', 'b'))
+        self.assertRaises(TypeError, lambda: kdf.a.groupby(kdf.a, as_index=kdf.b))
+        self.assertRaises(TypeError, lambda: kdf.a.groupby(kdf.a, kdf.b))
+
         # we can't use column name/names as a parameter `by` for `SeriesGroupBy`.
         self.assertRaises(KeyError, lambda: kdf.a.groupby(by='a'))
         self.assertRaises(KeyError, lambda: kdf.a.groupby(by=['a', 'b']))

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -71,6 +71,19 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         self.assert_eq(kdf.a.groupby(kdf.b).sum().sort_index(),
                        pdf.a.groupby(pdf.b).sum().sort_index())
 
+        for axis in [0, 'index']:
+            self.assert_eq(kdf.groupby('a', axis=axis).a.sum().sort_index(),
+                           pdf.groupby('a', axis=axis).a.sum().sort_index())
+            self.assert_eq(kdf.groupby('a', axis=axis)['a'].sum().sort_index(),
+                           pdf.groupby('a', axis=axis)['a'].sum().sort_index())
+            self.assert_eq(kdf.groupby('a', axis=axis)[['a']].sum().sort_index(),
+                           pdf.groupby('a', axis=axis)[['a']].sum().sort_index())
+            self.assert_eq(kdf.groupby('a', axis=axis)[['a', 'c']].sum().sort_index(),
+                           pdf.groupby('a', axis=axis)[['a', 'c']].sum().sort_index())
+
+            self.assert_eq(kdf.a.groupby(kdf.b, axis=axis).sum().sort_index(),
+                           pdf.a.groupby(pdf.b, axis=axis).sum().sort_index())
+
         self.assertRaises(ValueError, lambda: kdf.groupby('a', as_index=False).a)
         self.assertRaises(ValueError, lambda: kdf.groupby('a', as_index=False)['a'])
         self.assertRaises(ValueError, lambda: kdf.groupby('a', as_index=False)[['a']])
@@ -80,7 +93,8 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
 
         self.assertRaises(TypeError, lambda: kdf.a.groupby(kdf.b, as_index=False))
 
-        self.assertRaises(ValueError, lambda: kdf.groupby('a', axis=1))
+        self.assertRaises(NotImplementedError, lambda: kdf.groupby('a', axis=1))
+        self.assertRaises(NotImplementedError, lambda: kdf.groupby('a', axis='columns'))
         self.assertRaises(ValueError, lambda: kdf.groupby('a', 'b'))
         self.assertRaises(TypeError, lambda: kdf.a.groupby(kdf.a, kdf.b))
 

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -82,8 +82,6 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
 
         self.assertRaises(ValueError, lambda: kdf.groupby('a', 'b'))
         self.assertRaises(ValueError, lambda: kdf.a.groupby(kdf.a, kdf.b))
-        self.assertRaises(TypeError, lambda: kdf.groupby('a', as_index='b'))
-        self.assertRaises(TypeError, lambda: kdf.a.groupby(kdf.a, as_index=kdf.b))
 
         # we can't use column name/names as a parameter `by` for `SeriesGroupBy`.
         self.assertRaises(KeyError, lambda: kdf.a.groupby(by='a'))

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -81,7 +81,7 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         self.assertRaises(TypeError, lambda: kdf.a.groupby(kdf.b, as_index=False))
 
         self.assertRaises(ValueError, lambda: kdf.groupby('a', 'b'))
-        self.assertRaises(ValueError, lambda: kdf.a.groupby(kdf.a, kdf.b))
+        self.assertRaises(TypeError, lambda: kdf.a.groupby(kdf.a, kdf.b))
 
         # we can't use column name/names as a parameter `by` for `SeriesGroupBy`.
         self.assertRaises(KeyError, lambda: kdf.a.groupby(by='a'))

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -80,6 +80,7 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
 
         self.assertRaises(TypeError, lambda: kdf.a.groupby(kdf.b, as_index=False))
 
+        self.assertRaises(ValueError, lambda: kdf.groupby('a', axis=1))
         self.assertRaises(ValueError, lambda: kdf.groupby('a', 'b'))
         self.assertRaises(TypeError, lambda: kdf.a.groupby(kdf.a, kdf.b))
 


### PR DESCRIPTION
Resolve https://github.com/databricks/koalas/issues/1252

By doing type validation on item __as_index__  in groupby, 
I think it will be fine if other parameters are added later.
Now, when checking grouping of multiple columns, koalas can find mistakes.

```python
>>> pdf = pd.DataFrame({'A': ['foo', 'bar', 'foo', 'bar',
...                   'foo', 'bar', 'foo', 'foo'],
...                    'B': ['one', 'one', 'two', 'three',
...                    'two', 'two', 'one', 'three'],
...                    'C': np.random.randn(8),
...                    'D': np.random.randn(8)})
>>> kdf = ks.from_pandas(pdf)
>>> kdf.groupby('B', 'A').sum().sort_index()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/hwpark/Desktop/dev/git_koalas/koalas/databricks/koalas/generic.py", line 1286, in groupby
    'got [%s]' % type(as_index))
TypeError: as_index must be an boolean; however, got [<class 'str'>]
>>> pdf.groupby('B', 'A').sum()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/hwpark/Desktop/dev/git_koalas/venv/lib/python3.7/site-packages/pandas/core/generic.py", line 7883, in groupby
    axis = self._get_axis_number(axis)
  File "/Users/hwpark/Desktop/dev/git_koalas/venv/lib/python3.7/site-packages/pandas/core/generic.py", line 411, in _get_axis_number
    raise ValueError("No axis named {0} for object type {1}".format(axis, cls))
ValueError: No axis named A for object type <class 'pandas.core.frame.DataFrame'>
```