### PR TITLE
Add Codecov support in Github Actions.

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -60,9 +60,9 @@ jobs:
         export SPARK_HOME="$SPARK_CACHE_DIR/spark-$SPARK_VERSION-bin-hadoop2.7"
         ./dev/lint-python
         ./dev/pytest
-    # Push the results back to codecov
-    - name: Update Codecov
-      run: bash <(curl -s https://codecov.io/bash)
+    - uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   conda_python:
     name: Conda, Python
@@ -134,7 +134,7 @@ jobs:
         export SPARK_HOME="$SPARK_CACHE_DIR/spark-$SPARK_VERSION-bin-hadoop2.7"
         ./dev/lint-python
         ./dev/pytest
-    # Push the results back to codecov
-    - name: Update Codecov
-      run: bash <(curl -s https://codecov.io/bash)
+    - uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -60,7 +60,7 @@ jobs:
         export SPARK_HOME="$SPARK_CACHE_DIR/spark-$SPARK_VERSION-bin-hadoop2.7"
         ./dev/lint-python
         ./dev/pytest
-    - uses: codecov/codecov-action@v1
+    - uses: codecov/codecov-action@v1.0.5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -134,7 +134,7 @@ jobs:
         export SPARK_HOME="$SPARK_CACHE_DIR/spark-$SPARK_VERSION-bin-hadoop2.7"
         ./dev/lint-python
         ./dev/pytest
-    - uses: codecov/codecov-action@v1
+    - uses: codecov/codecov-action@v1.0.5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -60,9 +60,10 @@ jobs:
         export SPARK_HOME="$SPARK_CACHE_DIR/spark-$SPARK_VERSION-bin-hadoop2.7"
         ./dev/lint-python
         ./dev/pytest
-    - uses: codecov/codecov-action@v1.0.5
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
+    - name: Update Codecov
+      run: bash <(curl -s https://codecov.io/bash)
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   conda_python:
     name: Conda, Python
@@ -134,7 +135,8 @@ jobs:
         export SPARK_HOME="$SPARK_CACHE_DIR/spark-$SPARK_VERSION-bin-hadoop2.7"
         ./dev/lint-python
         ./dev/pytest
-    - uses: codecov/codecov-action@v1.0.5
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
+    - name: Update Codecov
+      run: bash <(curl -s https://codecov.io/bash)
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -60,10 +60,9 @@ jobs:
         export SPARK_HOME="$SPARK_CACHE_DIR/spark-$SPARK_VERSION-bin-hadoop2.7"
         ./dev/lint-python
         ./dev/pytest
-    - name: Update Codecov
-      run: bash <(curl -s https://codecov.io/bash)
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+    - uses: codecov/codecov-action@v1.0.5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   conda_python:
     name: Conda, Python
@@ -135,8 +134,7 @@ jobs:
         export SPARK_HOME="$SPARK_CACHE_DIR/spark-$SPARK_VERSION-bin-hadoop2.7"
         ./dev/lint-python
         ./dev/pytest
-    - name: Update Codecov
-      run: bash <(curl -s https://codecov.io/bash)
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+    - uses: codecov/codecov-action@v1.0.5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/dev/pytest
+++ b/dev/pytest
@@ -44,12 +44,12 @@ if [ "$#" = 0 ]; then
     if [[ "$SPARK_VERSION" == 2.3* ]] || [[ "$SPARK_VERSION" == 2.4.1* ]] || [[ "$SPARK_VERSION" == 2.4.2* ]]; then
         # Delta requires Spark 2.4.2+. We skip the related doctests.
         if [[ "$SPARK_VERSION" == 2.3* ]]; then
-            $PYTHON_EXECUTABLE -m pytest --cov=databricks -k " -melt -to_delta -read_delta" --verbose --showlocals --color=yes --doctest-modules databricks "${logopts[@]}"
+            $PYTHON_EXECUTABLE -m pytest --cov=databricks --cov-report xml:"$FWDIR/coverage.xml" -k " -melt -to_delta -read_delta" --verbose --showlocals --color=yes --doctest-modules databricks "${logopts[@]}"
         else
-            $PYTHON_EXECUTABLE -m pytest --cov=databricks -k "-to_delta -read_delta" --verbose --showlocals --color=yes --doctest-modules databricks "${logopts[@]}"
+            $PYTHON_EXECUTABLE -m pytest --cov=databricks --cov-report xml:"$FWDIR/coverage.xml" -k "-to_delta -read_delta" --verbose --showlocals --color=yes --doctest-modules databricks "${logopts[@]}"
         fi
     else
-        $PYTHON_EXECUTABLE -m pytest --cov=databricks --verbose --showlocals --color=yes --doctest-modules databricks "${logopts[@]}"
+        $PYTHON_EXECUTABLE -m pytest --cov=databricks --cov-report xml:"$FWDIR/coverage.xml" --verbose --showlocals --color=yes --doctest-modules databricks "${logopts[@]}"
     fi
 else
     $PYTHON_EXECUTABLE -m pytest "$@"


### PR DESCRIPTION
Codecov in Github Actions are not correctly working for now:

```
...
==> GitHub Actions detected.
    project root: .
    Yaml found at: codecov.yml
==> Running gcov in . (disable via -X gcov)
==> Python coveragepy exists disable via -X coveragepy
    -> Running coverage xml
==> Searching for coverage reports in:
    + .
    -> Found 1 reports
==> Detecting git/mercurial file structure
==> Reading reports
    + ./coverage.xml bytes=484024
==> Appending adjustments
    http://docs.codecov.io/docs/fixing-reports
    -> No adjustments found
==> Gzipping contents
==> Uploading reports
    url: https://codecov.io
    query: branch=master&commit=31b9ae070e85c9b84c100e2861ec9eacf1e5190a&build=&build_url=&name=&tag=&slug=databricks%2Fkoalas&service=github-actions&flags=&pr=&job=
    -> Pinging Codecov
https://codecov.io/upload/v4?package=bash-20191211-b8db533&token=secret&branch=master&commit=31b9ae070e85c9b84c100e2861ec9eacf1e5190a&build=&build_url=&name=&tag=&slug=databricks%2Fkoalas&service=github-actions&flags=&pr=&job=
HTTP 400
Please provide the repository token to upload reports via `-t :repository-token`
```