### PR TITLE
Fix _LocIndexerLike to handle a Series from index.

### DIFF
--- a/databricks/koalas/tests/test_ops_on_diff_frames.py
+++ b/databricks/koalas/tests/test_ops_on_diff_frames.py
@@ -647,6 +647,17 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
         with self.assertRaisesRegex(KeyError, "Key length \\(3\\) exceeds index depth \\(2\\)"):
             kdf[("1", "2", "3")] = ks.Series([100, 200, 300, 200])
 
+    def test_to_series_comparison(self):
+        kidx1 = ks.Index([1, 2, 3, 4, 5])
+        kidx2 = ks.Index([1, 2, 3, 4, 5])
+
+        self.assert_eq((kidx1.to_series() == kidx2.to_series()).all(), True)
+
+        kidx1.name = "koalas"
+        kidx2.name = "koalas"
+
+        self.assert_eq((kidx1.to_series() == kidx2.to_series()).all(), True)
+
 
 class OpsOnDiffFramesDisabledTest(ReusedSQLTestCase, SQLTestUtils):
     @classmethod

--- a/databricks/koalas/utils.py
+++ b/databricks/koalas/utils.py
@@ -279,14 +279,9 @@ def align_diff_series(func, this_series, *args, how="full"):
     cols = [arg for arg in args if isinstance(arg, IndexOpsMixin)]
     combined = combine_frames(this_series.to_frame(), *cols, how=how)
 
-    that_columns = [
-        combined["that"][arg._internal.column_labels[0]]._scol
-        if isinstance(arg, IndexOpsMixin)
-        else arg
-        for arg in args
-    ]
-
-    scol = func(combined["this"][this_series._internal.column_labels[0]]._scol, *that_columns)
+    scol = func(
+        combined["this"]._internal.column_scols[0], *combined["that"]._internal.column_scols
+    )
 
     return Series(
         combined._internal.copy(scol=scol, column_labels=this_series._internal.column_labels),


### PR DESCRIPTION
`DataFrame` (`DataFrame.loc`) should be able to handle a Series from index as well:

- before

```py
>>> import databricks.koalas as ks
>>> kdf = ks.DataFrame({('x','a'):[1,2,3], ('y','b'):[4,5,6]})
>>> kser = kdf.index.to_series()
>>> kser
0    0
1    1
2    2
Name: 0, dtype: int64
>>> kdf[[kser]]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/ueshin/workspace/databricks-koalas/master/databricks/koalas/frame.py", line 9306, in __getitem__
    return self.loc[:, key]
  File "/Users/ueshin/workspace/databricks-koalas/master/databricks/koalas/indexing.py", line 286, in __getitem__
    column_label_names=column_label_names,
  File "/Users/ueshin/workspace/databricks-koalas/master/databricks/koalas/internal.py", line 523, in __init__
    len(self._column_scols),
AssertionError: (1, 0)
```

- after

```py
>>> kdf[[kser]]
   0
0  0
1  1
2  2
```

Resolves #1305.