### PR TITLE
Add util function validate_bool_kwarg

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -46,7 +46,8 @@ from pyspark.sql.types import (BooleanType, ByteType, DecimalType, DoubleType, F
 from pyspark.sql.window import Window
 
 from databricks import koalas as ks  # For running doctests and reference resolution in PyCharm.
-from databricks.koalas.utils import validate_arguments_and_invoke_function, align_diff_frames
+from databricks.koalas.utils import (validate_arguments_and_invoke_function, align_diff_frames,
+                                     validate_bool_kwarg)
 from databricks.koalas.generic import _Frame
 from databricks.koalas.internal import (_InternalFrame, HIDDEN_COLUMNS, NATURAL_ORDER_COLUMN_NAME,
                                         SPARK_INDEX_NAME_FORMAT, SPARK_DEFAULT_INDEX_NAME)
@@ -2684,6 +2685,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         2013  7     84
         2014  10    31
         """
+        inplace = validate_bool_kwarg(inplace, "inplace")
         if isinstance(keys, (str, tuple)):
             keys = [keys]
         else:
@@ -2857,6 +2859,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         lion           mammal   80.5     run
         monkey         mammal    NaN    jump
         """
+        inplace = validate_bool_kwarg(inplace, "inplace")
         multi_index = len(self._internal.index_map) > 1
 
         def rename(index):
@@ -4194,6 +4197,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         1  Batman  Batmobile  1940-04-25
         """
         axis = validate_axis(axis)
+        inplace = validate_bool_kwarg(inplace, "inplace")
         if axis == 0:
             if subset is not None:
                 if isinstance(subset, str):
@@ -4316,6 +4320,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         """
         if value is not None:
             axis = validate_axis(axis)
+            inplace = validate_bool_kwarg(inplace, "inplace")
             if axis != 0:
                 raise NotImplementedError("fillna currently only works for axis=0 or axis='index'")
             if not isinstance(value, (float, int, str, bool, dict, pd.Series)):
@@ -4565,6 +4570,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             raise NotImplementedError("replace currently works only when limit=None")
         if regex is not False:
             raise NotImplementedError("replace currently doesn't supports regex")
+        inplace = validate_bool_kwarg(inplace, "inplace")
 
         if value is not None and not isinstance(value, (int, float, str, list, dict)):
             raise TypeError("Unsupported type {}".format(type(value)))
@@ -5595,6 +5601,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         4     D     7     2
         3  None     8     4
         """
+        inplace = validate_bool_kwarg(inplace, "inplace")
         if isinstance(by, (str, tuple)):
             by = [by]  # type: ignore
         else:
@@ -5692,6 +5699,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         a 1  2  1
         b 1  0  3
         """
+        inplace = validate_bool_kwarg(inplace, "inplace")
         axis = validate_axis(axis)
         if axis != 0:
             raise NotImplementedError("No other axis than 0 are supported at the moment")
@@ -6910,6 +6918,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         3  2  c
         4  3  d
         """
+        inplace = validate_bool_kwarg(inplace, "inplace")
         if subset is None:
             subset = self._internal.column_labels
         elif isinstance(subset, str):
@@ -7807,6 +7816,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         index_mapper_ret_stype = None
         columns_mapper_fn = None
 
+        inplace = validate_bool_kwarg(inplace, "inplace")
         if mapper:
             axis = validate_axis(axis)
             if axis == 0:

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -43,8 +43,7 @@ from databricks.koalas.missing.groupby import _MissingPandasLikeDataFrameGroupBy
     _MissingPandasLikeSeriesGroupBy
 from databricks.koalas.series import Series, _col
 from databricks.koalas.config import get_option
-from databricks.koalas.utils import (column_labels_level, scol_for, name_like_string,
-                                     validate_bool_kwarg)
+from databricks.koalas.utils import column_labels_level, scol_for, name_like_string
 from databricks.koalas.window import RollingGroupby, ExpandingGroupby
 
 # to keep it the same as pandas
@@ -1299,7 +1298,7 @@ class GroupBy(object):
         """
         return self._fillna(value, method, axis, inplace, limit)
 
-    def bfill(self, inplace=False, limit=None):
+    def bfill(self, limit=None):
         """
         Synonym for `DataFrame.fillna()` with ``method=`bfill```.
 
@@ -1346,11 +1345,11 @@ class GroupBy(object):
         2  3.0  1.0  5
         3  3.0  1.0  4
         """
-        return self._fillna(method='bfill', inplace=inplace, limit=limit)
+        return self._fillna(method='bfill', limit=limit)
 
     backfill = bfill
 
-    def ffill(self, inplace=False, limit=None):
+    def ffill(self, limit=None):
         """
         Synonym for `DataFrame.fillna()` with ``method=`ffill```.
 
@@ -1397,7 +1396,7 @@ class GroupBy(object):
         2  NaN  NaN  5
         3  3.0  1.0  4
         """
-        return self._fillna(method='ffill', inplace=inplace, limit=limit)
+        return self._fillna(method='ffill', limit=limit)
 
     pad = ffill
 

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -43,7 +43,8 @@ from databricks.koalas.missing.groupby import _MissingPandasLikeDataFrameGroupBy
     _MissingPandasLikeSeriesGroupBy
 from databricks.koalas.series import Series, _col
 from databricks.koalas.config import get_option
-from databricks.koalas.utils import column_labels_level, scol_for, name_like_string
+from databricks.koalas.utils import (column_labels_level, scol_for, name_like_string,
+                                     validate_bool_kwarg)
 from databricks.koalas.window import RollingGroupby, ExpandingGroupby
 
 # to keep it the same as pandas
@@ -1298,7 +1299,7 @@ class GroupBy(object):
         """
         return self._fillna(value, method, axis, inplace, limit)
 
-    def bfill(self, limit=None):
+    def bfill(self, inplace=False, limit=None):
         """
         Synonym for `DataFrame.fillna()` with ``method=`bfill```.
 
@@ -1345,11 +1346,11 @@ class GroupBy(object):
         2  3.0  1.0  5
         3  3.0  1.0  4
         """
-        return self._fillna(method='bfill', limit=limit)
+        return self._fillna(method='bfill', inplace=inplace, limit=limit)
 
     backfill = bfill
 
-    def ffill(self, limit=None):
+    def ffill(self, inplace=False, limit=None):
         """
         Synonym for `DataFrame.fillna()` with ``method=`ffill```.
 
@@ -1396,7 +1397,7 @@ class GroupBy(object):
         2  NaN  NaN  5
         3  3.0  1.0  4
         """
-        return self._fillna(method='ffill', limit=limit)
+        return self._fillna(method='ffill', inplace=inplace, limit=limit)
 
     pad = ffill
 

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -46,7 +46,8 @@ from databricks.koalas.missing.series import _MissingPandasLikeSeries
 from databricks.koalas.plot import KoalasSeriesPlotMethods
 from databricks.koalas.ml import corr
 from databricks.koalas.utils import (validate_arguments_and_invoke_function, scol_for,
-                                     combine_frames, name_like_string, validate_axis)
+                                     combine_frames, name_like_string, validate_axis,
+                                     validate_bool_kwarg)
 from databricks.koalas.datetimes import DatetimeMethods
 from databricks.koalas.strings import StringMethods
 
@@ -1068,6 +1069,7 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         3    4
         Name: foo, dtype: int64
         """
+        inplace = validate_bool_kwarg(inplace, "inplace")
         if inplace and not drop:
             raise TypeError('Cannot reset_index inplace on a Series to create a DataFrame')
 
@@ -1334,6 +1336,7 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         5     hippo
         Name: animal, dtype: object
         """
+        inplace = validate_bool_kwarg(inplace, "inplace")
         kseries = _col(self.to_frame().drop_duplicates())
 
         if inplace:
@@ -1423,6 +1426,7 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
 
     def _fillna(self, value=None, method=None, axis=None, inplace=False, limit=None, part_cols=()):
         axis = validate_axis(axis)
+        inplace = validate_bool_kwarg(inplace, "inplace")
         if axis != 0:
             raise NotImplementedError("fillna currently only works for axis=0 or axis='index'")
         if (value is None) and (method is None):
@@ -1513,6 +1517,7 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         1    2.0
         Name: 0, dtype: float64
         """
+        inplace = validate_bool_kwarg(inplace, "inplace")
         # TODO: last two examples from Pandas produce different results.
         kseries = _col(self.to_dataframe().dropna(axis=axis, inplace=False))
         if inplace:
@@ -1878,6 +1883,7 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         0    z
         Name: 0, dtype: object
         """
+        inplace = validate_bool_kwarg(inplace, "inplace")
         kseries = _col(self.to_dataframe().sort_values(by=self.name, ascending=ascending,
                                                        na_position=na_position))
         if inplace:
@@ -1965,6 +1971,7 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         b  1    0
         Name: 0, dtype: int64
         """
+        inplace = validate_bool_kwarg(inplace, "inplace")
         kseries = _col(self.to_dataframe().sort_index(axis=axis, level=level, ascending=ascending,
                                                       kind=kind, na_position=na_position))
         if inplace:

--- a/databricks/koalas/tests/test_utils.py
+++ b/databricks/koalas/tests/test_utils.py
@@ -17,7 +17,8 @@
 import pandas as pd
 
 from databricks.koalas.testing.utils import ReusedSQLTestCase, SQLTestUtils
-from databricks.koalas.utils import lazy_property, validate_arguments_and_invoke_function
+from databricks.koalas.utils import (lazy_property, validate_arguments_and_invoke_function,
+                                     validate_bool_kwarg)
 
 some_global_variable = 0
 
@@ -64,6 +65,20 @@ class UtilsTest(ReusedSQLTestCase, SQLTestUtils):
         # If lazy prop is not working, the second test would fail (because it'd be 2)
         self.assert_eq(obj.lazy_prop, 1)
         self.assert_eq(obj.lazy_prop, 1)
+
+    def test_validate_bool_kwarg(self):
+        # This should pass and run fine
+        koalas = True
+        self.assert_eq(validate_bool_kwarg(koalas, "koalas"), True)
+        koalas = False
+        self.assert_eq(validate_bool_kwarg(koalas, "koalas"), False)
+
+        # This should fail because we are explicitly setting a non-boolean value
+        koalas = "true"
+        with self.assertRaisesRegex(
+                ValueError,
+                'For argument "koalas" expected type bool, received type str.'):
+            validate_bool_kwarg(koalas, "koalas")
 
 
 class TestClassForLazyProp:

--- a/databricks/koalas/tests/test_utils.py
+++ b/databricks/koalas/tests/test_utils.py
@@ -72,6 +72,8 @@ class UtilsTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(validate_bool_kwarg(koalas, "koalas"), True)
         koalas = False
         self.assert_eq(validate_bool_kwarg(koalas, "koalas"), False)
+        koalas = None
+        self.assert_eq(validate_bool_kwarg(koalas, "koalas"), None)
 
         # This should fail because we are explicitly setting a non-boolean value
         koalas = "true"

--- a/databricks/koalas/utils.py
+++ b/databricks/koalas/utils.py
@@ -411,6 +411,16 @@ def validate_axis(axis=0, none_axis=0):
     return {None: none_axis, 'index': 0, 'columns': 1}.get(axis, axis)
 
 
+def validate_bool_kwarg(value, arg_name):
+    """ Ensures that argument passed in arg_name is of type bool. """
+    if not (isinstance(value, bool) or value is None):
+        raise ValueError(
+            'For argument "{}" expected type bool, received '
+            "type {}.".format(arg_name, type(value).__name__)
+        )
+    return value
+
+
 def compare_null_first(left, right, comp):
     return ((left.isNotNull() & right.isNotNull() & comp(left, right))
             | (left.isNull() & right.isNotNull()))


### PR DESCRIPTION
There is some mismatch between pandas and Koalas when using `inplace` parameter like the below.

- pandas (only allows `True` or `False`)
```python
>>> pdf
   A    B    C  D
0  1  2.0  NaN  0
1  1  4.0  NaN  1
2  2  NaN  NaN  5
3  2  3.0  1.0  4

>>> pdf.fillna('A', inplace=1)
Traceback (most recent call last):
...
ValueError: For argument "inplace" expected type bool, received type int.
```

- Koalas (allows any type)
```python
>>> kdf
   A    B    C  D
0  1  2.0  NaN  0
1  1  4.0  NaN  1
2  2  NaN  NaN  5
3  2  3.0  1.0  4

>>> kdf.fillna('A', inplace=1)
>>> kdf
   A    B    C  D
0  1  2.0    A  0
1  1  4.0    A  1
2  2    A    A  5
3  2  3.0  1.0  4
```

i think we should fix them to make work same with pandas.

so, i think we'd better have an util function `validate_bool_kwarg` for this (and also pandas has same one)