### PR TITLE
Applying tokenless codecov for GitHub Actions

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -64,9 +64,7 @@ jobs:
         export SPARK_HOME="$SPARK_CACHE_DIR/spark-$SPARK_VERSION-bin-hadoop2.7"
         ./dev/lint-python
         ./dev/pytest
-    - uses: codecov/codecov-action@v1.0.5
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
+    - uses: codecov/codecov-action@v1
 
   conda_python:
     name: Conda, Python
@@ -138,7 +136,5 @@ jobs:
         export SPARK_HOME="$SPARK_CACHE_DIR/spark-$SPARK_VERSION-bin-hadoop2.7"
         ./dev/lint-python
         ./dev/pytest
-    - uses: codecov/codecov-action@v1.0.5
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
+    - uses: codecov/codecov-action@v1
 


### PR DESCRIPTION
Thanks for the https://github.com/databricks/koalas/pull/1266#issuecomment-595211746 

We can use codecov for GitHub Actions without secret token for public repository.

See the https://github.com/codecov/codecov-action for more detail.