### PR TITLE
Using 'exclude' rather 'include' for GitHub Actions for future scalability

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -70,16 +70,18 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.7]
-        include:
+        spark-version: [2.4.5]
+        pandas-version: [0.24.2, 0.25.3]
+        pyarrow-version: [0.13.0, 0.14.1]
+        exclude:
           - python-version: 3.6
-            spark-version: 2.4.5
-            pandas-version: 0.24.2
-            pyarrow-version: 0.13.0
-            logger: databricks.koalas.usage_logging.usage_logger
-          - python-version: 3.7
-            spark-version: 2.4.5
             pandas-version: 0.25.3
+          - python-version: 3.6
             pyarrow-version: 0.14.1
+          - python-version: 3.7
+            pandas-version: 0.24.2
+          - python-version: 3.7
+            pyarrow-version: 0.13.0
     env:
       PYTHON_VERSION: ${{ matrix.python-version }}
       SPARK_VERSION: ${{ matrix.spark-version }}
@@ -88,7 +90,6 @@ jobs:
       # `QT_QPA_PLATFORM` for resolving 'QXcbConnection: Could not connect to display :0.0'
       DISPLAY: 0.0
       QT_QPA_PLATFORM: offscreen
-      KOALAS_USAGE_LOGGER: ${{ matrix.logger }}
       # The name of the directory '.cache' is for Travis CI. Once we remove Travis CI,
       # we should download Spark to a directory with a different name to prevent confusion.
       SPARK_CACHE_DIR: /home/runner/.cache/spark-versions
@@ -132,6 +133,10 @@ jobs:
         conda config --prepend envs_dirs $HOME/miniconda/envs
         conda activate test-environment
         export SPARK_HOME="$SPARK_CACHE_DIR/spark-$SPARK_VERSION-bin-hadoop2.7"
+        # Set live logger before run test only for python 3.6
+        if [ $PYTHON_VERSION == 3.6 ]; then
+            export KOALAS_USAGE_LOGGER=databricks.koalas.usage_logging.usage_logger
+        fi
         ./dev/lint-python
         ./dev/pytest
     # Push the results back to codecov


### PR DESCRIPTION
We're using `include` for matrix strategy like the below.

```yml
    strategy:
      matrix:
        python-version: [3.6, 3.7]
        include:
          - python-version: 3.6
            spark-version: 2.4.5
            pandas-version: 0.24.2
            pyarrow-version: 0.13.0
            logger: databricks.koalas.usage_logging.usage_logger
          - python-version: 3.7
            spark-version: 2.4.5
            pandas-version: 0.25.3
            pyarrow-version: 0.14.1
```

and while i'm working for supporting pandas 1.0.1, i wanted to add test for pandas 1.0.1 to the existing test like the below.

```yml
    strategy:
      matrix:
        python-version: [3.6, 3.7]
        include:
          - python-version: 3.6
            spark-version: 2.4.5
            pandas-version: 0.24.2
            pyarrow-version: 0.13.0
            logger: databricks.koalas.usage_logging.usage_logger
          - python-version: 3.7
            spark-version: 2.4.5
            pandas-version: 0.25.3
            pyarrow-version: 0.14.1
          # test for pandas 1.0.1
          - python-version: 3.6
            spark-version: 2.4.5
            pandas-version: 1.0.1
            pyarrow-version: 0.13.0
            logger: databricks.koalas.usage_logging.usage_logger
          - python-version: 3.7
            spark-version: 2.4.5
            pandas-version: 1.0.1
            pyarrow-version: 0.14.1
```

i expected that we have five tests total since two test cases are added, but the result was like the below.

![스크린샷 2020-02-11 오후 2 24 49](https://user-images.githubusercontent.com/44108233/74212963-47d5d900-4cda-11ea-8bb8-4bfdc3b18061.png)

As shown the above, they still have only 3 tests at the GitHub Actions.

the reason is the last ones overwrite the existing ones with `include`, not just added.

and i found that we can workaround with using `exclude` rather `include` like the below.

```yml
    strategy:
      matrix:
        python-version: [3.6, 3.7]
        spark-version: [2.4.5]
        pandas-version: [0.24.2, 0.25.3]
        pyarrow-version: [0.13.0, 0.14.1]
        exclude:
          - python-version: 3.6
            pandas-version: 0.25.3
          - python-version: 3.6
            pyarrow-version: 0.14.1
          - python-version: 3.7
            pandas-version: 0.24.2
          - python-version: 3.7
            pyarrow-version: 0.13.0
```

First we set the all candidate versions of modules at the matrix, and explicitly exclude that we don't need test for specific versions of other modules for specific python version.

unlike `include`, they consider all of lists are defined at `exclude` as an each valid case, not overwrite previous ones.

so, now if we wanna add the test for pandas 1.0.1, we can simply just like the below.

```yml
    strategy:
      matrix:
        python-version: [3.6, 3.7]
        spark-version: [2.4.5]
        # just add the version to the existing list we want to test additionally.
        pandas-version: [0.24.2, 0.25.3, 1.0.1]
        pyarrow-version: [0.13.0, 0.14.1]
        exclude:
          - python-version: 3.6
            pandas-version: 0.25.3
          - python-version: 3.6
            pyarrow-version: 0.14.1
          - python-version: 3.7
            pandas-version: 0.24.2
          - python-version: 3.7
            pyarrow-version: 0.13.0
```

Finally, we can see the test results on GitHub Actions which include tests of additional version of pandas like the below.

![스크린샷 2020-02-11 오후 2 35 23](https://user-images.githubusercontent.com/44108233/74213266-bff0ce80-4cdb-11ea-8ff8-943dbc5220b9.png)
