### PR TITLE
Support MultiIndex for `loc` indexer with slice as `row_sel`.

### DIFF
--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -1914,19 +1914,23 @@ class MultiIndex(Index):
         ).collect()[0]
         return tuple(result)
 
+    @staticmethod
+    def _comparator_for_monotonic_increasing(data_type):
+        if isinstance(data_type, BooleanType):
+            return compare_allow_null
+        else:
+            return compare_null_last
+
     def _is_monotonic(self):
-        col = self._scol
+        scol = self._scol
         window = Window.orderBy(NATURAL_ORDER_COLUMN_NAME).rowsBetween(-1, -1)
-        prev = F.lag(col, 1).over(window)
+        prev = F.lag(scol, 1).over(window)
 
         cond = F.lit(True)
         for field in self.spark_type[::-1]:
-            left = col.getField(field.name)
+            left = scol.getField(field.name)
             right = prev.getField(field.name)
-            if isinstance(field.dataType, BooleanType):
-                compare = compare_allow_null
-            else:
-                compare = compare_null_last
+            compare = MultiIndex._comparator_for_monotonic_increasing(field.dataType)
             cond = F.when(left.eqNullSafe(right), cond).otherwise(
                 compare(left, right, spark.Column.__gt__)
             )
@@ -1942,23 +1946,27 @@ class MultiIndex(Index):
 
         return _col(DataFrame(internal))
 
+    @staticmethod
+    def _comparator_for_monotonic_decreasing(data_type):
+        if isinstance(data_type, StringType):
+            return compare_disallow_null
+        elif isinstance(data_type, BooleanType):
+            return compare_allow_null
+        elif isinstance(data_type, NumericType):
+            return compare_null_last
+        else:
+            return compare_null_first
+
     def _is_monotonic_decreasing(self):
-        col = self._scol
+        scol = self._scol
         window = Window.orderBy(NATURAL_ORDER_COLUMN_NAME).rowsBetween(-1, -1)
-        prev = F.lag(col, 1).over(window)
+        prev = F.lag(scol, 1).over(window)
 
         cond = F.lit(True)
         for field in self.spark_type[::-1]:
-            left = col.getField(field.name)
+            left = scol.getField(field.name)
             right = prev.getField(field.name)
-            if isinstance(field.dataType, StringType):
-                compare = compare_disallow_null
-            elif isinstance(field.dataType, BooleanType):
-                compare = compare_allow_null
-            elif isinstance(field.dataType, NumericType):
-                compare = compare_null_last
-            else:
-                compare = compare_null_first
+            compare = MultiIndex._comparator_for_monotonic_decreasing(field.dataType)
             cond = F.when(left.eqNullSafe(right), cond).otherwise(
                 compare(left, right, spark.Column.__lt__)
             )

--- a/databricks/koalas/indexing.py
+++ b/databricks/koalas/indexing.py
@@ -519,6 +519,7 @@ class LocIndexer(_LocIndexerLike):
         )
 
     def _select_rows(self, rows_sel):
+        from databricks.koalas.indexes import MultiIndex
         from databricks.koalas.series import Series
 
         if isinstance(rows_sel, Series):
@@ -595,10 +596,62 @@ class LocIndexer(_LocIndexerLike):
                         else:
                             raise KeyError(rows_sel.stop)
 
-                if len(cond) > 0:
-                    return reduce(lambda x, y: x & y, cond), None, None
+                return reduce(lambda x, y: x & y, cond), None, None
             else:
-                LocIndexer._raiseNotImplemented("Cannot use slice for MultiIndex with Spark.")
+                index = self._kdf_or_kser.index
+                index_data_type = index.to_series().spark_type
+
+                start = rows_sel.start
+                if start is not None:
+                    if not isinstance(start, tuple):
+                        start = (start,)
+                    if len(start) == 0:
+                        start = None
+                stop = rows_sel.stop
+                if stop is not None:
+                    if not isinstance(stop, tuple):
+                        stop = (stop,)
+                    if len(stop) == 0:
+                        stop = None
+
+                depth = max(
+                    len(start) if start is not None else 0, len(stop) if stop is not None else 0
+                )
+                if depth == 0:
+                    return None, None, None
+                elif (
+                    depth > len(self._internal.index_map)
+                    or not index.droplevel(
+                        list(range(len(self._internal.index_map))[depth:])
+                    ).is_monotonic
+                ):
+                    raise KeyError(
+                        "Key length ({}) was greater than MultiIndex sort depth".format(depth)
+                    )
+
+                conds = []
+                if start is not None:
+                    start_scols = self._internal.index_spark_columns[: len(start)]
+                    data_types = [f.dataType for f in index_data_type[: len(start)]]
+                    cond = F.lit(True)
+                    for scol, value, dt in list(zip(start_scols, start, data_types))[::-1]:
+                        compare = MultiIndex._comparator_for_monotonic_increasing(dt)
+                        cond = F.when(scol.eqNullSafe(F.lit(value).cast(dt)), cond).otherwise(
+                            compare(scol, F.lit(value).cast(dt), spark.Column.__gt__)
+                        )
+                    conds.append(cond)
+                if stop is not None:
+                    stop_scols = self._internal.index_spark_columns[: len(stop)]
+                    data_types = [f.dataType for f in index_data_type[: len(stop)]]
+                    cond = F.lit(True)
+                    for scol, value, dt in list(zip(stop_scols, stop, data_types))[::-1]:
+                        compare = MultiIndex._comparator_for_monotonic_increasing(dt)
+                        cond = F.when(scol.eqNullSafe(F.lit(value).cast(dt)), cond).otherwise(
+                            compare(scol, F.lit(value).cast(dt), spark.Column.__lt__)
+                        )
+                    conds.append(cond)
+
+                return reduce(lambda x, y: x & y, conds), None, None
         elif is_list_like(rows_sel) and not isinstance(rows_sel, tuple):
             rows_sel = list(rows_sel)
             if len(rows_sel) == 0:

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -878,10 +878,11 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         datas.append([("x", "d", "o"), ("y", "c", None), ("y", "c", None), ("z", "a", "r")])
 
         for data in datas:
-            kmidx = ks.MultiIndex.from_tuples(data)
-            pmidx = kmidx.to_pandas()
-            self.assert_eq(kmidx.is_monotonic_increasing, pmidx.is_monotonic_increasing)
-            self.assert_eq(kmidx.is_monotonic_decreasing, pmidx.is_monotonic_decreasing)
+            with self.subTest(data=data):
+                kmidx = ks.MultiIndex.from_tuples(data)
+                pmidx = kmidx.to_pandas()
+                self.assert_eq(kmidx.is_monotonic_increasing, pmidx.is_monotonic_increasing)
+                self.assert_eq(kmidx.is_monotonic_decreasing, pmidx.is_monotonic_decreasing)
 
         # The datas below are showing different result depends on pandas version.
         # Because the behavior of handling null values is changed in pandas >= 1.0.0.
@@ -894,13 +895,14 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         datas.append([("x", "d", "o"), ("y", "c", None), ("y", "c", "q"), ("z", "a", "r")])
 
         for data in datas:
-            kmidx = ks.MultiIndex.from_tuples(data)
-            pmidx = kmidx.to_pandas()
-            expected_increasing_result = pmidx.is_monotonic_increasing
-            if LooseVersion(pd.__version__) < LooseVersion("1.0.0"):
-                expected_increasing_result = not expected_increasing_result
-            self.assert_eq(kmidx.is_monotonic_increasing, expected_increasing_result)
-            self.assert_eq(kmidx.is_monotonic_decreasing, pmidx.is_monotonic_decreasing)
+            with self.subTest(data=data):
+                kmidx = ks.MultiIndex.from_tuples(data)
+                pmidx = kmidx.to_pandas()
+                expected_increasing_result = pmidx.is_monotonic_increasing
+                if LooseVersion(pd.__version__) < LooseVersion("1.0.0"):
+                    expected_increasing_result = not expected_increasing_result
+                self.assert_eq(kmidx.is_monotonic_increasing, expected_increasing_result)
+                self.assert_eq(kmidx.is_monotonic_decreasing, pmidx.is_monotonic_decreasing)
 
     def test_difference(self):
         # Index


### PR DESCRIPTION
Adding support MultiIndex for `loc` indexer with slice as `row_sel`.

E.g.,

```py
>>> pser
x  a    1
   b    2
y  c    3
   d    4
z  e    5
dtype: int64
>>> pser.loc['y':]
y  c    3
   d    4
z  e    5
dtype: int64
>>> pser.loc[:'y']
x  a    1
   b    2
y  c    3
   d    4
dtype: int64
>>> pser.loc[('x','b'):]
x  b    2
y  c    3
   d    4
z  e    5
dtype: int64
>>> pser.loc[:('y','c')]
x  a    1
   b    2
y  c    3
dtype: int64
>>> pser.loc[('x','b'):('y','c')]
x  b    2
y  c    3
dtype: int64
>>> pser.loc['x':('y','c')]
x  a    1
   b    2
y  c    3
dtype: int64
>>> pser.loc[('x','b'):'y']
x  b    2
y  c    3
   d    4
dtype: int64
```

Resolves #1175, Closes #1182.