### PR TITLE
Raising NotImplementedError for elements that actually are not implemented.

### DIFF
--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -715,7 +715,7 @@ class IndexOpsMixin(object):
         """
         axis = validate_axis(axis)
         if axis != 0:
-            raise ValueError('axis should be either 0 or "index" currently.')
+            raise NotImplementedError('axis should be either 0 or "index" currently.')
 
         sdf = self._internal._sdf.select(self._scol)
         col = scol_for(sdf, sdf.columns[0])
@@ -778,7 +778,7 @@ class IndexOpsMixin(object):
         """
         axis = validate_axis(axis)
         if axis != 0:
-            raise ValueError('axis should be either 0 or "index" currently.')
+            raise NotImplementedError('axis should be either 0 or "index" currently.')
 
         sdf = self._internal._sdf.select(self._scol)
         col = scol_for(sdf, sdf.columns[0])

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -6123,7 +6123,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         if isinstance(other, ks.Series):
             raise ValueError("DataFrames.append() does not support appending Series to DataFrames")
         if sort:
-            raise ValueError("The 'sort' parameter is currently not supported")
+            raise NotImplementedError("The 'sort' parameter is currently not supported")
 
         if not ignore_index:
             index_scols = self._internal.index_scols

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -5457,6 +5457,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         a 1  2  1
         b 1  0  3
         """
+        axis = validate_axis(axis)
         if axis != 0:
             raise NotImplementedError("No other axis than 0 are supported at the moment")
         if kind is not None:

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -2063,7 +2063,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         axis = validate_axis(axis)
         if axis != 0:
-            raise ValueError('axis should be either 0 or "index" currently.')
+            raise NotImplementedError('axis should be either 0 or "index" currently.')
         if isinstance(key, str):
             key = (key,)
         if len(key) > len(self._internal.index_scols):
@@ -2901,7 +2901,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         """
         axis = validate_axis(axis)
         if axis != 0:
-            raise ValueError('axis should be either 0 or "index" currently.')
+            raise NotImplementedError('axis should be either 0 or "index" currently.')
 
         return self._apply_series_op(lambda kser: kser.diff(periods))
 
@@ -2955,7 +2955,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         """
         axis = validate_axis(axis)
         if axis != 0:
-            raise ValueError('axis should be either 0 or "index" currently.')
+            raise NotImplementedError('axis should be either 0 or "index" currently.')
         res = self._sdf.select([self[idx]._nunique(dropna, approx, rsd)
                                 for idx in self._internal.column_index]).toPandas()
         if self._internal.column_index_level == 1:
@@ -5458,9 +5458,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         b 1  0  3
         """
         if axis != 0:
-            raise ValueError("No other axes than 0 are supported at the moment")
+            raise NotImplementedError("No other axis than 0 are supported at the moment")
         if kind is not None:
-            raise ValueError("Specifying the sorting algorithm is supported at the moment.")
+            raise NotImplementedError(
+                "Specifying the sorting algorithm is not supported at the moment.")
 
         if level is None or (is_list_like(level) and len(level) == 0):  # type: ignore
             by = self._internal.index_scols
@@ -7139,7 +7140,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         """
         axis = validate_axis(axis)
         if axis != 0:
-            raise ValueError('axis should be either 0 or "index" currently.')
+            raise NotImplementedError('axis should be either 0 or "index" currently.')
 
         applied = []
         column_index = self._internal.column_index
@@ -7222,7 +7223,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         """
         axis = validate_axis(axis)
         if axis != 0:
-            raise ValueError('axis should be either 0 or "index" currently.')
+            raise NotImplementedError('axis should be either 0 or "index" currently.')
 
         applied = []
         column_index = self._internal.column_index
@@ -8047,9 +8048,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         result_as_series = False
         axis = validate_axis(axis)
         if axis != 0:
-            raise ValueError('axis should be either 0 or "index" currently.')
+            raise NotImplementedError('axis should be either 0 or "index" currently.')
         if numeric_only is not True:
-            raise ValueError("quantile currently doesn't supports numeric_only")
+            raise NotImplementedError("quantile currently doesn't supports numeric_only")
         if isinstance(q, float):
             result_as_series = True
             key = str(q)

--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -1277,7 +1277,8 @@ def get_dummies(data, prefix=None, prefix_sep='_', dummy_na=False, columns=None,
         remaining_columns = []
     else:
         if isinstance(prefix, str):
-            raise ValueError("get_dummies currently does not support prefix as string types")
+            raise NotImplementedError(
+                "get_dummies currently does not support prefix as string types")
         kdf = data.copy()
 
         if columns is None:
@@ -1318,8 +1319,9 @@ def get_dummies(data, prefix=None, prefix_sep='_', dummy_na=False, columns=None,
 
     if any(not isinstance(kdf._internal.spark_type_for(idx), _get_dummies_acceptable_types)
            for idx in column_index):
-        raise ValueError("get_dummies currently only accept {} values"
-                         .format(', '.join([t.typeName() for t in _get_dummies_acceptable_types])))
+        raise NotImplementedError(
+            "get_dummies currently only accept {} values"
+            .format(', '.join([t.typeName() for t in _get_dummies_acceptable_types])))
 
     if prefix is not None and len(column_index) != len(prefix):
         raise ValueError(

--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -1476,7 +1476,7 @@ def concat(objs, axis=0, join='outer', ignore_index=False):
 
     axis = validate_axis(axis)
     if axis != 0:
-        raise ValueError('axis should be either 0 or "index" currently.')
+        raise NotImplementedError('axis should be either 0 or "index" currently.')
 
     if len(objs) == 0:
         raise ValueError('No objects to concatenate')

--- a/databricks/koalas/strings.py
+++ b/databricks/koalas/strings.py
@@ -1936,7 +1936,7 @@ class StringMethods(object):
         Name: 0, dtype: object
         """
         if expand:
-            raise ValueError("expand=True is currently not supported.")
+            raise NotImplementedError("expand=True is currently not supported.")
 
         return _wrap_accessor_pandas(
             self,

--- a/databricks/koalas/strings.py
+++ b/databricks/koalas/strings.py
@@ -2005,7 +2005,7 @@ class StringMethods(object):
         Name: 0, dtype: object
         """
         if expand:
-            raise ValueError("expand=True is currently not supported.")
+            raise NotImplementedError("expand=True is currently not supported.")
 
         return _wrap_accessor_pandas(
             self,

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -2344,10 +2344,3 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         with self.assertRaisesRegex(ValueError, 'type of cond must be a DataFrame or Series'):
             kdf.mask(1)
-
-    def test_set_index(self):
-        kdf = ks.from_pandas(self.pdf)
-
-        with self.assertRaisesRegex(
-                NotImplementedError, 'axis should be either 0 or "index" currently.'):
-            kdf.set_index('a', axis=1)

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -712,7 +712,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         # Assert unsupported axis value yet
         msg = 'axis should be either 0 or "index" currently.'
-        with self.assertRaisesRegex(ValueError, msg):
+        with self.assertRaisesRegex(NotImplementedError, msg):
             kdf.nunique(axis=1)
 
         # multi-index columns
@@ -758,8 +758,8 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         kdf = ks.from_pandas(pdf)
 
         # Assert invalid parameters
-        self.assertRaises(ValueError, lambda: kdf.sort_index(axis=1))
-        self.assertRaises(ValueError, lambda: kdf.sort_index(kind='mergesort'))
+        self.assertRaises(NotImplementedError, lambda: kdf.sort_index(axis=1))
+        self.assertRaises(NotImplementedError, lambda: kdf.sort_index(kind='mergesort'))
         self.assertRaises(ValueError, lambda: kdf.sort_index(na_position='invalid'))
 
         # Assert default behavior without parameters
@@ -823,7 +823,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         with self.assertRaisesRegex(ValueError, msg):
             kdf.xs(('mammal', 1))
         msg = 'axis should be either 0 or "index" currently.'
-        with self.assertRaisesRegex(ValueError, msg):
+        with self.assertRaisesRegex(NotImplementedError, msg):
             kdf.xs('num_wings', axis=1)
         msg = r"'Key length \(4\) exceeds index depth \(3\)'"
         with self.assertRaisesRegex(KeyError, msg):
@@ -1972,7 +1972,8 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         self.assert_eq(kdf.all(), pdf.all())
 
-        with self.assertRaisesRegex(ValueError, 'axis should be either 0 or "index" currently.'):
+        with self.assertRaisesRegex(
+                NotImplementedError, 'axis should be either 0 or "index" currently.'):
             kdf.all(axis=1)
 
     def test_any(self):
@@ -2001,7 +2002,8 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         self.assert_eq(kdf.any(), pdf.any())
 
-        with self.assertRaisesRegex(ValueError, 'axis should be either 0 or "index" currently.'):
+        with self.assertRaisesRegex(
+                NotImplementedError, 'axis should be either 0 or "index" currently.'):
             kdf.any(axis=1)
 
     def test_rank(self):
@@ -2108,7 +2110,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         with self.assertRaisesRegex(ValueError, msg):
             kdf.diff(1.5)
         msg = 'axis should be either 0 or "index" currently.'
-        with self.assertRaisesRegex(ValueError, msg):
+        with self.assertRaisesRegex(NotImplementedError, msg):
             kdf.diff(axis=1)
 
         # multi-index columns
@@ -2313,10 +2315,12 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
     def test_quantile(self):
         kdf = ks.from_pandas(self.pdf)
 
-        with self.assertRaisesRegex(ValueError, 'axis should be either 0 or "index" currently.'):
+        with self.assertRaisesRegex(
+                NotImplementedError, 'axis should be either 0 or "index" currently.'):
             kdf.quantile(.5, axis=1)
 
-        with self.assertRaisesRegex(ValueError, "quantile currently doesn't supports numeric_only"):
+        with self.assertRaisesRegex(
+                NotImplementedError, "quantile currently doesn't supports numeric_only"):
             kdf.quantile(.5, numeric_only=False)
 
     def test_pct_change(self):
@@ -2340,3 +2344,10 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         with self.assertRaisesRegex(ValueError, 'type of cond must be a DataFrame or Series'):
             kdf.mask(1)
+
+    def test_set_index(self):
+        kdf = ks.from_pandas(self.pdf)
+
+        with self.assertRaisesRegex(
+                NotImplementedError, 'axis should be either 0 or "index" currently.'):
+            kdf.set_index('a', axis=1)

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -1120,7 +1120,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         # Assert using the sort parameter raises an exception
         msg = "The 'sort' parameter is currently not supported"
-        with self.assertRaises(ValueError, msg=msg):
+        with self.assertRaises(NotImplementedError, msg=msg):
             kdf.append(kdf, sort=True)
 
         # Assert using 'verify_integrity' only raises an exception for overlapping indices

--- a/databricks/koalas/tests/test_namespace.py
+++ b/databricks/koalas/tests/test_namespace.py
@@ -97,7 +97,8 @@ class NamespaceTest(ReusedSQLTestCase, SQLTestUtils):
             ValueError, "All objects passed", lambda: ks.concat([None, None]))
 
         self.assertRaisesRegex(
-            ValueError, 'axis should be either 0 or', lambda: ks.concat([kdf, kdf], axis=1))
+            NotImplementedError, 'axis should be either 0 or',
+            lambda: ks.concat([kdf, kdf], axis=1))
 
         pdf3 = pdf.copy()
         kdf3 = kdf.copy()

--- a/databricks/koalas/tests/test_reshape.py
+++ b/databricks/koalas/tests/test_reshape.py
@@ -40,7 +40,8 @@ class ReshapeTest(ReusedSQLTestCase):
             self.assert_eq(ks.get_dummies(kdf_or_kser), pd.get_dummies(pdf_or_ps), almost=True)
 
         kser = ks.Series([1, 1, 1, 2, 2, 1, 3, 4])
-        with self.assertRaises(ValueError, 'get_dummies currently does not support sparse'):
+        with self.assertRaises(
+                NotImplementedError, 'get_dummies currently does not support sparse'):
             ks.get_dummies(kser, sparse=True)
 
     def test_get_dummies_object(self):

--- a/databricks/koalas/tests/test_reshape.py
+++ b/databricks/koalas/tests/test_reshape.py
@@ -39,6 +39,10 @@ class ReshapeTest(ReusedSQLTestCase):
 
             self.assert_eq(ks.get_dummies(kdf_or_kser), pd.get_dummies(pdf_or_ps), almost=True)
 
+        kser = ks.Series([1, 1, 1, 2, 2, 1, 3, 4])
+        with self.assertRaises(ValueError, 'get_dummies currently does not support sparse'):
+            ks.get_dummies(kser, sparse=True)
+
     def test_get_dummies_object(self):
         pdf = pd.DataFrame({'a': [1, 2, 3, 4, 4, 3, 2, 1],
                             # 'a': pd.Categorical([1, 2, 3, 4, 4, 3, 2, 1]),

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -507,8 +507,8 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         kser = ks.from_pandas(pser)
 
         # Assert invalid parameters
-        self.assertRaises(ValueError, lambda: kser.sort_index(axis=1))
-        self.assertRaises(ValueError, lambda: kser.sort_index(kind='mergesort'))
+        self.assertRaises(NotImplementedError, lambda: kser.sort_index(axis=1))
+        self.assertRaises(NotImplementedError, lambda: kser.sort_index(kind='mergesort'))
         self.assertRaises(ValueError, lambda: kser.sort_index(na_position='invalid'))
 
         # Assert default behavior without parameters

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -452,6 +452,10 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
 
         self.assert_eq((kser % 2 == 0).all(), (pser % 2 == 0).all())
 
+        with self.assertRaisesRegex(
+                NotImplementedError, 'axis should be either 0 or "index" currently.'):
+            kser.all(axis=1)
+
     def test_any(self):
         for pser in [pd.Series([False, False], name='x'),
                      pd.Series([True, False], name='x'),

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -469,6 +469,10 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
 
         self.assert_eq((kser % 2 == 0).any(), (pser % 2 == 0).any())
 
+        with self.assertRaisesRegex(
+                NotImplementedError, 'axis should be either 0 or "index" currently.'):
+            kser.any(axis=1)
+
     def test_reset_index_with_default_index_types(self):
         pser = pd.Series([1, 2, 3], name='0', index=np.random.rand(3))
         kser = ks.from_pandas(pser)

--- a/databricks/koalas/tests/test_series_string.py
+++ b/databricks/koalas/tests/test_series_string.py
@@ -296,7 +296,7 @@ class SeriesStringTest(ReusedSQLTestCase, SQLTestUtils):
         pser = pd.Series(['This is a sentence.', 'This-is-a-long-word.'])
         self.check_func_on_series(lambda x: x.str.rsplit(n=2), pser)
         self.check_func_on_series(lambda x: x.str.rsplit(pat='-', n=2), pser)
-        with self.assertRaises(ValueError):
+        with self.assertRaises(NotImplementedError):
             self.check_func(lambda x: x.str.rsplit(expand=True))
 
     def test_string_translate(self):

--- a/databricks/koalas/tests/test_series_string.py
+++ b/databricks/koalas/tests/test_series_string.py
@@ -287,7 +287,7 @@ class SeriesStringTest(ReusedSQLTestCase, SQLTestUtils):
         pser = pd.Series(['This is a sentence.', 'This-is-a-long-word.'])
         self.check_func_on_series(lambda x: x.str.split(n=2), pser)
         self.check_func_on_series(lambda x: x.str.split(pat='-', n=2), pser)
-        with self.assertRaises(ValueError):
+        with self.assertRaises(NotImplementedError):
             self.check_func(lambda x: x.str.split(expand=True))
 
     def test_string_rsplit(self):


### PR DESCRIPTION
we're raising `ValueError` for some 'NotImplemented' elements.

i think it's better to raise `NotImplementedError` rather than `ValueError` for those elements so that we can find more easily when we want to implement them.