### PR TITLE
Add Series.plot.density into the documentation

### DIFF
--- a/docs/source/reference/series.rst
+++ b/docs/source/reference/series.rst
@@ -353,6 +353,7 @@ specific plotting methods of the form ``Series.plot.<kind>``.
    Series.plot.bar
    Series.plot.barh
    Series.plot.box
+   Series.plot.density
    Series.plot.hist
    Series.plot.line
    Series.plot.pie


### PR DESCRIPTION
i noticed pandas added it into documentation (https://pandas.pydata.org/pandas-docs/stable/reference/series.html#plotting). I am adding it accordingly in Koalas as well.