### PR TITLE
Support slice as `rows_sel` for `iloc` indexer.

### DIFF
--- a/databricks/koalas/tests/test_indexing.py
+++ b/databricks/koalas/tests/test_indexing.py
@@ -673,6 +673,27 @@ class IndexingTest(ReusedSQLTestCase):
         self.assert_eq(kseries.iloc[:1], pseries.iloc[:1])
         self.assert_eq(kseries.iloc[:-1], pseries.iloc[:-1])
 
+    def test_iloc_slice_rows_sel(self):
+        pdf = pd.DataFrame({"A": [1, 2] * 5, "B": [3, 4] * 5, "C": [5, 6] * 5})
+        kdf = ks.from_pandas(pdf)
+
+        for rows_sel in [
+            slice(None),
+            slice(0, 1),
+            slice(1, 2),
+            slice(-3, None),
+            slice(None, -3),
+            slice(None, None, 3),
+            slice(3, 8, 2),
+            slice(None, None, -2),
+            slice(8, 3, -2),
+            slice(8, None, -2),
+            slice(None, 3, -2),
+        ]:
+            with self.subTest(rows_sel=rows_sel):
+                self.assert_eq(kdf.iloc[rows_sel].sort_index(), pdf.iloc[rows_sel].sort_index())
+                self.assert_eq(kdf.A.iloc[rows_sel].sort_index(), pdf.A.iloc[rows_sel].sort_index())
+
     def test_setitem(self):
         pdf = pd.DataFrame(
             [[1, 2], [4, 5], [7, 8]],
@@ -713,16 +734,6 @@ class IndexingTest(ReusedSQLTestCase):
     def test_iloc_raises(self):
         pdf = pd.DataFrame({"A": [1, 2], "B": [3, 4], "C": [5, 6]})
         kdf = ks.from_pandas(pdf)
-
-        with self.assertRaisesRegex(
-            SparkPandasNotImplementedError, "Cannot use start or step with Spark."
-        ):
-            kdf.iloc[0:]
-
-        with self.assertRaisesRegex(
-            SparkPandasNotImplementedError, "Cannot use start or step with Spark."
-        ):
-            kdf.iloc[:2:2]
 
         with self.assertRaisesRegex(
             SparkPandasNotImplementedError,


### PR DESCRIPTION
Adding support slice as `rows_sel` for `iloc` indexer.
E.g.,

```py
>>> pdf = pd.DataFrame({'a':list('abcdefghij')})
>>> pdf
   a
0  a
1  b
2  c
3  d
4  e
5  f
6  g
7  h
8  i
9  j
>>> pdf.iloc[2:5]
   a
2  c
3  d
4  e
>>> pdf.iloc[2:-3]
   a
2  c
3  d
4  e
5  f
6  g
>>> pdf.iloc[-8:-3]
   a
2  c
3  d
4  e
5  f
6  g
>>> pdf.iloc[2:-3:2]
   a
2  c
4  e
6  g
>>> pdf.iloc[5:]
   a
5  f
6  g
7  h
8  i
9  j
>>> pdf.iloc[5:2]
Empty DataFrame
Columns: [a]
Index: []
```

Resolves #1230