### PR TITLE
Support Spark UDT when converting from/to pandas DataFrame/Series.

### DIFF
--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -21,6 +21,8 @@ import sys
 
 import numpy as np
 import pandas as pd
+import pyspark
+from pyspark.ml.linalg import SparseVector
 
 from databricks import koalas as ks
 from databricks.koalas.config import option_context
@@ -2921,3 +2923,16 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         pdf.columns = columns
         kdf.columns = columns
         self.assert_list_eq(pdf.axes, kdf.axes)
+
+    def test_udt(self):
+        sparse_values = {0: 0.1, 1: 1.1}
+        sparse_vector = SparseVector(len(sparse_values), sparse_values)
+        pdf = pd.DataFrame({"a": [sparse_vector], "b": [10]})
+
+        if LooseVersion(pyspark.__version__) < LooseVersion("2.4"):
+            with self.sql_conf({"spark.sql.execution.arrow.enabled": False}):
+                kdf = ks.from_pandas(pdf)
+                self.assert_eq(kdf, pdf)
+        else:
+            kdf = ks.from_pandas(pdf)
+            self.assert_eq(kdf, pdf)

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -26,16 +26,16 @@ import matplotlib
 
 matplotlib.use("agg")
 from matplotlib import pyplot as plt
-import pyspark
 import numpy as np
 import pandas as pd
+import pyspark
+from pyspark.ml.linalg import SparseVector
 
 from databricks import koalas as ks
 from databricks.koalas import Series
 from databricks.koalas.testing.utils import ReusedSQLTestCase, SQLTestUtils
 from databricks.koalas.exceptions import PandasNotImplementedError
 from databricks.koalas.missing.series import _MissingPandasLikeSeries
-from databricks.koalas.utils import default_session
 
 
 class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
@@ -510,15 +510,9 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
             )
 
     def test_value_counts(self):
-        if (
-            LooseVersion(pyspark.__version__) < LooseVersion("2.4")
-            and default_session().conf.get("spark.sql.execution.arrow.enabled") == "true"
-        ):
-            default_session().conf.set("spark.sql.execution.arrow.enabled", "false")
-            try:
+        if LooseVersion(pyspark.__version__) < LooseVersion("2.4"):
+            with self.sql_conf({"spark.sql.execution.arrow.enabled": False}):
                 self._test_value_counts()
-            finally:
-                default_session().conf.set("spark.sql.execution.arrow.enabled", "true")
             self.assertRaises(
                 RuntimeError,
                 lambda: ks.MultiIndex.from_tuples([("x", "a"), ("x", "b")]).value_counts(),
@@ -1283,3 +1277,16 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         kser = ks.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3], index=midx)
         pser = kser.to_pandas()
         self.assert_list_eq(kser.axes, pser.axes)
+
+    def test_udt(self):
+        sparse_values = {0: 0.1, 1: 1.1}
+        sparse_vector = SparseVector(len(sparse_values), sparse_values)
+        pser = pd.Series([sparse_vector])
+
+        if LooseVersion(pyspark.__version__) < LooseVersion("2.4"):
+            with self.sql_conf({"spark.sql.execution.arrow.enabled": False}):
+                kser = ks.from_pandas(pser)
+                self.assert_eq(kser, pser)
+        else:
+            kser = ks.from_pandas(pser)
+            self.assert_eq(kser, pser)


### PR DESCRIPTION
This is related to #1323.
Adding support Spark UDT when converting from/to pandas DataFrame/Series.