### PR TITLE
Implements union() for Index & MultiIndex

### DIFF
--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -1677,7 +1677,7 @@ class Index(IndexOpsMixin):
             other = MultiIndex.from_tuples(other)
         if not isinstance(other, Index) and not isinstance(self, MultiIndex):
             if isinstance(other, Series):
-                other = other.values
+                other = other.to_numpy()
             if isinstance(other, DataFrame):
                 raise ValueError("Index data must be 1-dimensional")
             other = Index(other)

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -1666,6 +1666,19 @@ class Index(IndexOpsMixin):
         >>> idx2 = ks.Index([3, 4, 5, 6])
         >>> idx1.union(idx2).sort_values()
         Int64Index([1, 2, 3, 4, 5, 6], dtype='int64')
+
+        MultiIndex
+
+        >>> midx1 = ks.MultiIndex.from_tuples([("x", "a"), ("x", "b"), ("x", "c"), ("x", "d")])
+        >>> midx2 = ks.MultiIndex.from_tuples([("x", "c"), ("x", "d"), ("x", "e"), ("x", "f")])
+        >>> midx1.union(midx2).sort_values()  # doctest: +SKIP
+        MultiIndex([('x', 'a'),
+                    ('x', 'b'),
+                    ('x', 'c'),
+                    ('x', 'd'),
+                    ('x', 'e'),
+                    ('x', 'f')],
+                   )
         """
         if not isinstance(other, Index) and isinstance(self, MultiIndex):
             if isinstance(other, list) and not all([isinstance(item, tuple) for item in other]):

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -1684,7 +1684,7 @@ class Index(IndexOpsMixin):
                     raise NotImplementedError(
                         "Union between Index and MultiIndex is not yet supported"
                     )
-                if isinstance(other, Series):
+                elif isinstance(other, Series):
                     other = other.to_frame().set_index(other.name).index
                 elif isinstance(other, DataFrame):
                     raise ValueError("Index data must be 1-dimensional")

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -1649,7 +1649,7 @@ class Index(IndexOpsMixin):
         Examples
         --------
 
-        Union matching dtypes
+        Index
 
         >>> idx1 = ks.Index([1, 2, 3, 4])
         >>> idx2 = ks.Index([3, 4, 5, 6])

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -1672,13 +1672,13 @@ class Index(IndexOpsMixin):
         sort = True if sort is None else sort
         sort = validate_bool_kwarg(sort, "sort")
         if type(self) is not type(other):
-            if type(self) is MultiIndex:
+            if isinstance(self, MultiIndex):
                 if not isinstance(other, list) or not all(
                     [isinstance(item, tuple) for item in other]
                 ):
                     raise TypeError("other must be a MultiIndex or a list of tuples")
                 other = MultiIndex.from_tuples(other)
-            elif type(self) is Index:
+            else:
                 if isinstance(other, MultiIndex):
                     # TODO: We can't support different type of values in a single column for now.
                     raise NotImplementedError(

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -1679,15 +1679,17 @@ class Index(IndexOpsMixin):
                     raise TypeError("other must be a MultiIndex or a list of tuples")
                 other = MultiIndex.from_tuples(other)
             elif type(self) is Index:
+                if isinstance(other, MultiIndex):
+                    # TODO: We can't support different type of values in a single column for now.
+                    raise NotImplementedError(
+                        "Union between Index and MultiIndex is not yet supported"
+                    )
                 if isinstance(other, Series):
                     other = other.to_frame().set_index(other.name).index
                 elif isinstance(other, DataFrame):
                     raise ValueError("Index data must be 1-dimensional")
                 else:
                     other = Index(other)
-            else:
-                # TODO: We can't support different type of values in a single column for now.
-                raise NotImplementedError("Union between Index and MultiIndex is not yet supported")
         sdf_self = self._internal._sdf.select(self._internal.index_spark_columns)
         sdf_other = other._internal._sdf.select(other._internal.index_spark_columns)
         sdf = sdf_self.union(sdf_other.subtract(sdf_self))

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -1671,20 +1671,23 @@ class Index(IndexOpsMixin):
         """
         sort = True if sort is None else sort
         sort = validate_bool_kwarg(sort, "sort")
-        if type(self) is MultiIndex and not isinstance(other, Index):
-            if not isinstance(other, list) or not all([isinstance(item, tuple) for item in other]):
-                raise TypeError("other must be a MultiIndex or a list of tuples")
-            other = MultiIndex.from_tuples(other)
-        elif type(self) is Index and not isinstance(other, Index):
-            if isinstance(other, Series):
-                other = other.to_frame().set_index(other.name).index
-            elif isinstance(other, DataFrame):
-                raise ValueError("Index data must be 1-dimensional")
-            else:
-                other = Index(other)
         if type(self) is not type(other):
-            # TODO: We can't support different type of values in a single column for now.
-            raise NotImplementedError("Union between Index and MultiIndex is not yet supported")
+            if type(self) is MultiIndex:
+                if not isinstance(other, list) or not all(
+                    [isinstance(item, tuple) for item in other]
+                ):
+                    raise TypeError("other must be a MultiIndex or a list of tuples")
+                other = MultiIndex.from_tuples(other)
+            elif type(self) is Index:
+                if isinstance(other, Series):
+                    other = other.to_frame().set_index(other.name).index
+                elif isinstance(other, DataFrame):
+                    raise ValueError("Index data must be 1-dimensional")
+                else:
+                    other = Index(other)
+            else:
+                # TODO: We can't support different type of values in a single column for now.
+                raise NotImplementedError("Union between Index and MultiIndex is not yet supported")
         sdf_self = self._internal._sdf.select(self._internal.index_spark_columns)
         sdf_other = other._internal._sdf.select(other._internal.index_spark_columns)
         sdf = sdf_self.union(sdf_other.subtract(sdf_self))

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -1677,10 +1677,11 @@ class Index(IndexOpsMixin):
             other = MultiIndex.from_tuples(other)
         if not isinstance(other, Index) and not isinstance(self, MultiIndex):
             if isinstance(other, Series):
-                other = other.to_numpy()
-            if isinstance(other, DataFrame):
+                other = other.to_frame().set_index(other.name).index
+            elif isinstance(other, DataFrame):
                 raise ValueError("Index data must be 1-dimensional")
-            other = Index(other)
+            else:
+                other = Index(other)
         if type(self) is not type(other):
             # TODO: We can't support different type of values in a single column for now.
             raise NotImplementedError("Union between Index and MultiIndex is not yet supported")

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -1671,11 +1671,11 @@ class Index(IndexOpsMixin):
         """
         sort = True if sort is None else sort
         sort = validate_bool_kwarg(sort, "sort")
-        if not isinstance(other, Index) and isinstance(self, MultiIndex):
+        if type(self) is MultiIndex and not isinstance(other, Index):
             if not isinstance(other, list) or not all([isinstance(item, tuple) for item in other]):
                 raise TypeError("other must be a MultiIndex or a list of tuples")
             other = MultiIndex.from_tuples(other)
-        if not isinstance(other, Index) and not isinstance(self, MultiIndex):
+        elif type(self) is Index and not isinstance(other, Index):
             if isinstance(other, Series):
                 other = other.to_frame().set_index(other.name).index
             elif isinstance(other, DataFrame):

--- a/databricks/koalas/missing/indexes.py
+++ b/databricks/koalas/missing/indexes.py
@@ -71,7 +71,6 @@ class _MissingPandasLikeIndex(object):
     take = unsupported_function("take")
     to_flat_index = unsupported_function("to_flat_index")
     to_native_types = unsupported_function("to_native_types")
-    union = unsupported_function("union")
     view = unsupported_function("view")
     where = unsupported_function("where")
 
@@ -154,7 +153,6 @@ class _MissingPandasLikeMultiIndex(object):
     to_flat_index = unsupported_function("to_flat_index")
     to_native_types = unsupported_function("to_native_types")
     truncate = unsupported_function("truncate")
-    union = unsupported_function("union")
     view = unsupported_function("view")
     where = unsupported_function("where")
 

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -1142,6 +1142,6 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
             )
 
         self.assertRaises(NotImplementedError, lambda: kidx1.union(kmidx1))
-        self.assertRaises(NotImplementedError, lambda: kmidx1.union(kidx1))
+        self.assertRaises(TypeError, lambda: kmidx1.union(kidx1))
         self.assertRaises(TypeError, lambda: kmidx1.union(["x", "a"]))
         self.assertRaises(ValueError, lambda: kidx1.union(ks.range(2)))

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -1003,6 +1003,7 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         self.assert_eq(kmidx.unique().sort_values(), pmidx.unique().sort_values())
 
     def test_union(self):
+        # Index
         pidx1 = pd.Index([1, 2, 3, 4, 3, 4, 3, 4])
         pidx2 = pd.Index([3, 4, 3, 4, 5, 6])
         kidx1 = ks.from_pandas(pidx1)
@@ -1018,7 +1019,18 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
             kidx2.union([1, 2, 3, 4, 3, 4, 3, 4]).sort_values(),
             pidx2.union([1, 2, 3, 4, 3, 4, 3, 4]).sort_values(),
         )
+        # Sorting Index
+        self.assert_eq(kidx1.union(kidx2, sort=None), pidx1.union(pidx2, sort=None))
+        self.assert_eq(kidx2.union(kidx1, sort=None), pidx2.union(pidx1, sort=None))
+        self.assert_eq(
+            kidx1.union([3, 4, 3, 4, 5, 6], sort=None), pidx1.union([3, 4, 3, 4, 5, 6], sort=None),
+        )
+        self.assert_eq(
+            kidx2.union([1, 2, 3, 4, 3, 4, 3, 4], sort=None),
+            pidx2.union([1, 2, 3, 4, 3, 4, 3, 4], sort=None),
+        )
 
+        # MultiIndex
         pmidx1 = pd.MultiIndex.from_tuples([("x", "a"), ("x", "b"), ("x", "a"), ("x", "b")])
         pmidx2 = pd.MultiIndex.from_tuples([("x", "a"), ("x", "b"), ("x", "c"), ("x", "d")])
         kmidx1 = ks.from_pandas(pmidx1)
@@ -1033,6 +1045,17 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         self.assert_eq(
             kmidx2.union([("x", "a"), ("x", "b"), ("x", "a"), ("x", "b")]).sort_values(),
             pmidx2.union([("x", "a"), ("x", "b"), ("x", "a"), ("x", "b")]).sort_values(),
+        )
+        # Sorting MultiIndex
+        self.assert_eq(kmidx1.union(kmidx2, sort=None), pmidx1.union(pmidx2, sort=None))
+        self.assert_eq(kmidx2.union(kmidx1, sort=None), pmidx2.union(pmidx1, sort=None))
+        self.assert_eq(
+            kmidx1.union([("x", "a"), ("x", "b"), ("x", "c"), ("x", "d")], sort=None),
+            pmidx1.union([("x", "a"), ("x", "b"), ("x", "c"), ("x", "d")], sort=None),
+        )
+        self.assert_eq(
+            kmidx2.union([("x", "a"), ("x", "b"), ("x", "a"), ("x", "b")], sort=None),
+            pmidx2.union([("x", "a"), ("x", "b"), ("x", "a"), ("x", "b")], sort=None),
         )
 
         self.assertRaises(NotImplementedError, lambda: kidx1.union(kmidx1))

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -1017,6 +1017,12 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         self.assert_eq(
             kidx2.union([1, 2, 3, 4]), pidx2.union([1, 2, 3, 4]),
         )
+        self.assert_eq(
+            kidx1.union(ks.Series([3, 4, 5, 6])), pidx1.union(pd.Series([3, 4, 5, 6])),
+        )
+        self.assert_eq(
+            kidx2.union(ks.Series([1, 2, 3, 4])), pidx2.union(pd.Series([1, 2, 3, 4])),
+        )
 
         # Testing if the result is correct after sort=False.
         # The `sort` argument is added in pandas 0.24.

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -1001,3 +1001,40 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
 
         self.assert_eq(kmidx.unique().sort_values(), pmidx.unique().sort_values())
         self.assert_eq(kmidx.unique().sort_values(), pmidx.unique().sort_values())
+
+    def test_union(self):
+        pidx1 = pd.Index([1, 2, 3, 4, 3, 4, 3, 4])
+        pidx2 = pd.Index([3, 4, 3, 4, 5, 6])
+        kidx1 = ks.from_pandas(pidx1)
+        kidx2 = ks.from_pandas(pidx2)
+
+        self.assert_eq(kidx1.union(kidx2).sort_values(), pidx1.union(pidx2).sort_values())
+        self.assert_eq(kidx2.union(kidx1).sort_values(), pidx2.union(pidx1).sort_values())
+        self.assert_eq(
+            kidx1.union([3, 4, 3, 4, 5, 6]).sort_values(),
+            pidx1.union([3, 4, 3, 4, 5, 6]).sort_values(),
+        )
+        self.assert_eq(
+            kidx2.union([1, 2, 3, 4, 3, 4, 3, 4]).sort_values(),
+            pidx2.union([1, 2, 3, 4, 3, 4, 3, 4]).sort_values(),
+        )
+
+        pmidx1 = pd.MultiIndex.from_tuples([("x", "a"), ("x", "b"), ("x", "a"), ("x", "b")])
+        pmidx2 = pd.MultiIndex.from_tuples([("x", "a"), ("x", "b"), ("x", "c"), ("x", "d")])
+        kmidx1 = ks.from_pandas(pmidx1)
+        kmidx2 = ks.from_pandas(pmidx2)
+
+        self.assert_eq(kmidx1.union(kmidx2).sort_values(), pmidx1.union(pmidx2).sort_values())
+        self.assert_eq(kmidx2.union(kmidx1).sort_values(), pmidx2.union(pmidx1).sort_values())
+        self.assert_eq(
+            kmidx1.union([("x", "a"), ("x", "b"), ("x", "c"), ("x", "d")]).sort_values(),
+            pmidx1.union([("x", "a"), ("x", "b"), ("x", "c"), ("x", "d")]).sort_values(),
+        )
+        self.assert_eq(
+            kmidx2.union([("x", "a"), ("x", "b"), ("x", "a"), ("x", "b")]).sort_values(),
+            pmidx2.union([("x", "a"), ("x", "b"), ("x", "a"), ("x", "b")]).sort_values(),
+        )
+
+        self.assertRaises(NotImplementedError, lambda: kidx1.union(kmidx1))
+        self.assertRaises(NotImplementedError, lambda: kmidx1.union(kidx1))
+        self.assertRaises(TypeError, lambda: kmidx1.union(["x", "a"]))

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -1012,12 +1012,10 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         self.assert_eq(kidx1.union(kidx2).sort_values(), pidx1.union(pidx2).sort_values())
         self.assert_eq(kidx2.union(kidx1).sort_values(), pidx2.union(pidx1).sort_values())
         self.assert_eq(
-            kidx1.union([3, 4, 5, 6]).sort_values(),
-            pidx1.union([3, 4, 5, 6]).sort_values(),
+            kidx1.union([3, 4, 5, 6]).sort_values(), pidx1.union([3, 4, 5, 6]).sort_values(),
         )
         self.assert_eq(
-            kidx2.union([1, 2, 3, 4]).sort_values(),
-            pidx2.union([1, 2, 3, 4]).sort_values(),
+            kidx2.union([1, 2, 3, 4]).sort_values(), pidx2.union([1, 2, 3, 4]).sort_values(),
         )
         # Sorting Index
         self.assert_eq(kidx1.union(kidx2, sort=None), pidx1.union(pidx2, sort=None))
@@ -1026,8 +1024,7 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
             kidx1.union([3, 4, 5, 6], sort=None), pidx1.union([3, 4, 5, 6], sort=None),
         )
         self.assert_eq(
-            kidx2.union([1, 2, 3, 4], sort=None),
-            pidx2.union([1, 2, 3, 4], sort=None),
+            kidx2.union([1, 2, 3, 4], sort=None), pidx2.union([1, 2, 3, 4], sort=None),
         )
 
         # MultiIndex

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -1043,6 +1043,14 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
                 kidx2.union([1, 2, 3, 4], sort=False).sort_values(),
                 pidx2.union([1, 2, 3, 4], sort=False).sort_values(),
             )
+            self.assert_eq(
+                kidx1.union(ks.Series([3, 4, 5, 6]), sort=False).sort_values(),
+                pidx1.union(pd.Series([3, 4, 5, 6]), sort=False).sort_values(),
+            )
+            self.assert_eq(
+                kidx2.union(ks.Series([1, 2, 3, 4]), sort=False).sort_values(),
+                pidx2.union(pd.Series([1, 2, 3, 4]), sort=False).sort_values(),
+            )
 
         # Duplicated values for Index is supported in pandas >= 1.0.0
         if LooseVersion(pd.__version__) >= LooseVersion("1.0.0"):

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -1018,14 +1018,16 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
             kidx2.union([1, 2, 3, 4]).sort_values(), pidx2.union([1, 2, 3, 4]).sort_values(),
         )
         # Sorting Index
-        self.assert_eq(kidx1.union(kidx2, sort=None), pidx1.union(pidx2, sort=None))
-        self.assert_eq(kidx2.union(kidx1, sort=None), pidx2.union(pidx1, sort=None))
-        self.assert_eq(
-            kidx1.union([3, 4, 5, 6], sort=None), pidx1.union([3, 4, 5, 6], sort=None),
-        )
-        self.assert_eq(
-            kidx2.union([1, 2, 3, 4], sort=None), pidx2.union([1, 2, 3, 4], sort=None),
-        )
+        if LooseVersion(pd.__version__) >= LooseVersion("0.24"):
+            # The `sort` argument is added in pandas 0.24.
+            self.assert_eq(kidx1.union(kidx2, sort=None), pidx1.union(pidx2, sort=None))
+            self.assert_eq(kidx2.union(kidx1, sort=None), pidx2.union(pidx1, sort=None))
+            self.assert_eq(
+                kidx1.union([3, 4, 5, 6], sort=None), pidx1.union([3, 4, 5, 6], sort=None),
+            )
+            self.assert_eq(
+                kidx2.union([1, 2, 3, 4], sort=None), pidx2.union([1, 2, 3, 4], sort=None),
+            )
 
         # MultiIndex
         pmidx1 = pd.MultiIndex.from_tuples([("x", "a"), ("x", "b"), ("x", "a"), ("x", "b")])
@@ -1044,16 +1046,18 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
             pmidx2.union([("x", "a"), ("x", "b"), ("x", "a"), ("x", "b")]).sort_values(),
         )
         # Sorting MultiIndex
-        self.assert_eq(kmidx1.union(kmidx2, sort=None), pmidx1.union(pmidx2, sort=None))
-        self.assert_eq(kmidx2.union(kmidx1, sort=None), pmidx2.union(pmidx1, sort=None))
-        self.assert_eq(
-            kmidx1.union([("x", "a"), ("x", "b"), ("x", "c"), ("x", "d")], sort=None),
-            pmidx1.union([("x", "a"), ("x", "b"), ("x", "c"), ("x", "d")], sort=None),
-        )
-        self.assert_eq(
-            kmidx2.union([("x", "a"), ("x", "b"), ("x", "a"), ("x", "b")], sort=None),
-            pmidx2.union([("x", "a"), ("x", "b"), ("x", "a"), ("x", "b")], sort=None),
-        )
+        if LooseVersion(pd.__version__) >= LooseVersion("0.24"):
+            # The `sort` argument is added in pandas 0.24.
+            self.assert_eq(kmidx1.union(kmidx2, sort=None), pmidx1.union(pmidx2, sort=None))
+            self.assert_eq(kmidx2.union(kmidx1, sort=None), pmidx2.union(pmidx1, sort=None))
+            self.assert_eq(
+                kmidx1.union([("x", "a"), ("x", "b"), ("x", "c"), ("x", "d")], sort=None),
+                pmidx1.union([("x", "a"), ("x", "b"), ("x", "c"), ("x", "d")], sort=None),
+            )
+            self.assert_eq(
+                kmidx2.union([("x", "a"), ("x", "b"), ("x", "a"), ("x", "b")], sort=None),
+                pmidx2.union([("x", "a"), ("x", "b"), ("x", "a"), ("x", "b")], sort=None),
+            )
 
         self.assertRaises(NotImplementedError, lambda: kidx1.union(kmidx1))
         self.assertRaises(NotImplementedError, lambda: kmidx1.union(kidx1))

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -1009,56 +1009,139 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         kidx1 = ks.from_pandas(pidx1)
         kidx2 = ks.from_pandas(pidx2)
 
-        self.assert_eq(kidx1.union(kidx2).sort_values(), pidx1.union(pidx2).sort_values())
-        self.assert_eq(kidx2.union(kidx1).sort_values(), pidx2.union(pidx1).sort_values())
+        self.assert_eq(kidx1.union(kidx2), pidx1.union(pidx2))
+        self.assert_eq(kidx2.union(kidx1), pidx2.union(pidx1))
         self.assert_eq(
-            kidx1.union([3, 4, 5, 6]).sort_values(), pidx1.union([3, 4, 5, 6]).sort_values(),
+            kidx1.union([3, 4, 5, 6]), pidx1.union([3, 4, 5, 6]),
         )
         self.assert_eq(
-            kidx2.union([1, 2, 3, 4]).sort_values(), pidx2.union([1, 2, 3, 4]).sort_values(),
+            kidx2.union([1, 2, 3, 4]), pidx2.union([1, 2, 3, 4]),
         )
-        # Sorting Index
+
+        # Testing if the result is correct after sort=False.
+        # The `sort` argument is added in pandas 0.24.
         if LooseVersion(pd.__version__) >= LooseVersion("0.24"):
-            # The `sort` argument is added in pandas 0.24.
-            self.assert_eq(kidx1.union(kidx2, sort=None), pidx1.union(pidx2, sort=None))
-            self.assert_eq(kidx2.union(kidx1, sort=None), pidx2.union(pidx1, sort=None))
             self.assert_eq(
-                kidx1.union([3, 4, 5, 6], sort=None), pidx1.union([3, 4, 5, 6], sort=None),
+                kidx1.union(kidx2, sort=False).sort_values(),
+                pidx1.union(pidx2, sort=False).sort_values(),
             )
             self.assert_eq(
-                kidx2.union([1, 2, 3, 4], sort=None), pidx2.union([1, 2, 3, 4], sort=None),
+                kidx2.union(kidx1, sort=False).sort_values(),
+                pidx2.union(pidx1, sort=False).sort_values(),
+            )
+            self.assert_eq(
+                kidx1.union([3, 4, 5, 6], sort=False).sort_values(),
+                pidx1.union([3, 4, 5, 6], sort=False).sort_values(),
+            )
+            self.assert_eq(
+                kidx2.union([1, 2, 3, 4], sort=False).sort_values(),
+                pidx2.union([1, 2, 3, 4], sort=False).sort_values(),
+            )
+
+        # Duplicated values for Index is supported in pandas >= 1.0.0
+        if LooseVersion(pd.__version__) >= LooseVersion("1.0.0"):
+            pidx1 = pd.Index([1, 2, 3, 4, 3, 4, 3, 4])
+            pidx2 = pd.Index([3, 4, 3, 4, 5, 6])
+            kidx1 = ks.from_pandas(pidx1)
+            kidx2 = ks.from_pandas(pidx2)
+
+            self.assert_eq(kidx1.union(kidx2), pidx1.union(pidx2))
+            self.assert_eq(kidx2.union(kidx1), pidx2.union(pidx1))
+            self.assert_eq(
+                kidx1.union([3, 4, 3, 3, 5, 6]), pidx1.union([3, 4, 3, 4, 5, 6]),
+            )
+            self.assert_eq(
+                kidx2.union([1, 2, 3, 4, 3, 4, 3, 4]), pidx2.union([1, 2, 3, 4, 3, 4, 3, 4]),
+            )
+            self.assert_eq(
+                kidx1.union(ks.Series([3, 4, 3, 3, 5, 6])),
+                pidx1.union(pd.Series([3, 4, 3, 4, 5, 6])),
+            )
+            self.assert_eq(
+                kidx2.union(ks.Series([1, 2, 3, 4, 3, 4, 3, 4])),
+                pidx2.union(pd.Series([1, 2, 3, 4, 3, 4, 3, 4])),
             )
 
         # MultiIndex
         pmidx1 = pd.MultiIndex.from_tuples([("x", "a"), ("x", "b"), ("x", "a"), ("x", "b")])
         pmidx2 = pd.MultiIndex.from_tuples([("x", "a"), ("x", "b"), ("x", "c"), ("x", "d")])
+        pmidx3 = pd.MultiIndex.from_tuples([(1, 1), (1, 2), (1, 3), (1, 4), (1, 3), (1, 4)])
+        pmidx4 = pd.MultiIndex.from_tuples([(1, 3), (1, 4), (1, 5), (1, 6)])
         kmidx1 = ks.from_pandas(pmidx1)
         kmidx2 = ks.from_pandas(pmidx2)
+        kmidx3 = ks.from_pandas(pmidx3)
+        kmidx4 = ks.from_pandas(pmidx4)
 
-        self.assert_eq(kmidx1.union(kmidx2).sort_values(), pmidx1.union(pmidx2).sort_values())
-        self.assert_eq(kmidx2.union(kmidx1).sort_values(), pmidx2.union(pmidx1).sort_values())
+        self.assert_eq(kmidx1.union(kmidx2), pmidx1.union(pmidx2))
+        self.assert_eq(kmidx2.union(kmidx1), pmidx2.union(pmidx1))
+        self.assert_eq(kmidx3.union(kmidx4), pmidx3.union(pmidx4))
+        self.assert_eq(kmidx4.union(kmidx3), pmidx4.union(pmidx3))
         self.assert_eq(
-            kmidx1.union([("x", "a"), ("x", "b"), ("x", "c"), ("x", "d")]).sort_values(),
-            pmidx1.union([("x", "a"), ("x", "b"), ("x", "c"), ("x", "d")]).sort_values(),
+            kmidx1.union([("x", "a"), ("x", "b"), ("x", "c"), ("x", "d")]),
+            pmidx1.union([("x", "a"), ("x", "b"), ("x", "c"), ("x", "d")]),
         )
         self.assert_eq(
-            kmidx2.union([("x", "a"), ("x", "b"), ("x", "a"), ("x", "b")]).sort_values(),
-            pmidx2.union([("x", "a"), ("x", "b"), ("x", "a"), ("x", "b")]).sort_values(),
+            kmidx2.union([("x", "a"), ("x", "b"), ("x", "a"), ("x", "b")]),
+            pmidx2.union([("x", "a"), ("x", "b"), ("x", "a"), ("x", "b")]),
         )
-        # Sorting MultiIndex
+        self.assert_eq(
+            kmidx3.union([(1, 3), (1, 4), (1, 5), (1, 6)]),
+            pmidx3.union([(1, 3), (1, 4), (1, 5), (1, 6)]),
+        )
+        self.assert_eq(
+            kmidx4.union([(1, 1), (1, 2), (1, 3), (1, 4), (1, 3), (1, 4)]),
+            pmidx4.union([(1, 1), (1, 2), (1, 3), (1, 4), (1, 3), (1, 4)]),
+        )
+
+        # Testing if the result is correct after sort=False.
+        # The `sort` argument is added in pandas 0.24.
         if LooseVersion(pd.__version__) >= LooseVersion("0.24"):
-            # The `sort` argument is added in pandas 0.24.
-            self.assert_eq(kmidx1.union(kmidx2, sort=None), pmidx1.union(pmidx2, sort=None))
-            self.assert_eq(kmidx2.union(kmidx1, sort=None), pmidx2.union(pmidx1, sort=None))
             self.assert_eq(
-                kmidx1.union([("x", "a"), ("x", "b"), ("x", "c"), ("x", "d")], sort=None),
-                pmidx1.union([("x", "a"), ("x", "b"), ("x", "c"), ("x", "d")], sort=None),
+                kmidx1.union(kmidx2, sort=False).sort_values(),
+                pmidx1.union(pmidx2, sort=False).sort_values(),
             )
             self.assert_eq(
-                kmidx2.union([("x", "a"), ("x", "b"), ("x", "a"), ("x", "b")], sort=None),
-                pmidx2.union([("x", "a"), ("x", "b"), ("x", "a"), ("x", "b")], sort=None),
+                kmidx2.union(kmidx1, sort=False).sort_values(),
+                pmidx2.union(pmidx1, sort=False).sort_values(),
+            )
+            self.assert_eq(
+                kmidx3.union(kmidx4, sort=False).sort_values(),
+                pmidx3.union(pmidx4, sort=False).sort_values(),
+            )
+            self.assert_eq(
+                kmidx4.union(kmidx3, sort=False).sort_values(),
+                pmidx4.union(pmidx3, sort=False).sort_values(),
+            )
+            self.assert_eq(
+                kmidx1.union(
+                    [("x", "a"), ("x", "b"), ("x", "c"), ("x", "d")], sort=False
+                ).sort_values(),
+                pmidx1.union(
+                    [("x", "a"), ("x", "b"), ("x", "c"), ("x", "d")], sort=False
+                ).sort_values(),
+            )
+            self.assert_eq(
+                kmidx2.union(
+                    [("x", "a"), ("x", "b"), ("x", "a"), ("x", "b")], sort=False
+                ).sort_values(),
+                pmidx2.union(
+                    [("x", "a"), ("x", "b"), ("x", "a"), ("x", "b")], sort=False
+                ).sort_values(),
+            )
+            self.assert_eq(
+                kmidx3.union([(1, 3), (1, 4), (1, 5), (1, 6)], sort=False).sort_values(),
+                pmidx3.union([(1, 3), (1, 4), (1, 5), (1, 6)], sort=False).sort_values(),
+            )
+            self.assert_eq(
+                kmidx4.union(
+                    [(1, 1), (1, 2), (1, 3), (1, 4), (1, 3), (1, 4)], sort=False
+                ).sort_values(),
+                pmidx4.union(
+                    [(1, 1), (1, 2), (1, 3), (1, 4), (1, 3), (1, 4)], sort=False
+                ).sort_values(),
             )
 
         self.assertRaises(NotImplementedError, lambda: kidx1.union(kmidx1))
         self.assertRaises(NotImplementedError, lambda: kmidx1.union(kidx1))
         self.assertRaises(TypeError, lambda: kmidx1.union(["x", "a"]))
+        self.assertRaises(ValueError, lambda: kidx1.union(ks.range(2)))

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -1004,30 +1004,30 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
 
     def test_union(self):
         # Index
-        pidx1 = pd.Index([1, 2, 3, 4, 3, 4, 3, 4])
-        pidx2 = pd.Index([3, 4, 3, 4, 5, 6])
+        pidx1 = pd.Index([1, 2, 3, 4])
+        pidx2 = pd.Index([3, 4, 5, 6])
         kidx1 = ks.from_pandas(pidx1)
         kidx2 = ks.from_pandas(pidx2)
 
         self.assert_eq(kidx1.union(kidx2).sort_values(), pidx1.union(pidx2).sort_values())
         self.assert_eq(kidx2.union(kidx1).sort_values(), pidx2.union(pidx1).sort_values())
         self.assert_eq(
-            kidx1.union([3, 4, 3, 4, 5, 6]).sort_values(),
-            pidx1.union([3, 4, 3, 4, 5, 6]).sort_values(),
+            kidx1.union([3, 4, 5, 6]).sort_values(),
+            pidx1.union([3, 4, 5, 6]).sort_values(),
         )
         self.assert_eq(
-            kidx2.union([1, 2, 3, 4, 3, 4, 3, 4]).sort_values(),
-            pidx2.union([1, 2, 3, 4, 3, 4, 3, 4]).sort_values(),
+            kidx2.union([1, 2, 3, 4]).sort_values(),
+            pidx2.union([1, 2, 3, 4]).sort_values(),
         )
         # Sorting Index
         self.assert_eq(kidx1.union(kidx2, sort=None), pidx1.union(pidx2, sort=None))
         self.assert_eq(kidx2.union(kidx1, sort=None), pidx2.union(pidx1, sort=None))
         self.assert_eq(
-            kidx1.union([3, 4, 3, 4, 5, 6], sort=None), pidx1.union([3, 4, 3, 4, 5, 6], sort=None),
+            kidx1.union([3, 4, 5, 6], sort=None), pidx1.union([3, 4, 5, 6], sort=None),
         )
         self.assert_eq(
-            kidx2.union([1, 2, 3, 4, 3, 4, 3, 4], sort=None),
-            pidx2.union([1, 2, 3, 4, 3, 4, 3, 4], sort=None),
+            kidx2.union([1, 2, 3, 4], sort=None),
+            pidx2.union([1, 2, 3, 4], sort=None),
         )
 
         # MultiIndex

--- a/docs/source/reference/indexing.rst
+++ b/docs/source/reference/indexing.rst
@@ -120,6 +120,7 @@ Combining / joining / set operations
    :toctree: api/
 
    Index.append
+   Index.union
    Index.difference
    Index.symmetric_difference
 
@@ -210,6 +211,7 @@ MultiIndex Combining / joining / set operations
    :toctree: api/
 
    MultiIndex.append
+   MultiIndex.union
    MultiIndex.difference
    MultiIndex.symmetric_difference
 


### PR DESCRIPTION
This PR proposes `Index.union` & `MultiIndex.union`
(https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Index.union.html#pandas.Index.union)


- Index
```python
>>> idx1 = ks.Index([1, 2, 3, 4])
>>> idx2 = ks.Index([3, 4, 5, 6])
>>> idx1.union(idx2).sort_values()
Int64Index([1, 2, 3, 4, 5, 6], dtype='int64')
```

- MultiIndex
```python
>>> midx1 = ks.MultiIndex.from_tuples([("x", "a"), ("x", "b"), ("x", "c"), ("x", "d")])
>>> midx2 = ks.MultiIndex.from_tuples([("x", "c"), ("x", "d"), ("x", "e"), ("x", "f")])
>>> midx1.union(midx2).sort_values()
MultiIndex([('x', 'a'),
            ('x', 'b'),
            ('x', 'c'),
            ('x', 'd'),
            ('x', 'e'),
            ('x', 'f')],
           )
```