### PR TITLE
Use `author` instead of `maintainer`.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,8 +52,8 @@ setup(
         'numpy>=1.14',
         'matplotlib>=3.0.0',
     ],
-    maintainer="Databricks",
-    maintainer_email="koalas@databricks.com",
+    author="Databricks",
+    author_email="koalas@databricks.com",
     license='http://www.apache.org/licenses/LICENSE-2.0',
     url="https://github.com/databricks/koalas",
     project_urls={


### PR DESCRIPTION
According to https://packaging.python.org/tutorials/packaging-projects/#creating-setup-py, we had better use `author` instead of `maintainer`.