### PR TITLE
[MINOR] applying util func 'validate_bool_kwarg' to 'DataFrame.query'

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -8605,10 +8605,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             raise ValueError(
                 'expr must be a string to be evaluated, {} given'
                 .format(type(expr)))
-        if not isinstance(inplace, bool):
-            raise ValueError(
-                'For argument "inplace" expected type bool, received type {}.'
-                .format(type(inplace).__name__))
+        inplace = validate_bool_kwarg(inplace, "inplace")
 
         sdf = self._sdf.filter(expr)
         internal = self._internal.copy(sdf=sdf)


### PR DESCRIPTION
This is nit.

there is a missing case for `validate_bool_kwarg` is found, just added.