### PR TITLE
Use Spark 2.4.5 in Travis and Github Actions

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -67,12 +67,12 @@ jobs:
         python-version: [3.6, 3.7]
         include:
           - python-version: 3.6
-            spark-version: 2.4.4
+            spark-version: 2.4.5
             pandas-version: 0.24.2
             pyarrow-version: 0.13.0
             logger: databricks.koalas.usage_logging.usage_logger
           - python-version: 3.7
-            spark-version: 2.4.4
+            spark-version: 2.4.5
             pandas-version: 0.25.3
             pyarrow-version: 0.14.1
     env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
       env:
         - PATH=$(echo "$PATH" | sed -e 's/:\/usr\/local\/lib\/jvm\/openjdk11\/bin//')
         - JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
-        - SPARK_VERSION=2.4.4
+        - SPARK_VERSION=2.4.5
         - PANDAS_VERSION=0.24.2
         - PYARROW_VERSION=0.13.0
         - KOALAS_USAGE_LOGGER='databricks.koalas.usage_logging.usage_logger'
@@ -35,7 +35,7 @@ matrix:
       env:
         - PATH=$(echo "$PATH" | sed -e 's/:\/usr\/local\/lib\/jvm\/openjdk11\/bin//')
         - JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
-        - SPARK_VERSION=2.4.4
+        - SPARK_VERSION=2.4.5
         - PANDAS_VERSION=0.25.3
         - PYARROW_VERSION=0.14.1
 


### PR DESCRIPTION
Spark 2.4.5 was released. This PR proposes to use it in both Travis CI and Github Actions.