### PR TITLE
Delegate read_csv, read_json, and read_parquet to pandas IO if Spark throws an exception.

### DIFF
--- a/databricks/koalas/config.py
+++ b/databricks/koalas/config.py
@@ -193,6 +193,18 @@ _options = [
         types=bool,
     ),
     Option(
+        key="io.read.fallback.pandas",
+        doc=(
+            "'io.read.fallback.pandas' sets whether or not to fallback to pandas when Spark "
+            "DataFrameReader throws an exception assuming it is caused by unsupported protocol "
+            "like 'http', 'https', and so on. If 'io.read.fallback.pandas' is set to True, "
+            "Koalas will try to fallback to read using pandas, but it could cause "
+            "an out-of-memory error."
+        ),
+        default=False,
+        types=bool,
+    ),
+    Option(
         key="plotting.max_rows",
         doc=(
             "'plotting.max_rows' sets the visual limit on top-n-based plots such as `plot.bar` "
@@ -201,10 +213,7 @@ _options = [
         ),
         default=1000,
         types=int,
-        check_func=(
-            lambda v: v is v >= 0,
-            "'plotting.max_rows' should be greater than or equal to 0.",
-        ),
+        check_func=(lambda v: v >= 0, "'plotting.max_rows' should be greater than or equal to 0.",),
     ),
     Option(
         key="plotting.sample_ratio",

--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -48,6 +48,7 @@ from databricks import koalas as ks  # For running doctests and reference resolu
 from databricks.koalas.base import IndexOpsMixin
 from databricks.koalas.utils import default_session, name_like_string, scol_for, validate_axis
 from databricks.koalas.frame import DataFrame, _reduce_spark_multi
+from databricks.koalas.indexes import Index
 from databricks.koalas.internal import _InternalFrame
 from databricks.koalas.typedef import pandas_wraps
 from databricks.koalas.series import Series, _col
@@ -81,7 +82,7 @@ __all__ = [
 ]
 
 
-def from_pandas(pobj: Union["pd.DataFrame", "pd.Series"]) -> Union["Series", "DataFrame"]:
+def from_pandas(pobj: Union[pd.DataFrame, pd.Series, pd.Index]) -> Union[Series, DataFrame, Index]:
     """Create a Koalas DataFrame or Series from a pandas DataFrame or Series.
 
     This is similar to Spark's `SparkSession.createDataFrame()` with pandas DataFrame,
@@ -363,7 +364,7 @@ def read_csv(
     return kdf
 
 
-def read_json(path: str, index_col: Optional[Union[str, List[str]]] = None, **options):
+def read_json(path: str, index_col: Optional[Union[str, List[str]]] = None, **options) -> DataFrame:
     """
     Convert a JSON string to pandas object.
 
@@ -401,7 +402,7 @@ def read_json(path: str, index_col: Optional[Union[str, List[str]]] = None, **op
         return read_spark_io(path, format="json", index_col=index_col, **options)
     except Py4JJavaError:
         pdf = pd.read_json(path, **options)
-        return from_pandas(pdf)
+        return from_pandas(pdf)  # type: ignore
 
 
 def read_delta(
@@ -605,7 +606,7 @@ def read_parquet(path, columns=None, index_col=None, **options) -> DataFrame:
             sdf = default_session().read.parquet(path)
         except Py4JJavaError:
             pdf = pd.read_parquet(path, columns=columns, **options)
-            return from_pandas(pdf)
+            return from_pandas(pdf)  # type: ignore
         if columns is not None:
             fields = [field.name for field in sdf.schema]
             cols = [col for col in columns if col in fields]

--- a/docs/source/user_guide/options.rst
+++ b/docs/source/user_guide/options.rst
@@ -255,6 +255,13 @@ compute.ordered_head            False          'compute.ordered_head' sets wheth
                                                'compute.ordered_head' is set to True, Koalas
                                                performs natural ordering beforehand, but it will
                                                cause a performance overhead.
+io.read.fallback.pandas         False          'io.read.fallback.pandas' sets whether or not to
+                                               fallback to pandas when Spark DataFrameReader throws
+                                               an exception assuming it is caused by unsupported
+                                               protocol like 'http', 'https', and so on. If
+                                               'io.read.fallback.pandas' is set to True, Koalas will
+                                               try to fallback to read using pandas, but it could
+                                               cause an out-of-memory error.
 plotting.max_rows               1000           'plotting.max_rows' sets the visual limit on top-n-
                                                based plots such as `plot.bar` and `plot.pie`. If it
                                                is set to 1000, the first 1000 data points will be


### PR DESCRIPTION
If the protocol in the specified path is not supported by Spark, Koalas fails even if pandas supports the protocol, e.g., `http` or `https`.
This PR proposes to add a config to enable to fallback to pandas with warnings.