### PR TITLE
[WIP] Fix Index.to_series to work properly

### DIFF
--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -662,7 +662,8 @@ class Index(IndexOpsMixin):
                 [None] if len(kdf._internal.index_map) > 1 else kdf._internal.index_names
             )
         else:
-            name = "0"
+            name = self.name if name is None else name
+            name = "0" if name is None else name
             sdf = sdf.withColumn(name, scol).select(scol, name)
             column_labels = [(name,)]
         if name is not None:

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -657,14 +657,14 @@ class Index(IndexOpsMixin):
         kdf = self._kdf
         sdf = kdf._sdf
         scol = self._scol
-        if kdf.empty:
-            name = "0"
-            sdf = sdf.withColumn(name, scol).select(scol, name)
-            column_labels = [(name,)]
-        else:
+        if not kdf.empty:
             column_labels = (
                 [None] if len(kdf._internal.index_map) > 1 else kdf._internal.index_names
             )
+        else:
+            name = "0"
+            sdf = sdf.withColumn(name, scol).select(scol, name)
+            column_labels = [(name,)]
         if name is not None:
             scol = scol.alias(name_like_string(name))
 

--- a/databricks/koalas/tests/test_ops_on_diff_frames.py
+++ b/databricks/koalas/tests/test_ops_on_diff_frames.py
@@ -647,6 +647,14 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
         with self.assertRaisesRegex(KeyError, "Key length \\(3\\) exceeds index depth \\(2\\)"):
             kdf[("1", "2", "3")] = ks.Series([100, 200, 300, 200])
 
+    def test_to_series_comparison(self):
+        pidx = pd.Index([1, 2, 3, 4, 5])
+        kidx1 = ks.Index([1, 2, 3, 4, 5])
+        kidx2 = ks.Index(pidx)
+        kidx3 = ks.from_pandas(pidx)
+
+        self.assert_eq((kidx1.to_series() == kidx2.to_series() == kidx3.to_series()).all(), True)
+
 
 class OpsOnDiffFramesDisabledTest(ReusedSQLTestCase, SQLTestUtils):
     @classmethod

--- a/databricks/koalas/tests/test_ops_on_diff_frames.py
+++ b/databricks/koalas/tests/test_ops_on_diff_frames.py
@@ -655,6 +655,12 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
 
         self.assert_eq((kidx1.to_series() == kidx2.to_series() == kidx3.to_series()).all(), True)
 
+        kidx1.name = "koalas"
+        kidx2.name = "koalas"
+        kidx3.name = "koalas"
+
+        self.assert_eq((kidx1.to_series() == kidx2.to_series() == kidx3.to_series()).all(), True)
+
 
 class OpsOnDiffFramesDisabledTest(ReusedSQLTestCase, SQLTestUtils):
     @classmethod


### PR DESCRIPTION
Resolves #1305 

- before fixing
```python
>>> pidx = pd.Index([1, 2, 3, 4, 5])
>>> kidx1 = ks.Index([1, 2, 3, 4, 5])
>>> kidx2 = ks.Index(pidx)
>>> kidx3 = ks.from_pandas(pidx)
>>> kidx1.to_series() == kidx2.to_series() == kidx3.to_series()
Traceback (most recent call last):
...
AssertionError: (1, 0)
```

- after fixing
```python
>>> pidx = pd.Index([1, 2, 3, 4, 5])
>>> kidx1 = ks.Index([1, 2, 3, 4, 5])
>>> kidx2 = ks.Index(pidx)
>>> kidx3 = ks.from_pandas(pidx)
>>> kidx1.to_series() == kidx2.to_series() == kidx3.to_series()
5    True
1    True
3    True
2    True
4    True
```