### PR TITLE
Support slice as `col_sel` for `loc` indexer.

### DIFF
--- a/databricks/koalas/indexing.py
+++ b/databricks/koalas/indexing.py
@@ -725,20 +725,19 @@ class LocIndexer(_LocIndexerLike):
 
         returns_series = False
 
-        if isinstance(cols_sel, slice):
-            if cols_sel == slice(None):
-                cols_sel = None
-            else:
-                raise LocIndexer._raiseNotImplemented(
-                    "Can only select columns either by name or reference or all"
-                )
-        elif isinstance(cols_sel, (Series, spark.Column)):
+        if isinstance(cols_sel, (Series, spark.Column)):
             returns_series = True
             cols_sel = [cols_sel]
 
-        if cols_sel is None:
+        if cols_sel is None or cols_sel == slice(None):
             column_labels = self._internal.column_labels
             data_spark_columns = self._internal.data_spark_columns
+        elif isinstance(cols_sel, slice):
+            start, stop = self._kdf_or_kser.columns.slice_locs(
+                start=cols_sel.start, end=cols_sel.stop
+            )
+            column_labels = self._internal.column_labels[start:stop]
+            data_spark_columns = self._internal.data_spark_columns[start:stop]
         elif isinstance(cols_sel, (str, tuple)):
             if isinstance(cols_sel, str):
                 cols_sel = (cols_sel,)

--- a/databricks/koalas/tests/test_indexing.py
+++ b/databricks/koalas/tests/test_indexing.py
@@ -478,6 +478,10 @@ class IndexingTest(ReusedSQLTestCase):
         self.assert_eq(kdf.loc[:, "a"], pdf.loc[:, "a"])
         self.assert_eq(kdf.loc[5:5, "a"], pdf.loc[5:5, "a"])
 
+        self.assert_eq(kdf.loc[:, "a":"a"], pdf.loc[:, "a":"a"])
+        self.assert_eq(kdf.loc[:, "a":"c"], pdf.loc[:, "a":"c"])
+        self.assert_eq(kdf.loc[:, "b":"c"], pdf.loc[:, "b":"c"], almost=True)
+
     def test_loc2d(self):
         kdf = self.kdf
         pdf = self.pdf
@@ -509,6 +513,10 @@ class IndexingTest(ReusedSQLTestCase):
         self.assert_eq(kdf.loc[5, ["a"]], pdf.loc[5, ["a"]])
         self.assert_eq(kdf.loc[9, ["a"]], pdf.loc[9, ["a"]])
 
+        self.assert_eq(kdf.loc[:, "a":"a"], pdf.loc[:, "a":"a"])
+        self.assert_eq(kdf.loc[:, "a":"d"], pdf.loc[:, "a":"d"])
+        self.assert_eq(kdf.loc[:, "c":"d"], pdf.loc[:, "c":"d"], almost=True)
+
     def test_loc2d_multiindex_columns(self):
         arrays = [np.array(["bar", "bar", "baz", "baz"]), np.array(["one", "two", "one", "two"])]
 
@@ -517,6 +525,33 @@ class IndexingTest(ReusedSQLTestCase):
 
         self.assert_eq(kdf.loc["B":"B", "bar"], pdf.loc["B":"B", "bar"])
         self.assert_eq(kdf.loc["B":"B", ["bar"]], pdf.loc["B":"B", ["bar"]])
+
+        self.assert_eq(kdf.loc[:, "bar":"bar"], pdf.loc[:, "bar":"bar"])
+        self.assert_eq(kdf.loc[:, "bar":("baz", "one")], pdf.loc[:, "bar":("baz", "one")])
+        self.assert_eq(
+            kdf.loc[:, ("bar", "two"):("baz", "one")], pdf.loc[:, ("bar", "two"):("baz", "one")]
+        )
+        self.assert_eq(kdf.loc[:, ("bar", "two"):"bar"], pdf.loc[:, ("bar", "two"):"bar"])
+        self.assert_eq(kdf.loc[:, "a":"bax"], pdf.loc[:, "a":"bax"])
+        self.assert_eq(
+            kdf.loc[:, ("bar", "x"):("baz", "a")],
+            pdf.loc[:, ("bar", "x"):("baz", "a")],
+            almost=True,
+        )
+
+        pdf = pd.DataFrame(
+            np.random.randn(3, 4),
+            index=["A", "B", "C"],
+            columns=pd.MultiIndex.from_tuples(
+                [("bar", "two"), ("bar", "one"), ("baz", "one"), ("baz", "two")]
+            ),
+        )
+        kdf = ks.from_pandas(pdf)
+
+        self.assert_eq(kdf.loc[:, "bar":"baz"], pdf.loc[:, "bar":"baz"])
+
+        self.assertRaises(KeyError, lambda: kdf.loc[:, "bar":("baz", "one")])
+        self.assertRaises(KeyError, lambda: kdf.loc[:, ("bar", "two"):"bar"])
 
     def test_loc2d_with_known_divisions(self):
         pdf = pd.DataFrame(


### PR DESCRIPTION
Adding support slice as `col_sel` for `loc` indexer.

E.g.,

```py
>>> kdf
   x     y     z
   a  b  c  d  e
0  1  2  3  4  5

>>> kdf.loc[:, 'y':]
   y     z
   c  d  e
0  3  4  5

>>> kdf.loc[:, :'y']
   x     y
   a  b  c  d
0  1  2  3  4

>>> kdf.loc[:, ('x', 'b'):]
   x  y     z
   b  c  d  e
0  2  3  4  5

>>> kdf.loc[:, :('y', 'c')]
   x     y
   a  b  c
0  1  2  3

>>> kdf.loc[:, ('x', 'b'):('y', 'c')]
   x  y
   b  c
0  2  3

>>> kdf.loc[:, 'x':('y', 'c')]
   x     y
   a  b  c
0  1  2  3

>>> kdf.loc[:, ('x', 'b'):'y']
   x  y
   b  c  d
0  2  3  4
```

Resolves #1176, Closes #1188.