### PR TITLE
Implements asof() for Index

### DIFF
--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -1640,6 +1640,9 @@ class Index(IndexOpsMixin):
         is in the index, or return the previous index label if the passed one
         is not in the index.
 
+        .. note:: This API is dependent on :meth:`Index.is_monotonic_increasing`
+            which can be expensive.
+
         Parameters
         ----------
         label : object

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -1631,6 +1631,55 @@ class Index(IndexOpsMixin):
         else:
             return ks.concat([kdf] * repeats).index
 
+    def asof(self, label):
+        """
+        Return the label from the index, or, if not present, the previous one.
+
+        Assuming that the index is sorted, return the passed index label if it
+        is in the index, or return the previous index label if the passed one
+        is not in the index.
+
+        Parameters
+        ----------
+        label : object
+            The label up to which the method returns the latest index label.
+
+        Returns
+        -------
+        object
+            The passed label if it is in the index. The previous label if the
+            passed label is not in the sorted index or `NaN` if there is no
+            such label.
+
+        Examples
+        --------
+        `Index.asof` returns the latest index label up to the passed label.
+
+        >>> idx = ks.Index(['2013-12-31', '2014-01-02', '2014-01-03'])
+        >>> idx.asof('2014-01-01')
+        '2013-12-31'
+
+        If the label is in the index, the method returns the passed label.
+
+        >>> idx.asof('2014-01-02')
+        '2014-01-02'
+
+        If all of the labels in the index are later than the passed label,
+        NaN is returned.
+
+        >>> idx.asof('1999-01-02')
+        nan
+        """
+        sdf = self._internal._sdf
+        if self.is_monotonic_increasing:
+            sdf = sdf.select(self._scol).where(self._scol <= label).select(F.max(self._scol))
+        elif self.is_monotonic_decreasing:
+            sdf = sdf.select(self._scol).where(self._scol >= label).select(F.min(self._scol))
+        else:
+            raise ValueError("index must be monotonic increasing or decreasing")
+        result = sdf.head()[0]
+        return result if result is not None else np.nan
+
     def __getattr__(self, item: str) -> Any:
         if hasattr(_MissingPandasLikeIndex, item):
             property_or_func = getattr(_MissingPandasLikeIndex, item)
@@ -2273,6 +2322,11 @@ class MultiIndex(Index):
 
     def argmin(self):
         raise TypeError("reduction operation 'argmin' not allowed for this dtype")
+
+    def asof(self, label):
+        raise NotImplementedError(
+            "only the default get_loc method is currently supported for MultiIndex"
+        )
 
     @property
     def is_all_dates(self):

--- a/databricks/koalas/missing/indexes.py
+++ b/databricks/koalas/missing/indexes.py
@@ -39,7 +39,6 @@ class _MissingPandasLikeIndex(object):
 
     # Functions
     argsort = unsupported_function("argsort")
-    asof = unsupported_function("asof")
     asof_locs = unsupported_function("asof_locs")
     delete = unsupported_function("delete")
     factorize = unsupported_function("factorize")
@@ -113,7 +112,6 @@ class _MissingPandasLikeMultiIndex(object):
 
     # Functions
     argsort = unsupported_function("argsort")
-    asof = unsupported_function("asof")
     asof_locs = unsupported_function("asof_locs")
     delete = unsupported_function("delete")
     equal_levels = unsupported_function("equal_levels")

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -3551,9 +3551,8 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         Truncates a sorted Series before and/or after some particular index value.
         Series should have sorted index.
 
-        .. note:: the current implementation of truncate uses is_monotonic_increasing internally
-            This leads to move all data into single partition in single machine and could cause
-            serious performance degradation. Avoid this method against very large dataset.
+        .. note:: This API is dependent on :meth:`Index.is_monotonic_increasing`
+            which can be expensive.
 
         Parameters
         ----------

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -1001,3 +1001,18 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
 
         self.assert_eq(kmidx.unique().sort_values(), pmidx.unique().sort_values())
         self.assert_eq(kmidx.unique().sort_values(), pmidx.unique().sort_values())
+
+    def test_asof(self):
+        pidx = pd.Index(["2013-12-31", "2014-01-02", "2014-01-03"])
+        kidx = ks.from_pandas(pidx)
+
+        self.assert_eq(kidx.asof("2014-01-01"), pidx.asof("2014-01-01"))
+        self.assert_eq(kidx.asof("2014-01-02"), pidx.asof("2014-01-02"))
+        self.assert_eq(np.isnan(kidx.asof("1999-01-02")), True)
+        self.assert_eq(np.isnan(pidx.asof("1999-01-02")), True)
+
+        kidx = ks.Index(["2013-12-31", "2015-01-02", "2014-01-03"])
+        self.assertRaises(ValueError, lambda: kidx.asof("2013-12-31"))
+
+        kmidx = ks.MultiIndex.from_tuples([("a", "a"), ("a", "b"), ("a", "c")])
+        self.assertRaises(NotImplementedError, lambda: kmidx.asof(("a", "b")))

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -1003,6 +1003,7 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         self.assert_eq(kmidx.unique().sort_values(), pmidx.unique().sort_values())
 
     def test_asof(self):
+        # Increasing values
         pidx = pd.Index(["2013-12-31", "2014-01-02", "2014-01-03"])
         kidx = ks.from_pandas(pidx)
 
@@ -1011,6 +1012,17 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         self.assert_eq(np.isnan(kidx.asof("1999-01-02")), True)
         self.assert_eq(np.isnan(pidx.asof("1999-01-02")), True)
 
+        # Decreasing values
+        pidx = pd.Index(["2014-01-03", "2014-01-02", "2013-12-31"])
+        kidx = ks.from_pandas(pidx)
+
+        self.assert_eq(kidx.asof("2014-01-01"), pidx.asof("2014-01-01"))
+        self.assert_eq(kidx.asof("2014-01-02"), pidx.asof("2014-01-02"))
+        self.assert_eq(kidx.asof("1999-01-02"), pidx.asof("1999-01-02"))
+        self.assert_eq(np.isnan(kidx.asof("2015-01-02")), True)
+        self.assert_eq(np.isnan(pidx.asof("2015-01-02")), True)
+
+        # Not increasing, neither decreasing (ValueError)
         kidx = ks.Index(["2013-12-31", "2015-01-02", "2014-01-03"])
         self.assertRaises(ValueError, lambda: kidx.asof("2013-12-31"))
 

--- a/docs/source/reference/indexing.rst
+++ b/docs/source/reference/indexing.rst
@@ -128,6 +128,7 @@ Selecting
 .. autosummary::
    :toctree: api/
 
+   Index.asof
    Index.isin
 
 .. _api.multiindex:


### PR DESCRIPTION
This PR proposes `Index.asof`
(https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Index.asof.html#pandas.Index.asof)

```python
>>> idx = ks.Index(['2013-12-31', '2014-01-02', '2014-01-03'])
>>> idx.asof('2014-01-01')
'2013-12-31'

>>> idx.asof('2014-01-02')
'2014-01-02'

>>> idx.asof('1999-01-02')
nan
```