### PR TITLE
Manage broadcast hint for dataframes.

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -6563,6 +6563,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         DataFrame
             A DataFrame of the two merged objects.
 
+        See Also
+        --------
+        broadcast : Marks a DataFrame as small enough for use in broadcast joins.
+
         Examples
         --------
         >>> df1 = ks.DataFrame({'lkey': ['foo', 'bar', 'baz', 'foo'],
@@ -6850,6 +6854,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         See Also
         --------
         DataFrame.merge: For column(s)-on-columns(s) operations.
+        broadcast : Marks a DataFrame as small enough for use in broadcast joins.
 
         Notes
         -----
@@ -7020,6 +7025,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         See Also
         --------
         DataFrame.merge : For column(s)-on-columns(s) operations.
+        broadcast : Marks a DataFrame as small enough for use in broadcast joins.
 
         Examples
         --------

--- a/databricks/koalas/tests/test_namespace.py
+++ b/databricks/koalas/tests/test_namespace.py
@@ -204,3 +204,15 @@ class NamespaceTest(ReusedSQLTestCase, SQLTestUtils):
                         repr(actual.sort_values(list(actual.columns)).reset_index(drop=True)),
                         repr(expected.sort_values(list(expected.columns)).reset_index(drop=True)),
                     )
+
+    # test dataframes equality with broadcast hint.
+    def test_broadcast(self):
+        kdf = ks.DataFrame(
+            {"key": ["K0", "K1", "K2", "K3"], "A": ["A0", "A1", "A2", "A3"]}, columns=["key", "A"]
+        )
+        self.assert_eq(kdf, ks.broadcast(kdf))
+
+        kser = ks.Series([1, 2, 3])
+        expected_error_message = "Invalid type : expected DataFrame got {}".format(type(kser))
+        with self.assertRaisesRegex(ValueError, expected_error_message):
+            ks.broadcast(kser)

--- a/docs/source/reference/general_functions.rst
+++ b/docs/source/reference/general_functions.rst
@@ -26,6 +26,7 @@ Data manipulations and SQL
    get_dummies
    concat
    sql
+   broadcast
 
 Top-level missing data
 ----------------------


### PR DESCRIPTION
Manage broadcast hint for dataframes.
Provides `broadcast` function which, from a given koalas DataFrame, returns a new one with broadcast hint.
Broadcast join can now be performed in `DataFrame.join`, `DataFrame.merge` and `DataFrame.update.`
A broadcast join may be more efficient than sort merge join (Spark default) between a small dataframe and a big daframe. It gives every node a copy of a the small dataframe, which reduces the number of shuffle between partitions. By default, Spark performs it if a dataframe is smaller than ~10MB, but the user should be able to force it.
