### PR TITLE
Let extra options have higher priority to allow workarounds in read_csv

### DIFF
--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -203,7 +203,6 @@ def read_csv(path, sep=',', header='infer', names=None, index_col=None,
         usecols = list(usecols)
     if usecols is None or callable(usecols) or len(usecols) > 0:
         reader = default_session().read
-        reader.options(**options)
         reader.option("inferSchema", True)
         reader.option("sep", sep)
 
@@ -225,6 +224,8 @@ def read_csv(path, sep=',', header='infer', names=None, index_col=None,
             if not isinstance(comment, str) or len(comment) != 1:
                 raise ValueError("Only length-1 comment characters supported")
             reader.option("comment", comment)
+
+        reader.options(**options)
 
         if isinstance(names, str):
             sdf = reader.schema(names).csv(path)

--- a/databricks/koalas/tests/test_csv.py
+++ b/databricks/koalas/tests/test_csv.py
@@ -228,6 +228,9 @@ class CsvTest(ReusedSQLTestCase, TestUtils):
             self.assert_eq(ks.read_csv(fn, escapechar='E'),
                            pd.read_csv(fn, escapechar='E'), almost=True)
 
+            self.assert_eq(ks.read_csv(fn, escapechar='ABC', escape="E"),
+                           pd.read_csv(fn, escapechar='E'), almost=True)
+
     def test_to_csv(self):
         pdf = pd.DataFrame({'aa': [1, 2, 3], 'bb': [4, 5, 6]}, index=[0, 1, 3])
         kdf = ks.DataFrame(pdf)


### PR DESCRIPTION
This PR proposes to let extra options have higher priority to allow workarounds.

For instance, after this PR, you can disable schema inference:

```python
>>> import databricks.koalas as ks
>>> ks.read_csv("tmp.csv").dtypes
a    int32
b    int32
c    int32
dtype: object
>>> ks.read_csv("tmp.csv", inferSchema=False).dtypes
a    object
b    object
c    object
```