### PR TITLE
Add __setitem__ for loc/iloc with Series.

### DIFF
--- a/databricks/koalas/indexing.py
+++ b/databricks/koalas/indexing.py
@@ -1176,6 +1176,7 @@ class iLocIndexer(_LocIndexerLike):
             )
             internal = internal.copy(
                 spark_frame=sdf,
+                column_labels=[internal.column_labels[0] or ("0",)],
                 data_spark_columns=[scol_for(sdf, internal.data_spark_column_names[0])],
                 spark_column=None,
             )

--- a/databricks/koalas/tests/test_indexing.py
+++ b/databricks/koalas/tests/test_indexing.py
@@ -909,6 +909,9 @@ class IndexingTest(ReusedSQLTestCase):
         pser = pd.Series([1, 2, 3], index=["cobra", "viper", "sidewinder"])
         kser = ks.from_pandas(pser)
 
+        pser1 = pser + 1
+        kser1 = kser + 1
+
         for key, value in [
             ([1, 2], 10),
             (1, 50),
@@ -921,8 +924,26 @@ class IndexingTest(ReusedSQLTestCase):
                 kser.iloc[key] = value
                 self.assert_eq(kser, pser)
 
+                # pser1.iloc[key] = value
+                # kser1.iloc[key] = value
+                # self.assert_eq(kser1, pser1)
+
         with self.assertRaises(ValueError):
             kser.iloc[1] = -kser
+
+        pser = pd.Index([1, 2, 3]).to_series()
+        kser = ks.Index([1, 2, 3]).to_series()
+
+        pser1 = pser + 1
+        kser1 = kser + 1
+
+        pser.iloc[0] = 10
+        kser.iloc[0] = 10
+        self.assert_eq(kser, pser)
+
+        # pser1.iloc[0] = 20
+        # kser1.iloc[0] = 20
+        # self.assert_eq(kser1, pser1)
 
     def test_iloc_raises(self):
         pdf = pd.DataFrame({"A": [1, 2], "B": [3, 4], "C": [5, 6]})

--- a/databricks/koalas/tests/test_indexing.py
+++ b/databricks/koalas/tests/test_indexing.py
@@ -15,6 +15,7 @@
 #
 
 import datetime
+from distutils.version import LooseVersion
 import unittest
 
 import numpy as np
@@ -912,9 +913,11 @@ class IndexingTest(ReusedSQLTestCase):
         kser.loc["x"] = kser * 10
         self.assert_eq(kser, pser)
 
-        pser.loc[("x", "viper"):"y"] = pser * 20
-        kser.loc[("x", "viper"):"y"] = kser * 20
-        self.assert_eq(kser, pser)
+        if LooseVersion(pd.__version__) < LooseVersion("1.0"):
+            # TODO: seems like a pandas' bug in pandas>=1.0.0?
+            pser.loc[("x", "viper"):"y"] = pser * 20
+            kser.loc[("x", "viper"):"y"] = kser * 20
+            self.assert_eq(kser, pser)
 
     def test_series_iloc_setitem(self):
         pser = pd.Series([1, 2, 3], index=["cobra", "viper", "sidewinder"])

--- a/databricks/koalas/tests/test_indexing.py
+++ b/databricks/koalas/tests/test_indexing.py
@@ -935,9 +935,9 @@ class IndexingTest(ReusedSQLTestCase):
                 kser.iloc[key] = value
                 self.assert_eq(kser, pser)
 
-                # pser1.iloc[key] = value
-                # kser1.iloc[key] = value
-                # self.assert_eq(kser1, pser1)
+                pser1.iloc[key] = value
+                kser1.iloc[key] = value
+                self.assert_eq(kser1, pser1)
 
         with self.assertRaises(ValueError):
             kser.iloc[1] = -kser
@@ -952,9 +952,9 @@ class IndexingTest(ReusedSQLTestCase):
         kser.iloc[0] = 10
         self.assert_eq(kser, pser)
 
-        # pser1.iloc[0] = 20
-        # kser1.iloc[0] = 20
-        # self.assert_eq(kser1, pser1)
+        pser1.iloc[0] = 20
+        kser1.iloc[0] = 20
+        self.assert_eq(kser1, pser1)
 
     def test_iloc_raises(self):
         pdf = pd.DataFrame({"A": [1, 2], "B": [3, 4], "C": [5, 6]})


### PR DESCRIPTION
Support `__setitem__` for `loc`/`iloc` with Series.

e.g.,

```py
>>> kser = ks.Series([1, 2, 3], index=["cobra", "viper", "sidewinder"])
>>> kser
cobra         1
viper         2
sidewinder    3
Name: 0, dtype: int64
>>> kser.loc[kser % 2 == 1] = -kser
>>> kser
cobra        -1
viper         2
sidewinder   -3
Name: 0, dtype: int64
>>> kser.loc[["viper", "sidewinder"]] = 10
>>> kser
cobra         -1
viper         10
sidewinder    10
Name: 0, dtype: int64
>>> kser.loc["viper"] = 50
>>> kser
cobra         -1
viper         50
sidewinder    10
Name: 0, dtype: int64
>>> kser.loc[:] = 10
>>> kser
cobra         10
viper         10
sidewinder    10
Name: 0, dtype: int64
>>> kser.loc[:"viper"] = 20
>>> kser
cobra         20
viper         20
sidewinder    10
Name: 0, dtype: int64
>>> kser.loc["viper":] = 30
>>> kser
cobra         20
viper         30
sidewinder    30
Name: 0, dtype: int64
```

or

```py
>>> kser = ks.Series([1, 2, 3], index=["cobra", "viper", "sidewinder"])
>>> kser
cobra         1
viper         2
sidewinder    3
Name: 0, dtype: int64
>>> kser.iloc[[1, 2]] = 10
>>> kser
cobra          1
viper         10
sidewinder    10
Name: 0, dtype: int64
>>> kser.iloc[1] = 50
>>> kser
cobra          1
viper         50
sidewinder    10
Name: 0, dtype: int64
>>> kser.iloc[:] = 10
>>> kser
cobra         10
viper         10
sidewinder    10
Name: 0, dtype: int64
>>> kser.iloc[:1] = 20
>>> kser
cobra         20
viper         10
sidewinder    10
Name: 0, dtype: int64
>>> kser.iloc[1:] = 30
>>> kser
cobra         20
viper         30
sidewinder    30
Name: 0, dtype: int64
```