### PR TITLE
Explicitly don't support to disable numeric_only in stats APIs at DataFrame

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -447,7 +447,7 @@ class DataFrame(_Frame, Generic[T]):
         """
         return [self.index, self.columns]
 
-    def _reduce_for_stat_function(self, sfun, name, axis=None, numeric_only=False):
+    def _reduce_for_stat_function(self, sfun, name, axis=None, numeric_only=True):
         """
         Applies sfun to each column and returns a pd.Series where the number of rows equal the
         number of columns.
@@ -459,12 +459,17 @@ class DataFrame(_Frame, Generic[T]):
             axis: used only for sanity check because series only support index axis.
         name : original pandas API name.
         axis : axis to apply. 0 or 1, or 'index' or 'columns.
-        numeric_only : boolean, default False
-            If True, sfun is applied on numeric columns (including booleans) only.
+        numeric_only : bool, default True
+            Include only float, int, boolean columns. False is not supported. This parameter
+            is mainly for pandas compatibility. Only 'DataFrame.count' uses this parameter
+            currently.
         """
         from inspect import signature
         from databricks.koalas import Series
         from databricks.koalas.series import _col
+
+        if name not in ("count", "min", "max") and not numeric_only:
+            raise ValueError("Disabling 'numeric_only' parameter is not supported.")
 
         axis = validate_axis(axis)
         if axis == 0:

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -937,9 +937,9 @@ class _Frame(object):
         ----------
         axis : {index (0), columns (1)}
             Axis for the function to be applied on.
-        numeric_only : bool, default None
-            Include only float, int, boolean columns. If None, will attempt to use
-            everything, then use only numeric data. Not implemented for Series.
+        numeric_only : bool, default True
+            Include only float, int, boolean columns. False is not supported. This parameter
+            is mainly for pandas compatibility.
 
         Returns
         -------
@@ -982,9 +982,9 @@ class _Frame(object):
         ----------
         axis : {index (0), columns (1)}
             Axis for the function to be applied on.
-        numeric_only : bool, default None
-            Include only float, int, boolean columns. If None, will attempt to use
-            everything, then use only numeric data. Not implemented for Series.
+        numeric_only : bool, default True
+            Include only float, int, boolean columns. False is not supported. This parameter
+            is mainly for pandas compatibility.
 
         Returns
         -------
@@ -1027,9 +1027,9 @@ class _Frame(object):
         ----------
         axis : {index (0), columns (1)}
             Axis for the function to be applied on.
-        numeric_only : bool, default None
-            Include only float, int, boolean columns. If None, will attempt to use
-            everything, then use only numeric data. Not implemented for Series.
+        numeric_only : bool, default True
+            Include only float, int, boolean columns. False is not supported. This parameter
+            is mainly for pandas compatibility.
 
         Returns
         -------
@@ -1066,9 +1066,9 @@ class _Frame(object):
         ----------
         axis : {index (0), columns (1)}
             Axis for the function to be applied on.
-        numeric_only : bool, default None
-            Include only float, int, boolean columns. If None, will attempt to use
-            everything, then use only numeric data. Not implemented for Series.
+        numeric_only : bool, default True
+            Include only float, int, boolean columns. False is not supported. This parameter
+            is mainly for pandas compatibility.
 
         Returns
         -------
@@ -1107,8 +1107,9 @@ class _Frame(object):
         axis : {index (0), columns (1)}
             Axis for the function to be applied on.
         numeric_only : bool, default None
-            Include only float, int, boolean columns. If None, will attempt to use
-            everything, then use only numeric data. Not implemented for Series.
+            If True, include only float, int, boolean columns. This parameter is mainly for
+            pandas compatibility. False is supported; however, the columns should
+            be all numeric or all non-numeric.
 
         Returns
         -------
@@ -1152,8 +1153,9 @@ class _Frame(object):
         axis : {index (0), columns (1)}
             Axis for the function to be applied on.
         numeric_only : bool, default None
-            Include only float, int, boolean columns. If None, will attempt to use
-            everything, then use only numeric data. Not implemented for Series.
+            If True, include only float, int, boolean columns. This parameter is mainly for
+            pandas compatibility. False is supported; however, the columns should
+            be all numeric or all non-numeric.
 
         Returns
         -------
@@ -1196,9 +1198,9 @@ class _Frame(object):
         ----------
         axis : {index (0), columns (1)}
             Axis for the function to be applied on.
-        numeric_only : bool, default None
-            Include only float, int, boolean columns. If None, will attempt to use
-            everything, then use only numeric data. Not implemented for Series.
+        numeric_only : bool, default True
+            Include only float, int, boolean columns. False is not supported. This parameter
+            is mainly for pandas compatibility.
 
         Returns
         -------
@@ -1241,9 +1243,9 @@ class _Frame(object):
         ----------
         axis : {index (0), columns (1)}
             Axis for the function to be applied on.
-        numeric_only : bool, default None
-            Include only float, int, boolean columns. If None, will attempt to use
-            everything, then use only numeric data. Not implemented for Series.
+        numeric_only : bool, default True
+            Include only float, int, boolean columns. False is not supported. This parameter
+            is mainly for pandas compatibility.
 
         Returns
         -------


### PR DESCRIPTION
Spark can't contain mixed types in its output. Statistic APIs in DataFrame outputs it. This PR explicitly disallow `numeric_only` or mention the limitation by it.