### PR TITLE
Fix iloc for Series when the series is modified.

### DIFF
--- a/databricks/koalas/indexing.py
+++ b/databricks/koalas/indexing.py
@@ -951,10 +951,16 @@ class iLocIndexer(_LocIndexerLike):
     @lazy_property
     def _internal(self):
         internal = super(iLocIndexer, self)._internal
-        sdf = _InternalFrame.attach_distributed_sequence_column(
-            internal.spark_frame, column_name=self._sequence_col
-        )
-        return internal.with_new_sdf(sdf.orderBy(NATURAL_ORDER_COLUMN_NAME))
+        if self._is_series:
+            sdf = internal.spark_frame.select(
+                internal.index_spark_columns + [internal.spark_column]
+            )
+            scol = scol_for(sdf, internal.data_spark_column_names[0])
+        else:
+            sdf = internal.spark_frame
+            scol = None
+        sdf = _InternalFrame.attach_distributed_sequence_column(sdf, column_name=self._sequence_col)
+        return internal.copy(spark_frame=sdf.orderBy(NATURAL_ORDER_COLUMN_NAME), spark_column=scol)
 
     @lazy_property
     def _sequence_col(self):

--- a/databricks/koalas/internal.py
+++ b/databricks/koalas/internal.py
@@ -845,6 +845,8 @@ class _InternalFrame(object):
             If None, the original one is used.
         :return: the copied _InternalFrame.
         """
+        assert self.spark_column is None
+
         if data_columns is None:
             data_columns = self.data_spark_column_names
         else:

--- a/databricks/koalas/tests/test_indexing.py
+++ b/databricks/koalas/tests/test_indexing.py
@@ -809,6 +809,9 @@ class IndexingTest(ReusedSQLTestCase):
             with self.subTest(rows_sel=rows_sel):
                 self.assert_eq(kdf.iloc[rows_sel].sort_index(), pdf.iloc[rows_sel].sort_index())
                 self.assert_eq(kdf.A.iloc[rows_sel].sort_index(), pdf.A.iloc[rows_sel].sort_index())
+                self.assert_eq(
+                    (kdf.A + 1).iloc[rows_sel].sort_index(), (pdf.A + 1).iloc[rows_sel].sort_index()
+                )
 
     def test_iloc_iterable_rows_sel(self):
         pdf = pd.DataFrame({"A": [1, 2] * 5, "B": [3, 4] * 5, "C": [5, 6] * 5})
@@ -826,6 +829,9 @@ class IndexingTest(ReusedSQLTestCase):
             with self.subTest(rows_sel=rows_sel):
                 self.assert_eq(kdf.iloc[rows_sel].sort_index(), pdf.iloc[rows_sel].sort_index())
                 self.assert_eq(kdf.A.iloc[rows_sel].sort_index(), pdf.A.iloc[rows_sel].sort_index())
+                self.assert_eq(
+                    (kdf.A + 1).iloc[rows_sel].sort_index(), (pdf.A + 1).iloc[rows_sel].sort_index()
+                )
 
             with self.subTest(rows_sel=rows_sel):
                 self.assert_eq(

--- a/databricks/koalas/tests/test_indexing.py
+++ b/databricks/koalas/tests/test_indexing.py
@@ -776,13 +776,18 @@ class IndexingTest(ReusedSQLTestCase):
             #                pdf.iloc[pdf.index == "B", indexer])
 
     def test_iloc_series(self):
-        pseries = pd.Series([1, 2, 3])
-        kseries = ks.from_pandas(pseries)
+        pser = pd.Series([1, 2, 3])
+        kser = ks.from_pandas(pser)
 
-        self.assert_eq(kseries.iloc[0], pseries.iloc[0])
-        self.assert_eq(kseries.iloc[:], pseries.iloc[:])
-        self.assert_eq(kseries.iloc[:1], pseries.iloc[:1])
-        self.assert_eq(kseries.iloc[:-1], pseries.iloc[:-1])
+        self.assert_eq(kser.iloc[0], pser.iloc[0])
+        self.assert_eq(kser.iloc[:], pser.iloc[:])
+        self.assert_eq(kser.iloc[:1], pser.iloc[:1])
+        self.assert_eq(kser.iloc[:-1], pser.iloc[:-1])
+
+        self.assert_eq((kser + 1).iloc[0], (pser + 1).iloc[0])
+        self.assert_eq((kser + 1).iloc[:], (pser + 1).iloc[:])
+        self.assert_eq((kser + 1).iloc[:1], (pser + 1).iloc[:1])
+        self.assert_eq((kser + 1).iloc[:-1], (pser + 1).iloc[:-1])
 
     def test_iloc_slice_rows_sel(self):
         pdf = pd.DataFrame({"A": [1, 2] * 5, "B": [3, 4] * 5, "C": [5, 6] * 5})


### PR DESCRIPTION
Fixing a bug in iloc for Series when the series is modified.

```py
>>> kser = ks.Series([1, 2, 3])
>>> (kser + 1).iloc[0]
Traceback (most recent call last):

...

pyspark.sql.utils.AnalysisException: 'Cannot resolve column name "`(0 + 1)`" among (__distributed_sequence_column__, __index_level_0__, 0);'
```
