### PR TITLE
[MINOR] Fix exception message for sample_ratio more properly

### DIFF
--- a/databricks/koalas/config.py
+++ b/databricks/koalas/config.py
@@ -217,7 +217,7 @@ _options = [
         types=(float, type(None)),
         check_func=(
             lambda v: v is None or 1 >= v >= 0,
-            "'plotting.sample_ratio' should be 1 >= value >= 0.",
+            "'plotting.sample_ratio' should be 1.0 >= value >= 0.0.",
         ),
     ),
 ]  # type: List[Option]


### PR DESCRIPTION
While i'm using the option `plotting.sample_ratio`.

I got a little bit confusion caused by improper exception message.

If i use `1.1` as a value for `plotting.sample_ratio`, it raises following exception.

```python
>>> with option_context("plotting.sample_ratio", 1.1):
...     kdf.plot.area()
Traceback (most recent call last):
...
ValueError: 'plotting.sample_ratio' should be 1 >= value >= 0.
```

it says 'plotting.sample_ratio' should be `1 >= value >= 0`.

So I used 1, it raises exception again.


```python
>>> with option_context("plotting.sample_ratio", 1):
...     kdf.plot.area()
...
Traceback (most recent call last):
ValueError: The value for option 'plotting.sample_ratio' was <class 'int'>; however, expected types are [(<class 'float'>, <class 'NoneType'>)].
```

Maybe it might not be such a big deal, but i think we better make this error message more properly like `'plotting.sample_ratio' should be 1.0 >= value >= 0.0.`