### PR TITLE
Fix index operator against Series and Frame to use iloc conditionally

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -9625,6 +9625,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         if isinstance(key, (str, tuple, list)):
             return self.loc[:, key]
         elif isinstance(key, slice):
+            if any(type(n) == int or None for n in [key.start, key.stop]):
+                # Seems like pandas Frame always uses int as positional search when slicing
+                # with ints.
+                return self.iloc[key]
             return self.loc[key]
         elif isinstance(key, Series):
             return self.loc[key.astype(bool)]

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -3624,7 +3624,7 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
             if before > after:
                 raise ValueError("Truncate: %s must be after %s" % (after, before))
 
-        result = _col(self.to_frame()[before:after])
+        result = _col(self.to_frame().loc[before:after])
 
         return result.copy() if copy else result
 

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -31,7 +31,7 @@ from pandas.io.formats.printing import pprint_thing
 from databricks.koalas.typedef import as_python_type
 from pyspark import sql as spark
 from pyspark.sql import functions as F, Column
-from pyspark.sql.types import BooleanType, StructType
+from pyspark.sql.types import BooleanType, StructType, LongType, IntegerType
 from pyspark.sql.window import Window
 
 from databricks import koalas as ks  # For running doctests and reference resolution in PyCharm.
@@ -4533,6 +4533,12 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
 
     def __getitem__(self, key):
         try:
+            if (isinstance(key, slice) and any(type(n) == int for n in [key.start, key.stop])) or (
+                type(key) == int and not isinstance(self.index.spark_type, (IntegerType, LongType))
+            ):
+                # Seems like pandas Series always uses int as positional search when slicing
+                # with ints, searches based on index values when the value is int.
+                return self.iloc[key]
             return self.loc[key]
         except SparkPandasIndexingError:
             raise KeyError(

--- a/databricks/koalas/tests/test_indexing.py
+++ b/databricks/koalas/tests/test_indexing.py
@@ -13,8 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-from distutils.version import LooseVersion
+import datetime
 import unittest
 
 import numpy as np
@@ -768,3 +767,59 @@ class IndexingTest(ReusedSQLTestCase):
 
         with self.assertRaisesRegex(IndexError, "out of range"):
             kdf.iloc[:, [5, 6]]
+
+    def test_index_operator_datetime(self):
+        dates = pd.date_range("20130101", periods=6)
+        pdf = pd.DataFrame(np.random.randn(6, 4), index=dates, columns=list("ABCD"))
+        kdf = ks.from_pandas(pdf)
+
+        # Positional iloc search
+        self.assert_eq(kdf[:4], pdf[:4])
+        self.assert_eq(kdf[:3], pdf[:3])
+        self.assert_eq(kdf[3:], pdf[3:])
+        self.assert_eq(kdf[2:], pdf[2:])
+        self.assert_eq(kdf[2:3], pdf[2:3])
+        self.assert_eq(kdf[2:-1], pdf[2:-1])
+        self.assert_eq(kdf[10:3], pdf[10:3])
+
+        # Index loc search
+        self.assert_eq(kdf.A[4], pdf.A[4])
+        self.assert_eq(kdf.A[3], pdf.A[3])
+
+        # Positional iloc search
+        self.assert_eq(kdf.A[:4], pdf.A[:4])
+        self.assert_eq(kdf.A[:3], pdf.A[:3])
+        self.assert_eq(kdf.A[3:], pdf.A[3:])
+        self.assert_eq(kdf.A[2:], pdf.A[2:])
+        self.assert_eq(kdf.A[2:3], pdf.A[2:3])
+        self.assert_eq(kdf.A[2:-1], pdf.A[2:-1])
+        self.assert_eq(kdf.A[10:3], pdf.A[10:3])
+
+        dt1 = datetime.datetime.strptime("2013-01-02", "%Y-%m-%d")
+        dt2 = datetime.datetime.strptime("2013-01-04", "%Y-%m-%d")
+
+        # Index loc search
+        self.assert_eq(kdf[:dt2], pdf[:dt2])
+        self.assert_eq(kdf[dt1:], pdf[dt1:])
+        self.assert_eq(kdf[dt1:dt2], pdf[dt1:dt2])
+        self.assert_eq(kdf.A[dt2], pdf.A[dt2])
+        self.assert_eq(kdf.A[:dt2], pdf.A[:dt2])
+        self.assert_eq(kdf.A[dt1:], pdf.A[dt1:])
+        self.assert_eq(kdf.A[dt1:dt2], pdf.A[dt1:dt2])
+
+    def test_index_operator_int(self):
+        pdf = pd.DataFrame(np.random.randn(6, 4), index=[1, 3, 5, 7, 9, 11], columns=list("ABCD"))
+        kdf = ks.from_pandas(pdf)
+
+        # Positional iloc search
+        self.assert_eq(kdf[:4], pdf[:4])
+        self.assert_eq(kdf[:3], pdf[:3])
+        self.assert_eq(kdf[3:], pdf[3:])
+        self.assert_eq(kdf[2:], pdf[2:])
+        self.assert_eq(kdf[2:3], pdf[2:3])
+        self.assert_eq(kdf[2:-1], pdf[2:-1])
+        self.assert_eq(kdf[10:3], pdf[10:3])
+
+        # Index loc search
+        self.assert_eq(kdf.A[5], pdf.A[5])
+        self.assert_eq(kdf.A[3], pdf.A[3])

--- a/databricks/koalas/tests/test_indexing.py
+++ b/databricks/koalas/tests/test_indexing.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
 import datetime
 import unittest
 


### PR DESCRIPTION
Looks pandas conditionally uses `iloc` approach when the input is `int` against index operators in Series and Frame.

```python
import databricks.koalas as ks
import pandas as pd
import numpy as np

dates = pd.date_range('20130101', periods=6)
pdf = pd.DataFrame(np.random.randn(6,4), index=dates, columns=list('ABCD'))
kdf = ks.from_pandas(pdf)
kdf[0:3]
```

```
                   A         B         C         D
2013-01-01  2.143975 -2.069608 -0.013988 -0.311598
2013-01-02 -0.448577  0.076479 -0.356269  0.965872
2013-01-03  0.203477  0.738288 -1.453629 -0.146019
```

Resolves #287