### PR TITLE
Support iterable as `rows_sel` for `iloc` indexer

### DIFF
--- a/databricks/koalas/indexing.py
+++ b/databricks/koalas/indexing.py
@@ -798,15 +798,16 @@ class iLocIndexer(_LocIndexerLike):
     Allowed inputs are:
 
     - An integer for column selection, e.g. ``5``.
+    - A list or array of integers for row selection with distinct index values,
+      e.g. ``[3, 4, 0]``
     - A list or array of integers for column selection, e.g. ``[4, 3, 0]``.
     - A boolean array for column selection.
-    - A slice object with ints for column selection, e.g. ``1:7``.
-    - A slice object with ints without start and step for row selection, e.g. ``:7``.
+    - A slice object with ints for row and column selection, e.g. ``1:7``.
 
     Not allowed inputs which pandas allows are:
 
-    - An integer for row selection, e.g. ``5``.
-    - A list or array of integers for row selection, e.g. ``[4, 3, 0]``.
+    - A list or array of integers for row selection with duplicated indexes,
+      e.g. ``[4, 4, 0]``.
     - A boolean array for row selection.
     - A ``callable`` function with one argument (the calling Series, DataFrame
       or Panel) and that returns valid output for indexing (one of the above).
@@ -847,12 +848,9 @@ class iLocIndexer(_LocIndexerLike):
     d    4
     Name: 0, dtype: int64
 
-    A list of integers for row selection is not allowed.
-
     >>> df.iloc[[0]]
-    Traceback (most recent call last):
-     ...
-    databricks.koalas.exceptions.SparkPandasNotImplementedError: ...
+       a  b  c  d
+    0  1  2  3  4
 
     With a `slice` object.
 


### PR DESCRIPTION
Adding support slice as `rows_sel` for `iloc` indexer.
E.g.,

```python
>>> pdf = pd.DataFrame({'a':list('abcdefghij'), 'b':list('abcdefghij')})
>>> pdf.iloc[[-1, 1, 2,3]]
   a  b
9  j  j
1  b  b
2  c  c
3  d  d
>>> pdf.iloc[[-1, 1, 2,3], :]
   a  b
9  j  j
1  b  b
2  c  c
3  d  d
>>> pdf.iloc[[-1, 1, 2,3], :1]
   a
9  j
1  b
2  c
3  d
>>> pdf.iloc[[]]
Empty DataFrame
Columns: [a, b]
Index: []
```

Resolve #556