### PR TITLE
Fix MultiIndex.drop() to follow renaming et al.

### DIFF
--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -565,7 +565,7 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         )
         self.assert_eq(pidx.drop("a"), kidx.drop("a"))
         self.assert_eq(pidx.drop(["a", "b"]), kidx.drop(["a", "b"]))
-        self.assert_eq(pidx.drop(["a", "b"], level=1), kidx.drop(["a", "b"], level=1))
+        self.assert_eq(pidx.drop(["x", "y"], level=1), kidx.drop(["x", "y"], level=1))
         self.assert_eq(pidx.drop(["x", "y"], level="level2"), kidx.drop(["x", "y"], level="level2"))
 
         pidx.names = ["lv1", "lv2"]

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -565,7 +565,18 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         )
         self.assert_eq(pidx.drop("a"), kidx.drop("a"))
         self.assert_eq(pidx.drop(["a", "b"]), kidx.drop(["a", "b"]))
+        self.assert_eq(pidx.drop(["a", "b"], level=1), kidx.drop(["a", "b"], level=1))
         self.assert_eq(pidx.drop(["x", "y"], level="level2"), kidx.drop(["x", "y"], level="level2"))
+
+        pidx.names = ["lv1", "lv2"]
+        kidx.names = ["lv1", "lv2"]
+        self.assert_eq(pidx.drop(["x", "y"], level="lv2"), kidx.drop(["x", "y"], level="lv2"))
+
+        self.assertRaises(IndexError, lambda: kidx.drop(["a", "b"], level=2))
+        self.assertRaises(KeyError, lambda: kidx.drop(["a", "b"], level="level"))
+
+        kidx.names = ["lv", "lv"]
+        self.assertRaises(ValueError, lambda: kidx.drop(["x", "y"], level="lv"))
 
     def test_sort_values(self):
         pidx = pd.Index([-10, -100, 200, 100])


### PR DESCRIPTION
`MultiIndex.drop()` doesn't follow renaming et al which makes index spark column name and index name differ.

E.g.,

```py
>>> import databricks.koalas as ks
>>> kidx = ks.MultiIndex.from_tuples(
...     [("a", "x"), ("b", "y"), ("c", "z")], names=["level1", "level2"]
... )
>>> kidx.names = ["lv1", "lv2"]
>>> kidx
MultiIndex([('a', 'x'),
            ('b', 'y'),
            ('c', 'z')],
           names=['lv1', 'lv2'])
>>> kidx.drop(["x", "y"], level="lv2")
Traceback (most recent call last):

...

pyspark.sql.utils.AnalysisException: 'Cannot resolve column name "lv2" among (level1, level2, __natural_order__);'
```