### PR TITLE
Add 'axes' for DataFrame & Series and 'assert_list_eq' for testing

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -411,7 +411,7 @@ class DataFrame(_Frame, Generic[T]):
     def axes(self):
         """
         Return a list representing the axes of the DataFrame.
-        
+
         It has the row axis labels and column axis labels as the only members.
         They are returned in that order.
 
@@ -421,10 +421,6 @@ class DataFrame(_Frame, Generic[T]):
         >>> df = ks.DataFrame({'col1': [1, 2], 'col2': [3, 4]})
         >>> df.axes
         [RangeIndex(start=0, stop=2, step=1), Index(['col1', 'col2'], dtype='object')]
-
-        MultiIndex (for Series also)
-
-        MultiIndex columns
         """
         return [self.index, self.columns]
 

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -407,6 +407,27 @@ class DataFrame(_Frame, Generic[T]):
         """
         return 2
 
+    @property
+    def axes(self):
+        """
+        Return a list representing the axes of the DataFrame.
+        
+        It has the row axis labels and column axis labels as the only members.
+        They are returned in that order.
+
+        Examples
+        --------
+
+        >>> df = ks.DataFrame({'col1': [1, 2], 'col2': [3, 4]})
+        >>> df.axes
+        [RangeIndex(start=0, stop=2, step=1), Index(['col1', 'col2'], dtype='object')]
+
+        MultiIndex (for Series also)
+
+        MultiIndex columns
+        """
+        return [self.index, self.columns]
+
     def _reduce_for_stat_function(self, sfun, name, axis=None, numeric_only=False):
         """
         Applies sfun to each column and returns a pd.Series where the number of rows equal the

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -420,7 +420,7 @@ class DataFrame(_Frame, Generic[T]):
 
         >>> df = ks.DataFrame({'col1': [1, 2], 'col2': [3, 4]})
         >>> df.axes
-        [RangeIndex(start=0, stop=2, step=1), Index(['col1', 'col2'], dtype='object')]
+        [Int64Index([0, 1], dtype='int64'), Index(['col1', 'col2'], dtype='object')]
         """
         return [self.index, self.columns]
 

--- a/databricks/koalas/missing/frame.py
+++ b/databricks/koalas/missing/frame.py
@@ -29,9 +29,6 @@ def unsupported_property(property_name, deprecated=False, reason=""):
 
 class _MissingPandasLikeDataFrame(object):
 
-    # Properties
-    axes = unsupported_property('axes')
-
     # Deprecated properties
     blocks = unsupported_property('blocks', deprecated=True)
     ftypes = unsupported_property('ftypes', deprecated=True)

--- a/databricks/koalas/missing/series.py
+++ b/databricks/koalas/missing/series.py
@@ -29,9 +29,6 @@ def unsupported_property(property_name, deprecated=False, reason=""):
 
 class _MissingPandasLikeSeries(object):
 
-    # Properties
-    axes = unsupported_property('axes')
-
     # Deprecated properties
     blocks = unsupported_property('blocks', deprecated=True)
     ftypes = unsupported_property('ftypes', deprecated=True)

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -354,17 +354,14 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
     @property
     def axes(self):
         """
-        Return a list representing the axes of the DataFrame.
-
-        It has the row axis labels and column axis labels as the only members.
-        They are returned in that order.
+        Return a list of the row axis labels.
 
         Examples
         --------
 
         >>> kser = ks.Series([1, 2, 3])
         >>> kser.axes
-        [RangeIndex(start=0, stop=2, step=1), Index(['col1', 'col2'], dtype='object')]
+        [Int64Index([0, 1, 2], dtype='int64')]
         """
         return [self.index]
 

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -352,6 +352,23 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         return self.dtype
 
     @property
+    def axes(self):
+        """
+        Return a list representing the axes of the DataFrame.
+
+        It has the row axis labels and column axis labels as the only members.
+        They are returned in that order.
+
+        Examples
+        --------
+
+        >>> kser = ks.Series([1, 2, 3])
+        >>> kser.axes
+        [RangeIndex(start=0, stop=2, step=1), Index(['col1', 'col2'], dtype='object')]
+        """
+        return [self.index]
+
+    @property
     def spark_type(self):
         """ Returns the data type as defined by Spark, as a Spark DataType object."""
         return self._internal.spark_type_for(self._internal.column_labels[0])

--- a/databricks/koalas/testing/utils.py
+++ b/databricks/koalas/testing/utils.py
@@ -216,6 +216,10 @@ class ReusedSQLTestCase(unittest.TestCase, SQLTestUtils):
     def assert_array_eq(self, left, right):
         self.assertTrue((left == right).all())
 
+    def assert_list_eq(self, left, right):
+        for litem, ritem in zip(left, right):
+            self.assert_eq(litem, ritem)
+
     @staticmethod
     def _to_pandas(df):
         if isinstance(df, (DataFrame, Series, Index)):

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -2444,3 +2444,14 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         kdf.columns = columns
         with self.assertRaisesRegex(ValueError, "Doesn't support for MultiIndex columns"):
             kdf.query("('A', 'Z') > ('B', 'X')")
+
+    def test_axes(self):
+        pdf = self.pdf
+        kdf = ks.from_pandas(pdf)
+        self.assert_list_eq(pdf.axes, kdf.axes)
+
+        # multi-index columns
+        columns = pd.MultiIndex.from_tuples([('x', 'a'), ('y', 'b')])
+        pdf.columns = columns
+        kdf.columns = columns
+        self.assert_list_eq(pdf.axes, kdf.axes)

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -1124,3 +1124,17 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
                        pser.pct_change(periods=-100000000), almost=True)
         self.assert_eq(kser.pct_change(periods=100000000),
                        pser.pct_change(periods=100000000), almost=True)
+
+    def test_axes(self):
+        kser = ks.Series([90, 91, 85], index=[2, 4, 1])
+        pser = kser.to_pandas()
+        self.assert_list_eq(kser.axes, pser.axes)
+
+        # for MultiIndex
+        midx = pd.MultiIndex([['lama', 'cow', 'falcon'],
+                              ['speed', 'weight', 'length']],
+                             [[0, 0, 0, 1, 1, 1, 2, 2, 2],
+                              [0, 1, 2, 0, 1, 2, 0, 1, 2]])
+        kser = ks.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3], index=midx)
+        pser = kser.to_pandas()
+        self.assert_list_eq(kser.axes, pser.axes)

--- a/docs/source/reference/frame.rst
+++ b/docs/source/reference/frame.rst
@@ -27,6 +27,7 @@ Attributes and underlying data
 
    DataFrame.dtypes
    DataFrame.shape
+   DataFrame.axes
    DataFrame.ndim
    DataFrame.size
    DataFrame.select_dtypes

--- a/docs/source/reference/series.rst
+++ b/docs/source/reference/series.rst
@@ -28,6 +28,7 @@ Attributes
    Series.name
    Series.spark_type
    Series.shape
+   Series.axes
    Series.size
    Series.empty
    Series.T


### PR DESCRIPTION
Implement `axes` for DataFrame & Series.
(https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.axes.html)

```python
>>> df = ks.DataFrame({'col1': [1, 2], 'col2': [3, 4]})
>>> df.axes
[RangeIndex(start=0, stop=2, step=1), Index(['col1', 'col2'],
dtype='object')]
```

and add test function `assert_list_eq` for comparing all member of list with `assert_eq`