### PR TITLE
Fix style at test_csv.py according to the linter script

### DIFF
--- a/databricks/koalas/tests/test_csv.py
+++ b/databricks/koalas/tests/test_csv.py
@@ -267,8 +267,11 @@ class CsvTest(ReusedSQLTestCase, TestUtils):
                 ks.read_csv(fn, escapechar="E"), pd.read_csv(fn, escapechar="E"), almost=True
             )
 
-            self.assert_eq(ks.read_csv(fn, escapechar='ABC', escape="E"),
-                           pd.read_csv(fn, escapechar='E'), almost=True)
+            self.assert_eq(
+                ks.read_csv(fn, escapechar="ABC", escape="E"),
+                pd.read_csv(fn, escapechar="E"),
+                almost=True,
+            )
 
     def test_to_csv(self):
         pdf = pd.DataFrame({"aa": [1, 2, 3], "bb": [4, 5, 6]}, index=[0, 1, 3])


### PR DESCRIPTION
The PR was synced after Black integration and the tests passed at https://github.com/databricks/koalas/pull/1296. But looks there was a sync'ing problem.