### PR TITLE
Remove workarounds in `_InternalFrame.scol_for` and `.column_name_for`.

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -4614,6 +4614,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         if columns not in self.columns:
             raise ValueError("Wrong columns {}.".format(columns))
+        if isinstance(columns, str):
+            columns = (columns,)
 
         if isinstance(values, list):
             values = [col if isinstance(col, tuple) else (col,) for col in values]
@@ -5077,7 +5079,6 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             except:
                 pass
 
-        columns = []
         column_index = []
         for idx in self._internal.column_index:
             if len(include) > 0:
@@ -5090,10 +5091,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                     self._internal.spark_type_for(idx) in exclude_spark_type)
 
             if should_include:
-                columns.append(self._internal.column_name_for(idx))
                 column_index.append(idx)
 
-        column_scols = [self._internal.scol_for(col) for col in columns]
+        column_scols = [self._internal.scol_for(idx) for idx in column_index]
         return DataFrame(self._internal.with_new_columns(column_scols, column_index=column_index))
 
     def count(self, axis=None):

--- a/databricks/koalas/indexing.py
+++ b/databricks/koalas/indexing.py
@@ -641,15 +641,14 @@ class LocIndexer(_LocIndexerLike):
                 if any(len(key) != level for key in cols_sel):
                     raise ValueError('All the key level should be the same as column index level.')
 
-            index_to_column = list(zip(self._internal.column_index, self._internal.data_columns))
             column_index = []
             column_scols = []
             for key in cols_sel:
                 found = False
-                for idx, column in index_to_column:
+                for idx in self._internal.column_index:
                     if idx == key or idx[0] == key:
                         column_index.append(idx)
-                        column_scols.append(self._internal.scol_for(column))
+                        column_scols.append(self._internal.scol_for(idx))
                         found = True
                 if not found:
                     raise KeyError("['{}'] not in index".format(name_like_string(key)))


### PR DESCRIPTION
Now that we can remove workarounds added previously in `_InternalFrame.scol_for` and `.column_name_for`.
Now they only allow tuples for columns or strings as index column names to avoid misuse of these methods.