### PR TITLE
Add links to the previous talks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,12 @@ See [FAQ](https://koalas.readthedocs.io/en/latest/user_guide/faq.html) in the of
 
 See [Best Practices](https://koalas.readthedocs.io/en/latest/user_guide/best_practices.html) in the official documentation.
 
+
+## Koalas talks
+
+See [Koalas talks](https://koalas.readthedocs.io/en/latest/getting_started/videos.html) in the official documentation.
+
+- [New Developments in the Open Source Ecosystem: Apache Spark 3.0, Delta Lake, and Koalas](https://databricks.com/session_eu19/new-developments-in-the-open-source-ecosystem-apache-spark-3-0-delta-lake-and-koalas) - Spark + AI Summit Europe 2019 (Oct 16, 2019)
+- [Koalas: Making an Easy Transition from Pandas to Apache Spark](https://databricks.com/session_eu19/koalas-making-an-easy-transition-from-pandas-to-apache-spark) - Spark + AI Summit Europe 2019 (Oct 16, 2019)
+- [Koalas: Pandas on Apache Spark](https://databricks.com/session_eu19/koalas-pandas-on-apache-spark) - Spark + AI Summit Europe 2019 (Oct 16, 2019)
+- [Official Announcement of Koalas Open Source Project](https://databricks.com/session/official-announcement-of-koalas-open-source-project) - Spark + AI Summit 2019 (Apr 24, 2019)

--- a/docs/source/getting_started/index.rst
+++ b/docs/source/getting_started/index.rst
@@ -6,4 +6,5 @@ Getting started
 
    install
    10min
+   videos
 

--- a/docs/source/getting_started/videos.rst
+++ b/docs/source/getting_started/videos.rst
@@ -1,0 +1,47 @@
+============
+Koalas talks
+============
+
+Watch videos and webinars for the open-source Koalas project.
+
+Spark + AI Summit Europe 2019 (Oct 16, 2019)
+--------------------------------------------
+
+New Developments in the Open Source Ecosystem: Apache Spark 3.0, Delta Lake, and Koalas
+=======================================================================================
+
+.. raw:: html
+
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/scM_WQMhB3A?start=1470" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+https://databricks.com/session_eu19/new-developments-in-the-open-source-ecosystem-apache-spark-3-0-delta-lake-and-koalas
+
+Koalas: Making an Easy Transition from Pandas to Apache Spark
+=============================================================
+
+.. raw:: html
+
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/Wfj2Vuse7as" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+https://databricks.com/session_eu19/koalas-making-an-easy-transition-from-pandas-to-apache-spark
+
+Koalas: Pandas on Apache Spark
+==============================
+
+.. raw:: html
+
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/NpAMbzerAp0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+https://databricks.com/session_eu19/koalas-pandas-on-apache-spark
+
+Spark + AI Summit 2019 (Apr 24, 2019)
+-------------------------------------
+
+Official Announcement of Koalas Open Source Project
+===================================================
+
+.. raw:: html
+
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/Shzb15DZ9Qg" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+https://databricks.com/session/official-announcement-of-koalas-open-source-project


### PR DESCRIPTION
The "Koalas talks" page in the documentations is like:

![Screen Shot 2020-03-02 at 4 31 20 PM](https://user-images.githubusercontent.com/506656/75731001-509b4880-5ca3-11ea-9d78-40078444f977.png)
