### PR TITLE
Filter out draft release notes when generating release documentation

### DIFF
--- a/dev/gendoc.py
+++ b/dev/gendoc.py
@@ -80,7 +80,7 @@ def list_releases_to_document(cur_version):
     cur_version = "v" + cur_version
     releases = [(
         release['name'], release['tag_name'], release['body']
-    ) for release in retry(get_json, url=tag_url)]
+    ) for release in retry(get_json, url=tag_url) if not release['draft']]
     filtered = filter(
         lambda release: LooseVersion(release[1]) <= LooseVersion(cur_version), releases)
     return sorted(filtered, reverse=True, key=lambda release: LooseVersion(release[1]))


### PR DESCRIPTION
Currently, draft release note is included in the documentation. We should only include published release notes. Travis CI and Read the Docs can see this because it uses my github auth totkens to unlimit Github API calls., so they can upload.

This PR filter out draft release note explicitly. I manually tested and verified it works.

FYI, the JSON looks like this:

```json
  {
    "url": "https://api.github.com/repos/databricks/koalas/releases/18404404",
    "assets_url": "https://api.github.com/repos/databricks/koalas/releases/18404404/assets",
    "upload_url": "https://uploads.github.com/repos/databricks/koalas/releases/18404404/assets{?name,label}",
    "html_url": "https://github.com/databricks/koalas/releases/tag/v0.11.0",
    "id": 18404404,
    "node_id": "MDc6UmVsZWFzZTE4NDA0NDA0",
    "tag_name": "v0.11.0",
        "browser_download_url": "https://github.com/databricks/koalas/releases/download/v0.0.5/databricks-koala-0.0.5.tar.gz"
      },
      {
        "url": "https://api.github.com/repos/databricks/koalas/releases/assets/11735544",
        "id": 11735544,
        "node_id": "MDEyOlJlbGVhc2VBc3NldDExNzM1NTQ0",
        "name": "databricks_koala-0.0.5-py3-none-any.whl",
        "label": null,
        "uploader": {
          "login": "thunterdb",
          "id": 7594753,
          "node_id": "MDQ6VXNlcjc1OTQ3NTM=",
          "avatar_url": "https://avatars0.githubusercontent.com/u/7594753?v=4",
          "gravatar_id": "",
          "url": "https://api.github.com/users/thunterdb",
          "html_url": "https://github.com/thunterdb",
          "followers_url": "https://api.github.com/users/thunterdb/followers",
          "following_url": "https://api.github.com/users/thunterdb/following{/other_user}",
          "gists_url": "https://api.github.com/users/thunterdb/gists{/gist_id}",
          "starred_url": "https://api.github.com/users/thunterdb/starred{/owner}{/repo}",
          "subscriptions_url": "https://api.github.com/users/thunterdb/subscriptions",
          "organizations_url": "https://api.github.com/users/thunterdb/orgs",
          "repos_url": "https://api.github.com/users/thunterdb/repos",
          "events_url": "https://api.github.com/users/thunterdb/events{/privacy}",
          "received_events_url": "https://api.github.com/users/thunterdb/received_events",
          "type": "User",
          "site_admin": false
        },
        "content_type": "application/octet-stream",
        "state": "uploaded",
        "size": 30894,
        "download_count": 968,
        "created_at": "2019-03-26T13:51:53Z",
        "updated_at": "2019-03-26T13:51:55Z",
        "browser_download_url": "https://github.com/databricks/koalas/releases/download/v0.0.5/databricks_koala-0.0.5-py3-none-any.whl"
      }
    ],
    "tarball_url": "https://api.github.com/repos/databricks/koalas/tarball/v0.0.5",
    "zipball_url": "https://api.github.com/repos/databricks/koalas/zipball/v0.0.5",
    "body": "This is the initial release outside Databricks.\r\n\r\nThis release is meant to be a technology preview. See the README.md file for more information."
  }
```

as an example.