### PR TITLE
Fix DataFrame.pivot to support multi-index when using input's index

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -5467,13 +5467,12 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             df = self
             index = [index]
         else:
-            df = self.copy()
-            num_index_col = len(df._internal.index_columns)
-            df.reset_index(inplace=True)
-            sdf = _InternalFrame.attach_distributed_column(
-                df._sdf.drop(SPARK_DEFAULT_INDEX_NAME), SPARK_DEFAULT_INDEX_NAME
-            )
-            df = DataFrame(df._internal.with_new_sdf(sdf))
+            num_index_col = len(self._internal.index_columns)
+            sdf = _InternalFrame.attach_distributed_column(self._sdf, "__DUMMY__")
+            df = DataFrame(self._internal.copy(sdf=sdf))
+            df["__DUMMY__"] = scol_for(sdf, "__DUMMY__")
+            df.set_index(df.columns[-1], append=True, inplace=True)
+            df.reset_index(level=range(num_index_col), inplace=True)
             index = df._internal.column_labels[:num_index_col]
 
         df = df.pivot_table(index=index, columns=columns, values=values, aggfunc="first")

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -1673,7 +1673,7 @@ class _Frame(object):
         sdf = sdf.select([median(col).alias(col) for col in kdf._internal.data_columns])
 
         # Attach a dummy column for index to avoid default index.
-        sdf = sdf.withColumn("__DUMMY__", F.monotonically_increasing_id())
+        sdf = _InternalFrame.attach_distributed_column(sdf, "__DUMMY__")
 
         # This is expected to be small so it's fine to transpose.
         return (

--- a/databricks/koalas/internal.py
+++ b/databricks/koalas/internal.py
@@ -579,12 +579,17 @@ class _InternalFrame(object):
         elif default_index_type == "distributed-sequence":
             return _InternalFrame.attach_distributed_sequence_column(sdf, column_name=index_column)
         elif default_index_type == "distributed":
-            return sdf.select(F.monotonically_increasing_id().alias(index_column), *scols)
+            return _InternalFrame.attach_distributed_column(sdf, column_name=index_column)
         else:
             raise ValueError(
                 "'compute.default_index_type' should be one of 'sequence',"
                 " 'distributed-sequence' and 'distributed'"
             )
+
+    @staticmethod
+    def attach_distributed_column(sdf, column_name):
+        scols = [scol_for(sdf, column) for column in sdf.columns]
+        return sdf.select(F.monotonically_increasing_id().alias(column_name), *scols)
 
     @staticmethod
     def attach_distributed_sequence_column(sdf, column_name):


### PR DESCRIPTION
This PR fix `DataFrame.pivot` to support multi-index when using input's index

```python
import databricks.koalas as ks
import pandas as pd

pdf = pd.DataFrame({'a': [4, 2, 3, 4, 8, 6],
                    'b': [1, 2, 2, 4, 2, 4],
                    'e': [10, 20, 20, 40, 20, 40],
                    'c': [1, 2, 9, 4, 7, 4],
                    'd': [-1, -2, -3, -4, -5, -6]},
                   index=[10, 20, 30, 40, 50, 60])

kdf = ks.DataFrame(pdf)
kdf.columns = pd.MultiIndex.from_tuples([('x', 'a'), ('x', 'b'), ('y', 'e'), ('z', 'c'), ('w', 'd')])
kdf = kdf.set_index(('x', 'b'), append=True)
kdf.pivot(columns=('x', 'a'), values=('y', 'e'))
```

Before:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/.../koalas/databricks/koalas/frame.py", line 5451, in pivot
    df.set_index("__DUMMY__", append=True, inplace=True)
  File "/.../koalas/databricks/koalas/frame.py", line 2951, in set_index
    raise KeyError(key)
KeyError: '__DUMMY__'
```

After:

```
('x', 'a')     2     3     4     6     8
60 4         NaN   NaN   NaN  40.0   NaN
30 2         NaN  20.0   NaN   NaN   NaN
50 2         NaN   NaN   NaN   NaN  20.0
20 2        20.0   NaN   NaN   NaN   NaN
10 1         NaN   NaN  10.0   NaN   NaN
40 4         NaN   NaN  40.0   NaN   NaN
```
