### PR TITLE
Implement DataFrame.take

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -8644,6 +8644,86 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         """
         self._internal.spark_internal_df.explain(extended)
 
+    def take(self, indices, axis=0, **kwargs):
+        """
+        Return the elements in the given *positional* indices along an axis.
+
+        This means that we are not indexing according to actual values in
+        the index attribute of the object. We are indexing according to the
+        actual position of the element in the object.
+
+        ..note:: This method has some disadvantage in terms of performance since
+            implemented by using :meth:`DataFrame.map_in_pandas`.
+            See the note of :meth:`DataFrame.map_in_pandas` if you want to know
+            about those disadvantage for more detail.
+
+        Parameters
+        ----------
+        indices : array-like
+            An array of ints indicating which positions to take.
+        axis : {0 or 'index', 1 or 'columns', None}, default 0
+            The axis on which to select elements. ``0`` means that we are
+            selecting rows, ``1`` means that we are selecting columns.
+        **kwargs
+            For compatibility with :meth:`numpy.take`. Has no effect on the
+            output.
+
+        Returns
+        -------
+        taken : same type as caller
+            An array-like containing the elements taken from the object.
+
+        See Also
+        --------
+        DataFrame.loc : Select a subset of a DataFrame by labels.
+        DataFrame.iloc : Select a subset of a DataFrame by positions.
+        numpy.take : Take elements from an array along an axis.
+
+        Examples
+        --------
+        >>> df = ks.DataFrame([('falcon', 'bird', 389.0),
+        ...                    ('parrot', 'bird', 24.0),
+        ...                    ('lion', 'mammal', 80.5),
+        ...                    ('monkey', 'mammal', np.nan)],
+        ...                   columns=['name', 'class', 'max_speed'],
+        ...                   index=[0, 2, 3, 1])
+        >>> df
+             name   class  max_speed
+        0  falcon    bird      389.0
+        2  parrot    bird       24.0
+        3    lion  mammal       80.5
+        1  monkey  mammal        NaN
+
+        Take elements at positions 0 and 3 along the axis 0 (default).
+
+        Note how the actual indices selected (0 and 1) do not correspond to
+        our selected indices 0 and 3. That's because we are selecting the 0th
+        and 3rd rows, not rows whose indices equal 0 and 3.
+
+        >>> df.take([0, 3])
+             name   class  max_speed
+        0  falcon    bird      389.0
+        1  monkey  mammal        NaN
+
+        Take elements at indices 1 and 2 along the axis 1 (column selection).
+
+        >>> df.take([1, 2], axis=1)
+            class  max_speed
+        0    bird      389.0
+        2    bird       24.0
+        3  mammal       80.5
+        1  mammal        NaN
+
+        We may take elements using negative integers for positive indices,
+        starting from the end of the object, just like with Python lists.
+
+        >>> df.take([-1, -2])
+             name   class  max_speed
+        1  monkey  mammal        NaN
+        3    lion  mammal       80.5
+        """
+        return self.map_in_pandas(lambda pdf: pdf.take(indices, axis, **kwargs))
+
     def _to_internal_pandas(self):
         """
         Return a pandas DataFrame directly from _internal to avoid overhead of copy.

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -9653,29 +9653,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         3    lion  mammal       80.5
         """
         axis = validate_axis(axis)
-        sdf = self._sdf
         if axis == 0:
-            length = len(self)
-            indices = [length + idx if idx < 0 else idx for idx in indices]
-            sdf = sdf.select(self._internal.spark_columns)
-            sequence_col = verify_temp_column_name(sdf, "__distributed_sequence__")
-            sdf = _InternalFrame.attach_distributed_sequence_column(sdf, column_name=sequence_col)
-            cond = sdf[sequence_col].isin(indices)
-            sdf = sdf.where(cond)
-            internal = self._internal.copy(spark_frame=sdf.select(self._internal.spark_columns))
+            return self.iloc[indices, :]
         elif axis == 1:
-            length = len(self.columns)
-            indices = [length + idx if idx < 0 else idx for idx in indices]
-            data_scols = self._internal.data_spark_columns
-            column_labels = self._internal.column_labels
-            selected_data_scols = [data_scols[index] for index in indices]
-            selected_sdf = sdf.select(self._internal.index_spark_columns + selected_data_scols)
-            internal = _InternalFrame(
-                spark_frame=selected_sdf,
-                index_map=self._internal.index_map,
-                column_labels=[column_labels[index] for index in indices],
-            )
-        return DataFrame(internal)
+            return self.iloc[:, indices]
 
     def _to_internal_pandas(self):
         """

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -62,7 +62,6 @@ from databricks.koalas.utils import (
     validate_arguments_and_invoke_function,
     align_diff_frames,
     validate_bool_kwarg,
-    verify_temp_column_name,
 )
 from databricks.koalas.generic import _Frame
 from databricks.koalas.internal import (

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -9652,6 +9652,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         3    lion  mammal       80.5
         """
         axis = validate_axis(axis)
+        if not is_list_like(indices) or isinstance(indices, (dict, set)):
+            raise ValueError("`indices` must be a list-like except dict or set")
         if axis == 0:
             return self.iloc[indices, :]
         elif axis == 1:

--- a/databricks/koalas/missing/frame.py
+++ b/databricks/koalas/missing/frame.py
@@ -77,7 +77,6 @@ class _MissingPandasLikeDataFrame(object):
     swapaxes = unsupported_function('swapaxes')
     swaplevel = unsupported_function('swaplevel')
     tail = unsupported_function('tail')
-    take = unsupported_function('take')
     to_feather = unsupported_function('to_feather')
     to_gbq = unsupported_function('to_gbq')
     to_hdf = unsupported_function('to_hdf')

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -2484,3 +2484,39 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         kdf.columns = columns
         with self.assertRaisesRegex(ValueError, "Doesn't support for MultiIndex columns"):
             kdf.query("('A', 'Z') > ('B', 'X')")
+
+    def test_take(self):
+        kdf = ks.DataFrame(
+            {'A': range(1, 6),
+             'B': range(10, 0, -2),
+             'C': range(10, 5, -1)})
+        pdf = kdf.to_pandas()
+
+        # axis=0 (default)
+        self.assert_eq(kdf.take([1, 2]),
+                       pdf.take([1, 2]))
+        self.assert_eq(kdf.take([-1, -2]),
+                       pdf.take([-1, -2]))
+
+        # axis=1
+        self.assert_eq(kdf.take([1, 2], axis=1),
+                       pdf.take([1, 2], axis=1))
+        self.assert_eq(kdf.take([-1, -2], axis=1),
+                       pdf.take([-1, -2], axis=1))
+
+        # MultiIndex columns
+        columns = pd.MultiIndex.from_tuples([('A', 'Z'), ('B', 'X'), ('C', 'C')])
+        kdf.columns = columns
+        pdf.columns = columns
+
+        # MultiIndex columns with axis=0 (default)
+        self.assert_eq(kdf.take([1, 2]),
+                       pdf.take([1, 2]))
+        self.assert_eq(kdf.take([-1, -2]),
+                       pdf.take([-1, -2]))
+
+        # MultiIndex columns with axis=1
+        self.assert_eq(kdf.take([1, 2], axis=1),
+                       pdf.take([1, 2], axis=1))
+        self.assert_eq(kdf.take([-1, -2], axis=1),
+                       pdf.take([-1, -2], axis=1))

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -3051,6 +3051,12 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             kdf.take([-1, -2], axis=1).sort_index(), pdf.take([-1, -2], axis=1).sort_index(),
         )
 
+        # Checking the type of indices.
+        self.assertRaises(ValueError, lambda: kdf.take(1))
+        self.assertRaises(ValueError, lambda: kdf.take("1"))
+        self.assertRaises(ValueError, lambda: kdf.take({1, 2}))
+        self.assertRaises(ValueError, lambda: kdf.take({1: None, 2: None}))
+
     def test_axes(self):
         pdf = self.pdf
         kdf = ks.from_pandas(pdf)

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -2973,12 +2973,15 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         pdf = kdf.to_pandas()
 
         # axis=0 (default)
-        self.assert_eq(kdf.take([1, 2]), pdf.take([1, 2]))
-        self.assert_eq(kdf.take([-1, -2]), pdf.take([-1, -2]))
+        self.assert_eq(kdf.take([1, 2]).sort_index(), pdf.take([1, 2]).sort_index())
+        self.assert_eq(kdf.take([-1, -2]).sort_index(), pdf.take([-1, -2]).sort_index())
 
-        # axis=1
-        self.assert_eq(kdf.take([1, 2], axis=1), pdf.take([1, 2], axis=1))
-        self.assert_eq(kdf.take([-1, -2], axis=1), pdf.take([-1, -2], axis=1))
+        # self.assert_eq(
+        #     kdf.take([1, 2], axis=1).sort_index(), pdf.take([1, 2], axis=1).sort_index()
+        # )
+        # self.assert_eq(
+        #     kdf.take([-1, -2], axis=1).sort_index(), pdf.take([-1, -2], axis=1).sort_index()
+        # )
 
         # MultiIndex columns
         columns = pd.MultiIndex.from_tuples([("A", "Z"), ("B", "X"), ("C", "C")])
@@ -2986,12 +2989,15 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         pdf.columns = columns
 
         # MultiIndex columns with axis=0 (default)
-        self.assert_eq(kdf.take([1, 2]), pdf.take([1, 2]))
-        self.assert_eq(kdf.take([-1, -2]), pdf.take([-1, -2]))
+        self.assert_eq(kdf.take([1, 2]).sort_index(), pdf.take([1, 2]).sort_index())
+        self.assert_eq(kdf.take([-1, -2]).sort_index(), pdf.take([-1, -2]).sort_index())
 
-        # MultiIndex columns with axis=1
-        self.assert_eq(kdf.take([1, 2], axis=1), pdf.take([1, 2], axis=1))
-        self.assert_eq(kdf.take([-1, -2], axis=1), pdf.take([-1, -2], axis=1))
+        # self.assert_eq(
+        #     kdf.take([1, 2], axis=1).sort_index(), pdf.take([1, 2], axis=1).sort_index()
+        # )
+        # self.assert_eq(
+        #     kdf.take([-1, -2], axis=1).sort_index(), pdf.take([-1, -2], axis=1).sort_index()
+        # )
 
     def test_axes(self):
         pdf = self.pdf

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -2976,12 +2976,11 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(kdf.take([1, 2]).sort_index(), pdf.take([1, 2]).sort_index())
         self.assert_eq(kdf.take([-1, -2]).sort_index(), pdf.take([-1, -2]).sort_index())
 
-        # self.assert_eq(
-        #     kdf.take([1, 2], axis=1).sort_index(), pdf.take([1, 2], axis=1).sort_index()
-        # )
-        # self.assert_eq(
-        #     kdf.take([-1, -2], axis=1).sort_index(), pdf.take([-1, -2], axis=1).sort_index()
-        # )
+        # axis=1
+        self.assert_eq(kdf.take([1, 2], axis=1).sort_index(), pdf.take([1, 2], axis=1).sort_index())
+        self.assert_eq(
+            kdf.take([-1, -2], axis=1).sort_index(), pdf.take([-1, -2], axis=1).sort_index()
+        )
 
         # MultiIndex columns
         columns = pd.MultiIndex.from_tuples([("A", "Z"), ("B", "X"), ("C", "C")])
@@ -2992,12 +2991,11 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(kdf.take([1, 2]).sort_index(), pdf.take([1, 2]).sort_index())
         self.assert_eq(kdf.take([-1, -2]).sort_index(), pdf.take([-1, -2]).sort_index())
 
-        # self.assert_eq(
-        #     kdf.take([1, 2], axis=1).sort_index(), pdf.take([1, 2], axis=1).sort_index()
-        # )
-        # self.assert_eq(
-        #     kdf.take([-1, -2], axis=1).sort_index(), pdf.take([-1, -2], axis=1).sort_index()
-        # )
+        # axis=1
+        self.assert_eq(kdf.take([1, 2], axis=1).sort_index(), pdf.take([1, 2], axis=1).sort_index())
+        self.assert_eq(
+            kdf.take([-1, -2], axis=1).sort_index(), pdf.take([-1, -2], axis=1).sort_index()
+        )
 
     def test_axes(self):
         pdf = self.pdf

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -2975,11 +2975,38 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         # axis=0 (default)
         self.assert_eq(kdf.take([1, 2]).sort_index(), pdf.take([1, 2]).sort_index())
         self.assert_eq(kdf.take([-1, -2]).sort_index(), pdf.take([-1, -2]).sort_index())
+        self.assert_eq(
+            kdf.take(range(100, 110)).sort_index(), pdf.take(range(100, 110)).sort_index()
+        )
+        self.assert_eq(
+            kdf.take(range(-110, -100)).sort_index(), pdf.take(range(-110, -100)).sort_index()
+        )
+        self.assert_eq(
+            kdf.take([10, 100, 1000, 10000]).sort_index(),
+            pdf.take([10, 100, 1000, 10000]).sort_index(),
+        )
+        self.assert_eq(
+            kdf.take([-10, -100, -1000, -10000]).sort_index(),
+            pdf.take([-10, -100, -1000, -10000]).sort_index(),
+        )
 
         # axis=1
         self.assert_eq(kdf.take([1, 2], axis=1).sort_index(), pdf.take([1, 2], axis=1).sort_index())
         self.assert_eq(
             kdf.take([-1, -2], axis=1).sort_index(), pdf.take([-1, -2], axis=1).sort_index()
+        )
+        self.assert_eq(
+            kdf.take(range(1, 3), axis=1).sort_index(), pdf.take(range(1, 3), axis=1).sort_index(),
+        )
+        self.assert_eq(
+            kdf.take(range(-1, -3), axis=1).sort_index(),
+            pdf.take(range(-1, -3), axis=1).sort_index(),
+        )
+        self.assert_eq(
+            kdf.take([2, 1], axis=1).sort_index(), pdf.take([2, 1], axis=1).sort_index(),
+        )
+        self.assert_eq(
+            kdf.take([-1, -2], axis=1).sort_index(), pdf.take([-1, -2], axis=1).sort_index(),
         )
 
         # MultiIndex columns
@@ -2990,11 +3017,38 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         # MultiIndex columns with axis=0 (default)
         self.assert_eq(kdf.take([1, 2]).sort_index(), pdf.take([1, 2]).sort_index())
         self.assert_eq(kdf.take([-1, -2]).sort_index(), pdf.take([-1, -2]).sort_index())
+        self.assert_eq(
+            kdf.take(range(100, 110)).sort_index(), pdf.take(range(100, 110)).sort_index()
+        )
+        self.assert_eq(
+            kdf.take(range(-110, -100)).sort_index(), pdf.take(range(-110, -100)).sort_index()
+        )
+        self.assert_eq(
+            kdf.take([10, 100, 1000, 10000]).sort_index(),
+            pdf.take([10, 100, 1000, 10000]).sort_index(),
+        )
+        self.assert_eq(
+            kdf.take([-10, -100, -1000, -10000]).sort_index(),
+            pdf.take([-10, -100, -1000, -10000]).sort_index(),
+        )
 
         # axis=1
         self.assert_eq(kdf.take([1, 2], axis=1).sort_index(), pdf.take([1, 2], axis=1).sort_index())
         self.assert_eq(
             kdf.take([-1, -2], axis=1).sort_index(), pdf.take([-1, -2], axis=1).sort_index()
+        )
+        self.assert_eq(
+            kdf.take(range(1, 3), axis=1).sort_index(), pdf.take(range(1, 3), axis=1).sort_index(),
+        )
+        self.assert_eq(
+            kdf.take(range(-1, -3), axis=1).sort_index(),
+            pdf.take(range(-1, -3), axis=1).sort_index(),
+        )
+        self.assert_eq(
+            kdf.take([2, 1], axis=1).sort_index(), pdf.take([2, 1], axis=1).sort_index(),
+        )
+        self.assert_eq(
+            kdf.take([-1, -2], axis=1).sort_index(), pdf.take([-1, -2], axis=1).sort_index(),
         )
 
     def test_axes(self):

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -2487,9 +2487,9 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
     def test_take(self):
         kdf = ks.DataFrame(
-            {'A': range(1, 6),
-             'B': range(10, 0, -2),
-             'C': range(10, 5, -1)})
+            {'A': range(0, 50000),
+             'B': range(100000, 0, -2),
+             'C': range(100000, 50000, -1)})
         pdf = kdf.to_pandas()
 
         # axis=0 (default)

--- a/docs/source/reference/frame.rst
+++ b/docs/source/reference/frame.rst
@@ -155,6 +155,7 @@ Reindexing / Selection / Label manipulation
    DataFrame.head
    DataFrame.reset_index
    DataFrame.set_index
+   DataFrame.take
    DataFrame.isin
    DataFrame.sample
 


### PR DESCRIPTION
This PR proposes Implement of [DataFrame.take](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.take.html#pandas.DataFrame.take)


```python
>>> df = ks.DataFrame([('falcon', 'bird', 389.0),
...                    ('parrot', 'bird', 24.0),
...                    ('lion', 'mammal', 80.5),
...                    ('monkey', 'mammal', np.nan)],
...                   columns=['name', 'class', 'max_speed'],
...                   index=[0, 2, 3, 1])
>>> df
     name   class  max_speed
0  falcon    bird      389.0
2  parrot    bird       24.0
3    lion  mammal       80.5
1  monkey  mammal        NaN

>>> df.take([0, 3])
     name   class  max_speed
0  falcon    bird      389.0
1  monkey  mammal        NaN

>>> df.take([1, 2], axis=1)
    class  max_speed
0    bird      389.0
2    bird       24.0
3  mammal       80.5
1  mammal        NaN

>>> df.take([-1, -2])
     name   class  max_speed
1  monkey  mammal        NaN
3    lion  mammal       80.5
```