### PR TITLE
Fix GroupBy.apply() to respect various output

### DIFF
--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -26,6 +26,7 @@ from itertools import product
 from typing import Any, List, Tuple, Union
 
 import numpy as np
+import pandas as pd
 from pandas._libs.parsers import is_datetime64_dtype
 from pandas.core.dtypes.common import is_datetime64tz_dtype
 
@@ -814,8 +815,8 @@ class GroupBy(object):
 
              To avoid this, specify return type in ``func``, for instance, as below:
 
-             >>> def pandas_div_sum(x) -> ks.DataFrame[float, float]:
-             ...    return x[['B', 'C']] / x[['B', 'C']].sum()
+             >>> def pandas_div(x) -> ks.DataFrame[float, float]:
+             ...    return x[['B', 'C']] / x[['B', 'C']]
 
              If the return type is specified, the output column names become
              `c0, c1, c2 ... cn`. These names are positionally mapped to the returned
@@ -832,11 +833,12 @@ class GroupBy(object):
 
         Returns
         -------
-        applied : DataFrame
+        applied : DataFrame or Series
 
         See Also
         --------
         aggregate : Apply aggregate function to the GroupBy object.
+        DataFrame.apply : Apply a function to a DataFrame.
         Series.apply : Apply a function to a Series.
 
         Examples
@@ -853,24 +855,6 @@ class GroupBy(object):
         its argument and returns a DataFrame. `apply` combines the result for
         each group together into a new DataFrame:
 
-        >>> def pandas_div_sum(x) -> ks.DataFrame[float, float]:
-        ...    return x[['B', 'C']] / x[['B', 'C']].sum()
-        >>> g.apply(pandas_div_sum)  # doctest: +NORMALIZE_WHITESPACE
-                 c0   c1
-        0  1.000000  1.0
-        1  0.333333  0.4
-        2  0.666667  0.6
-
-        >>> def plus_max(x) -> ks.DataFrame[str, np.int, np.int]:
-        ...    return x + x.max()
-        >>> g.apply(plus_max)  # doctest: +NORMALIZE_WHITESPACE
-           c0  c1  c2
-        0  bb   6  10
-        1  aa   3  10
-        2  aa   4  12
-
-        You can omit the type hint and let Koalas infer its type.
-
         >>> def plus_min(x):
         ...    return x + x.min()
         >>> g.apply(plus_min).sort_index()  # doctest: +NORMALIZE_WHITESPACE
@@ -879,11 +863,28 @@ class GroupBy(object):
         1  aa  3  10
         2  bb  6  10
 
+        You can specify the type hint and prevent schema inference for better performance.
+
+        >>> def pandas_div(x) -> ks.DataFrame[float, float]:
+        ...    return x[['B', 'C']] / x[['B', 'C']]
+        >>> g.apply(pandas_div).sort_index()  # doctest: +NORMALIZE_WHITESPACE
+            c0   c1
+        0  1.0  1.0
+        1  1.0  1.0
+        2  1.0  1.0
+
+        >>> def pandas_length(x) -> int:
+        ...    return len(x)
+        >>> g.apply(pandas_length).sort_index()  # doctest: +NORMALIZE_WHITESPACE
+        0    1
+        1    2
+        Name: 0, dtype: int32
+
         In case of Series, it works as below.
 
         >>> def plus_max(x) -> ks.Series[np.int]:
         ...    return x + x.max()
-        >>> df.B.groupby(df.A).apply(plus_max)
+        >>> df.B.groupby(df.A).apply(plus_max).sort_index()
         0    6
         1    3
         2    4
@@ -891,36 +892,81 @@ class GroupBy(object):
 
         >>> def plus_min(x):
         ...    return x + x.min()
-        >>> df.B.groupby(df.A).apply(plus_min)
+        >>> df.B.groupby(df.A).apply(plus_min).sort_index()
         0    2
         1    3
         2    6
         Name: B, dtype: int64
+
+        You can also return a scalar value as a aggregated value of the group:
+
+        >>> def plus_max(x) -> np.int:
+        ...    return len(x)
+        >>> df.B.groupby(df.A).apply(plus_max).sort_index()
+        0    1
+        1    2
+        Name: B, dtype: int32
         """
         if not isinstance(func, Callable):
             raise TypeError("%s object is not callable" % type(func))
 
         spec = inspect.getfullargspec(func)
         return_sig = spec.annotations.get("return", None)
-        if return_sig is None:
-            return_schema = None  # schema will inferred.
-        else:
-            return_schema = _infer_return_type(func).tpe
-
-        should_infer_schema = return_schema is None
+        should_infer_schema = return_sig is None
         input_groupnames = [s.name for s in self._groupkeys]
+
+        should_return_series = False
+        is_series_groupby = isinstance(self, SeriesGroupBy)
+        if is_series_groupby:
+            name = self._kser.name
 
         if should_infer_schema:
             # Here we execute with the first 1000 to get the return type.
             limit = get_option("compute.shortcut_limit")
-            pdf = self._kdf.head(limit)._to_internal_pandas()
-            pdf = pdf.groupby(input_groupnames).apply(func)
-            kdf = DataFrame(pdf)
+            pdf = self._kdf.head(limit + 1)._to_internal_pandas()
+            if is_series_groupby:
+                pser_or_pdf = pdf.groupby(input_groupnames)[name].apply(func)
+            else:
+                pser_or_pdf = pdf.groupby(input_groupnames).apply(func)
+            kser_or_kdf = ks.from_pandas(pser_or_pdf)
+            if len(pdf) <= limit:
+                return kser_or_kdf
+
+            kdf = kser_or_kdf
+            if isinstance(kser_or_kdf, ks.Series):
+                should_return_series = True
+                kdf = kser_or_kdf.to_frame()
+
             return_schema = kdf._sdf.drop(*HIDDEN_COLUMNS).schema
+        else:
+            if not is_series_groupby and getattr(return_sig, "__origin__", None) == ks.Series:
+                raise TypeError(
+                    "Series as a return type hint at frame groupby is not supported "
+                    "currently; however got [%s]. Use DataFrame type hint instead." % return_sig
+                )
+
+            return_schema = _infer_return_type(func).tpe
+            if not isinstance(return_schema, StructType):
+                should_return_series = True
+                if is_series_groupby:
+                    return_schema = StructType([StructField(name, return_schema)])
+                else:
+                    return_schema = StructType([StructField("0", return_schema)])
+
+        def pandas_groupby_apply(pdf):
+            if is_series_groupby:
+                pdf_or_ser = pdf.groupby(input_groupnames)[name].apply(func)
+            else:
+                pdf_or_ser = pdf.groupby(input_groupnames).apply(func)
+
+            if not isinstance(pdf_or_ser, pd.DataFrame):
+                return pd.DataFrame(pdf_or_ser)
+            else:
+                return pdf_or_ser
 
         sdf = GroupBy._spark_group_map_apply(
             self._kdf,
-            lambda pdf: pdf.groupby(input_groupnames).apply(func),
+            pandas_groupby_apply,
             self._groupkeys_scols,
             return_schema,
             retain_index=should_infer_schema,
@@ -932,7 +978,11 @@ class GroupBy(object):
         else:
             # Otherwise, it loses index.
             internal = _InternalFrame(spark_frame=sdf, index_map=None)
-        return DataFrame(internal)
+
+        if should_return_series:
+            return _col(DataFrame(internal))
+        else:
+            return DataFrame(internal)
 
     # TODO: implement 'dropna' parameter
     def filter(self, func):
@@ -2095,11 +2145,6 @@ class SeriesGroupBy(GroupBy):
 
     def aggregate(self, *args, **kwargs):
         return _MissingPandasLikeSeriesGroupBy.aggregate(self, *args, **kwargs)
-
-    def apply(self, func):
-        return _col(super(SeriesGroupBy, self).transform(func))
-
-    apply.__doc__ = GroupBy.transform.__doc__
 
     def transform(self, func):
         return _col(super(SeriesGroupBy, self).transform(func))


### PR DESCRIPTION
This PR fixes `SeriesGroupBy.apply()` to work, and also to respect various output.
For example, pandas supports below:

**Series groupby:**

Function: series -> scalar
Return: a series

Function: series -> series
Return: a series

Function: series -> frame
Return: a frame


**DataFrame groupby:**

Function: frame -> scalar
Return: a series

Function: frame -> series
Return: a frame but the values of the series becomes columns.

Function: frame -> frame
Return: a frame


Resolves #1300