### PR TITLE
Fix nan tests for Index.asof() and remove unnecessary code

### DIFF
--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -1676,9 +1676,9 @@ class Index(IndexOpsMixin):
         """
         sdf = self._internal._sdf
         if self.is_monotonic_increasing:
-            sdf = sdf.select(self._scol).where(self._scol <= label).select(F.max(self._scol))
+            sdf = sdf.where(self._scol <= label).select(F.max(self._scol))
         elif self.is_monotonic_decreasing:
-            sdf = sdf.select(self._scol).where(self._scol >= label).select(F.min(self._scol))
+            sdf = sdf.where(self._scol >= label).select(F.min(self._scol))
         else:
             raise ValueError("index must be monotonic increasing or decreasing")
         result = sdf.head()[0]

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -1019,8 +1019,7 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
 
         self.assert_eq(kidx.asof("2014-01-01"), pidx.asof("2014-01-01"))
         self.assert_eq(kidx.asof("2014-01-02"), pidx.asof("2014-01-02"))
-        self.assert_eq(np.isnan(kidx.asof("1999-01-02")), True)
-        self.assert_eq(np.isnan(pidx.asof("1999-01-02")), True)
+        self.assert_eq(repr(kidx.asof("1999-01-02")), repr(pidx.asof("1999-01-02")))
 
         # Decreasing values
         pidx = pd.Index(["2014-01-03", "2014-01-02", "2013-12-31"])
@@ -1029,8 +1028,7 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         self.assert_eq(kidx.asof("2014-01-01"), pidx.asof("2014-01-01"))
         self.assert_eq(kidx.asof("2014-01-02"), pidx.asof("2014-01-02"))
         self.assert_eq(kidx.asof("1999-01-02"), pidx.asof("1999-01-02"))
-        self.assert_eq(np.isnan(kidx.asof("2015-01-02")), True)
-        self.assert_eq(np.isnan(pidx.asof("2015-01-02")), True)
+        self.assert_eq(repr(kidx.asof("2015-01-02")), repr(pidx.asof("2015-01-02")))
 
         # Not increasing, neither decreasing (ValueError)
         kidx = ks.Index(["2013-12-31", "2015-01-02", "2014-01-03"])


### PR DESCRIPTION
Some refactoring is done for `Index.asof()`