### PR TITLE
Add the support for operations between different DataFrames in groupby()

### DIFF
--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -1443,7 +1443,7 @@ class _Frame(object):
 
             # This is to match the output with pandas'. Pandas seems returning different results
             # when given series is from different dataframes. It only applies when as_index is
-            # False. Seems like a bug in pandas.
+            # False.
             should_drop_index = any(
                 isinstance(col_or_s, ks.Series) and df is not col_or_s._kdf for col_or_s in by
             )
@@ -1461,6 +1461,7 @@ class _Frame(object):
         )
 
     def _resolve_grouping_series(self, by):
+        should_use_name = False
         if isinstance(self, ks.Series):
             kdf = self._kdf
         else:
@@ -1476,11 +1477,15 @@ class _Frame(object):
                     )
 
                 kdf = align_diff_frames(assign_columns, kdf, col_or_s, fillna=False, how="inner")
+                # Should use name to search series because now the anchor is different
+                should_use_name = True
 
         new_by_series = []
         for col_or_s in by:
-            if isinstance(col_or_s, ks.Series):
+            if isinstance(col_or_s, ks.Series) and should_use_name:
                 new_by_series.append(kdf[col_or_s.name])
+            elif isinstance(col_or_s, ks.Series):
+                new_by_series.append(col_or_s)
             elif isinstance(col_or_s, tuple):
                 new_by_series.append(kdf[col_or_s])
             else:

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -34,7 +34,12 @@ from pyspark.sql.types import DataType, DoubleType, FloatType
 from databricks import koalas as ks  # For running doctests and reference resolution in PyCharm.
 from databricks.koalas.indexing import AtIndexer, iAtIndexer, iLocIndexer, LocIndexer
 from databricks.koalas.internal import _InternalFrame, NATURAL_ORDER_COLUMN_NAME
-from databricks.koalas.utils import validate_arguments_and_invoke_function, scol_for, validate_axis
+from databricks.koalas.utils import (
+    validate_arguments_and_invoke_function,
+    scol_for,
+    validate_axis,
+    align_diff_frames,
+)
 from databricks.koalas.window import Rolling, Expanding
 
 
@@ -1399,34 +1404,32 @@ class _Frame(object):
         ...Falcon      375.0
         ...Parrot       25.0
         """
-        from databricks.koalas.frame import DataFrame
-        from databricks.koalas.series import Series
         from databricks.koalas.groupby import DataFrameGroupBy, SeriesGroupBy
 
         df_or_s = self
-        if isinstance(by, DataFrame):
+        if isinstance(by, ks.DataFrame):
             raise ValueError("Grouper for '{}' not 1-dimensional".format(type(by)))
         elif isinstance(by, str):
-            if isinstance(df_or_s, Series):
+            if isinstance(df_or_s, ks.Series):
                 raise KeyError(by)
             by = [(by,)]
         elif isinstance(by, tuple):
-            if isinstance(df_or_s, Series):
+            if isinstance(df_or_s, ks.Series):
                 for key in by:
                     if isinstance(key, str):
                         raise KeyError(key)
             for key in by:
-                if isinstance(key, DataFrame):
+                if isinstance(key, ks.DataFrame):
                     raise ValueError("Grouper for '{}' not 1-dimensional".format(type(key)))
             by = [by]
-        elif isinstance(by, Series):
+        elif isinstance(by, ks.Series):
             by = [by]
         elif isinstance(by, Iterable):
-            if isinstance(df_or_s, Series):
+            if isinstance(df_or_s, ks.Series):
                 for key in by:
                     if isinstance(key, str):
                         raise KeyError(key)
-            by = [key if isinstance(key, (tuple, Series)) else (key,) for key in by]
+            by = [key if isinstance(key, (tuple, ks.Series)) else (key,) for key in by]
         else:
             raise ValueError("Grouper for '{}' not 1-dimensional".format(type(by)))
         if not len(by):
@@ -1434,18 +1437,56 @@ class _Frame(object):
         axis = validate_axis(axis)
         if axis != 0:
             raise NotImplementedError('axis should be either 0 or "index" currently.')
-        if isinstance(df_or_s, DataFrame):
-            df = df_or_s  # type: DataFrame
-            col_by = [_resolve_col(df, col_or_s) for col_or_s in by]
-            return DataFrameGroupBy(df_or_s, col_by, as_index=as_index)
-        if isinstance(df_or_s, Series):
-            col = df_or_s  # type: Series
-            anchor = df_or_s._kdf
-            col_by = [_resolve_col(anchor, col_or_s) for col_or_s in by]
+
+        if isinstance(df_or_s, ks.DataFrame):
+            df = df_or_s  # type: ks.DataFrame
+
+            # This is to match the output with pandas'. Pandas seems returning different results
+            # when given series is from different dataframes. It only applies when as_index is
+            # False. Seems like a bug in pandas.
+            should_drop_index = any(
+                isinstance(col_or_s, ks.Series) and df is not col_or_s._kdf for col_or_s in by
+            )
+
+            kdf, col_by = self._resolve_grouping_series(by)
+            return DataFrameGroupBy(
+                kdf, col_by, as_index=as_index, should_drop_index=should_drop_index
+            )
+        if isinstance(df_or_s, ks.Series):
+            col = df_or_s  # type: ks.Series
+            _, col_by = self._resolve_grouping_series(by)
             return SeriesGroupBy(col, col_by, as_index=as_index)
         raise TypeError(
             "Constructor expects DataFrame or Series; however, " "got [%s]" % (df_or_s,)
         )
+
+    def _resolve_grouping_series(self, by):
+        if isinstance(self, ks.Series):
+            kdf = self._kdf
+        else:
+            kdf = self
+        for col_or_s in by:
+            if isinstance(col_or_s, ks.Series) and kdf is not col_or_s._kdf:
+
+                def assign_columns(kdf, this_column_labels, that_column_labels):
+                    raise NotImplementedError(
+                        "Duplicated labels with groupby() and "
+                        "'compute.ops_on_diff_frames' option are not supported currently "
+                        "Please use unique labels in series and frames."
+                    )
+
+                kdf = align_diff_frames(assign_columns, kdf, col_or_s, fillna=False, how="inner")
+
+        new_by_series = []
+        for col_or_s in by:
+            if isinstance(col_or_s, ks.Series):
+                new_by_series.append(kdf[col_or_s.name])
+            elif isinstance(col_or_s, tuple):
+                new_by_series.append(kdf[col_or_s])
+            else:
+                raise ValueError(col_or_s)
+
+        return kdf, new_by_series
 
     def bool(self):
         """
@@ -1831,17 +1872,3 @@ class _Frame(object):
             return F.count(F.nanvl(col, F.lit(None)))
         else:
             return F.count(col)
-
-
-def _resolve_col(kdf, col_like):
-    if isinstance(col_like, ks.Series):
-        if kdf is not col_like._kdf:
-            raise ValueError(
-                "Cannot combine the series because it comes from a different dataframe. "
-                "In order to allow this operation, enable 'compute.ops_on_diff_frames' option."
-            )
-        return col_like
-    elif isinstance(col_like, tuple):
-        return kdf[col_like]
-    else:
-        raise ValueError(col_like)

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -1878,7 +1878,7 @@ class DataFrameGroupBy(GroupBy):
         kdf: DataFrame,
         by: List[Series],
         as_index: bool = True,
-        should_drop_index: bool = True,
+        should_drop_index: bool = False,
         agg_columns: List[Union[str, Tuple[str, ...]]] = None,
     ):
         self._kdf = kdf
@@ -1921,7 +1921,11 @@ class DataFrameGroupBy(GroupBy):
                     if name in groupkey_names:
                         raise ValueError("cannot insert {}, already exists".format(name))
             return DataFrameGroupBy(
-                self._kdf, self._groupkeys, as_index=self._as_index, agg_columns=item
+                self._kdf,
+                self._groupkeys,
+                as_index=self._as_index,
+                agg_columns=item,
+                should_drop_index=self._should_drop_index,
             )
 
     def _apply_series_op(self, op):

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -208,7 +208,7 @@ class GroupBy(object):
             GroupBy._spark_groupby(self._kdf, func_or_funcs, self._groupkeys_scols, index_map)
         )
         if not self._as_index:
-            kdf = kdf.reset_index()
+            kdf = kdf.reset_index(drop=self._should_drop_index)
 
         if relabeling:
             kdf = kdf[order]
@@ -1868,7 +1868,7 @@ class GroupBy(object):
         )
         kdf = DataFrame(internal)
         if not self._as_index:
-            kdf = kdf.reset_index()
+            kdf = kdf.reset_index(drop=self._should_drop_index)
         return kdf
 
 
@@ -1878,12 +1878,14 @@ class DataFrameGroupBy(GroupBy):
         kdf: DataFrame,
         by: List[Series],
         as_index: bool = True,
+        should_drop_index: bool = True,
         agg_columns: List[Union[str, Tuple[str, ...]]] = None,
     ):
         self._kdf = kdf
         self._groupkeys = by
         self._groupkeys_scols = [s._scol for s in self._groupkeys]
         self._as_index = as_index
+        self._should_drop_index = should_drop_index
         self._have_agg_columns = True
 
         if agg_columns is None:
@@ -2051,6 +2053,9 @@ class SeriesGroupBy(GroupBy):
             raise TypeError("as_index=False only valid with DataFrame")
         self._as_index = True
         self._have_agg_columns = True
+
+        # Not used currently. It's a placeholder to match with DataFrameGroupBy.
+        self._should_drop_index = False
 
     def __getattr__(self, item: str) -> Any:
         if hasattr(_MissingPandasLikeSeriesGroupBy, item):

--- a/databricks/koalas/tests/test_ops_on_diff_frames_groupby.py
+++ b/databricks/koalas/tests/test_ops_on_diff_frames_groupby.py
@@ -1,0 +1,169 @@
+#
+# Copyright (C) 2019 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import pandas as pd
+
+from databricks import koalas as ks
+from databricks.koalas.config import set_option, reset_option
+from databricks.koalas.testing.utils import ReusedSQLTestCase, SQLTestUtils
+
+
+class OpsOnDiffFramesGroupByTest(ReusedSQLTestCase, SQLTestUtils):
+    @classmethod
+    def setUpClass(cls):
+        super(OpsOnDiffFramesGroupByTest, cls).setUpClass()
+        set_option("compute.ops_on_diff_frames", True)
+
+    @classmethod
+    def tearDownClass(cls):
+        reset_option("compute.ops_on_diff_frames")
+        super(OpsOnDiffFramesGroupByTest, cls).tearDownClass()
+
+    def test_groupby_different_lengths(self):
+        pdfs1 = [
+            pd.DataFrame({"c": [4, 2, 7, 3, None, 1, 1, 1, 2], "d": list("abcdefght")}),
+            pd.DataFrame({"c": [4, 2, 7, None, 1, 1, 2], "d": list("abcdefg")}),
+            pd.DataFrame({"c": [4, 2, 7, 3, None, 1, 1, 1, 2, 2], "d": list("abcdefghti")}),
+        ]
+        pdfs2 = [
+            pd.DataFrame({"a": [1, 2, 6, 4, 4, 6, 4, 3, 7], "b": [4, 2, 7, 3, 3, 1, 1, 1, 2]}),
+            pd.DataFrame({"a": [1, 2, 6, 4, 4, 6, 4, 7], "b": [4, 2, 7, 3, 3, 1, 1, 2]}),
+            pd.DataFrame({"a": [1, 2, 6, 4, 4, 6, 4, 3, 7], "b": [4, 2, 7, 3, 3, 1, 1, 1, 2]}),
+        ]
+
+        for pdf1, pdf2 in zip(pdfs1, pdfs2):
+            kdf1 = ks.from_pandas(pdf1)
+            kdf2 = ks.from_pandas(pdf2)
+
+            for as_index in [True, False]:
+                if as_index:
+                    sort = lambda df: df.sort_index()
+                else:
+                    sort = lambda df: df.sort_values("c").reset_index(drop=True)
+                self.assert_eq(
+                    sort(kdf1.groupby(kdf2.a, as_index=as_index).sum()),
+                    sort(pdf1.groupby(pdf2.a, as_index=as_index).sum()),
+                )
+
+                self.assert_eq(
+                    sort(kdf1.groupby(kdf2.a, as_index=as_index).c.sum()),
+                    sort(pdf1.groupby(pdf2.a, as_index=as_index).c.sum()),
+                )
+                self.assert_eq(
+                    sort(kdf1.groupby(kdf2.a, as_index=as_index)["c"].sum()),
+                    sort(pdf1.groupby(pdf2.a, as_index=as_index)["c"].sum()),
+                )
+
+    def test_groupby_multiindex_columns(self):
+        pdf1 = pd.DataFrame(
+            {("y", "c"): [4, 2, 7, 3, None, 1, 1, 1, 2], ("z", "d"): list("abcdefght"),}
+        )
+        pdf2 = pd.DataFrame(
+            {("x", "a"): [1, 2, 6, 4, 4, 6, 4, 3, 7], ("x", "b"): [4, 2, 7, 3, 3, 1, 1, 1, 2],}
+        )
+        kdf1 = ks.from_pandas(pdf1)
+        kdf2 = ks.from_pandas(pdf2)
+
+        self.assert_eq(
+            kdf1.groupby(kdf2[("x", "a")]).sum().sort_index(),
+            pdf1.groupby(pdf2[("x", "a")]).sum().sort_index(),
+        )
+
+        self.assert_eq(
+            kdf1.groupby(kdf2[("x", "a")], as_index=False)
+            .sum()
+            .sort_values(("y", "c"))
+            .reset_index(drop=True),
+            pdf1.groupby(pdf2[("x", "a")], as_index=False)
+            .sum()
+            .sort_values(("y", "c"))
+            .reset_index(drop=True),
+        )
+        self.assert_eq(
+            kdf1.groupby(kdf2[("x", "a")])[[("y", "c")]].sum().sort_index(),
+            pdf1.groupby(pdf2[("x", "a")])[[("y", "c")]].sum().sort_index(),
+        )
+
+    def test_aggregate(self):
+        pdf1 = pd.DataFrame({"C": [0.362, 0.227, 1.267, -0.562], "B": [1, 2, 3, 4]})
+        pdf2 = pd.DataFrame({"A": [1, 1, 2, 2]})
+        kdf1 = ks.from_pandas(pdf1)
+        kdf2 = ks.from_pandas(pdf2)
+
+        for as_index in [True, False]:
+            stats_kdf = kdf1.groupby(kdf2.A, as_index=as_index).agg({"B": "min", "C": "sum"})
+            stats_pdf = pdf1.groupby(pdf2.A, as_index=as_index).agg({"B": "min", "C": "sum"})
+            self.assert_eq(
+                stats_kdf.sort_values(by=["B", "C"]).reset_index(drop=True),
+                stats_pdf.sort_values(by=["B", "C"]).reset_index(drop=True),
+            )
+
+            stats_kdf = kdf1.groupby(kdf2.A, as_index=as_index).agg(
+                {"B": ["min", "max"], "C": "sum"}
+            )
+            stats_pdf = pdf1.groupby(pdf2.A, as_index=as_index).agg(
+                {"B": ["min", "max"], "C": "sum"}
+            )
+            self.assert_eq(
+                stats_kdf.sort_values(by=[("B", "min"), ("B", "max"), ("C", "sum")]).reset_index(
+                    drop=True
+                ),
+                stats_pdf.sort_values(by=[("B", "min"), ("B", "max"), ("C", "sum")]).reset_index(
+                    drop=True
+                ),
+            )
+
+        # multi-index columns
+        columns = pd.MultiIndex.from_tuples([("Y", "C"), ("X", "B")])
+        pdf1.columns = columns
+        kdf1.columns = columns
+
+        columns = pd.MultiIndex.from_tuples([("X", "A")])
+        pdf2.columns = columns
+        kdf2.columns = columns
+
+        for as_index in [True, False]:
+            stats_kdf = kdf1.groupby(kdf2[("X", "A")], as_index=as_index).agg(
+                {("X", "B"): "min", ("Y", "C"): "sum"}
+            )
+            stats_pdf = pdf1.groupby(pdf2[("X", "A")], as_index=as_index).agg(
+                {("X", "B"): "min", ("Y", "C"): "sum"}
+            )
+            self.assert_eq(
+                stats_kdf.sort_values(by=[("X", "B"), ("Y", "C")]).reset_index(drop=True),
+                stats_pdf.sort_values(by=[("X", "B"), ("Y", "C")]).reset_index(drop=True),
+            )
+
+        stats_kdf = kdf1.groupby(kdf2[("X", "A")]).agg(
+            {("X", "B"): ["min", "max"], ("Y", "C"): "sum"}
+        )
+        stats_pdf = pdf1.groupby(pdf2[("X", "A")]).agg(
+            {("X", "B"): ["min", "max"], ("Y", "C"): "sum"}
+        )
+        self.assert_eq(
+            stats_kdf.sort_values(
+                by=[("X", "B", "min"), ("X", "B", "max"), ("Y", "C", "sum")]
+            ).reset_index(drop=True),
+            stats_pdf.sort_values(
+                by=[("X", "B", "min"), ("X", "B", "max"), ("Y", "C", "sum")]
+            ).reset_index(drop=True),
+        )
+
+    def test_duplicated_labels(self):
+        kdf1 = ks.DataFrame({"A": [3, 2, 1]})
+        kdf2 = ks.DataFrame({"A": [1, 2, 3]})
+        self.assertRaisesRegex(
+            NotImplementedError, "Duplicated labels with group", lambda: kdf1.groupby(kdf2.A),
+        )

--- a/databricks/koalas/utils.py
+++ b/databricks/koalas/utils.py
@@ -192,18 +192,19 @@ def align_diff_frames(resolve_func, this, that, fillna=True, how="full"):
         - left: `resolve_func` should resolve columns including that columns.
             For instance, if 'this' has columns A, B, C and that has B, C, D, `this_columns` is
             B, C but `that_columns` are B, C, D.
+        - inner: Same as 'full' mode; however, internally performs inner join instead.
     :return: Aligned DataFrame
     """
-    assert how == "full" or how == "left"
+    assert how == "full" or how == "left" or how == "inner"
 
     this_column_labels = this._internal.column_labels
     that_column_labels = that._internal.column_labels
     common_column_labels = set(this_column_labels).intersection(that_column_labels)
 
-    # 1. Full outer join given two dataframes.
+    # 1. Perform the join given two dataframes.
     combined = combine_frames(this, that, how=how)
 
-    # 2. Apply given function to transform the columns in a batch and keep the new columns.
+    # 2. Apply the given function to transform the columns in a batch and keep the new columns.
     combined_column_labels = combined._internal.column_labels
 
     that_columns_to_apply = []


### PR DESCRIPTION
This PR proposes to support the operations between series from different DataFrames in `groupby()`.

```python
import databricks.koalas as ks
ks.set_option('compute.ops_on_diff_frames', True)
kdf = ks.DataFrame({"a": [1, 2, 6, 4, 4, 6, 4, 7], "b": [4, 2, 7, 3, 3, 1, 1, 2]})
kdf.groupby(ks.Series([4, 2, 7, 3, 1, 1, 1, 2, 2])).sum()
```

The approach is similar with other implementations of `compute.ops_on_diff_frames`.

Before:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/.../koalas/databricks/koalas/generic.py", line 1437, in groupby
    col_by = [_resolve_col(df, col_or_s) for col_or_s in by]
  File "/.../koalas/databricks/koalas/generic.py", line 1437, in <listcomp>
    col_by = [_resolve_col(df, col_or_s) for col_or_s in by]
  File "/.../koalas/databricks/koalas/generic.py", line 1835, in _resolve_col
    "Cannot combine the series because it comes from a different dataframe. "
ValueError: Cannot combine the series because it comes from a different dataframe. In order to allow this operation, enable 'compute.ops_on_diff_frames' option.
```

After:

```
    a  b
0
7   6  7
1  14  5
3   4  3
2   9  4
4   1  4
```