### PR TITLE
Allow negative numbers for head.

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -5074,7 +5074,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         return self._apply_series_op(op)
 
-    def head(self, n=5):
+    def head(self, n: int = 5) -> "DataFrame":
         """
         Return the first `n` rows.
 
@@ -5126,11 +5126,16 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         1        bee
         2     falcon
         """
-        if get_option("compute.ordered_head"):
-            sdf = self._sdf.orderBy(NATURAL_ORDER_COLUMN_NAME)
+        if n < 0:
+            n = len(self) + n
+        if n <= 0:
+            return DataFrame(self._internal.with_filter(F.lit(False)))
         else:
-            sdf = self._sdf
-        return DataFrame(self._internal.with_new_sdf(sdf.limit(n)))
+            if get_option("compute.ordered_head"):
+                sdf = self._sdf.orderBy(NATURAL_ORDER_COLUMN_NAME)
+            else:
+                sdf = self._sdf
+            return DataFrame(self._internal.with_new_sdf(sdf.limit(n)))
 
     def pivot_table(self, values=None, index=None, columns=None, aggfunc="mean", fill_value=None):
         """

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -1844,7 +1844,7 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         else:
             raise ValueError("Need to specify at least one of 'labels' or 'index'")
 
-    def head(self, n=5):
+    def head(self, n: int = 5) -> "Series":
         """
         Return the first n rows.
 

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -360,6 +360,9 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         self.assert_eq(kdf.head(2), pdf.head(2))
         self.assert_eq(kdf.head(3), pdf.head(3))
+        self.assert_eq(kdf.head(0), pdf.head(0))
+        self.assert_eq(kdf.head(-3), pdf.head(-3))
+        self.assert_eq(kdf.head(-10), pdf.head(-10))
 
     def test_attributes(self):
         kdf = self.kdf

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -105,6 +105,9 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         pser = self.pser
 
         self.assert_eq(kser.head(3), pser.head(3))
+        self.assert_eq(kser.head(0), pser.head(0))
+        self.assert_eq(kser.head(-3), pser.head(-3))
+        self.assert_eq(kser.head(-10), pser.head(-10))
 
         # TODO: self.assert_eq(kser.tail(3), pser.tail(3))
 


### PR DESCRIPTION
Pandas allows negative numbers for `head`.

```py
>>> pdf
   a  b
0  1  4
1  2  5
2  3  6
3  4  3
4  5  2
5  6  1
6  7  0
7  8  0
8  9  0
>>> pdf.head(-3)
   a  b
0  1  4
1  2  5
2  3  6
3  4  3
4  5  2
5  6  1
```

whereas:

```py
>>> ks.from_pandas(pdf).head(-3)
Traceback (most recent call last):
...
pyspark.sql.utils.AnalysisException: 'The limit expression must be equal to or greater than 0, but got -3;;\nGlobalLimit -3\n+- LocalLimit -3\n   +- Project [__index_level_0__#117L, a#118L, b#119L, monotonically_increasing_id() AS __natural_order__#123L]\n      +- LogicalRDD [__index_level_0__#117L, a#118L, b#119L], false\n'
```