### PR TITLE
Implement DataFrame.map_in_pandas

### DIFF
--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -2339,6 +2339,46 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             self.assert_eq(kdf.apply(lambda x: len(x), axis=1).sort_index(),
                            pdf.apply(lambda x: len(x), axis=1).sort_index())
 
+    def test_map_in_pandas(self):
+        pdf = pd.DataFrame({'a': [1, 2, 3, 4, 5, 6] * 100,
+                            'b': [1., 1., 2., 3., 5., 8.] * 100,
+                            'c': [1, 4, 9, 16, 25, 36] * 100},
+                           columns=['a', 'b', 'c'],
+                           index=np.random.rand(600))
+        kdf = ks.DataFrame(pdf)
+
+        self.assert_eq(
+            kdf.map_in_pandas(lambda pdf: pdf + 1).sort_index(),
+            (pdf + 1).sort_index())
+        with option_context("compute.shortcut_limit", 500):
+            self.assert_eq(
+                kdf.map_in_pandas(lambda pdf: pdf + 1).sort_index(),
+                (pdf + 1).sort_index())
+
+        with self.assertRaisesRegex(AssertionError, "the first argument should be a callable"):
+            kdf.map_in_pandas(1)
+
+        with self.assertRaisesRegex(TypeError, "The given function.*frame as its type hints"):
+            def f2(_) -> ks.Series[int]:
+                pass
+            kdf.map_in_pandas(f2)
+
+        with self.assertRaisesRegex(ValueError, "The given function should return a frame"):
+            kdf.map_in_pandas(lambda pdf: 1)
+
+        # multi-index columns
+        columns = pd.MultiIndex.from_tuples([('x', 'a'), ('x', 'b'), ('y', 'c')])
+        pdf.columns = columns
+        kdf.columns = columns
+
+        self.assert_eq(
+            kdf.map_in_pandas(lambda x: x + 1).sort_index(),
+            (pdf + 1).sort_index())
+        with option_context("compute.shortcut_limit", 500):
+            self.assert_eq(
+                kdf.map_in_pandas(lambda x: x + 1).sort_index(),
+                (pdf + 1).sort_index())
+
     def test_empty_timestamp(self):
         pdf = pd.DataFrame({'t': [datetime(2019, 1, 1, 0, 0, 0),
                                   datetime(2019, 1, 2, 0, 0, 0),


### PR DESCRIPTION
This PR implements a Koalas specific API in order to directly use pandas DataFrame APIs.

For pandas Series APIs, we have a workaround for instance:

```python
>>> ks.range(10)[['id']].apply(lambda series: series)['id']
0    0
1    1
2    2
3    3
4    4
5    5
6    6
7    7
8    8
9    9
Name: id, dtype: int64
```

however, there is no way to use the APIs in the pandas DataFrame.

There is a similar API called [`map_partitions`](https://docs.dask.org/en/latest/dataframe-api.html#dask.dataframe.DataFrame.map_partitions) in Dask and this API is inspired by it.