### PR TITLE
[MINOR] Uncomment doctest for DataFrame.query

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -8539,7 +8539,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 1  3  4
                 2  5  6
                 >>> num = 1
-                >>> df.map_in_pandas(lambda pdf: pdf.query('A > @num'))  # doctest: +SKIP
+                >>> df.map_in_pandas(lambda pdf: pdf.query('A > @num'))
                    A  B
                 1  3  4
                 2  5  6


### PR DESCRIPTION
As requested at https://github.com/databricks/koalas/pull/1273#discussion_r380129074 ,

and since `map_in_pandas` (#1276 ) has been merged,

just uncommented existing doctest for DataFrame.query