### PR TITLE
Refine _InternalFrame by renaming and leveraging OrderedDict

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -6491,9 +6491,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         self,
         right: "DataFrame",
         how: str = "inner",
-        on: Union[str, List[str], Tuple[str, ...], List[Tuple[str, ...]]] = None,
-        left_on: Union[str, List[str], Tuple[str, ...], List[Tuple[str, ...]]] = None,
-        right_on: Union[str, List[str], Tuple[str, ...], List[Tuple[str, ...]]] = None,
+        on: Optional[Union[str, List[str], Tuple[str, ...], List[Tuple[str, ...]]]] = None,
+        left_on: Optional[Union[str, List[str], Tuple[str, ...], List[Tuple[str, ...]]]] = None,
+        right_on: Optional[Union[str, List[str], Tuple[str, ...], List[Tuple[str, ...]]]] = None,
         left_index: bool = False,
         right_index: bool = False,
         suffixes: Tuple[str, str] = ("_x", "_y"),
@@ -6608,7 +6608,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             instead of NaN.
         """
 
-        def to_list(os) -> List[Union[str, Tuple[str, ...]]]:
+        def to_list(
+            os: Optional[Union[str, List[str], Tuple[str, ...], List[Tuple[str, ...]]]]
+        ) -> List[Tuple[str, ...]]:
             if os is None:
                 return []
             elif isinstance(os, tuple):
@@ -6616,7 +6618,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             elif isinstance(os, str):
                 return [(os,)]
             else:
-                return [o if isinstance(o, tuple) else (o,) for o in os]
+                return [o if isinstance(o, tuple) else (o,) for o in os]  # type: ignore
 
         if isinstance(right, ks.Series):
             right = right.to_frame()

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -384,7 +384,7 @@ class DataFrame(_Frame, Generic[T]):
             assert columns is None
             assert dtype is None
             assert not copy
-            super(DataFrame, self).__init__(_InternalFrame(sdf=data, index_map=None))
+            super(DataFrame, self).__init__(_InternalFrame(spark_frame=data, index_map=None))
         elif isinstance(data, ks.Series):
             assert index is None
             assert columns is None
@@ -405,7 +405,7 @@ class DataFrame(_Frame, Generic[T]):
 
     @property
     def _sdf(self) -> spark.DataFrame:
-        return self._internal.sdf
+        return self._internal.spark_frame
 
     @property
     def ndim(self):
@@ -470,7 +470,7 @@ class DataFrame(_Frame, Generic[T]):
             exprs = []
             num_args = len(signature(sfun).parameters)
             for label in self._internal.column_labels:
-                col_sdf = self._internal.scol_for(label)
+                col_sdf = self._internal.spark_column_for(label)
                 col_type = self._internal.spark_type_for(label)
 
                 is_numeric_or_boolean = isinstance(col_type, (NumericType, BooleanType))
@@ -518,7 +518,9 @@ class DataFrame(_Frame, Generic[T]):
             def calculate_columns_axis(*cols):
                 return getattr(pd.concat(cols, axis=1), name)(axis=axis, numeric_only=numeric_only)
 
-            df = self._sdf.select(calculate_columns_axis(*self._internal.column_scols).alias("0"))
+            df = self._sdf.select(
+                calculate_columns_axis(*self._internal.data_spark_columns).alias("0")
+            )
             return DataFrame(df)["0"]
 
         else:
@@ -554,7 +556,9 @@ class DataFrame(_Frame, Generic[T]):
         from databricks.koalas.series import Series
 
         return Series(
-            self._internal.copy(scol=self._internal.scol_for(label), column_labels=[label]),
+            self._internal.copy(
+                spark_column=self._internal.spark_column_for(label), column_labels=[label]
+            ),
             anchor=self,
         )
 
@@ -1196,8 +1200,8 @@ class DataFrame(_Frame, Generic[T]):
         """
 
         columns = self.columns
-        internal_index_columns = self._internal.index_columns
-        internal_data_columns = self._internal.data_columns
+        internal_index_columns = self._internal.index_spark_column_names
+        internal_data_columns = self._internal.data_spark_column_names
 
         def extract_kv_from_spark_row(row):
             k = (
@@ -1893,7 +1897,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                             F.lit(col).alias(SPARK_INDEX_NAME_FORMAT(i))
                             for i, col in enumerate(label)
                         ]
-                        + [self._internal.scol_for(label).alias("value")]
+                        + [self._internal.spark_column_for(label).alias("value")]
                     )
                     for label in self._internal.column_labels
                 ]
@@ -1904,9 +1908,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             [
                 F.to_json(
                     F.struct(
-                        F.array([scol.cast("string") for scol in self._internal.index_scols]).alias(
-                            "a"
-                        )
+                        F.array(
+                            [scol.cast("string") for scol in self._internal.index_spark_columns]
+                        ).alias("a")
                     )
                 ).alias("index"),
                 F.col("pairs.*"),
@@ -1928,10 +1932,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         )
 
         internal = self._internal.copy(
-            sdf=transposed_df,
-            index_map=[(col, None) for col in internal_index_columns],
+            spark_frame=transposed_df,
+            index_map=OrderedDict((col, None) for col in internal_index_columns),
             column_labels=[tuple(json.loads(col)["a"]) for col in new_data_columns],
-            column_scols=[scol_for(transposed_df, col) for col in new_data_columns],
+            data_spark_columns=[scol_for(transposed_df, col) for col in new_data_columns],
             column_label_names=None,
         )
 
@@ -2066,7 +2070,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             )
 
             # Otherwise, it loses index.
-            internal = _InternalFrame(sdf=sdf, index_map=None)
+            internal = _InternalFrame(spark_frame=sdf, index_map=None)
 
         return DataFrame(internal)
 
@@ -2289,7 +2293,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             )
 
             # Otherwise, it loses index.
-            internal = _InternalFrame(sdf=sdf, index_map=None)
+            internal = _InternalFrame(spark_frame=sdf, index_map=None)
 
         result = DataFrame(internal)
         if should_return_series:
@@ -2567,17 +2571,19 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             raise NotImplementedError('axis should be either 0 or "index" currently.')
         if isinstance(key, str):
             key = (key,)
-        if len(key) > len(self._internal.index_scols):
+        if len(key) > len(self._internal.index_spark_columns):
             raise KeyError(
                 "Key length ({}) exceeds index depth ({})".format(
-                    len(key), len(self._internal.index_scols)
+                    len(key), len(self._internal.index_spark_columns)
                 )
             )
         if level is None:
             level = 0
 
-        scols = self._internal.scols[:level] + self._internal.scols[level + len(key) :]
-        rows = [self._internal.scols[lvl] == index for lvl, index in enumerate(key, level)]
+        scols = (
+            self._internal.spark_columns[:level] + self._internal.spark_columns[level + len(key) :]
+        )
+        rows = [self._internal.spark_columns[lvl] == index for lvl, index in enumerate(key, level)]
 
         sdf = (
             self._sdf.select(scols + list(HIDDEN_COLUMNS))
@@ -2585,15 +2591,15 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             .filter(reduce(lambda x, y: x & y, rows))
         )
 
-        if len(key) == len(self._internal.index_scols):
-            result = _col(DataFrame(_InternalFrame(sdf=sdf, index_map=None)).T)
+        if len(key) == len(self._internal.index_spark_columns):
+            result = _col(DataFrame(_InternalFrame(spark_frame=sdf, index_map=None)).T)
             result.name = key
         else:
-            internal = self._internal.copy(
-                sdf=sdf,
-                index_map=self._internal.index_map[:level]
-                + self._internal.index_map[level + len(key) :],
+            new_index_map = OrderedDict(
+                list(self._internal.index_map.items())[:level]
+                + list(self._internal.index_map.items())[level + len(key) :]
             )
+            internal = self._internal.copy(spark_frame=sdf, index_map=new_index_map,)
             result = DataFrame(internal)
 
         return result
@@ -2719,7 +2725,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             cond = cond[
                 [
                     (
-                        cond._internal.scol_for(label)
+                        cond._internal.spark_column_for(label)
                         if label in cond._internal.column_labels
                         else F.lit(False)
                     ).alias(name)
@@ -2729,7 +2735,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             kdf[tmp_cond_col_names] = cond
         elif isinstance(cond, Series):
             cond = cond.to_frame()
-            cond = cond[[cond._internal.column_scols[0].alias(name) for name in tmp_cond_col_names]]
+            cond = cond[
+                [cond._internal.data_spark_columns[0].alias(name) for name in tmp_cond_col_names]
+            ]
             kdf[tmp_cond_col_names] = cond
         else:
             raise ValueError("type of cond must be a DataFrame or Series")
@@ -2741,7 +2749,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             other = other[
                 [
                     (
-                        other._internal.scol_for(label)
+                        other._internal.spark_column_for(label)
                         if label in other._internal.column_labels
                         else F.lit(np.nan)
                     ).alias(name)
@@ -2752,7 +2760,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         elif isinstance(other, Series):
             other = other.to_frame()
             other = other[
-                [other._internal.column_scols[0].alias(name) for name in tmp_other_col_names]
+                [other._internal.data_spark_columns[0].alias(name) for name in tmp_other_col_names]
             ]
             kdf[tmp_other_col_names] = other
         else:
@@ -2770,19 +2778,21 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         # |                4|  4|500|             false|                 -4|             false|  ...
         # +-----------------+---+---+------------------+-------------------+------------------+--...
 
-        column_scols = []
+        data_spark_columns = []
         for label in self._internal.column_labels:
-            column_scols.append(
+            data_spark_columns.append(
                 F.when(
                     kdf[tmp_cond_col_name(name_like_string(label))]._scol,
-                    kdf._internal.scol_for(label),
+                    kdf._internal.spark_column_for(label),
                 )
                 .otherwise(kdf[tmp_other_col_name(name_like_string(label))]._scol)
-                .alias(kdf._internal.column_name_for(label))
+                .alias(kdf._internal.spark_column_name_for(label))
             )
 
         return DataFrame(
-            kdf._internal.with_new_columns(column_scols, column_labels=self._internal.column_labels)
+            kdf._internal.with_new_columns(
+                data_spark_columns, column_labels=self._internal.column_labels
+            )
         )
 
     def mask(self, cond, other=np.nan):
@@ -2999,16 +3009,19 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         else:
             column_labels = self._internal.column_labels
         if append:
-            index_map = self._internal.index_map + [
-                (self._internal.column_name_for(label), label) for label in keys
-            ]
+            index_map = OrderedDict(
+                list(self._internal.index_map.items())
+                + [(self._internal.spark_column_name_for(label), label) for label in keys]
+            )
         else:
-            index_map = [(self._internal.column_name_for(label), label) for label in keys]
+            index_map = OrderedDict(
+                (self._internal.spark_column_name_for(label), label) for label in keys
+            )
 
         internal = self._internal.copy(
             index_map=index_map,
             column_labels=column_labels,
-            column_scols=[self._internal.scol_for(label) for label in column_labels],
+            data_spark_columns=[self._internal.spark_column_for(label) for label in column_labels],
         )
 
         if inplace:
@@ -3174,7 +3187,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         if level is None:
             new_index_map = [
                 (column, name if name is not None else rename(i))
-                for i, (column, name) in enumerate(self._internal.index_map)
+                for i, (column, name) in enumerate(self._internal.index_map.items())
             ]
             index_map = []
         else:
@@ -3195,7 +3208,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 idx = []
                 for l in level:
                     try:
-                        i = self._internal.index_columns.index(l)
+                        i = self._internal.index_spark_column_names.index(l)
                         idx.append(i)
                     except ValueError:
                         if multi_index:
@@ -3203,7 +3216,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                         else:
                             raise KeyError(
                                 "Level unknown must be same as name ({})".format(
-                                    self._internal.index_columns[0]
+                                    self._internal.index_spark_column_names[0]
                                 )
                             )
             else:
@@ -3211,35 +3224,41 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             idx.sort()
 
             new_index_map = []
-            index_map = self._internal.index_map.copy()
+            index_map_items = list(self._internal.index_map.items())
+            new_index_map_items = index_map_items.copy()
             for i in idx:
-                info = self._internal.index_map[i]
+                info = index_map_items[i]
                 index_column, index_name = info
                 new_index_map.append(
                     (index_column, index_name if index_name is not None else rename(i))
                 )
-                index_map.remove(info)
+                new_index_map_items.remove(info)
+
+            index_map = OrderedDict(new_index_map_items)
 
         new_data_scols = [
-            self._internal.scol_for(column).alias(name_like_string(name))
+            scol_for(self._sdf, column).alias(name_like_string(name))
             for column, name in new_index_map
         ]
 
         if len(index_map) > 0:
-            index_scols = [scol_for(self._sdf, column) for column, _ in index_map]
+            index_scols = [scol_for(self._sdf, column) for column in index_map]
             sdf = self._sdf.select(
-                index_scols + new_data_scols + self._internal.column_scols + list(HIDDEN_COLUMNS)
+                index_scols
+                + new_data_scols
+                + self._internal.data_spark_columns
+                + list(HIDDEN_COLUMNS)
             )
         else:
             sdf = self._sdf.select(
-                new_data_scols + self._internal.column_scols + list(HIDDEN_COLUMNS)
+                new_data_scols + self._internal.data_spark_columns + list(HIDDEN_COLUMNS)
             )
 
             # Now, new internal Spark columns are named as same as index name.
             new_index_map = [(column, name) for column, name in new_index_map]
 
             sdf = _InternalFrame.attach_default_index(sdf)
-            index_map = [(SPARK_DEFAULT_INDEX_NAME, None)]
+            index_map = OrderedDict({SPARK_DEFAULT_INDEX_NAME: None})
 
         if drop:
             new_index_map = []
@@ -3266,12 +3285,12 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             column_labels = [name for _, name in new_index_map] + self._internal.column_labels
 
         internal = self._internal.copy(
-            sdf=sdf,
+            spark_frame=sdf,
             index_map=index_map,
             column_labels=column_labels,
-            column_scols=(
+            data_spark_columns=(
                 [scol_for(sdf, name_like_string(name)) for _, name in new_index_map]
-                + [scol_for(sdf, col) for col in self._internal.data_columns]
+                + [scol_for(sdf, col) for col in self._internal.data_spark_column_names]
             ),
         )
 
@@ -3611,7 +3630,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         def op(kser):
             label = kser._internal.column_labels[0]
             if label in decimals:
-                return F.round(kser._scol, decimals[label]).alias(kser._internal.data_columns[0])
+                return F.round(kser._scol, decimals[label]).alias(
+                    kser._internal.data_spark_column_names[0]
+                )
             else:
                 return kser
 
@@ -3633,9 +3654,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             diff = set(subset).difference(set(self._internal.column_labels))
             if len(diff) > 0:
                 raise KeyError(", ".join([str(d) if len(d) > 1 else d[0] for d in diff]))
-        group_cols = [self._internal.column_name_for(label) for label in subset]
+        group_cols = [self._internal.spark_column_name_for(label) for label in subset]
 
-        index_column = self._internal.index_columns[0]
         if self._internal.index_names[0] is not None:
             name = self._internal.index_names[0]
         else:
@@ -3721,7 +3741,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         from databricks.koalas.series import _col
 
         name, column, sdf = self._mark_duplicates(subset, keep)
-        index_column = self._internal.index_columns[0]
+        index_column = self._internal.index_spark_column_names[0]
 
         sdf = sdf.withColumn(column, F.col("__duplicated__"))
 
@@ -3729,10 +3749,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         return _col(
             DataFrame(
                 _InternalFrame(
-                    sdf=sdf,
-                    index_map=[(index_column, self._internal.index_names[0])],
+                    spark_frame=sdf,
+                    index_map=OrderedDict({index_column: self._internal.index_names[0]}),
                     column_labels=[name],
-                    column_scols=[scol_for(sdf, column)],
+                    data_spark_columns=[scol_for(sdf, column)],
                 )
             )
         )
@@ -3799,7 +3819,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             from databricks.koalas.namespace import _get_index_map
 
             index_map = _get_index_map(self, index_col)
-            internal = _InternalFrame(sdf=self, index_map=index_map)
+            internal = _InternalFrame(spark_frame=self, index_map=index_map)
             return DataFrame(internal)
 
     def cache(self):
@@ -4160,7 +4180,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         2       3        6  9
         """
         if index_col is None:
-            return self._internal.spark_df
+            return self._internal.to_external_spark_frame
         else:
             if isinstance(index_col, str):
                 index_col = [index_col]
@@ -4168,18 +4188,19 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             data_column_names = []
             data_columns = []
             data_columns_column_labels = zip(
-                self._internal.data_columns, self._internal.column_labels
+                self._internal.data_spark_column_names, self._internal.column_labels
             )
-            # TODO: this code is similar with _InternalFrame.spark_df. Might have to deduplicate.
+            # TODO: this code is similar with _InternalFrame.to_new_spark_frame. Might have to
+            #  deduplicate.
             for i, (column, label) in enumerate(data_columns_column_labels):
-                scol = self._internal.scol_for(label)
+                scol = self._internal.spark_column_for(label)
                 name = str(i) if label is None else name_like_string(label)
                 data_column_names.append(name)
                 if column != name:
                     scol = scol.alias(name)
                 data_columns.append(scol)
 
-            old_index_scols = self._internal.index_scols
+            old_index_scols = self._internal.index_spark_columns
 
             if len(index_col) != len(old_index_scols):
                 raise ValueError(
@@ -4190,7 +4211,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             if any(col in data_column_names for col in index_col):
                 raise ValueError("'index_col' cannot be overlapped with other columns.")
 
-            sdf = self._internal.spark_internal_df
+            sdf = self._internal.to_internal_spark_frame
             new_index_scols = [
                 index_scol.alias(col) for index_scol, col in zip(old_index_scols, index_col)
             ]
@@ -4214,7 +4235,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         2   0.6   0.0
         3   0.2   0.1
         """
-        return self._internal.pandas_df.copy()
+        return self._internal.to_pandas_frame.copy()
 
     # Alias to maintain backward compatibility with Spark
     toPandas = to_pandas
@@ -4303,11 +4324,11 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         for label in self._internal.column_labels:
             for i in range(len(label)):
                 if label[: len(label) - i] in pairs:
-                    name = self._internal.column_name_for(label)
+                    name = self._internal.spark_column_name_for(label)
                     scol = pairs[label[: len(label) - i]].alias(name)
                     break
             else:
-                scol = self._internal.scol_for(label)
+                scol = self._internal.spark_column_for(label)
             scols.append(scol)
 
         column_labels = self._internal.column_labels.copy()
@@ -4978,7 +4999,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             subset = [subset]
         else:
             subset = [sub if isinstance(sub, tuple) else (sub,) for sub in subset]
-        subset = [self._internal.column_name_for(label) for label in subset]
+        subset = [self._internal.spark_column_name_for(label) for label in subset]
 
         sdf = self._sdf
         if (
@@ -4991,7 +5012,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             for name, replacement in to_replace.items():
                 if isinstance(name, str):
                     name = (name,)
-                df_column = self._internal.column_name_for(name)
+                df_column = self._internal.spark_column_name_for(name)
                 if isinstance(replacement, dict):
                     sdf = sdf.replace(replacement, subset=df_column)
                 else:
@@ -5068,7 +5089,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                     scol = F.when(scol < lower, lower).otherwise(scol)
                 if upper is not None:
                     scol = F.when(scol > upper, upper).otherwise(scol)
-                return scol.alias(kser._internal.data_columns[0])
+                return scol.alias(kser._internal.data_spark_column_names[0])
             else:
                 return kser
 
@@ -5282,7 +5303,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             if isinstance(values, list):
                 agg_cols = [
                     F.expr(
-                        "{1}(`{0}`) as `{0}`".format(self._internal.column_name_for(value), aggfunc)
+                        "{1}(`{0}`) as `{0}`".format(
+                            self._internal.spark_column_name_for(value), aggfunc
+                        )
                     )
                     for value in values
                 ]
@@ -5290,7 +5313,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 agg_cols = [
                     F.expr(
                         "{1}(`{0}`) as `{0}`".format(
-                            self._internal.column_name_for(values), aggfunc
+                            self._internal.spark_column_name_for(values), aggfunc
                         )
                     )
                 ]
@@ -5299,7 +5322,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 key if isinstance(key, tuple) else (key,): value for key, value in aggfunc.items()
             }
             agg_cols = [
-                F.expr("{1}(`{0}`) as `{0}`".format(self._internal.column_name_for(key), value))
+                F.expr(
+                    "{1}(`{0}`) as `{0}`".format(self._internal.spark_column_name_for(key), value)
+                )
                 for key, value in aggfunc.items()
             ]
             agg_columns = [key for key, _ in aggfunc.items()]
@@ -5310,15 +5335,15 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         if index is None:
             sdf = (
                 self._sdf.groupBy()
-                .pivot(pivot_col=self._internal.column_name_for(columns))
+                .pivot(pivot_col=self._internal.spark_column_name_for(columns))
                 .agg(*agg_cols)
             )
 
         elif isinstance(index, list):
             index = [label if isinstance(label, tuple) else (label,) for label in index]
             sdf = (
-                self._sdf.groupBy([self._internal.scol_for(label) for label in index])
-                .pivot(pivot_col=self._internal.column_name_for(columns))
+                self._sdf.groupBy([self._internal.spark_column_for(label) for label in index])
+                .pivot(pivot_col=self._internal.spark_column_name_for(columns))
                 .agg(*agg_cols)
             )
         else:
@@ -5329,7 +5354,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         if index is not None:
             if isinstance(values, list):
-                index_columns = [self._internal.column_name_for(label) for label in index]
+                index_columns = [self._internal.spark_column_name_for(label) for label in index]
                 data_columns = [column for column in sdf.columns if column not in index_columns]
 
                 if len(values) > 1:
@@ -5345,45 +5370,45 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                     sdf = sdf.select(index_columns + data_columns)
 
                     column_name_to_index = dict(
-                        zip(self._internal.data_columns, self._internal.column_labels)
+                        zip(self._internal.data_spark_column_names, self._internal.column_labels)
                     )
                     column_labels = [
                         tuple(list(column_name_to_index[name.split("_")[1]]) + [name.split("_")[0]])
                         for name in data_columns
                     ]
-                    index_map = list(zip(index_columns, index))
+                    index_map = OrderedDict(zip(index_columns, index))
                     column_label_names = ([None] * column_labels_level(values)) + [
                         str(columns) if len(columns) > 1 else columns[0]
                     ]
                     internal = _InternalFrame(
-                        sdf=sdf,
+                        spark_frame=sdf,
                         index_map=index_map,
                         column_labels=column_labels,
-                        column_scols=[scol_for(sdf, col) for col in data_columns],
+                        data_spark_columns=[scol_for(sdf, col) for col in data_columns],
                         column_label_names=column_label_names,
                     )
                     kdf = DataFrame(internal)
                 else:
                     column_labels = [tuple(list(values[0]) + [column]) for column in data_columns]
-                    index_map = list(zip(index_columns, index))
+                    index_map = OrderedDict(zip(index_columns, index))
                     column_label_names = ([None] * len(values[0])) + [
                         str(columns) if len(columns) > 1 else columns[0]
                     ]
                     internal = _InternalFrame(
-                        sdf=sdf,
+                        spark_frame=sdf,
                         index_map=index_map,
                         column_labels=column_labels,
-                        column_scols=[scol_for(sdf, col) for col in data_columns],
+                        data_spark_columns=[scol_for(sdf, col) for col in data_columns],
                         column_label_names=column_label_names,
                     )
                     kdf = DataFrame(internal)
                 return kdf
             else:
-                index_columns = [self._internal.column_name_for(label) for label in index]
-                index_map = list(zip(index_columns, index))
+                index_columns = [self._internal.spark_column_name_for(label) for label in index]
+                index_map = OrderedDict(zip(index_columns, index))
                 column_label_names = [str(columns) if len(columns) > 1 else columns[0]]
                 internal = _InternalFrame(
-                    sdf=sdf, index_map=index_map, column_label_names=column_label_names
+                    spark_frame=sdf, index_map=index_map, column_label_names=column_label_names
                 )
                 return DataFrame(internal)
         else:
@@ -5391,14 +5416,14 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 index_values = values[-1]
             else:
                 index_values = values
-            index_map = []
+            index_map = OrderedDict()
             for i, index_value in enumerate(index_values):
                 colname = SPARK_INDEX_NAME_FORMAT(i)
                 sdf = sdf.withColumn(colname, F.lit(index_value))
-                index_map.append((colname, None))
+                index_map[colname] = None
             column_label_names = [str(columns) if len(columns) > 1 else columns[0]]
             internal = _InternalFrame(
-                sdf=sdf, index_map=index_map, column_label_names=column_label_names
+                spark_frame=sdf, index_map=index_map, column_label_names=column_label_names
             )
             return DataFrame(internal)
 
@@ -5524,19 +5549,19 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             # as a dummy to avoid overhead.
             with option_context("compute.default_index_type", "distributed"):
                 df = self.reset_index()
-            index = df._internal.column_labels[: len(self._internal.index_columns)]
+            index = df._internal.column_labels[: len(self._internal.index_spark_column_names)]
 
         df = df.pivot_table(index=index, columns=columns, values=values, aggfunc="first")
 
         if should_use_existing_index:
             return df
         else:
-            index_columns = df._internal.index_columns
+            index_columns = df._internal.index_spark_column_names
             internal = df._internal.copy(
-                index_map=[
+                index_map=OrderedDict(
                     (index_column, name)
                     for index_column, name in zip(index_columns, self._internal.index_names)
-                ]
+                )
             )
             return DataFrame(internal)
 
@@ -5563,26 +5588,26 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 )
             column_label_names = columns.names
             data_columns = [name_like_string(label) for label in column_labels]
-            column_scols = [
-                self._internal.scol_for(label).alias(name)
+            data_spark_columns = [
+                self._internal.spark_column_for(label).alias(name)
                 for label, name in zip(self._internal.column_labels, data_columns)
             ]
             self._internal = self._internal.with_new_columns(
-                column_scols, column_labels=column_labels
+                data_spark_columns, column_labels=column_labels
             )
             sdf = self._sdf.select(
-                self._internal.index_scols
+                self._internal.index_spark_columns
                 + [
-                    self._internal.scol_for(label).alias(name)
+                    self._internal.spark_column_for(label).alias(name)
                     for label, name in zip(self._internal.column_labels, data_columns)
                 ]
                 + list(HIDDEN_COLUMNS)
             )
-            column_scols = [scol_for(sdf, col) for col in data_columns]
+            data_spark_columns = [scol_for(sdf, col) for col in data_columns]
             self._internal = self._internal.copy(
-                sdf=sdf,
+                spark_frame=sdf,
                 column_labels=column_labels,
-                column_scols=column_scols,
+                data_spark_columns=data_spark_columns,
                 column_label_names=column_label_names,
             )
         else:
@@ -5599,18 +5624,18 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 column_label_names = None
             data_columns = [name_like_string(label) for label in column_labels]
             sdf = self._sdf.select(
-                self._internal.index_scols
+                self._internal.index_spark_columns
                 + [
-                    self._internal.scol_for(label).alias(name)
+                    self._internal.spark_column_for(label).alias(name)
                     for label, name in zip(self._internal.column_labels, data_columns)
                 ]
                 + list(HIDDEN_COLUMNS)
             )
-            column_scols = [scol_for(sdf, col) for col in data_columns]
+            data_spark_columns = [scol_for(sdf, col) for col in data_columns]
             self._internal = self._internal.copy(
-                sdf=sdf,
+                spark_frame=sdf,
                 column_labels=column_labels,
-                column_scols=column_scols,
+                data_spark_columns=data_spark_columns,
                 column_label_names=column_label_names,
             )
 
@@ -5813,8 +5838,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             if should_include:
                 column_labels.append(label)
 
-        column_scols = [self._internal.scol_for(label) for label in column_labels]
-        return DataFrame(self._internal.with_new_columns(column_scols, column_labels=column_labels))
+        data_spark_columns = [self._internal.spark_column_for(label) for label in column_labels]
+        return DataFrame(
+            self._internal.with_new_columns(data_spark_columns, column_labels=column_labels)
+        )
 
     def count(self, axis=None):
         """
@@ -5981,13 +6008,15 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 *(
                     (column, label)
                     for column, label in zip(
-                        self._internal.data_columns, self._internal.column_labels
+                        self._internal.data_spark_column_names, self._internal.column_labels
                     )
                     if label not in drop_column_labels
                 )
             )
-            column_scols = [self._internal.scol_for(label) for label in labels]
-            internal = self._internal.with_new_columns(column_scols, column_labels=list(labels))
+            data_spark_columns = [self._internal.spark_column_for(label) for label in labels]
+            internal = self._internal.with_new_columns(
+                data_spark_columns, column_labels=list(labels)
+            )
             return DataFrame(internal)
         else:
             raise ValueError("Need to specify at least one of 'labels' or 'columns'")
@@ -6213,11 +6242,11 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             )
 
         if level is None or (is_list_like(level) and len(level) == 0):  # type: ignore
-            by = self._internal.index_scols
+            by = self._internal.index_spark_columns
         elif is_list_like(level):
-            by = [self._internal.index_scols[l] for l in level]  # type: ignore
+            by = [self._internal.index_spark_columns[l] for l in level]  # type: ignore
         else:
-            by = [self._internal.index_scols[level]]
+            by = [self._internal.index_spark_columns[level]]
 
         return self._sort(by=by, ascending=ascending, inplace=inplace, na_position=na_position)
 
@@ -6415,28 +6444,30 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 % (set(values.keys()).difference(self.columns))
             )
 
-        column_scols = []
+        data_spark_columns = []
         if isinstance(values, dict):
             for i, col in enumerate(self.columns):
                 if col in values:
-                    column_scols.append(
-                        self._internal.scol_for(self._internal.column_labels[i])
+                    data_spark_columns.append(
+                        self._internal.spark_column_for(self._internal.column_labels[i])
                         .isin(values[col])
-                        .alias(self._internal.data_columns[i])
+                        .alias(self._internal.data_spark_column_names[i])
                     )
                 else:
-                    column_scols.append(F.lit(False).alias(self._internal.data_columns[i]))
+                    data_spark_columns.append(
+                        F.lit(False).alias(self._internal.data_spark_column_names[i])
+                    )
         elif is_list_like(values):
-            column_scols += [
-                self._internal.scol_for(label)
+            data_spark_columns += [
+                self._internal.spark_column_for(label)
                 .isin(list(values))
-                .alias(self._internal.column_name_for(label))
+                .alias(self._internal.spark_column_name_for(label))
                 for label in self._internal.column_labels
             ]
         else:
             raise TypeError("Values should be iterable, Series, DataFrame or dict.")
 
-        return DataFrame(self._internal.with_new_columns(column_scols))
+        return DataFrame(self._internal.with_new_columns(data_spark_columns))
 
     @property
     def shape(self):
@@ -6576,18 +6607,16 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         As described in #263, joining string columns currently returns None for missing values
             instead of NaN.
         """
-        _to_list = lambda os: (
-            os
-            if os is None
-            else [os]
-            if isinstance(os, tuple)
-            else [(os,)]
-            if isinstance(os, str)
-            else [
-                o if isinstance(o, tuple) else (o,)  # type: ignore
-                for o in os
-            ]
-        )
+
+        def to_list(os) -> List[Union[str, Tuple[str, ...]]]:
+            if os is None:
+                return []
+            elif isinstance(os, tuple):
+                return [os]
+            elif isinstance(os, str):
+                return [(os,)]
+            else:
+                return [o if isinstance(o, tuple) else (o,) for o in os]
 
         if isinstance(right, ks.Series):
             right = right.to_frame()
@@ -6598,33 +6627,35 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                     'Can only pass argument "on" OR "left_on" and "right_on", '
                     "not a combination of both."
                 )
-            left_keys = _to_list(on)
-            right_keys = _to_list(on)
+            left_key_names = list(map(self._internal.spark_column_name_for, to_list(on)))
+            right_key_names = list(map(right._internal.spark_column_name_for, to_list(on)))
         else:
             # TODO: need special handling for multi-index.
             if left_index:
-                left_keys = self._internal.index_columns
+                left_key_names = self._internal.index_spark_column_names
             else:
-                left_keys = _to_list(left_on)
+                left_key_names = list(map(self._internal.spark_column_name_for, to_list(left_on)))
             if right_index:
-                right_keys = right._internal.index_columns
+                right_key_names = right._internal.index_spark_column_names
             else:
-                right_keys = _to_list(right_on)
+                right_key_names = list(
+                    map(right._internal.spark_column_name_for, to_list(right_on))
+                )
 
-            if left_keys and not right_keys:
+            if left_key_names and not right_key_names:
                 raise ValueError("Must pass right_on or right_index=True")
-            if right_keys and not left_keys:
+            if right_key_names and not left_key_names:
                 raise ValueError("Must pass left_on or left_index=True")
-            if not left_keys and not right_keys:
+            if not left_key_names and not right_key_names:
                 common = list(self.columns.intersection(right.columns))
                 if len(common) == 0:
                     raise ValueError(
                         "No common columns to perform merge on. Merge options: "
                         "left_on=None, right_on=None, left_index=False, right_index=False"
                     )
-                left_keys = _to_list(common)
-                right_keys = _to_list(common)
-            if len(left_keys) != len(right_keys):  # type: ignore
+                left_key_names = list(map(self._internal.spark_column_name_for, to_list(common)))
+                right_key_names = list(map(right._internal.spark_column_name_for, to_list(common)))
+            if len(left_key_names) != len(right_key_names):  # type: ignore
                 raise ValueError("len(left_keys) must equal len(right_keys)")
 
         if how == "full":
@@ -6645,11 +6676,12 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         left_table = self._sdf.alias("left_table")
         right_table = right._sdf.alias("right_table")
 
-        left_scol_for = lambda label: scol_for(left_table, self._internal.column_name_for(label))
-        right_scol_for = lambda label: scol_for(right_table, right._internal.column_name_for(label))
-
-        left_key_columns = [left_scol_for(label) for label in left_keys]  # type: ignore
-        right_key_columns = [right_scol_for(label) for label in right_keys]  # type: ignore
+        left_key_columns = [  # type: ignore
+            scol_for(left_table, label) for label in left_key_names
+        ]
+        right_key_columns = [  # type: ignore
+            scol_for(right_table, label) for label in right_key_names
+        ]
 
         join_condition = reduce(
             lambda x, y: x & y,
@@ -6668,11 +6700,22 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         exprs = []
         data_columns = []
         column_labels = []
+
+        left_scol_for = lambda label: scol_for(
+            left_table, self._internal.spark_column_name_for(label)
+        )
+        right_scol_for = lambda label: scol_for(
+            right_table, right._internal.spark_column_name_for(label)
+        )
+
         for label in self._internal.column_labels:
-            col = self._internal.column_name_for(label)
+            col = self._internal.spark_column_name_for(label)
             scol = left_scol_for(label)
             if label in duplicate_columns:
-                if label in left_keys and label in right_keys:  # type: ignore
+                spark_column_name = self._internal.spark_column_name_for(label)
+                if (
+                    spark_column_name in left_key_names and spark_column_name in right_key_names
+                ):  # type: ignore
                     right_scol = right_scol_for(label)
                     if how == "right":
                         scol = right_scol
@@ -6688,10 +6731,13 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             data_columns.append(col)
             column_labels.append(label)
         for label in right._internal.column_labels:
-            col = right._internal.column_name_for(label)
+            col = right._internal.spark_column_name_for(label)
             scol = right_scol_for(label)
             if label in duplicate_columns:
-                if label in left_keys and label in right_keys:  # type: ignore
+                spark_column_name = self._internal.spark_column_name_for(label)
+                if (
+                    spark_column_name in left_key_names and spark_column_name in right_key_names
+                ):  # type: ignore
                     continue
                 else:
                     col = col + right_suffix
@@ -6701,8 +6747,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             data_columns.append(col)
             column_labels.append(label)
 
-        left_index_scols = self._internal.index_scols
-        right_index_scols = right._internal.index_scols
+        left_index_scols = self._internal.index_spark_columns
+        right_index_scols = right._internal.index_spark_columns
 
         # Retain indices if they are used for joining
         if left_index:
@@ -6714,13 +6760,13 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                     exprs.extend(right_index_scols)
                     index_map = right._internal.index_map
                 else:
-                    index_map = []
+                    index_map = OrderedDict()
                     for (col, name), left_scol, right_scol in zip(
-                        self._internal.index_map, left_index_scols, right_index_scols
+                        self._internal.index_map.items(), left_index_scols, right_index_scols
                     ):
                         scol = F.when(left_scol.isNotNull(), left_scol).otherwise(right_scol)
                         exprs.append(scol.alias(col))
-                        index_map.append((col, name))
+                        index_map[col] = name
             else:
                 exprs.extend(right_index_scols)
                 index_map = right._internal.index_map
@@ -6728,15 +6774,15 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             exprs.extend(left_index_scols)
             index_map = self._internal.index_map
         else:
-            index_map = []
+            index_map = OrderedDict()
 
         selected_columns = joined_table.select(*exprs)
 
         internal = _InternalFrame(
-            sdf=selected_columns,
+            spark_frame=selected_columns,
             index_map=index_map if index_map else None,
             column_labels=column_labels,
-            column_scols=[scol_for(selected_columns, col) for col in data_columns],
+            data_spark_columns=[scol_for(selected_columns, col) for col in data_columns],
         )
         return DataFrame(internal)
 
@@ -6913,14 +6959,14 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             raise NotImplementedError("The 'sort' parameter is currently not supported")
 
         if not ignore_index:
-            index_scols = self._internal.index_scols
-            if len(index_scols) != len(other._internal.index_scols):
+            index_scols = self._internal.index_spark_columns
+            if len(index_scols) != len(other._internal.index_spark_columns):
                 raise ValueError("Both DataFrames have to have the same number of index levels")
 
             if verify_integrity and len(index_scols) > 0:
                 if (
                     self._sdf.select(index_scols)
-                    .intersect(other._sdf.select(other._internal.index_scols))
+                    .intersect(other._sdf.select(other._internal.index_spark_columns))
                     .count()
                 ) > 0:
                     raise ValueError("Indices have overlapping values")
@@ -7012,9 +7058,11 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         update_sdf = self.join(other[update_columns], rsuffix="_new")._sdf
 
         for column_labels in update_columns:
-            column_name = self._internal.column_name_for(column_labels)
+            column_name = self._internal.spark_column_name_for(column_labels)
             old_col = scol_for(update_sdf, column_name)
-            new_col = scol_for(update_sdf, other._internal.column_name_for(column_labels) + "_new")
+            new_col = scol_for(
+                update_sdf, other._internal.spark_column_name_for(column_labels) + "_new"
+            )
             if overwrite:
                 update_sdf = update_sdf.withColumn(
                     column_name, F.when(new_col.isNull(), old_col).otherwise(new_col)
@@ -7024,7 +7072,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                     column_name, F.when(old_col.isNull(), new_col).otherwise(old_col)
                 )
         sdf = update_sdf.select(
-            [scol_for(update_sdf, col) for col in self._internal.columns] + list(HIDDEN_COLUMNS)
+            [scol_for(update_sdf, col) for col in self._internal.spark_column_names]
+            + list(HIDDEN_COLUMNS)
         )
         internal = self._internal.with_new_sdf(sdf)
         self._internal = internal
@@ -7423,11 +7472,11 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         exprs = []
         column_labels = []
         for label in self._internal.column_labels:
-            scol = self._internal.scol_for(label)
+            scol = self._internal.spark_column_for(label)
             spark_type = self._internal.spark_type_for(label)
             if isinstance(spark_type, DoubleType) or isinstance(spark_type, FloatType):
                 exprs.append(
-                    F.nanvl(scol, F.lit(None)).alias(self._internal.column_name_for(label))
+                    F.nanvl(scol, F.lit(None)).alias(self._internal.spark_column_name_for(label))
                 )
                 column_labels.append(label)
             elif isinstance(spark_type, NumericType):
@@ -7452,11 +7501,12 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         sdf = sdf.replace("stddev", "std", subset="summary")
 
         internal = _InternalFrame(
-            sdf=sdf,
-            index_map=[("summary", None)],
+            spark_frame=sdf,
+            index_map=OrderedDict({"summary": None}),
             column_labels=column_labels,
-            column_scols=[
-                scol_for(sdf, self._internal.column_name_for(label)) for label in column_labels
+            data_spark_columns=[
+                scol_for(sdf, self._internal.spark_column_name_for(label))
+                for label in column_labels
             ],
         )
         return DataFrame(internal).astype("float64")
@@ -7733,9 +7783,11 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
     def _reindex_index(self, index):
         # When axis is index, we can mimic pandas' by a right outer join.
-        assert len(self._internal.index_columns) <= 1, "Index should be single column or not set."
+        assert (
+            len(self._internal.index_spark_column_names) <= 1
+        ), "Index should be single column or not set."
 
-        index_column = self._internal.index_columns[0]
+        index_column = self._internal.index_spark_column_names[0]
 
         kser = ks.Series(list(index))
         labels = kser._internal._sdf.select(kser._scol.alias(index_column))
@@ -7764,7 +7816,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         scols, labels = [], []
         for label in label_columns:
             if label in self._internal.column_labels:
-                scols.append(self._internal.scol_for(label))
+                scols.append(self._internal.spark_column_for(label))
             else:
                 scols.append(F.lit(np.nan).alias(name_like_string(label)))
             labels.append(label)
@@ -7952,7 +8004,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                     F.struct(
                         *(
                             [F.lit(c).alias(name) for c, name in zip(label, var_name)]
-                            + [self._internal.scol_for(label).alias(value_name)]
+                            + [self._internal.spark_column_for(label).alias(value_name)]
                         )
                     )
                     for label in column_labels
@@ -7962,7 +8014,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         )
 
         columns = (
-            [self._internal.scol_for(label).alias(name_like_string(label)) for label in id_vars]
+            [
+                self._internal.spark_column_for(label).alias(name_like_string(label))
+                for label in id_vars
+            ]
             + [F.col("pairs.%s" % name) for name in var_name[: self._internal.column_labels_level]]
             + [F.col("pairs.%s" % value_name)]
         )
@@ -8230,23 +8285,23 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         """
         from databricks.koalas.series import _col
 
-        if len(self._internal.index_columns) > 1:
+        if len(self._internal.index_spark_column_names) > 1:
             # The index after `reset_index()` will never be used, so use "distributed" index
             # as a dummy to avoid overhead.
             with option_context("compute.default_index_type", "distributed"):
                 df = self.reset_index()
-            index = df._internal.column_labels[: len(self._internal.index_columns) - 1]
-            columns = df.columns[len(self._internal.index_columns) - 1]
+            index = df._internal.column_labels[: len(self._internal.index_spark_column_names) - 1]
+            columns = df.columns[len(self._internal.index_spark_column_names) - 1]
             df = df.pivot_table(
                 index=index, columns=columns, values=self._internal.column_labels, aggfunc="first"
             )
             internal = df._internal.copy(
-                index_map=[
+                index_map=OrderedDict(
                     (index_column, name)
                     for index_column, name in zip(
-                        df._internal.index_columns, self._internal.index_names[:-1]
+                        df._internal.index_spark_column_names, self._internal.index_names[:-1]
                     )
-                ],
+                ),
                 column_label_names=(
                     df._internal.column_label_names[:-1]
                     + [
@@ -8278,7 +8333,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                     F.struct(
                         *(
                             [F.lit(c).alias(name) for c, name in zip(idx, new_index_columns)]
-                            + [self._internal.scol_for(idx).alias(ser_name)]
+                            + [self._internal.spark_column_for(idx).alias(ser_name)]
                         )
                     )
                     for idx in column_labels
@@ -8296,12 +8351,14 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         for i, index_name in enumerate(self._internal.index_names):
             new_index_map.append((SPARK_INDEX_NAME_FORMAT(i + new_index_len), index_name))
             existing_index_columns.append(
-                self._internal.index_scols[i].alias(SPARK_INDEX_NAME_FORMAT(i + new_index_len))
+                self._internal.index_spark_columns[i].alias(
+                    SPARK_INDEX_NAME_FORMAT(i + new_index_len)
+                )
             )
 
         exploded_df = sdf.withColumn("pairs", pairs).select(existing_index_columns + columns)
 
-        return _col(DataFrame(_InternalFrame(exploded_df, index_map=new_index_map)))
+        return _col(DataFrame(_InternalFrame(exploded_df, index_map=OrderedDict(new_index_map))))
 
     # TODO: axis, skipna, and many arguments should be implemented.
     def all(self, axis: Union[int, str] = 0) -> bool:
@@ -8354,7 +8411,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         applied = []
         column_labels = self._internal.column_labels
         for label in column_labels:
-            scol = self._internal.scol_for(label)
+            scol = self._internal.spark_column_for(label)
             all_col = F.min(F.coalesce(scol.cast("boolean"), F.lit(True)))
             applied.append(F.when(all_col.isNull(), True).otherwise(all_col))
 
@@ -8379,13 +8436,13 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             else (self._internal.column_label_names[i],)
         )
         internal = self._internal.copy(
-            sdf=sdf,
-            index_map=[
+            spark_frame=sdf,
+            index_map=OrderedDict(
                 (SPARK_INDEX_NAME_FORMAT(i), index_column_name(i))
                 for i in range(self._internal.column_labels_level)
-            ],
+            ),
             column_labels=None,
-            column_scols=[scol_for(sdf, value_column)],
+            data_spark_columns=[scol_for(sdf, value_column)],
             column_label_names=None,
         )
 
@@ -8442,7 +8499,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         applied = []
         column_labels = self._internal.column_labels
         for label in column_labels:
-            scol = self._internal.scol_for(label)
+            scol = self._internal.spark_column_for(label)
             all_col = F.max(F.coalesce(scol.cast("boolean"), F.lit(False)))
             applied.append(F.when(all_col.isNull(), False).otherwise(all_col))
 
@@ -8467,13 +8524,13 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             else (self._internal.column_label_names[i],)
         )
         internal = self._internal.copy(
-            sdf=sdf,
-            index_map=[
+            spark_frame=sdf,
+            index_map=OrderedDict(
                 (SPARK_INDEX_NAME_FORMAT(i), index_column_name(i))
                 for i in range(self._internal.column_labels_level)
-            ],
+            ),
             column_labels=None,
-            column_scols=[scol_for(sdf, value_column)],
+            data_spark_columns=[scol_for(sdf, value_column)],
             column_label_names=None,
         )
 
@@ -8618,7 +8675,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         axis = validate_axis(axis, none_axis=1)
 
-        index_scols = self._internal.index_scols
+        index_scols = self._internal.index_spark_columns
 
         if items is not None:
             if is_list_like(items):
@@ -8835,7 +8892,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             #           .withColumn("index_1", mapper_fn_udf(col("index_1"))
             #   ```
 
-            index_columns = internal.index_columns
+            index_columns = internal.index_spark_column_names
             num_indices = len(index_columns)
             if level:
                 if level < 0 or level >= num_indices:
@@ -8847,9 +8904,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 index_mapper_udf = pandas_udf(
                     lambda s: s.map(index_mapper_fn), returnType=index_mapper_ret_stype
                 )
-                return index_mapper_udf(scol_for(internal.sdf, index_col_name))
+                return index_mapper_udf(scol_for(internal.spark_frame, index_col_name))
 
-            sdf = internal.sdf
+            sdf = internal.spark_frame
             if level is None:
                 for i in range(num_indices):
                     sdf = sdf.withColumn(index_columns[i], gen_new_index_column(i))
@@ -8884,8 +8941,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             else:
                 new_data_columns = [str(col) for col in new_column_labels]
             new_data_scols = [
-                scol_for(internal.sdf, old_col_name).alias(new_col_name)
-                for old_col_name, new_col_name in zip(internal.data_columns, new_data_columns)
+                scol_for(internal.spark_frame, old_col_name).alias(new_col_name)
+                for old_col_name, new_col_name in zip(
+                    internal.data_spark_column_names, new_data_columns
+                )
             ]
             internal = internal.with_new_columns(new_data_scols, column_labels=new_column_labels)
         if inplace:
@@ -8971,7 +9030,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         def op(kser):
             prev_row = F.lag(kser._scol, periods).over(window)
-            return ((kser._scol - prev_row) / prev_row).alias(kser._internal.data_columns[0])
+            return ((kser._scol - prev_row) / prev_row).alias(
+                kser._internal.data_spark_column_names[0]
+            )
 
         return self._apply_series_op(op)
 
@@ -9035,7 +9096,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         c  z    2
         Name: 0, dtype: int64
         """
-        max_cols = map(lambda scol: F.max(scol), self._internal.column_scols)
+        max_cols = map(lambda scol: F.max(scol), self._internal.data_spark_columns)
         sdf_max = self._sdf.select(*max_cols).head()
         # `sdf_max` looks like below
         # +------+------+------+
@@ -9044,7 +9105,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         # |     3|   4.0|   400|
         # +------+------+------+
 
-        conds = (scol == max_val for scol, max_val in zip(self._internal.column_scols, sdf_max))
+        conds = (
+            scol == max_val for scol, max_val in zip(self._internal.data_spark_columns, sdf_max)
+        )
         cond = reduce(lambda x, y: x | y, conds)
 
         kdf = DataFrame(self._internal.with_filter(cond))
@@ -9112,10 +9175,12 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         c  z    1
         Name: 0, dtype: int64
         """
-        min_cols = map(lambda scol: F.min(scol), self._internal.column_scols)
+        min_cols = map(lambda scol: F.min(scol), self._internal.data_spark_columns)
         sdf_min = self._sdf.select(*min_cols).head()
 
-        conds = (scol == min_val for scol, min_val in zip(self._internal.column_scols, sdf_min))
+        conds = (
+            scol == min_val for scol, min_val in zip(self._internal.data_spark_columns, sdf_min)
+        )
         cond = reduce(lambda x, y: x | y, conds)
 
         kdf = DataFrame(self._internal.with_filter(cond))
@@ -9309,14 +9374,14 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         args = ", ".join(map(str, quantiles))
 
         percentile_cols = []
-        for column in self._internal.data_columns:
+        for column in self._internal.data_spark_column_names:
             percentile_cols.append(
                 F.expr("approx_percentile(`%s`, array(%s), %s)" % (column, args, accuracy)).alias(
                     column
                 )
             )
         sdf = sdf.select(percentile_cols)
-        # Here, after select percntile cols, a sdf looks like below:
+        # Here, after select percntile cols, a spark_frame looks like below:
         # +---------+---------+
         # |        a|        b|
         # +---------+---------+
@@ -9324,7 +9389,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         # +---------+---------+
 
         cols_dict = OrderedDict()
-        for column in self._internal.data_columns:
+        for column in self._internal.data_spark_column_names:
             cols_dict[column] = list()
             for i in range(len(quantiles)):
                 cols_dict[column].append(scol_for(sdf, column).getItem(i).alias(column))
@@ -9346,9 +9411,11 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         sdf = sdf.select(F.explode(F.col("arrays"))).selectExpr("col.*")
 
         internal = self._internal.copy(
-            sdf=sdf,
-            column_scols=[scol_for(sdf, col) for col in self._internal.data_columns],
-            index_map=[(internal_index_column, None)],
+            spark_frame=sdf,
+            data_spark_columns=[
+                scol_for(sdf, col) for col in self._internal.data_spark_column_names
+            ],
+            index_map=OrderedDict({internal_index_column: None}),
             column_labels=self._internal.column_labels,
             column_label_names=None,
         )
@@ -9443,8 +9510,11 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         data_columns = [label[0] for label in self._internal.column_labels]
         sdf = self._sdf.select(
-            self._internal.index_scols
-            + [scol.alias(col) for scol, col in zip(self._internal.column_scols, data_columns)]
+            self._internal.index_spark_columns
+            + [
+                scol.alias(col)
+                for scol, col in zip(self._internal.data_spark_columns, data_columns)
+            ]
         ).filter(expr)
         internal = self._internal.with_new_sdf(sdf, data_columns=data_columns)
 
@@ -9480,7 +9550,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         == Physical Plan ==
         ...
         """
-        self._internal.spark_internal_df.explain(extended)
+        self._internal.to_internal_spark_frame.explain(extended)
 
     def _to_internal_pandas(self):
         """
@@ -9488,7 +9558,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         This method is for internal use only.
         """
-        return self._internal.pandas_df
+        return self._internal.to_pandas_frame
 
     def __repr__(self):
         max_display_count = get_option("display.max_rows")

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -200,10 +200,10 @@ class GroupBy(object):
         else:
             agg_cols = [col.name for col in self._agg_columns]
             func_or_funcs = OrderedDict([(col, func_or_funcs) for col in agg_cols])
-        index_map = [
+        index_map = OrderedDict(
             (SPARK_INDEX_NAME_FORMAT(i), s._internal.column_labels[0])
             for i, s in enumerate(self._groupkeys)
-        ]
+        )
         kdf = DataFrame(
             GroupBy._spark_groupby(self._kdf, func_or_funcs, self._groupkeys_scols, index_map)
         )
@@ -232,7 +232,7 @@ class GroupBy(object):
         for key, value in func.items():
             label = key if isinstance(key, tuple) else (key,)
             for aggfunc in [value] if isinstance(value, str) else value:
-                name = kdf._internal.column_name_for(label)
+                name = kdf._internal.spark_column_name_for(label)
                 data_col = "('{0}', '{1}')".format(name, aggfunc) if multi_aggs else name
                 data_columns.append(data_col)
                 column_labels.append(tuple(list(label) + [aggfunc]) if multi_aggs else label)
@@ -255,9 +255,9 @@ class GroupBy(object):
                     reordered.append(F.expr("{1}(`{0}`) as `{2}`".format(name, aggfunc, data_col)))
         sdf = sdf.groupby(*groupkey_cols).agg(*reordered)
         return _InternalFrame(
-            sdf=sdf,
+            spark_frame=sdf,
             column_labels=column_labels,
-            column_scols=[scol_for(sdf, col) for col in data_columns],
+            data_spark_columns=[scol_for(sdf, col) for col in data_columns],
             index_map=index_map,
         )
 
@@ -528,17 +528,17 @@ class GroupBy(object):
         sdf = self._kdf._sdf
         sdf = sdf.groupby(*groupkey_cols).count()
         if (len(self._agg_columns) > 0) and (self._have_agg_columns):
-            name = self._agg_columns[0]._internal.data_columns[0]
+            name = self._agg_columns[0]._internal.data_spark_column_names[0]
             sdf = sdf.withColumnRenamed("count", name)
         else:
             name = "count"
         internal = _InternalFrame(
-            sdf=sdf,
-            index_map=[
+            spark_frame=sdf,
+            index_map=OrderedDict(
                 (SPARK_INDEX_NAME_FORMAT(i), s._internal.column_labels[0])
                 for i, s in enumerate(groupkeys)
-            ],
-            column_scols=[scol_for(sdf, name)],
+            ),
+            data_spark_columns=[scol_for(sdf, name)],
         )
         return _col(DataFrame(internal))
 
@@ -931,7 +931,7 @@ class GroupBy(object):
             internal = kdf._internal.with_new_sdf(sdf)
         else:
             # Otherwise, it loses index.
-            internal = _InternalFrame(sdf=sdf, index_map=None)
+            internal = _InternalFrame(spark_frame=sdf, index_map=None)
         return DataFrame(internal)
 
     # TODO: implement 'dropna' parameter
@@ -985,13 +985,13 @@ class GroupBy(object):
 
     @staticmethod
     def _spark_group_map_apply(kdf, func, groupkeys_scols, return_schema, retain_index):
-        index_columns = kdf._internal.index_columns
+        index_columns = kdf._internal.index_spark_column_names
         index_names = kdf._internal.index_names
-        data_columns = kdf._internal.data_columns
+        data_columns = kdf._internal.data_spark_column_names
         column_labels = kdf._internal.column_labels
 
         def rename_output(pdf):
-            # TODO: This logic below was borrowed from `DataFrame.pandas_df` to set the index
+            # TODO: This logic below was borrowed from `DataFrame.to_pandas_frame` to set the index
             #   within each pdf properly. we might have to deduplicate it.
             import pandas as pd
 
@@ -1182,11 +1182,11 @@ class GroupBy(object):
             s.alias(SPARK_INDEX_NAME_FORMAT(i)) for i, s in enumerate(self._groupkeys_scols)
         ]
         sdf = self._kdf._sdf
-        index = self._kdf._internal.index_columns[0]
+        index = self._kdf._internal.index_spark_column_names[0]
 
         stat_exprs = []
         for kser, c in zip(self._agg_columns, self._agg_columns_scols):
-            name = kser._internal.data_columns[0]
+            name = kser._internal.data_spark_column_names[0]
 
             if skipna:
                 order_column = Column(c._jc.desc_nulls_last())
@@ -1201,14 +1201,15 @@ class GroupBy(object):
             stat_exprs.append(F.max(scol_for(sdf, name)).alias(name))
         sdf = sdf.groupby(*groupkey_cols).agg(*stat_exprs)
         internal = _InternalFrame(
-            sdf=sdf,
-            index_map=[
+            spark_frame=sdf,
+            index_map=OrderedDict(
                 (SPARK_INDEX_NAME_FORMAT(i), s._internal.column_labels[0])
                 for i, s in enumerate(groupkeys)
-            ],
+            ),
             column_labels=[kser._internal.column_labels[0] for kser in self._agg_columns],
-            column_scols=[
-                scol_for(sdf, kser._internal.data_columns[0]) for kser in self._agg_columns
+            data_spark_columns=[
+                scol_for(sdf, kser._internal.data_spark_column_names[0])
+                for kser in self._agg_columns
             ],
         )
         return DataFrame(internal)
@@ -1258,11 +1259,11 @@ class GroupBy(object):
             s.alias(SPARK_INDEX_NAME_FORMAT(i)) for i, s in enumerate(self._groupkeys_scols)
         ]
         sdf = self._kdf._sdf
-        index = self._kdf._internal.index_columns[0]
+        index = self._kdf._internal.index_spark_column_names[0]
 
         stat_exprs = []
         for kser, c in zip(self._agg_columns, self._agg_columns_scols):
-            name = kser._internal.data_columns[0]
+            name = kser._internal.data_spark_column_names[0]
 
             if skipna:
                 order_column = Column(c._jc.asc_nulls_last())
@@ -1277,14 +1278,15 @@ class GroupBy(object):
             stat_exprs.append(F.max(scol_for(sdf, name)).alias(name))
         sdf = sdf.groupby(*groupkey_cols).agg(*stat_exprs)
         internal = _InternalFrame(
-            sdf=sdf,
-            index_map=[
+            spark_frame=sdf,
+            index_map=OrderedDict(
                 (SPARK_INDEX_NAME_FORMAT(i), s._internal.column_labels[0])
                 for i, s in enumerate(groupkeys)
-            ],
+            ),
             column_labels=[kser._internal.column_labels[0] for kser in self._agg_columns],
-            column_scols=[
-                scol_for(sdf, kser._internal.data_columns[0]) for kser in self._agg_columns
+            data_spark_columns=[
+                scol_for(sdf, kser._internal.data_spark_column_names[0])
+                for kser in self._agg_columns
             ],
         )
         return DataFrame(internal)
@@ -1702,7 +1704,7 @@ class GroupBy(object):
             internal = kdf._internal.with_new_sdf(sdf)
         else:
             return_type = _infer_return_type(func).tpe
-            data_columns = self._kdf._internal.data_columns
+            data_columns = self._kdf._internal.data_spark_column_names
             return_schema = StructType(
                 [StructField(c, return_type) for c in data_columns if c not in input_groupnames]
             )
@@ -1715,7 +1717,7 @@ class GroupBy(object):
                 retain_index=False,
             )
             # Otherwise, it loses index.
-            internal = _InternalFrame(sdf=sdf, index_map=None)
+            internal = _InternalFrame(spark_frame=sdf, index_map=None)
 
         return DataFrame(internal)
 
@@ -1836,7 +1838,7 @@ class GroupBy(object):
             stat_exprs = []
             for kser, c in zip(self._agg_columns, self._agg_columns_scols):
                 spark_type = kser.spark_type
-                name = kser._internal.data_columns[0]
+                name = kser._internal.data_spark_column_names[0]
                 label = kser._internal.column_labels[0]
                 # TODO: we should have a function that takes dataframes and converts the numeric
                 # types. Converting the NaNs is used in a few places, it should be in utils.
@@ -1855,13 +1857,13 @@ class GroupBy(object):
             sdf = sdf.select(*groupkey_cols).distinct()
 
         internal = _InternalFrame(
-            sdf=sdf,
-            index_map=[
+            spark_frame=sdf,
+            index_map=OrderedDict(
                 (SPARK_INDEX_NAME_FORMAT(i), s._internal.column_labels[0])
                 for i, s in enumerate(self._groupkeys)
-            ],
+            ),
             column_labels=column_labels,
-            column_scols=[scol_for(sdf, col) for col in data_columns],
+            data_spark_columns=[scol_for(sdf, col) for col in data_columns],
             column_label_names=self._kdf._internal.column_label_names,
         )
         kdf = DataFrame(internal)
@@ -2015,15 +2017,13 @@ class DataFrameGroupBy(GroupBy):
 
         # Reindex the DataFrame to reflect initial grouping and agg columns.
         internal = _InternalFrame(
-            sdf=sdf,
-            index_map=(
-                [
-                    (s._internal.data_columns[0], s._internal.column_labels[0])
-                    for s in self._groupkeys
-                ]
+            spark_frame=sdf,
+            index_map=OrderedDict(
+                (s._internal.data_spark_column_names[0], s._internal.column_labels[0])
+                for s in self._groupkeys
             ),
             column_labels=column_labels,
-            column_scols=[scol_for(sdf, col) for col in data_columns],
+            data_spark_columns=[scol_for(sdf, col) for col in data_columns],
         )
 
         # Cast columns to ``"float64"`` to match `pandas.DataFrame.groupby`.
@@ -2040,8 +2040,12 @@ class SeriesGroupBy(GroupBy):
         #   `SeriesGroupBy` creates another DataFrame and
         #   internal IDs of the columns become different. Maybe we should refactor the whole
         #   class in the future.
-        self._groupkeys_scols = [F.col(s._internal.data_columns[0]) for s in self._groupkeys]
-        self._agg_columns_scols = [F.col(s._internal.data_columns[0]) for s in self._agg_columns]
+        self._groupkeys_scols = [
+            F.col(s._internal.data_spark_column_names[0]) for s in self._groupkeys
+        ]
+        self._agg_columns_scols = [
+            F.col(s._internal.data_spark_column_names[0]) for s in self._agg_columns
+        ]
 
         if not as_index:
             raise TypeError("as_index=False only valid with DataFrame")
@@ -2143,21 +2147,21 @@ class SeriesGroupBy(GroupBy):
         if len(self._kdf._internal.index_names) > 1:
             raise ValueError("nsmallest do not support multi-index now")
         sdf = self._kdf._sdf
-        name = self._agg_columns[0]._internal.data_columns[0]
+        name = self._agg_columns[0]._internal.data_spark_column_names[0]
         window = Window.partitionBy(self._groupkeys_scols).orderBy(
             scol_for(sdf, name), NATURAL_ORDER_COLUMN_NAME
         )
         sdf = sdf.withColumn("rank", F.row_number().over(window)).filter(F.col("rank") <= n)
         internal = _InternalFrame(
-            sdf=sdf.drop(NATURAL_ORDER_COLUMN_NAME),
-            index_map=(
+            spark_frame=sdf.drop(NATURAL_ORDER_COLUMN_NAME),
+            index_map=OrderedDict(
                 [
-                    (s._internal.data_columns[0], s._internal.column_labels[0])
+                    (s._internal.data_spark_column_names[0], s._internal.column_labels[0])
                     for s in self._groupkeys
                 ]
-                + self._kdf._internal.index_map
+                + list(self._kdf._internal.index_map.items())
             ),
-            column_scols=[scol_for(sdf, name)],
+            data_spark_columns=[scol_for(sdf, name)],
         )
         return _col(DataFrame(internal))
 
@@ -2195,21 +2199,21 @@ class SeriesGroupBy(GroupBy):
         if len(self._kdf._internal.index_names) > 1:
             raise ValueError("nlargest do not support multi-index now")
         sdf = self._kdf._sdf
-        name = self._agg_columns[0]._internal.data_columns[0]
+        name = self._agg_columns[0]._internal.data_spark_column_names[0]
         window = Window.partitionBy(self._groupkeys_scols).orderBy(
             F.col(name).desc(), NATURAL_ORDER_COLUMN_NAME
         )
         sdf = sdf.withColumn("rank", F.row_number().over(window)).filter(F.col("rank") <= n)
         internal = _InternalFrame(
-            sdf=sdf.drop(NATURAL_ORDER_COLUMN_NAME),
-            index_map=(
+            spark_frame=sdf.drop(NATURAL_ORDER_COLUMN_NAME),
+            index_map=OrderedDict(
                 [
-                    (s._internal.data_columns[0], s._internal.column_labels[0])
+                    (s._internal.data_spark_column_names[0], s._internal.column_labels[0])
                     for s in self._groupkeys
                 ]
-                + self._kdf._internal.index_map
+                + list(self._kdf._internal.index_map.items())
             ),
-            column_scols=[scol_for(sdf, name)],
+            data_spark_columns=[scol_for(sdf, name)],
         )
         return _col(DataFrame(internal))
 
@@ -2260,7 +2264,7 @@ class SeriesGroupBy(GroupBy):
             for i, s in enumerate(self._groupkeys_scols + self._agg_columns_scols)
         ]
         sdf = self._kdf._sdf
-        agg_column = self._agg_columns[0]._internal.data_columns[0]
+        agg_column = self._agg_columns[0]._internal.data_spark_column_names[0]
         sdf = sdf.groupby(*groupkey_cols).count().withColumnRenamed("count", agg_column)
 
         if sort:
@@ -2270,12 +2274,12 @@ class SeriesGroupBy(GroupBy):
                 sdf = sdf.orderBy(F.col(agg_column).desc())
 
         internal = _InternalFrame(
-            sdf=sdf,
-            index_map=[
+            spark_frame=sdf,
+            index_map=OrderedDict(
                 (SPARK_INDEX_NAME_FORMAT(i), s._internal.column_labels[0])
                 for i, s in enumerate(groupkeys)
-            ],
-            column_scols=[scol_for(sdf, agg_column)],
+            ),
+            data_spark_columns=[scol_for(sdf, agg_column)],
         )
         return _col(DataFrame(internal))
 

--- a/databricks/koalas/internal.py
+++ b/databricks/koalas/internal.py
@@ -674,14 +674,7 @@ class _InternalFrame(object):
 
     def spark_column_name_for(self, labels: Union[str, Tuple[str, ...]]) -> str:
         """ Return the actual Spark column name for the given column name or index. """
-        column_labels_to_name = dict(zip(self.column_labels, self.data_spark_column_names))
-        if labels in column_labels_to_name:
-            return column_labels_to_name[labels]  # type: ignore
-        else:
-            for index_spark_column_name, index_name in self.index_map.items():
-                if index_name == labels:
-                    return index_spark_column_name
-            raise KeyError(name_like_string(labels))
+        return self._sdf.select(self.spark_column_for(labels)).columns[0]
 
     def spark_column_for(self, labels: Union[str, Tuple[str, ...]]):
         """ Return Spark Column for the given column name or index. """
@@ -689,9 +682,7 @@ class _InternalFrame(object):
         if labels in column_labels_to_scol:
             return column_labels_to_scol[labels]  # type: ignore
         else:
-            if labels not in self.index_spark_column_names:
-                raise KeyError(name_like_string(labels))
-            return scol_for(self._sdf, self.spark_column_name_for(labels))
+            raise KeyError(name_like_string(labels))
 
     def spark_type_for(self, labels: Union[str, Tuple[str, ...]]) -> DataType:
         """ Return DataType for the given column name or index. """

--- a/databricks/koalas/internal.py
+++ b/databricks/koalas/internal.py
@@ -672,20 +672,20 @@ class _InternalFrame(object):
             (sdf[offset_column] + sdf[row_number_column] - 1).alias(column_name), *scols
         )
 
-    def spark_column_name_for(self, labels: Union[str, Tuple[str, ...]]) -> str:
-        """ Return the actual Spark column name for the given column name or index. """
+    def spark_column_name_for(self, labels: Tuple[str, ...]) -> str:
+        """ Return the actual Spark column name for the given column name. """
         return self._sdf.select(self.spark_column_for(labels)).columns[0]
 
-    def spark_column_for(self, labels: Union[str, Tuple[str, ...]]):
-        """ Return Spark Column for the given column name or index. """
+    def spark_column_for(self, labels: Tuple[str, ...]):
+        """ Return Spark Column for the given column name. """
         column_labels_to_scol = dict(zip(self.column_labels, self.data_spark_columns))
         if labels in column_labels_to_scol:
             return column_labels_to_scol[labels]  # type: ignore
         else:
             raise KeyError(name_like_string(labels))
 
-    def spark_type_for(self, labels: Union[str, Tuple[str, ...]]) -> DataType:
-        """ Return DataType for the given column name or index. """
+    def spark_type_for(self, labels: Tuple[str, ...]) -> DataType:
+        """ Return DataType for the given column name. """
         return self._sdf.select(self.spark_column_for(labels)).schema[0].dataType
 
     @property

--- a/databricks/koalas/internal.py
+++ b/databricks/koalas/internal.py
@@ -20,6 +20,7 @@ An internal immutable DataFrame with some metadata to manage indexes.
 import re
 from typing import Dict, List, Optional, Tuple, Union, TYPE_CHECKING
 from itertools import accumulate
+from collections import OrderedDict
 
 import numpy as np
 import pandas as pd
@@ -60,9 +61,7 @@ SPARK_INDEX_NAME_PATTERN = re.compile(r"__index_level_[0-9]+__")
 
 NATURAL_ORDER_COLUMN_NAME = "__natural_order__"
 
-HIDDEN_COLUMNS = set([NATURAL_ORDER_COLUMN_NAME])
-
-IndexMap = Tuple[str, Optional[Tuple[str, ...]]]
+HIDDEN_COLUMNS = {NATURAL_ORDER_COLUMN_NAME}
 
 
 class _InternalFrame(object):
@@ -93,7 +92,7 @@ class _InternalFrame(object):
     However, all columns including index column are also stored in Spark DataFrame internally
     as below.
 
-    >>> kdf._internal.spark_internal_df.show()  # doctest: +NORMALIZE_WHITESPACE
+    >>> kdf._internal.to_internal_spark_frame.show()  # doctest: +NORMALIZE_WHITESPACE
     +-----------------+---+---+---+---+---+
     |__index_level_0__|  A|  B|  C|  D|  E|
     +-----------------+---+---+---+---+---+
@@ -106,24 +105,30 @@ class _InternalFrame(object):
     In order to fill this gap, the current metadata is used by mapping Spark's internal column
     to Koalas' index. See the method below:
 
-    * `sdf` represents the internal Spark DataFrame
+    * `spark_frame` represents the internal Spark DataFrame
 
-    * `data_columns` represents non-indexing columns
+    * `data_spark_column_names` represents non-indexing Spark column names
 
-    * `index_columns` represents internal index columns
+    * `data_spark_columns` represents non-indexing Spark columns
 
-    * `columns` represents all columns
+    * `index_spark_column_names` represents internal index Spark column names
 
-    * `index_names` represents the external index name
+    * `index_spark_columns` represents internal index Spark columns
 
-    * `index_map` is zipped pairs of `index_columns` and `index_names`
+    * `spark_column_names` represents all columns
 
-    * `spark_df` represents Spark DataFrame derived by the metadata
+    * `index_names` represents the external index name as a label
 
-    * `pandas_df` represents pandas DataFrame derived by the metadata
+    * `index_map` is zipped pairs of `index_spark_column_names` and `index_names`
+
+    * `to_external_spark_frame` represents Spark DataFrame derived by the metadata.
+
+    * `to_internal_spark_frame` represents Spark DataFrame derived by the metadata. Includes index.
+
+    * `to_pandas_frame` represents pandas DataFrame derived by the metadata
 
     >>> internal = kdf._internal
-    >>> internal.sdf.show()  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
+    >>> internal.spark_frame.show()  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
     +-----------------+---+---+---+---+---+-----------------+
     |__index_level_0__|  A|  B|  C|  D|  E|__natural_order__|
     +-----------------+---+---+---+---+---+-----------------+
@@ -132,17 +137,17 @@ class _InternalFrame(object):
     |                2|  3|  7| 11| 15| 19|...|
     |                3|  4|  8| 12| 16| 20|...|
     +-----------------+---+---+---+---+---+-----------------+
-    >>> internal.data_columns
+    >>> internal.data_spark_column_names
     ['A', 'B', 'C', 'D', 'E']
-    >>> internal.index_columns
+    >>> internal.index_spark_column_names
     ['__index_level_0__']
-    >>> internal.columns
+    >>> internal.spark_column_names
     ['__index_level_0__', 'A', 'B', 'C', 'D', 'E']
     >>> internal.index_names
     [None]
     >>> internal.index_map
-    [('__index_level_0__', None)]
-    >>> internal.spark_internal_df.show()  # doctest: +NORMALIZE_WHITESPACE
+    OrderedDict([('__index_level_0__', None)])
+    >>> internal.to_internal_spark_frame.show()  # doctest: +NORMALIZE_WHITESPACE
     +-----------------+---+---+---+---+---+
     |__index_level_0__|  A|  B|  C|  D|  E|
     +-----------------+---+---+---+---+---+
@@ -151,7 +156,7 @@ class _InternalFrame(object):
     |                2|  3|  7| 11| 15| 19|
     |                3|  4|  8| 12| 16| 20|
     +-----------------+---+---+---+---+---+
-    >>> internal.spark_df.show()  # doctest: +NORMALIZE_WHITESPACE
+    >>> internal.to_external_spark_frame.show()  # doctest: +NORMALIZE_WHITESPACE
     +---+---+---+---+---+
     |  A|  B|  C|  D|  E|
     +---+---+---+---+---+
@@ -160,7 +165,7 @@ class _InternalFrame(object):
     |  3|  7| 11| 15| 19|
     |  4|  8| 12| 16| 20|
     +---+---+---+---+---+
-    >>> internal.pandas_df
+    >>> internal.to_pandas_frame
        A  B   C   D   E
     0  1  5   9  13  17
     1  2  6  10  14  18
@@ -178,7 +183,7 @@ class _InternalFrame(object):
     3  7  11  15  19
     4  8  12  16  20
 
-    >>> kdf1._internal.spark_internal_df.show()  # doctest: +NORMALIZE_WHITESPACE
+    >>> kdf1._internal.to_internal_spark_frame.show()  # doctest: +NORMALIZE_WHITESPACE
     +---+---+---+---+---+
     |  A|  B|  C|  D|  E|
     +---+---+---+---+---+
@@ -189,7 +194,7 @@ class _InternalFrame(object):
     +---+---+---+---+---+
 
     >>> internal = kdf1._internal
-    >>> internal.sdf.show()  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
+    >>> internal.spark_frame.show()  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
     +-----------------+---+---+---+---+---+-----------------+
     |__index_level_0__|  A|  B|  C|  D|  E|__natural_order__|
     +-----------------+---+---+---+---+---+-----------------+
@@ -198,17 +203,17 @@ class _InternalFrame(object):
     |                2|  3|  7| 11| 15| 19|...|
     |                3|  4|  8| 12| 16| 20|...|
     +-----------------+---+---+---+---+---+-----------------+
-    >>> internal.data_columns
+    >>> internal.data_spark_column_names
     ['B', 'C', 'D', 'E']
-    >>> internal.index_columns
+    >>> internal.index_spark_column_names
     ['A']
-    >>> internal.columns
+    >>> internal.spark_column_names
     ['A', 'B', 'C', 'D', 'E']
     >>> internal.index_names
     [('A',)]
     >>> internal.index_map
-    [('A', ('A',))]
-    >>> internal.spark_internal_df.show()  # doctest: +NORMALIZE_WHITESPACE
+    OrderedDict([('A', ('A',))])
+    >>> internal.to_internal_spark_frame.show()  # doctest: +NORMALIZE_WHITESPACE
     +---+---+---+---+---+
     |  A|  B|  C|  D|  E|
     +---+---+---+---+---+
@@ -217,7 +222,7 @@ class _InternalFrame(object):
     |  3|  7| 11| 15| 19|
     |  4|  8| 12| 16| 20|
     +---+---+---+---+---+
-    >>> internal.pandas_df  # doctest: +NORMALIZE_WHITESPACE
+    >>> internal.to_pandas_frame  # doctest: +NORMALIZE_WHITESPACE
        B   C   D   E
     A
     1  5   9  13  17
@@ -225,9 +230,9 @@ class _InternalFrame(object):
     3  7  11  15  19
     4  8  12  16  20
 
-    The `spark_df` will drop the index columns:
+    The `to_external_spark_frame` will drop the index columns:
 
-    >>> internal.spark_df.show()  # doctest: +NORMALIZE_WHITESPACE
+    >>> internal.to_external_spark_frame.show()  # doctest: +NORMALIZE_WHITESPACE
     +---+---+---+---+
     |  B|  C|  D|  E|
     +---+---+---+---+
@@ -237,9 +242,10 @@ class _InternalFrame(object):
     |  8| 12| 16| 20|
     +---+---+---+---+
 
-    but if `drop=False`, the columns will still remain in `spark_df`:
+    but if `drop=False`, the columns will still remain in `to_external_spark_frame`:
 
-    >>> kdf.set_index("A", drop=False)._internal.spark_df.show()  # doctest: +NORMALIZE_WHITESPACE
+    >>> kdf.set_index("A", drop=False)._internal.to_external_spark_frame.show()
+    ... # doctest: +NORMALIZE_WHITESPACE
     +---+---+---+---+---+
     |  A|  B|  C|  D|  E|
     +---+---+---+---+---+
@@ -260,7 +266,7 @@ class _InternalFrame(object):
     2 3  7  11  15  19
     3 4  8  12  16  20
 
-    >>> kdf2._internal.spark_internal_df.show()  # doctest: +NORMALIZE_WHITESPACE
+    >>> kdf2._internal.to_internal_spark_frame.show()  # doctest: +NORMALIZE_WHITESPACE
     +-----------------+---+---+---+---+---+
     |__index_level_0__|  A|  B|  C|  D|  E|
     +-----------------+---+---+---+---+---+
@@ -271,7 +277,7 @@ class _InternalFrame(object):
     +-----------------+---+---+---+---+---+
 
     >>> internal = kdf2._internal
-    >>> internal.sdf.show()  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
+    >>> internal.spark_frame.show()  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
     +-----------------+---+---+---+---+---+-----------------+
     |__index_level_0__|  A|  B|  C|  D|  E|__natural_order__|
     +-----------------+---+---+---+---+---+-----------------+
@@ -280,17 +286,17 @@ class _InternalFrame(object):
     |                2|  3|  7| 11| 15| 19|...|
     |                3|  4|  8| 12| 16| 20|...|
     +-----------------+---+---+---+---+---+-----------------+
-    >>> internal.data_columns
+    >>> internal.data_spark_column_names
     ['B', 'C', 'D', 'E']
-    >>> internal.index_columns
+    >>> internal.index_spark_column_names
     ['__index_level_0__', 'A']
-    >>> internal.columns
+    >>> internal.spark_column_names
     ['__index_level_0__', 'A', 'B', 'C', 'D', 'E']
     >>> internal.index_names
     [None, ('A',)]
     >>> internal.index_map
-    [('__index_level_0__', None), ('A', ('A',))]
-    >>> internal.spark_internal_df.show()  # doctest: +NORMALIZE_WHITESPACE
+    OrderedDict([('__index_level_0__', None), ('A', ('A',))])
+    >>> internal.to_internal_spark_frame.show()  # doctest: +NORMALIZE_WHITESPACE
     +-----------------+---+---+---+---+---+
     |__index_level_0__|  A|  B|  C|  D|  E|
     +-----------------+---+---+---+---+---+
@@ -299,7 +305,7 @@ class _InternalFrame(object):
     |                2|  3|  7| 11| 15| 19|
     |                3|  4|  8| 12| 16| 20|
     +-----------------+---+---+---+---+---+
-    >>> internal.pandas_df  # doctest: +NORMALIZE_WHITESPACE
+    >>> internal.to_pandas_frame  # doctest: +NORMALIZE_WHITESPACE
          B   C   D   E
       A
     0 1  5   9  13  17
@@ -327,7 +333,7 @@ class _InternalFrame(object):
     4  17  18  19  20
 
     >>> internal = kdf3._internal
-    >>> internal.sdf.show()  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
+    >>> internal.spark_frame.show()  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
     +-----------------+------+------+------+------+-----------------+
     |__index_level_0__|(X, A)|(X, B)|(Y, C)|(Y, D)|__natural_order__|
     +-----------------+------+------+------+------+-----------------+
@@ -337,7 +343,7 @@ class _InternalFrame(object):
     |                3|    13|    14|    15|    16|...|
     |                4|    17|    18|    19|    20|...|
     +-----------------+------+------+------+------+-----------------+
-    >>> internal.data_columns
+    >>> internal.data_spark_column_names
     ['(X, A)', '(X, B)', '(Y, C)', '(Y, D)']
     >>> internal.column_labels
     [('X', 'A'), ('X', 'B'), ('Y', 'C'), ('Y', 'D')]
@@ -354,7 +360,7 @@ class _InternalFrame(object):
     Name: B, dtype: int64
 
     >>> internal = kseries._internal
-    >>> internal.sdf.show()  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
+    >>> internal.spark_frame.show()  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
     +-----------------+---+---+---+---+---+-----------------+
     |__index_level_0__|  A|  B|  C|  D|  E|__natural_order__|
     +-----------------+---+---+---+---+---+-----------------+
@@ -363,19 +369,19 @@ class _InternalFrame(object):
     |                2|  3|  7| 11| 15| 19|...|
     |                3|  4|  8| 12| 16| 20|...|
     +-----------------+---+---+---+---+---+-----------------+
-    >>> internal.scol
+    >>> internal.spark_column
     Column<b'B'>
-    >>> internal.data_columns
+    >>> internal.data_spark_column_names
     ['B']
-    >>> internal.index_columns
+    >>> internal.index_spark_column_names
     ['A']
-    >>> internal.columns
+    >>> internal.spark_column_names
     ['A', 'B']
     >>> internal.index_names
     [('A',)]
     >>> internal.index_map
-    [('A', ('A',))]
-    >>> internal.spark_internal_df.show()  # doctest: +NORMALIZE_WHITESPACE
+    OrderedDict([('A', ('A',))])
+    >>> internal.to_internal_spark_frame.show()  # doctest: +NORMALIZE_WHITESPACE
     +---+---+
     |  A|  B|
     +---+---+
@@ -384,7 +390,7 @@ class _InternalFrame(object):
     |  3|  7|
     |  4|  8|
     +---+---+
-    >>> internal.pandas_df  # doctest: +NORMALIZE_WHITESPACE
+    >>> internal.to_pandas_frame  # doctest: +NORMALIZE_WHITESPACE
        B
     A
     1  5
@@ -395,28 +401,29 @@ class _InternalFrame(object):
 
     def __init__(
         self,
-        sdf: spark.DataFrame,
-        index_map: Optional[List[IndexMap]],
+        spark_frame: spark.DataFrame,
+        index_map: Optional[Dict[str, Optional[Tuple[str, ...]]]],
         column_labels: Optional[List[Tuple[str, ...]]] = None,
-        column_scols: Optional[List[spark.Column]] = None,
+        data_spark_columns: Optional[List[spark.Column]] = None,
         column_label_names: Optional[List[str]] = None,
-        scol: Optional[spark.Column] = None,
+        spark_column: Optional[spark.Column] = None,
     ) -> None:
         """
         Create a new internal immutable DataFrame to manage Spark DataFrame, column fields and
         index fields and names.
 
-        :param sdf: Spark DataFrame to be managed.
-        :param index_map: list of string pair
+        :param spark_frame: Spark DataFrame to be managed.
+        :param index_map: dictionary of string pairs
                            Each pair holds the index field name which exists in Spark fields,
                            and the index name.
         :param column_labels: list of tuples with the same length
                               The multi-level values in the tuples.
-        :param column_scols: list of Spark Column
-                              Spark Columns to appear as columns. If scol is not None, this
-                              argument is ignored, otherwise if this is None, calculated from sdf.
+        :param data_spark_columns: list of Spark Column
+                                   Spark Columns to appear as columns. If spark_column is not None,
+                                   this argument is ignored, otherwise if this is None, calculated
+                                   from spark_frame.
         :param column_label_names: Names for each of the index levels.
-        :param scol: Spark Column to be managed.
+        :param spark_column: Spark Column to be managed.
 
         See the examples below to refer what each parameter means.
 
@@ -448,13 +455,13 @@ class _InternalFrame(object):
         +-----------+-----------+------+------+------+...
 
         >>> internal._index_map  # doctest: +NORMALIZE_WHITESPACE
-        [('row_index_a', ('row_index_a',)), ('row_index_b', ('row_index_b',)),
-         ('(a, x)', ('a', 'x'))]
+        OrderedDict([('row_index_a', ('row_index_a',)), ('row_index_b', ('row_index_b',)),
+         ('(a, x)', ('a', 'x'))])
 
         >>> internal._column_labels
         [('a', 'y')]
 
-        >>> internal._column_scols
+        >>> internal._data_spark_columns
         [Column<b'(a, y)'>]
 
         >>> list(internal._column_label_names)
@@ -463,22 +470,26 @@ class _InternalFrame(object):
         >>> internal._scol
         Column<b'(a, y)'>
         """
-        assert isinstance(sdf, spark.DataFrame)
-        assert not sdf.isStreaming, "Koalas does not support Structured Streaming."
+
+        assert isinstance(spark_frame, spark.DataFrame)
+        assert not spark_frame.isStreaming, "Koalas does not support Structured Streaming."
 
         if index_map is None:
-            assert not any(SPARK_INDEX_NAME_PATTERN.match(name) for name in sdf.columns), (
+            assert not any(SPARK_INDEX_NAME_PATTERN.match(name) for name in spark_frame.columns), (
                 "Index columns should not appear in columns of the Spark DataFrame. Avoid "
                 "index column names [%s]." % SPARK_INDEX_NAME_PATTERN
             )
 
             # Create default index.
-            sdf = _InternalFrame.attach_default_index(sdf)
-            index_map = [(SPARK_DEFAULT_INDEX_NAME, None)]
+            spark_frame = _InternalFrame.attach_default_index(spark_frame)
+            index_map = OrderedDict({SPARK_DEFAULT_INDEX_NAME: None})
 
-        if NATURAL_ORDER_COLUMN_NAME not in sdf.columns:
-            sdf = sdf.withColumn(NATURAL_ORDER_COLUMN_NAME, F.monotonically_increasing_id())
+        if NATURAL_ORDER_COLUMN_NAME not in spark_frame.columns:
+            spark_frame = spark_frame.withColumn(
+                NATURAL_ORDER_COLUMN_NAME, F.monotonically_increasing_id()
+            )
 
+        assert isinstance(index_map, OrderedDict), index_map
         assert all(
             isinstance(index_field, str)
             and (
@@ -488,27 +499,29 @@ class _InternalFrame(object):
                     and all(isinstance(name, str) for name in index_name)
                 )
             )
-            for index_field, index_name in index_map
+            for index_field, index_name in index_map.items()
         ), index_map
-        assert scol is None or isinstance(scol, spark.Column)
-        assert column_scols is None or all(isinstance(scol, spark.Column) for scol in column_scols)
+        assert spark_column is None or isinstance(spark_column, spark.Column)
+        assert data_spark_columns is None or all(
+            isinstance(scol, spark.Column) for scol in data_spark_columns
+        )
 
-        self._sdf = sdf  # type: spark.DataFrame
-        self._index_map = index_map  # type: List[IndexMap]
-        self._scol = scol  # type: Optional[spark.Column]
-        if scol is not None:
-            self._column_scols = [scol]
-        elif column_scols is None:
-            index_columns = set(index_column for index_column, _ in self._index_map)
-            self._column_scols = [
-                scol_for(sdf, col)
-                for col in sdf.columns
+        self._sdf = spark_frame  # type: spark.DataFrame
+        self._index_map = index_map  # type: Dict[str, Optional[Tuple[str, ...]]]
+        self._scol = spark_column  # type: Optional[spark.Column]
+        if spark_column is not None:
+            self._data_spark_columns = [spark_column]
+        elif data_spark_columns is None:
+            index_columns = set(index_column for index_column in self._index_map)
+            self._data_spark_columns = [
+                scol_for(spark_frame, col)
+                for col in spark_frame.columns
                 if col not in index_columns and col not in HIDDEN_COLUMNS
             ]
         else:
-            self._column_scols = column_scols
+            self._data_spark_columns = data_spark_columns
 
-        if scol is not None:
+        if spark_column is not None:
             assert column_labels is not None and len(column_labels) == 1, column_labels
             assert all(
                 label is None or (isinstance(label, tuple) and len(label) > 0)
@@ -516,11 +529,13 @@ class _InternalFrame(object):
             ), column_labels
             self._column_labels = column_labels
         elif column_labels is None:
-            self._column_labels = [(sdf.select(scol).columns[0],) for scol in self._column_scols]
+            self._column_labels = [
+                (spark_frame.select(scol).columns[0],) for scol in self._data_spark_columns
+            ]
         else:
-            assert len(column_labels) == len(self._column_scols), (
+            assert len(column_labels) == len(self._data_spark_columns), (
                 len(column_labels),
-                len(self._column_scols),
+                len(self._data_spark_columns),
             )
             assert all(isinstance(i, tuple) for i in column_labels), column_labels
             assert len(set(len(i) for i in column_labels)) <= 1, column_labels
@@ -544,19 +559,19 @@ class _InternalFrame(object):
         notion so corresponding column should be generated.
         There are several types of default index can be configured by `compute.default_index_type`.
 
-        >>> sdf = ks.range(10).to_spark()
-        >>> sdf
+        >>> spark_frame = ks.range(10).to_spark()
+        >>> spark_frame
         DataFrame[id: bigint]
 
         It adds the default index column '__index_level_0__'.
 
-        >>> sdf = _InternalFrame.attach_default_index(sdf)
-        >>> sdf
+        >>> spark_frame = _InternalFrame.attach_default_index(spark_frame)
+        >>> spark_frame
         DataFrame[__index_level_0__: int, id: bigint]
 
         It throws an exception if the given column name already exists.
 
-        >>> _InternalFrame.attach_default_index(sdf)
+        >>> _InternalFrame.attach_default_index(spark_frame)
         ... # doctest: +ELLIPSIS
         Traceback (most recent call last):
           ...
@@ -657,83 +672,81 @@ class _InternalFrame(object):
             (sdf[offset_column] + sdf[row_number_column] - 1).alias(column_name), *scols
         )
 
-    @lazy_property
-    def _column_labels_to_name(self) -> Dict[Tuple[str, ...], str]:
-        return dict(zip(self.column_labels, self.data_columns))
-
-    def column_name_for(self, column_labels_or_index_column: Union[str, Tuple[str, ...]]) -> str:
+    def spark_column_name_for(self, labels: Union[str, Tuple[str, ...]]) -> str:
         """ Return the actual Spark column name for the given column name or index. """
-        if column_labels_or_index_column in self._column_labels_to_name:
-            return self._column_labels_to_name[column_labels_or_index_column]
+        column_labels_to_name = dict(zip(self.column_labels, self.data_spark_column_names))
+        if labels in column_labels_to_name:
+            return column_labels_to_name[labels]  # type: ignore
         else:
-            if column_labels_or_index_column not in self.index_columns:
-                raise KeyError(name_like_string(column_labels_or_index_column))
-            return column_labels_or_index_column  # type: ignore
+            for index_spark_column_name, index_name in self.index_map.items():
+                if index_name == labels:
+                    return index_spark_column_name
+            raise KeyError(name_like_string(labels))
 
-    @lazy_property
-    def _column_labels_to_scol(self) -> Dict[Tuple[str, ...], spark.Column]:
-        return dict(zip(self.column_labels, self.column_scols))
-
-    def scol_for(self, column_labels_or_index_column: Union[str, Tuple[str, ...]]):
+    def spark_column_for(self, labels: Union[str, Tuple[str, ...]]):
         """ Return Spark Column for the given column name or index. """
-        if column_labels_or_index_column in self._column_labels_to_scol:
-            return self._column_labels_to_scol[column_labels_or_index_column]
+        column_labels_to_scol = dict(zip(self.column_labels, self.data_spark_columns))
+        if labels in column_labels_to_scol:
+            return column_labels_to_scol[labels]  # type: ignore
         else:
-            if column_labels_or_index_column not in self.index_columns:
-                raise KeyError(name_like_string(column_labels_or_index_column))
-            return scol_for(self._sdf, self.column_name_for(column_labels_or_index_column))
+            if labels not in self.index_spark_column_names:
+                raise KeyError(name_like_string(labels))
+            return scol_for(self._sdf, self.spark_column_name_for(labels))
 
-    def spark_type_for(
-        self, column_labels_or_index_column: Union[str, Tuple[str, ...]]
-    ) -> DataType:
+    def spark_type_for(self, labels: Union[str, Tuple[str, ...]]) -> DataType:
         """ Return DataType for the given column name or index. """
-        return self._sdf.select(self.scol_for(column_labels_or_index_column)).schema[0].dataType
+        return self._sdf.select(self.spark_column_for(labels)).schema[0].dataType
 
     @property
-    def sdf(self) -> spark.DataFrame:
+    def spark_frame(self) -> spark.DataFrame:
         """ Return the managed Spark DataFrame. """
         return self._sdf
 
+    @property
+    def spark_column(self) -> Optional[spark.Column]:
+        """ Return the managed Spark Column. """
+        return self._scol
+
     @lazy_property
-    def data_columns(self) -> List[str]:
+    def data_spark_column_names(self) -> List[str]:
         """ Return the managed column field names. """
-        return self.sdf.select(self.column_scols).columns
+        return self.spark_frame.select(self.data_spark_columns).columns
 
     @property
-    def column_scols(self) -> List[spark.Column]:
+    def data_spark_columns(self) -> List[spark.Column]:
         """ Return Spark Columns for the managed data columns. """
-        return self._column_scols
+        return self._data_spark_columns
 
     @lazy_property
-    def index_columns(self) -> List[str]:
+    def index_spark_column_names(self) -> List[str]:
         """ Return the managed index field names. """
-        return [index_column for index_column, _ in self._index_map]
+        return list(self.index_map.keys())
 
     @lazy_property
-    def index_scols(self) -> List[spark.Column]:
+    def index_spark_columns(self) -> List[spark.Column]:
         """ Return Spark Columns for the managed index columns. """
-        return [self.scol_for(column) for column in self.index_columns]
+        return [scol_for(self._sdf, column) for column in self.index_spark_column_names]
 
     @lazy_property
-    def columns(self) -> List[str]:
+    def spark_column_names(self) -> List[str]:
         """ Return all the field names including index field names. """
-        index_columns = set(self.index_columns)
-        return self.index_columns + [
-            column for column in self.data_columns if column not in index_columns
+        index_columns = set(self.index_spark_column_names)
+        return self.index_spark_column_names + [
+            column for column in self.data_spark_column_names if column not in index_columns
         ]
 
     @lazy_property
-    def scols(self) -> List[spark.Column]:
+    def spark_columns(self) -> List[spark.Column]:
         """ Return Spark Columns for the managed columns including index columns. """
-        index_columns = set(self.index_columns)
-        return self.index_scols + [
-            self.scol_for(label)
+        index_columns = set(self.index_spark_column_names)
+        return self.index_spark_columns + [
+            self.spark_column_for(label)
             for label in self.column_labels
-            if self.column_name_for(label) not in index_columns
+            if self.spark_column_name_for(label) not in index_columns
         ]
 
     @property
-    def index_map(self) -> List[IndexMap]:
+    def index_map(self) -> Dict[str, Optional[Tuple[str, ...]]]:
         """ Return the managed index information. """
         assert len(self._index_map) > 0
         return self._index_map
@@ -741,12 +754,7 @@ class _InternalFrame(object):
     @lazy_property
     def index_names(self) -> List[Optional[Tuple[str, ...]]]:
         """ Return the managed index names. """
-        return [index_name for _, index_name in self.index_map]
-
-    @property
-    def scol(self) -> Optional[spark.Column]:
-        """ Return the managed Spark Column. """
-        return self._scol
+        return list(self.index_map.values())
 
     @property
     def column_labels(self) -> List[Tuple[str, ...]]:
@@ -764,28 +772,28 @@ class _InternalFrame(object):
         return self._column_label_names
 
     @lazy_property
-    def spark_internal_df(self) -> spark.DataFrame:
+    def to_internal_spark_frame(self) -> spark.DataFrame:
         """
         Return as Spark DataFrame. This contains index columns as well
         and should be only used for internal purposes.
         """
-        index_columns = set(self.index_columns)
+        index_columns = set(self.index_spark_column_names)
         data_columns = []
-        for i, (column, label) in enumerate(zip(self.data_columns, self.column_labels)):
+        for i, (column, label) in enumerate(zip(self.data_spark_column_names, self.column_labels)):
             if column not in index_columns:
-                scol = self.scol_for(label)
+                scol = self.spark_column_for(label)
                 name = str(i) if label is None else name_like_string(label)
                 if column != name:
                     scol = scol.alias(name)
                 data_columns.append(scol)
-        return self._sdf.select(self.index_scols + data_columns)
+        return self._sdf.select(self.index_spark_columns + data_columns)
 
     @lazy_property
-    def spark_df(self) -> spark.DataFrame:
-        """ Return as Spark DataFrame. """
+    def to_external_spark_frame(self) -> spark.DataFrame:
+        """ Return as new Spark DataFrame. """
         data_columns = []
-        for i, (column, label) in enumerate(zip(self.data_columns, self.column_labels)):
-            scol = self.scol_for(label)
+        for i, (column, label) in enumerate(zip(self.data_spark_column_names, self.column_labels)):
+            scol = self.spark_column_for(label)
             name = str(i) if label is None else name_like_string(label)
             if column != name:
                 scol = scol.alias(name)
@@ -793,20 +801,20 @@ class _InternalFrame(object):
         return self._sdf.select(data_columns)
 
     @lazy_property
-    def pandas_df(self):
+    def to_pandas_frame(self) -> pd.DataFrame:
         """ Return as pandas DataFrame. """
-        sdf = self.spark_internal_df
+        sdf = self.to_internal_spark_frame
         pdf = sdf.toPandas()
         if len(pdf) == 0 and len(sdf.schema) > 0:
             pdf = pdf.astype(
                 {field.name: spark_type_to_pandas_dtype(field.dataType) for field in sdf.schema}
             )
 
-        index_columns = self.index_columns
+        index_columns = self.index_spark_column_names
         if len(index_columns) > 0:
             append = False
             for index_field in index_columns:
-                drop = index_field not in self.data_columns
+                drop = index_field not in self.data_spark_column_names
                 pdf = pdf.set_index(index_field, drop=drop, append=append)
                 append = True
             pdf = pdf[
@@ -816,7 +824,9 @@ class _InternalFrame(object):
                     else str(i)
                     if label is None
                     else name_like_string(label)
-                    for i, (col, label) in enumerate(zip(self.data_columns, self.column_labels))
+                    for i, (col, label) in enumerate(
+                        zip(self.data_spark_column_names, self.column_labels)
+                    )
                 ]
             ]
 
@@ -845,14 +855,16 @@ class _InternalFrame(object):
         :return: the copied _InternalFrame.
         """
         if data_columns is None:
-            data_columns = self.data_columns
+            data_columns = self.data_spark_column_names
         else:
             assert len(data_columns) == len(self.column_labels), (
                 len(data_columns),
                 len(self.column_labels),
             )
         sdf = sdf.drop(NATURAL_ORDER_COLUMN_NAME)
-        return self.copy(sdf=sdf, column_scols=[scol_for(sdf, col) for col in data_columns])
+        return self.copy(
+            spark_frame=sdf, data_spark_columns=[scol_for(sdf, col) for col in data_columns]
+        )
 
     def with_new_columns(
         self,
@@ -891,25 +903,27 @@ class _InternalFrame(object):
                 len(column_labels),
             )
 
-        column_scols = []
+        data_spark_columns = []
         for scol_or_kser, label in zip(scols_or_ksers, column_labels):
             if isinstance(scol_or_kser, Series):
-                scol = scol_or_kser._internal.scol
+                scol = scol_or_kser._internal.spark_column
             else:
                 scol = scol_or_kser
-            column_scols.append(scol)
+            data_spark_columns.append(scol)
 
         hidden_columns = []
         if keep_order:
             hidden_columns.append(NATURAL_ORDER_COLUMN_NAME)
 
-        sdf = self._sdf.select(self.index_scols + column_scols + hidden_columns)
+        sdf = self._sdf.select(self.index_spark_columns + data_spark_columns + hidden_columns)
 
         return self.copy(
-            sdf=sdf,
+            spark_frame=sdf,
             column_labels=column_labels,
-            column_scols=[scol_for(sdf, col) for col in self._sdf.select(column_scols).columns],
-            scol=None,
+            data_spark_columns=[
+                scol_for(sdf, col) for col in self._sdf.select(data_spark_columns).columns
+            ],
+            spark_column=None,
         )
 
     def with_filter(self, pred: Union[spark.Column, "Series"]):
@@ -927,46 +941,46 @@ class _InternalFrame(object):
             spark_type = self._sdf.select(pred).schema[0].dataType
             assert isinstance(spark_type, BooleanType), spark_type
 
-        return self.copy(sdf=self._sdf.drop(NATURAL_ORDER_COLUMN_NAME).filter(pred))
+        return self.copy(spark_frame=self._sdf.drop(NATURAL_ORDER_COLUMN_NAME).filter(pred))
 
     def copy(
         self,
-        sdf: Union[spark.DataFrame, _NoValueType] = _NoValue,
-        index_map: Union[List[IndexMap], _NoValueType] = _NoValue,
-        column_labels: Union[List[Tuple[str, ...]], _NoValueType] = _NoValue,
-        column_scols: Union[List[spark.Column], _NoValueType] = _NoValue,
+        spark_frame: Union[spark.DataFrame, _NoValueType] = _NoValue,
+        index_map: Optional[Union[Dict[str, Optional[Tuple[str, ...]]], _NoValueType]] = _NoValue,
+        column_labels: Optional[Union[List[Tuple[str, ...]], _NoValueType]] = _NoValue,
+        data_spark_columns: Optional[Union[List[spark.Column], _NoValueType]] = _NoValue,
         column_label_names: Optional[Union[List[str], _NoValueType]] = _NoValue,
-        scol: Union[spark.Column, _NoValueType] = _NoValue,
+        spark_column: Optional[Union[spark.Column, _NoValueType]] = _NoValue,
     ) -> "_InternalFrame":
         """ Copy the immutable DataFrame.
 
-        :param sdf: the new Spark DataFrame. If None, then the original one is used.
+        :param spark_frame: the new Spark DataFrame. If None, then the original one is used.
         :param index_map: the new index information. If None, then the original one is used.
         :param column_labels: the new column index.
-        :param column_scols: the new Spark Columns. If None, then the original ones are used.
+        :param data_spark_columns: the new Spark Columns. If None, then the original ones are used.
         :param column_label_names: the new names of the index levels.
-        :param scol: the new Spark Column. If None, then the original one is used.
+        :param spark_column: the new Spark Column. If None, then the original one is used.
         :return: the copied immutable DataFrame.
         """
-        if sdf is _NoValue:
-            sdf = self._sdf
+        if spark_frame is _NoValue:
+            spark_frame = self._sdf
         if index_map is _NoValue:
             index_map = self._index_map
         if column_labels is _NoValue:
             column_labels = self._column_labels
-        if column_scols is _NoValue:
-            column_scols = self._column_scols
+        if data_spark_columns is _NoValue:
+            data_spark_columns = self._data_spark_columns
         if column_label_names is _NoValue:
             column_label_names = self._column_label_names
-        if scol is _NoValue:
-            scol = self._scol
+        if spark_column is _NoValue:
+            spark_column = self._scol
         return _InternalFrame(
-            sdf,
+            spark_frame,
             index_map=index_map,
             column_labels=column_labels,
-            column_scols=column_scols,
+            data_spark_columns=data_spark_columns,
             column_label_names=column_label_names,
-            scol=scol,
+            spark_column=spark_column,
         )
 
     @staticmethod
@@ -986,14 +1000,16 @@ class _InternalFrame(object):
 
         index = pdf.index
 
-        index_map = []  # type: List[IndexMap]
+        index_map = []  # type: ignore
         if isinstance(index, pd.MultiIndex):
             if index.names is None:
                 index_map = [(SPARK_INDEX_NAME_FORMAT(i), None) for i in range(len(index.levels))]
             else:
                 index_map = [
                     (
-                        SPARK_INDEX_NAME_FORMAT(i) if name is None else name_like_string(name),
+                        SPARK_INDEX_NAME_FORMAT(i)  # type: ignore
+                        if name is None
+                        else name_like_string(name),
                         name if name is None or isinstance(name, tuple) else (name,),
                     )
                     for i, name in enumerate(index.names)
@@ -1002,7 +1018,9 @@ class _InternalFrame(object):
             name = index.name
             index_map = [
                 (
-                    name_like_string(name) if name is not None else SPARK_DEFAULT_INDEX_NAME,
+                    name_like_string(name)  # type: ignore
+                    if name is not None
+                    else SPARK_DEFAULT_INDEX_NAME,
                     name if name is None or isinstance(name, tuple) else (name,),
                 )
             ]
@@ -1028,9 +1046,9 @@ class _InternalFrame(object):
             reset_index[name] = col.replace({np.nan: None})
         sdf = default_session().createDataFrame(reset_index, schema=schema)
         return _InternalFrame(
-            sdf=sdf,
-            index_map=index_map,
+            spark_frame=sdf,
+            index_map=OrderedDict(index_map),
             column_labels=column_labels,
-            column_scols=[scol_for(sdf, col) for col in data_columns],
+            data_spark_columns=[scol_for(sdf, col) for col in data_columns],
             column_label_names=column_label_names,
         )

--- a/databricks/koalas/ml.py
+++ b/databricks/koalas/ml.py
@@ -82,7 +82,9 @@ def to_numeric_df(kdf: "ks.DataFrame") -> Tuple[pyspark.sql.DataFrame, List[Tupl
     numeric_column_labels = [
         label for label in kdf._internal.column_labels if kdf[label].dtype in accepted_types
     ]
-    numeric_df = kdf._sdf.select(*[kdf._internal.scol_for(idx) for idx in numeric_column_labels])
+    numeric_df = kdf._sdf.select(
+        *[kdf._internal.spark_column_for(idx) for idx in numeric_column_labels]
+    )
     va = VectorAssembler(inputCols=numeric_df.columns, outputCol=CORRELATION_OUTPUT_COLUMN)
     v = va.transform(numeric_df).select(CORRELATION_OUTPUT_COLUMN)
     return v, numeric_column_labels

--- a/databricks/koalas/mlflow.py
+++ b/databricks/koalas/mlflow.py
@@ -85,14 +85,15 @@ class PythonModelWrapper(object):
         if isinstance(data, pd.DataFrame):
             return self._model.predict(data)
         if isinstance(data, DataFrame):
-            return_col = self._model_udf(*data._internal.column_scols)
+            return_col = self._model_udf(*data._internal.data_spark_columns)
             # TODO: the columns should be named according to the mlflow spec
             # However, this is only possible with spark >= 3.0
             # s = F.struct(*data.columns)
             # return_col = self._model_udf(s)
             column_labels = [(col,) for col in data._sdf.select(return_col).columns]
             return Series(
-                data._internal.copy(scol=return_col, column_labels=column_labels), anchor=data
+                data._internal.copy(spark_column=return_col, column_labels=column_labels),
+                anchor=data,
             )
 
 

--- a/databricks/koalas/plot.py
+++ b/databricks/koalas/plot.py
@@ -529,7 +529,7 @@ class KoalasHistPlot(HistPlot):
 
         for i, label in enumerate(self.data._internal.column_labels):
             # 'y' is a Spark DataFrame that selects one column.
-            y = sdf.select(self.data._internal.scol_for(label))
+            y = sdf.select(self.data._internal.spark_column_for(label))
             ax = self._get_ax(i)
 
             kwds = self.kwds.copy()
@@ -689,7 +689,7 @@ class KoalasKdePlot(KdePlot):
 
         for i, label in enumerate(self.data._internal.column_labels):
             # 'y' is a Spark DataFrame that selects one column.
-            y = sdf.select(self.data._internal.scol_for(label))
+            y = sdf.select(self.data._internal.spark_column_for(label))
             ax = self._get_ax(i)
 
             kwds = self.kwds.copy()

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -397,8 +397,8 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         pdf.columns = ["x", "y"]
         self.assert_eq(kdf.columns, pd.Index(["x", "y"]))
         self.assert_eq(kdf, pdf)
-        self.assert_eq(kdf._internal.data_columns, ["x", "y"])
-        self.assert_eq(kdf._internal.spark_df.columns, ["x", "y"])
+        self.assert_eq(kdf._internal.data_spark_column_names, ["x", "y"])
+        self.assert_eq(kdf._internal.to_external_spark_frame.columns, ["x", "y"])
 
         columns = pdf.columns
         columns.name = "lvl_1"
@@ -425,23 +425,23 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         kdf.columns = ["x", "y"]
         self.assert_eq(kdf.columns, pd.Index(["x", "y"]))
         self.assert_eq(kdf, pdf)
-        self.assert_eq(kdf._internal.data_columns, ["x", "y"])
-        self.assert_eq(kdf._internal.spark_df.columns, ["x", "y"])
+        self.assert_eq(kdf._internal.data_spark_column_names, ["x", "y"])
+        self.assert_eq(kdf._internal.to_external_spark_frame.columns, ["x", "y"])
 
         pdf.columns = columns
         kdf.columns = columns
         self.assert_eq(kdf.columns, columns)
         self.assert_eq(kdf, pdf)
-        self.assert_eq(kdf._internal.data_columns, ["(A, 0)", "(B, 1)"])
-        self.assert_eq(kdf._internal.spark_df.columns, ["(A, 0)", "(B, 1)"])
+        self.assert_eq(kdf._internal.data_spark_column_names, ["(A, 0)", "(B, 1)"])
+        self.assert_eq(kdf._internal.to_external_spark_frame.columns, ["(A, 0)", "(B, 1)"])
 
         columns.names = ["lvl_1", "lvl_2"]
 
         kdf.columns = columns
         self.assert_eq(kdf.columns.names, ["lvl_1", "lvl_2"])
         self.assert_eq(kdf, pdf)
-        self.assert_eq(kdf._internal.data_columns, ["(A, 0)", "(B, 1)"])
-        self.assert_eq(kdf._internal.spark_df.columns, ["(A, 0)", "(B, 1)"])
+        self.assert_eq(kdf._internal.data_spark_column_names, ["(A, 0)", "(B, 1)"])
+        self.assert_eq(kdf._internal.to_external_spark_frame.columns, ["(A, 0)", "(B, 1)"])
 
     def test_rename_dataframe(self):
         kdf1 = ks.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})

--- a/databricks/koalas/tests/test_internal.py
+++ b/databricks/koalas/tests/test_internal.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from collections import OrderedDict
 
 import pandas as pd
 
@@ -25,38 +26,42 @@ class InternalFrameTest(ReusedSQLTestCase, SQLTestUtils):
         pdf = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
 
         internal = _InternalFrame.from_pandas(pdf)
-        sdf = internal.sdf
+        sdf = internal.spark_frame
 
-        self.assert_eq(internal.index_map, [(SPARK_DEFAULT_INDEX_NAME, None)])
+        self.assert_eq(internal.index_map, OrderedDict({SPARK_DEFAULT_INDEX_NAME: None}))
         self.assert_eq(internal.column_labels, [("a",), ("b",)])
-        self.assert_eq(internal.data_columns, ["a", "b"])
-        self.assertTrue(internal.scol_for(("a",))._jc.equals(sdf["a"]._jc))
-        self.assertTrue(internal.scol_for(("b",))._jc.equals(sdf["b"]._jc))
+        self.assert_eq(internal.data_spark_column_names, ["a", "b"])
+        self.assertTrue(internal.spark_column_for(("a",))._jc.equals(sdf["a"]._jc))
+        self.assertTrue(internal.spark_column_for(("b",))._jc.equals(sdf["b"]._jc))
 
-        self.assert_eq(internal.pandas_df, pdf)
+        self.assert_eq(internal.to_pandas_frame, pdf)
 
         # multi-index
         pdf.set_index("a", append=True, inplace=True)
 
         internal = _InternalFrame.from_pandas(pdf)
-        sdf = internal.sdf
+        sdf = internal.spark_frame
 
-        self.assert_eq(internal.index_map, [(SPARK_DEFAULT_INDEX_NAME, None), ("a", ("a",))])
+        self.assert_eq(
+            internal.index_map, OrderedDict([(SPARK_DEFAULT_INDEX_NAME, None), ("a", ("a",))])
+        )
         self.assert_eq(internal.column_labels, [("b",)])
-        self.assert_eq(internal.data_columns, ["b"])
-        self.assertTrue(internal.scol_for(("b",))._jc.equals(sdf["b"]._jc))
+        self.assert_eq(internal.data_spark_column_names, ["b"])
+        self.assertTrue(internal.spark_column_for(("b",))._jc.equals(sdf["b"]._jc))
 
-        self.assert_eq(internal.pandas_df, pdf)
+        self.assert_eq(internal.to_pandas_frame, pdf)
 
         # multi-index columns
         pdf.columns = pd.MultiIndex.from_tuples([("x", "b")])
 
         internal = _InternalFrame.from_pandas(pdf)
-        sdf = internal.sdf
+        sdf = internal.spark_frame
 
-        self.assert_eq(internal.index_map, [(SPARK_DEFAULT_INDEX_NAME, None), ("a", ("a",))])
+        self.assert_eq(
+            internal.index_map, OrderedDict([(SPARK_DEFAULT_INDEX_NAME, None), ("a", ("a",))])
+        )
         self.assert_eq(internal.column_labels, [("x", "b")])
-        self.assert_eq(internal.data_columns, ["(x, b)"])
-        self.assertTrue(internal.scol_for(("x", "b"))._jc.equals(sdf["(x, b)"]._jc))
+        self.assert_eq(internal.data_spark_column_names, ["(x, b)"])
+        self.assertTrue(internal.spark_column_for(("x", "b"))._jc.equals(sdf["(x, b)"]._jc))
 
-        self.assert_eq(internal.pandas_df, pdf)
+        self.assert_eq(internal.to_pandas_frame, pdf)

--- a/databricks/koalas/utils.py
+++ b/databricks/koalas/utils.py
@@ -74,15 +74,15 @@ def combine_frames(this, *args, how="full"):
 
         # Note that the order of each element in index_map is guaranteed according to the index
         # level.
-        this_and_that_index_map = zip(this_index_map, that_index_map)
+        this_and_that_index_map = zip(this_index_map.items(), that_index_map.items())
 
         # If the same named index is found, that's used.
         for (this_column, this_name), (that_column, that_name) in this_and_that_index_map:
             if this_name == that_name:
                 # We should merge the Spark columns into one
                 # to mimic pandas' behavior.
-                this_scol = this._internal.scol_for(this_column)
-                that_scol = that._internal.scol_for(that_column)
+                this_scol = scol_for(this._sdf, this_column)
+                that_scol = scol_for(that._sdf, that_column)
                 join_scol = this_scol == that_scol
                 join_scols.append(join_scol)
                 merged_index_scols.append(
@@ -98,16 +98,16 @@ def combine_frames(this, *args, how="full"):
         joined_df = joined_df.select(
             merged_index_scols
             + [
-                this[label]._scol.alias("__this_%s" % this._internal.column_name_for(label))
+                this[label]._scol.alias("__this_%s" % this._internal.spark_column_name_for(label))
                 for label in this._internal.column_labels
             ]
             + [
-                that[label]._scol.alias("__that_%s" % that._internal.column_name_for(label))
+                that[label]._scol.alias("__that_%s" % that._internal.spark_column_name_for(label))
                 for label in that._internal.column_labels
             ]
         )
 
-        index_columns = set(this._internal.index_columns)
+        index_columns = set(this._internal.index_spark_column_names)
         new_data_columns = [c for c in joined_df.columns if c not in index_columns]
         level = max(this._internal.column_labels_level, that._internal.column_labels_level)
         column_labels = [
@@ -127,9 +127,9 @@ def combine_frames(this, *args, how="full"):
         )
         return DataFrame(
             this._internal.copy(
-                sdf=joined_df,
+                spark_frame=joined_df,
                 column_labels=column_labels,
-                column_scols=[scol_for(joined_df, col) for col in new_data_columns],
+                data_spark_columns=[scol_for(joined_df, col) for col in new_data_columns],
                 column_label_names=column_label_names,
             )
         )
@@ -233,7 +233,7 @@ def align_diff_frames(resolve_func, this, that, fillna=True, how="full"):
                 columns_to_keep.append(F.lit(None).cast(FloatType()).alias(str(combined_label)))
                 column_labels_to_keep.append(combined_label)
             else:
-                columns_to_keep.append(combined._internal.scol_for(combined_label))
+                columns_to_keep.append(combined._internal.spark_column_for(combined_label))
                 column_labels_to_keep.append(combined_label)
 
     that_columns_to_apply += additional_that_columns
@@ -280,11 +280,14 @@ def align_diff_series(func, this_series, *args, how="full"):
     combined = combine_frames(this_series.to_frame(), *cols, how=how)
 
     scol = func(
-        combined["this"]._internal.column_scols[0], *combined["that"]._internal.column_scols
+        combined["this"]._internal.data_spark_columns[0],
+        *combined["that"]._internal.data_spark_columns
     )
 
     return Series(
-        combined._internal.copy(scol=scol, column_labels=this_series._internal.column_labels),
+        combined._internal.copy(
+            spark_column=scol, column_labels=this_series._internal.column_labels
+        ),
         anchor=combined,
     )
 


### PR DESCRIPTION
This PR proposes to refine and refactor `_InternalFrame`.

- `index_map`: uses `OrderedDict` instead of `List[Tuple[...]]`

</br>

- `column_name_for` -> `spark_column_name_for`
    Now, it purely searches by labels (and index name) instead of internal Spark column name when it searches index.
- `scol_for` -> `spark_column_for`

</br>

- `sdf` -> `spark_frame`
- `scol` -> `spark_column`
- `scols` -> `spark_columns`
- `columns ` -> `spark_column_names`

</br>

- `data_columns` -> `data_spark_column_names`
- `column_scols` -> `data_spark_columns`

</br>

- `index_columns` -> `index_spark_column_names`
- `index_scols` -> `index_spark_columns`

</br>

- `spark_internal_df` -> `to_internal_spark_frame`
- `spark_df` -> `to_external_spark_frame`
- `pandas_df` -> `to_pandas_frame`

