### PR TITLE
Implements MultiIndex.unique()

### DIFF
--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -986,3 +986,16 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
 
         self.assertRaises(ValueError, lambda: kmidx.repeat(-1))
         self.assertRaises(ValueError, lambda: kmidx.repeat("abc"))
+
+    def test_unique(self):
+        pidx = pd.Index(["a", "b", "a"])
+        kidx = ks.from_pandas(pidx)
+
+        self.assert_eq(kidx.unique().sort_values(), pidx.unique().sort_values())
+        self.assert_eq(kidx.unique().sort_values(), pidx.unique().sort_values())
+
+        pmidx = pd.MultiIndex.from_tuples([("x", "a"), ("x", "b"), ("x", "a")])
+        kmidx = ks.from_pandas(pmidx)
+
+        self.assert_eq(kmidx.unique().sort_values(), pmidx.unique().sort_values())
+        self.assert_eq(kmidx.unique().sort_values(), pmidx.unique().sort_values())

--- a/docs/source/reference/indexing.rst
+++ b/docs/source/reference/indexing.rst
@@ -199,6 +199,7 @@ MultiIndex Modifying and computations
    MultiIndex.copy
    MultiIndex.rename
    MultiIndex.repeat
+   MultiIndex.unique
    MultiIndex.min
    MultiIndex.max
    MultiIndex.value_counts


### PR DESCRIPTION
This PR proposes `unique` for MultiIndex and integration with existing `Index.unique`

```python
>>> ks.MultiIndex.from_tuples([("A", "X"), ("A", "Y"), ("A", "X")]).unique()
MultiIndex([('A', 'X'),
            ('A', 'Y')],
           )
```