### PR TITLE
Implement DataFrame.apply

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -1819,7 +1819,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             ... def length(s) -> int:
             ...    return len(s)
             ...
-            >>> df = ks.DataFrame(range(1000), columns=['A'])
+            >>> df = ks.DataFrame({'A': range(1000)})
             >>> df.apply(length, axis=0)  # doctest: +SKIP
             0     83
             1     83

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -41,7 +41,8 @@ from pyspark import sql as spark
 from pyspark.sql import functions as F, Column
 from pyspark.sql.functions import pandas_udf
 from pyspark.sql.types import (BooleanType, ByteType, DecimalType, DoubleType, FloatType,
-                               IntegerType, LongType, NumericType, ShortType)
+                               IntegerType, LongType, NumericType, ShortType, StructType,
+                               StructField)
 from pyspark.sql.window import Window
 
 from databricks import koalas as ks  # For running doctests and reference resolution in PyCharm.
@@ -1799,6 +1800,229 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         return DataFrame(internal)
 
     T = property(transpose)
+
+    def apply(self, func, axis=0):
+        """
+        Apply a function along an axis of the DataFrame.
+
+        Objects passed to the function are Series objects whose index is
+        either the DataFrame's index (``axis=0``) or the DataFrame's columns
+        (``axis=1``).
+
+        .. note:: when `axis` is 0 or 'index', the `func` is unable to access
+            to the whole input series. Koalas internally splits the input series into multiple
+            batches and calls `func` with each batch multiple times. Therefore, operations
+            such as global aggregations are impossible. See the example below.
+
+            >>> # This case does not return the length of whole series but of the batch internally
+            ... # used.
+            ... def length(s) -> int:
+            ...    return len(s)
+            ...
+            >>> df = ks.DataFrame(range(1000), columns=['A'])
+            >>> df.apply(length, axis=0)  # doctest: +SKIP
+            0     83
+            1     83
+            2     83
+            ...
+            10    83
+            11    83
+            Name: 0, dtype: int32
+
+        .. note:: this API executes the function once to infer the type which is
+            potentially expensive, for instance, when the dataset is created after
+            aggregations or sorting.
+
+            To avoid this, specify return type in ``func``, for instance, as below:
+
+            >>> def square(s) -> ks.Series[np.int32]:
+            ...     return s ** 2
+
+            Koalas uses return type hint and does not try to infer the type.
+
+            In case when axis is 1, it requires to specify `DataFrame` with type hints
+            as below:
+
+            >>> def plus_one(x) -> ks.DataFrame[float, float]:
+            ...    return x + 1
+
+            If the return type is specified, the output column names become
+            `c0, c1, c2 ... cn`. These names are positionally mapped to the returned
+            DataFrame in ``func``. See examples below.
+
+
+        Parameters
+        ----------
+        func : function
+            Function to apply to each column or row.
+        axis : {0 or 'index', 1 or 'columns'}, default 0
+            Axis along which the function is applied:
+
+            * 0 or 'index': apply function to each column.
+            * 1 or 'columns': apply function to each row.
+
+        Returns
+        -------
+        Series or DataFrame
+            Result of applying ``func`` along the given axis of the
+            DataFrame.
+
+        See Also
+        --------
+        DataFrame.applymap: For elementwise operations.
+        DataFrame.aggregate: Only perform aggregating type operations.
+        DataFrame.transform: Only perform transforming type operations.
+
+        Examples
+        --------
+        >>> df = ks.DataFrame([[4, 9]] * 3, columns=['A', 'B'])
+        >>> df
+           A  B
+        0  4  9
+        1  4  9
+        2  4  9
+
+        Using a numpy universal function (in this case the same as
+        ``np.sqrt(df)``):
+
+        >>> def sqrt(x) -> ks.Series[float]:
+        ...    return np.sqrt(x)
+        ...
+        >>> df.apply(sqrt, axis=0)
+             A    B
+        0  2.0  3.0
+        1  2.0  3.0
+        2  2.0  3.0
+
+        You can omit the type hint and let Koalas infer its type.
+
+        >>> df.apply(np.sqrt, axis=0)
+             A    B
+        0  2.0  3.0
+        1  2.0  3.0
+        2  2.0  3.0
+
+        When `axis` is 1 or 'columns', it applies the function for each row.
+
+        >>> def summation(x) -> np.int64:
+        ...    return np.sum(x)
+        ...
+        >>> df.apply(summation, axis=1)
+        0    13
+        1    13
+        2    13
+        Name: 0, dtype: int64
+
+        Likewise, you can omit the type hint and let Koalas infer its type.
+
+        >>> df.apply(np.sum, axis=1)
+        0    13
+        1    13
+        2    13
+        Name: 0, dtype: int64
+
+        Returning a list-like will result in a Series
+
+        >>> df.apply(lambda x: [1, 2], axis=1)
+        0    [1, 2]
+        1    [1, 2]
+        2    [1, 2]
+        Name: 0, dtype: object
+
+        In order to specify the types when `axis` is '1', it should use DataFrame[...]
+        annotation. In this case, the column names are automatically generated.
+
+        >>> def identify(x) -> ks.DataFrame[np.int64, np.int64]:
+        ...     return x
+        ...
+        >>> df.apply(identify, axis=1)
+           c0  c1
+        0   4   9
+        1   4   9
+        2   4   9
+        """
+        from databricks.koalas.groupby import GroupBy
+        from databricks.koalas.series import _col
+
+        if isinstance(func, np.ufunc):
+            f = func
+            func = lambda *args, **kwargs: f(*args, **kwargs)
+
+        assert callable(func), "the first argument should be a callable function."
+
+        axis = validate_axis(axis)
+        should_return_series = False
+        spec = inspect.getfullargspec(func)
+        return_sig = spec.annotations.get("return", None)
+        should_infer_schema = return_sig is None
+
+        def apply_func(pdf):
+            pdf_or_pser = pdf.apply(func, axis=axis)
+            if isinstance(pdf_or_pser, pd.Series):
+                return pdf_or_pser.to_frame()
+            else:
+                return pdf_or_pser
+
+        if should_infer_schema:
+            # Here we execute with the first 1000 to get the return type.
+            # If the records were less than 1000, it uses pandas API directly for a shortcut.
+            limit = get_option("compute.shortcut_limit")
+            pdf = self.head(limit + 1)._to_internal_pandas()
+            applied = pdf.apply(func, axis=axis)
+            kser_or_kdf = ks.from_pandas(applied)
+            if len(pdf) <= limit:
+                return kser_or_kdf
+
+            kdf = kser_or_kdf
+            if isinstance(kser_or_kdf, ks.Series):
+                should_return_series = True
+                kdf = kser_or_kdf.to_frame()
+
+            return_schema = kdf._internal._sdf.drop(*HIDDEN_COLUMNS).schema
+
+            sdf = GroupBy._spark_group_map_apply(
+                self, apply_func, (F.spark_partition_id(),),
+                return_schema, retain_index=True)
+
+            # If schema is inferred, we can restore indexes too.
+            internal = kdf._internal.copy(sdf=sdf,
+                                          column_scols=[scol_for(sdf, col)
+                                                        for col in kdf._internal.data_columns])
+        else:
+            return_schema = _infer_return_type(func).tpe
+            require_index_axis = getattr(return_sig, "__origin__", None) == ks.Series
+            require_column_axis = getattr(return_sig, "__origin__", None) == ks.DataFrame
+            if require_index_axis:
+                if axis != 0:
+                    raise TypeError(
+                        "The given function should specify a scalar or a series as its type "
+                        "hints when axis is 0 or 'index'; however, the return type "
+                        "was %s" % return_sig)
+                fields_types = zip(self.columns, [return_schema] * len(self.columns))
+                return_schema = StructType([StructField(c, t) for c, t in fields_types])
+            elif require_column_axis:
+                if axis != 1:
+                    raise TypeError(
+                        "The given function should specify a scalar or a frame as its type "
+                        "hints when axis is 1 or 'column'; however, the return type "
+                        "was %s" % return_sig)
+            else:
+                # any axis is fine.
+                should_return_series = True
+                return_schema = StructType([StructField("0", return_schema)])
+
+            sdf = GroupBy._spark_group_map_apply(
+                self, apply_func, (F.spark_partition_id(),),
+                return_schema, retain_index=False)
+
+            # Otherwise, it loses index.
+            internal = _InternalFrame(sdf=sdf, index_map=None)
+
+        result = DataFrame(internal)
+        if should_return_series:
+            return _col(result)
+        else:
+            return result
 
     def transform(self, func):
         """

--- a/databricks/koalas/missing/frame.py
+++ b/databricks/koalas/missing/frame.py
@@ -40,7 +40,6 @@ class _MissingPandasLikeDataFrame(object):
 
     # Functions
     align = unsupported_function('align')
-    apply = unsupported_function('apply')
     asfreq = unsupported_function('asfreq')
     asof = unsupported_function('asof')
     at_time = unsupported_function('at_time')

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -2267,14 +2267,11 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
                            columns=['a', 'b', 'c'],
                            index=np.random.rand(600))
         kdf = ks.DataFrame(pdf)
-
-        def _test(kdf, expected):
-            self.assert_eq(kdf.transform(lambda x: x + 1).sort_index(), expected)
-
-            with option_context("compute.shortcut_limit", 500):
-                self.assert_eq(kdf.transform(lambda x: x + 1).sort_index(), expected)
-
-        _test(kdf, pdf.transform(lambda x: x + 1).sort_index())
+        self.assert_eq(kdf.transform(lambda x: x + 1).sort_index(),
+                       pdf.transform(lambda x: x + 1).sort_index())
+        with option_context("compute.shortcut_limit", 500):
+            self.assert_eq(kdf.transform(lambda x: x + 1).sort_index(),
+                           pdf.transform(lambda x: x + 1).sort_index())
 
         with self.assertRaisesRegex(AssertionError, "the first argument should be a callable"):
             kdf.transform(1)
@@ -2284,7 +2281,63 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         pdf.columns = columns
         kdf.columns = columns
 
-        _test(kdf, pdf.transform(lambda x: x + 1).sort_index())
+        self.assert_eq(kdf.transform(lambda x: x + 1).sort_index(),
+                       pdf.transform(lambda x: x + 1).sort_index())
+        with option_context("compute.shortcut_limit", 500):
+            self.assert_eq(kdf.transform(lambda x: x + 1).sort_index(),
+                           pdf.transform(lambda x: x + 1).sort_index())
+
+    def test_apply(self):
+        pdf = pd.DataFrame({'a': [1, 2, 3, 4, 5, 6] * 100,
+                            'b': [1., 1., 2., 3., 5., 8.] * 100,
+                            'c': [1, 4, 9, 16, 25, 36] * 100},
+                           columns=['a', 'b', 'c'],
+                           index=np.random.rand(600))
+        kdf = ks.DataFrame(pdf)
+
+        self.assert_eq(kdf.apply(lambda x: x + 1).sort_index(),
+                       pdf.apply(lambda x: x + 1).sort_index())
+        with option_context("compute.shortcut_limit", 500):
+            self.assert_eq(kdf.apply(lambda x: x + 1).sort_index(),
+                           pdf.apply(lambda x: x + 1).sort_index())
+
+        # returning a Series
+        self.assert_eq(kdf.apply(lambda x: len(x), axis=1).sort_index(),
+                       pdf.apply(lambda x: len(x), axis=1).sort_index())
+        with option_context("compute.shortcut_limit", 500):
+            self.assert_eq(kdf.apply(lambda x: len(x), axis=1).sort_index(),
+                           pdf.apply(lambda x: len(x), axis=1).sort_index())
+
+        with self.assertRaisesRegex(AssertionError, "the first argument should be a callable"):
+            kdf.apply(1)
+
+        with self.assertRaisesRegex(TypeError, "The given function.*1 or 'column'; however"):
+            def f1(_) -> ks.DataFrame[int]:
+                pass
+            kdf.apply(f1, axis=0)
+
+        with self.assertRaisesRegex(TypeError, "The given function.*0 or 'index'; however"):
+            def f2(_) -> ks.Series[int]:
+                pass
+            kdf.apply(f2, axis=1)
+
+        # multi-index columns
+        columns = pd.MultiIndex.from_tuples([('x', 'a'), ('x', 'b'), ('y', 'c')])
+        pdf.columns = columns
+        kdf.columns = columns
+
+        self.assert_eq(kdf.apply(lambda x: x + 1).sort_index(),
+                       pdf.apply(lambda x: x + 1).sort_index())
+        with option_context("compute.shortcut_limit", 500):
+            self.assert_eq(kdf.apply(lambda x: x + 1).sort_index(),
+                           pdf.apply(lambda x: x + 1).sort_index())
+
+        # returning a Series
+        self.assert_eq(kdf.apply(lambda x: len(x), axis=1).sort_index(),
+                       pdf.apply(lambda x: len(x), axis=1).sort_index())
+        with option_context("compute.shortcut_limit", 500):
+            self.assert_eq(kdf.apply(lambda x: len(x), axis=1).sort_index(),
+                           pdf.apply(lambda x: len(x), axis=1).sort_index())
 
     def test_empty_timestamp(self):
         pdf = pd.DataFrame({'t': [datetime(2019, 1, 1, 0, 0, 0),

--- a/docs/source/reference/frame.rst
+++ b/docs/source/reference/frame.rst
@@ -98,6 +98,7 @@ Function application, GroupBy & Window
 .. autosummary::
    :toctree: api/
 
+   DataFrame.apply
    DataFrame.applymap
    DataFrame.pipe
    DataFrame.agg


### PR DESCRIPTION
This PR proposes to implement `DataFrame.apply` with both `axis` 0 and 1. Note that, `DataFrame.apply(..., axis=1)` with global aggregations is impossible.

It can be tested with the examples below:

```python
import numpy as np
import databricks.koalas as ks

df = ks.DataFrame([[4, 9]] * 10, columns=['A', 'B'])

df.apply(np.sqrt, axis=0)

def sqrt(x) -> ks.Series[float]:
    return np.sqrt(x)
df.apply(sqrt, axis=0)


df.apply(np.sum, axis=1)

def summation(x) -> int:
   return np.sum(x)

df.apply(summation, axis=1)
```

Basically the approach is using group map Pandas UDF by grouping by partitions.

```python
from pyspark.sql.functions import pandas_udf, PandasUDFType
from pyspark.sql import functions as F

df = spark.createDataFrame(
    [(1, 1.0), (1, 2.0), (2, 3.0), (2, 5.0), (2, 10.0)],
    ("id", "v"))

@pandas_udf("id long, v double", PandasUDFType.GROUPED_MAP)
def func(pdf):
    return pdf.apply(...)

df.groupby(F.spark_partition_id()).apply(func).show()
```

Resolves #1228
Resolves #65
