### PR TITLE
Implement DataFrame.query

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -8345,17 +8345,17 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
               you can just workaround by using :meth:`DataFrame.map_in_pandas`
               although it is less performant. See the example below.
 
-            >>> df = ks.DataFrame([(1, 2), (3, 4), (5, 6)], columns=['A', 'B'])
-            >>> df
-               A  B
-            0  1  2
-            1  3  4
-            2  5  6
-            >>> num = 1
-            >>> df.map_in_pandas(lambda pdf: pdf.query('A > @num'))  # doctest: +SKIP
-               A  B
-            1  3  4
-            2  5  6
+                >>> df = ks.DataFrame([(1, 2), (3, 4), (5, 6)], columns=['A', 'B'])
+                >>> df
+                   A  B
+                0  1  2
+                1  3  4
+                2  5  6
+                >>> num = 1
+                >>> df.map_in_pandas(lambda pdf: pdf.query('A > @num'))  # doctest: +SKIP
+                   A  B
+                1  3  4
+                2  5  6
 
         Parameters
         ----------

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -8390,6 +8390,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
            A   B  C C
         0  1  10   10
         """
+        if isinstance(self.columns, pd.MultiIndex):
+            raise ValueError("Doesn't support for MultiIndex columns")
         if not isinstance(expr, str):
             raise ValueError(
                 'expr must be a string to be evaluated, {} given'

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -8352,7 +8352,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             1  3  4
             2  5  6
             >>> num = 1
-            >>> df.map_in_pandas(lambda pdf: pdf.query('A > @num'))
+            >>> df.map_in_pandas(lambda pdf: pdf.query('A > @num'))  # doctest: +SKIP
                A  B
             1  3  4
             2  5  6

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -8335,6 +8335,14 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         """
         Query the columns of a DataFrame with a boolean expression.
 
+        .. note::
+            * MultiIndex columns are not supported.
+            * If you want to use MultiIndex columns, you can just workaround
+              by using `DataFrame.apply` although it is less performance.
+            * Internal columns that starting with __.. are able to access,
+              however, they are not supposed to be accessed.
+            * This delegates to Spark SQL so the syntax follows Spark SQL
+
         Parameters
         ----------
         expr : str

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -8336,14 +8336,12 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         Query the columns of a DataFrame with a boolean expression.
 
         .. note::
-            * MultiIndex columns are not supported.
             * Using variables in the environment with `@` is not supported.
             * Internal columns that starting with __. are able to access,
               however, they are not supposed to be accessed.
             * This delegates to Spark SQL so the syntax follows Spark SQL
-            * If you want to use MultiIndex columns, or variables in the environment,
-              you can just workaround by using :meth:`DataFrame.map_in_pandas`
-              although it is less performant. See the example below.
+            * If you want the exactly same syntax with pandas' you can work around
+              by using :meth:`DataFrame.map_in_pandas`. See the example below.
 
                 >>> df = ks.DataFrame([(1, 2), (3, 4), (5, 6)], columns=['A', 'B'])
                 >>> df

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -8338,8 +8338,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         .. note::
             * MultiIndex columns are not supported.
             * If you want to use MultiIndex columns, you can just workaround
-              by using `DataFrame.apply` although it is less performance.
-            * Internal columns that starting with __.. are able to access,
+              by using :meth:`DataFrame.apply` although it is less performant.
+            * Internal columns that starting with __. are able to access,
               however, they are not supposed to be accessed.
             * This delegates to Spark SQL so the syntax follows Spark SQL
 

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -8337,11 +8337,25 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         .. note::
             * MultiIndex columns are not supported.
-            * If you want to use MultiIndex columns, you can just workaround
-              by using :meth:`DataFrame.apply` although it is less performant.
+            * Using variables in the environment with `@` is not supported.
             * Internal columns that starting with __. are able to access,
               however, they are not supposed to be accessed.
             * This delegates to Spark SQL so the syntax follows Spark SQL
+            * If you want to use MultiIndex columns, or variables in the environment,
+              you can just workaround by using :meth:`DataFrame.map_in_pandas`
+              although it is less performant. See the example below.
+
+            >>> df = ks.DataFrame([(1, 2), (3, 4), (5, 6)], columns=['A', 'B'])
+            >>> df
+               A  B
+            0  1  2
+            1  3  4
+            2  5  6
+            >>> num = 1
+            >>> df.map_in_pandas(lambda pdf: pdf.query('A > @num'))
+               A  B
+            1  3  4
+            2  5  6
 
         Parameters
         ----------

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -8331,6 +8331,132 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         return DataFrame(internal) if not result_as_series else DataFrame(internal).T[key]
 
+    def query(self, expr, inplace=False, **kwargs):
+        """
+        Query the columns of a DataFrame with a boolean expression.
+
+        Parameters
+        ----------
+        expr : str
+            The query string to evaluate.  You can refer to variables
+            in the environment by prefixing them with an '@' character like
+            ``@a + b``.
+
+            .. versionadded:: 0.25.0
+
+            You can refer to column names that contain spaces by surrounding
+            them in backticks.
+
+            For example, if one of your columns is called ``a a`` and you want
+            to sum it with ``b``, your query should be ```a a` + b``.
+
+        inplace : bool
+            Whether the query should modify the data in place or return
+            a modified copy.
+        **kwargs
+            See the documentation for :func:`eval` for complete details
+            on the keyword arguments accepted by :meth:`DataFrame.query`.
+
+            .. versionadded:: 0.18.0
+
+        Returns
+        -------
+        DataFrame
+            DataFrame resulting from the provided query expression.
+
+        See Also
+        --------
+        eval : Evaluate a string describing operations on
+            DataFrame columns.
+        DataFrame.eval : Evaluate a string describing operations on
+            DataFrame columns.
+
+        Notes
+        -----
+        The result of the evaluation of this expression is first passed to
+        :attr:`DataFrame.loc` and if that fails because of a
+        multidimensional key (e.g., a DataFrame) then the result will be passed
+        to :meth:`DataFrame.__getitem__`.
+
+        This method uses the top-level :func:`eval` function to
+        evaluate the passed query.
+
+        The :meth:`~pandas.DataFrame.query` method uses a slightly
+        modified Python syntax by default. For example, the ``&`` and ``|``
+        (bitwise) operators have the precedence of their boolean cousins,
+        :keyword:`and` and :keyword:`or`. This *is* syntactically valid Python,
+        however the semantics are different.
+
+        You can change the semantics of the expression by passing the keyword
+        argument ``parser='python'``. This enforces the same semantics as
+        evaluation in Python space. Likewise, you can pass ``engine='python'``
+        to evaluate an expression using Python itself as a backend. This is not
+        recommended as it is inefficient compared to using ``numexpr`` as the
+        engine.
+
+        The :attr:`DataFrame.index` and
+        :attr:`DataFrame.columns` attributes of the
+        :class:`~pandas.DataFrame` instance are placed in the query namespace
+        by default, which allows you to treat both the index and columns of the
+        frame as a column in the frame.
+        The identifier ``index`` is used for the frame index; you can also
+        use the name of the index to identify it in a query. Please note that
+        Python keywords may not be used as identifiers.
+
+        For further details and examples see the ``query`` documentation in
+        :ref:`indexing <indexing.query>`.
+
+        Examples
+        --------
+        >>> df = ks.DataFrame({'A': range(1, 6),
+        ...                    'B': range(10, 0, -2),
+        ...                    'C C': range(10, 5, -1)})
+        >>> df
+           A   B  C C
+        0  1  10   10
+        1  2   8    9
+        2  3   6    8
+        3  4   4    7
+        4  5   2    6
+        >>> df.query('A > B')
+           A  B  C C
+        4  5  2    6
+
+        The previous expression is equivalent to
+
+        >>> df[df.A > df.B]
+           A  B  C C
+        4  5  2    6
+
+        For columns with spaces in their name, you can use backtick quoting.
+
+        >>> df.query('B == `C C`')
+           A   B  C C
+        0  1  10   10
+
+        The previous expression is equivalent to
+
+        >>> df[df.B == df['C C']]
+           A   B  C C
+        0  1  10   10
+        """
+        if not isinstance(expr, str):
+            raise ValueError(
+                'expr must be a string to be evaluated, {} given'
+                .format(type(expr)))
+        if not isinstance(inplace, bool):
+            raise ValueError(
+                'For argument "inplace" expected type bool, received type {}.'
+                .format(type(inplace).__name__))
+
+        sdf = self._sdf.filter(expr)
+        internal = self._internal.copy(sdf=sdf)
+
+        if inplace:
+            self._internal = internal
+        else:
+            return DataFrame(internal)
+
     def explain(self, extended: bool = False):
         """
         Prints the underlying (logical and physical) Spark plans to the console for debugging

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -8331,18 +8331,14 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         return DataFrame(internal) if not result_as_series else DataFrame(internal).T[key]
 
-    def query(self, expr, inplace=False, **kwargs):
+    def query(self, expr, inplace=False):
         """
         Query the columns of a DataFrame with a boolean expression.
 
         Parameters
         ----------
         expr : str
-            The query string to evaluate.  You can refer to variables
-            in the environment by prefixing them with an '@' character like
-            ``@a + b``.
-
-            .. versionadded:: 0.25.0
+            The query string to evaluate.
 
             You can refer to column names that contain spaces by surrounding
             them in backticks.
@@ -8353,58 +8349,11 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         inplace : bool
             Whether the query should modify the data in place or return
             a modified copy.
-        **kwargs
-            See the documentation for :func:`eval` for complete details
-            on the keyword arguments accepted by :meth:`DataFrame.query`.
-
-            .. versionadded:: 0.18.0
 
         Returns
         -------
         DataFrame
             DataFrame resulting from the provided query expression.
-
-        See Also
-        --------
-        eval : Evaluate a string describing operations on
-            DataFrame columns.
-        DataFrame.eval : Evaluate a string describing operations on
-            DataFrame columns.
-
-        Notes
-        -----
-        The result of the evaluation of this expression is first passed to
-        :attr:`DataFrame.loc` and if that fails because of a
-        multidimensional key (e.g., a DataFrame) then the result will be passed
-        to :meth:`DataFrame.__getitem__`.
-
-        This method uses the top-level :func:`eval` function to
-        evaluate the passed query.
-
-        The :meth:`~pandas.DataFrame.query` method uses a slightly
-        modified Python syntax by default. For example, the ``&`` and ``|``
-        (bitwise) operators have the precedence of their boolean cousins,
-        :keyword:`and` and :keyword:`or`. This *is* syntactically valid Python,
-        however the semantics are different.
-
-        You can change the semantics of the expression by passing the keyword
-        argument ``parser='python'``. This enforces the same semantics as
-        evaluation in Python space. Likewise, you can pass ``engine='python'``
-        to evaluate an expression using Python itself as a backend. This is not
-        recommended as it is inefficient compared to using ``numexpr`` as the
-        engine.
-
-        The :attr:`DataFrame.index` and
-        :attr:`DataFrame.columns` attributes of the
-        :class:`~pandas.DataFrame` instance are placed in the query namespace
-        by default, which allows you to treat both the index and columns of the
-        frame as a column in the frame.
-        The identifier ``index`` is used for the frame index; you can also
-        use the name of the index to identify it in a query. Please note that
-        Python keywords may not be used as identifiers.
-
-        For further details and examples see the ``query`` documentation in
-        :ref:`indexing <indexing.query>`.
 
         Examples
         --------
@@ -8418,6 +8367,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         2  3   6    8
         3  4   4    7
         4  5   2    6
+
         >>> df.query('A > B')
            A  B  C C
         4  5  2    6

--- a/databricks/koalas/missing/frame.py
+++ b/databricks/koalas/missing/frame.py
@@ -65,7 +65,6 @@ class _MissingPandasLikeDataFrame(object):
     mode = unsupported_function('mode')
     prod = unsupported_function('prod')
     product = unsupported_function('product')
-    query = unsupported_function('query')
     reindex_like = unsupported_function('reindex_like')
     rename_axis = unsupported_function('rename_axis')
     reorder_levels = unsupported_function('reorder_levels')

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -2409,7 +2409,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
                  '`A + B` < `"C", "D"`',
                  '`"C", "D"` == `B ?!`')
         for expr in exprs:
-            self.assert_eq(kdf.query(expr), pdf.query(expr))
+            self.assert_eq(repr(kdf.query(expr)), repr(pdf.query(expr)))
 
         # test `inplace=True`
         for expr in exprs:

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -2400,16 +2400,16 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
     def test_query(self):
         kdf = ks.DataFrame(
-            {'A + B': range(1, 6),
-             'B !': range(10, 0, -2),
-             '"C", "D"': range(10, 5, -1)})
+            {'A': range(1, 6),
+             'B': range(10, 0, -2),
+             'C': range(10, 5, -1)})
         pdf = kdf.to_pandas()
 
-        exprs = ('`A + B` > `B !`',
-                 '`A + B` < `"C", "D"`',
-                 '`"C", "D"` == `B ?!`')
+        exprs = ('A > B',
+                 'A < C',
+                 'C == B')
         for expr in exprs:
-            self.assert_eq(repr(kdf.query(expr)), repr(pdf.query(expr)))
+            self.assert_eq(kdf.query(expr), pdf.query(expr))
 
         # test `inplace=True`
         for expr in exprs:

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -2401,11 +2401,11 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
     def test_query(self):
         kdf = ks.DataFrame(
             {'A + B': range(1, 6),
-             'B ?!': range(10, 0, -2),
+             'B !': range(10, 0, -2),
              '"C", "D"': range(10, 5, -1)})
         pdf = kdf.to_pandas()
 
-        exprs = ('`A + B` > `B ?!`',
+        exprs = ('`A + B` > `B !`',
                  '`A + B` < `"C", "D"`',
                  '`"C", "D"` == `B ?!`')
         for expr in exprs:

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -2397,3 +2397,42 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         with self.assertRaisesRegex(ValueError, 'type of cond must be a DataFrame or Series'):
             kdf.mask(1)
+
+    def test_query(self):
+        kdf = ks.DataFrame(
+            {'A + B': range(1, 6),
+             'B ?!': range(10, 0, -2),
+             '"C", "D"': range(10, 5, -1)})
+        pdf = kdf.to_pandas()
+
+        exprs = ('`A + B` > `B ?!`',
+                 '`A + B` < `"C", "D"`',
+                 '`"C", "D"` == `B ?!`')
+        for expr in exprs:
+            self.assert_eq(kdf.query(expr), pdf.query(expr))
+
+        # test `inplace=True`
+        for expr in exprs:
+            dummy_kdf = kdf.copy()
+            dummy_pdf = pdf.copy()
+
+            pdf.query(expr, inplace=True)
+            kdf.query(expr, inplace=True)
+
+            self.assert_eq(dummy_kdf, dummy_pdf)
+
+        invalid_exprs = (1, 1.0, (exprs[0],), [exprs[0]])
+        for expr in invalid_exprs:
+            with self.assertRaisesRegex(
+                    ValueError,
+                    'expr must be a string to be evaluated, {} given'
+                    .format(type(expr))):
+                kdf.query(expr)
+
+        invalid_inplaces = (1, 0, 'True', 'False')
+        for inplace in invalid_inplaces:
+            with self.assertRaisesRegex(
+                    ValueError,
+                    'For argument "inplace" expected type bool, received type {}.'
+                    .format(type(inplace).__name__)):
+                kdf.query('a < b', inplace=inplace)

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -2421,6 +2421,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
             self.assert_eq(dummy_kdf, dummy_pdf)
 
+        # invalid values for `expr`
         invalid_exprs = (1, 1.0, (exprs[0],), [exprs[0]])
         for expr in invalid_exprs:
             with self.assertRaisesRegex(
@@ -2429,6 +2430,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
                     .format(type(expr))):
                 kdf.query(expr)
 
+        # invalid values for `inplace`
         invalid_inplaces = (1, 0, 'True', 'False')
         for inplace in invalid_inplaces:
             with self.assertRaisesRegex(
@@ -2436,3 +2438,9 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
                     'For argument "inplace" expected type bool, received type {}.'
                     .format(type(inplace).__name__)):
                 kdf.query('a < b', inplace=inplace)
+
+        # doesn't support for MultiIndex columns
+        columns = pd.MultiIndex.from_tuples([('A', 'Z'), ('B', 'X'), ('C', 'C')])
+        kdf.columns = columns
+        with self.assertRaisesRegex(ValueError, "Doesn't support for MultiIndex columns"):
+            kdf.query("('A', 'Z') > ('B', 'X')")

--- a/docs/source/reference/frame.rst
+++ b/docs/source/reference/frame.rst
@@ -64,6 +64,7 @@ Indexing, iteration
    DataFrame.get
    DataFrame.where
    DataFrame.mask
+   DataFrame.query
 
 Binary operator functions
 -------------------------


### PR DESCRIPTION
This PR proposes to implement `DataFrame.query`

```python
>>> df = ks.DataFrame({'A': range(1, 6),
...                    'B': range(10, 0, -2),
...                    'C C': range(10, 5, -1)})
>>> df
   A   B  C C
0  1  10   10
1  2   8    9
2  3   6    8
3  4   4    7
4  5   2    6

>>> df.query('A > B')
   A  B  C C
4  5  2    6

The previous expression is equivalent to

>>> df[df.A > df.B]
   A  B  C C
4  5  2    6

For columns with spaces in their name, you can use backtick quoting.

>>> df.query('B == `C C`')
   A   B  C C
0  1  10   10

The previous expression is equivalent to

>>> df[df.B == df['C C']]
   A   B  C C
0  1  10   10
```