### PR TITLE
add conda-forge channel

### DIFF
--- a/docs/source/getting_started/install.rst
+++ b/docs/source/getting_started/install.rst
@@ -45,11 +45,11 @@ To put your self inside this environment run::
 The final step required is to install Koalas. This can be done with the
 following command::
 
-    conda install koalas
+    conda install -c conda-forge koalas
 
 To install a specific Koalas version::
 
-    conda install koalas=0.19.0
+    conda install -c conda-forge koalas=0.19.0
 
 
 Installing from PyPI


### PR DESCRIPTION
By default, Anaconda does not have `conda-forge` channel in the config, causing

```
conda install koalas
```

from [Getting started](https://koalas.readthedocs.io/en/latest/getting_started/install.html) to fail. The issue is not apparent for the people not accustomed to `conda` as demonstrated in [this SO post](https://stackoverflow.com/questions/60263669/how-to-install-koalas-with-conda/60263951#60263951). 