### PR TITLE
Solves issue with key handling during groupby - apply

### DIFF
--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -928,6 +928,15 @@ class GroupBy(object):
                 pser_or_pdf = pdf.groupby(input_groupnames)[name].apply(func)
             else:
                 pser_or_pdf = pdf.groupby(input_groupnames).apply(func)
+                keys = set(input_groupnames)
+                should_drop_columns = (
+                    isinstance(pser_or_pdf, pd.DataFrame)
+                    and keys.issubset(set(pser_or_pdf.index.names))
+                    and keys.issubset(set(pser_or_pdf.columns))
+                )
+                if should_drop_columns:
+                    pser_or_pdf = pser_or_pdf.drop(input_groupnames, axis=1)
+
             kser_or_kdf = ks.from_pandas(pser_or_pdf)
             if len(pdf) <= limit:
                 return kser_or_kdf

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -1162,15 +1162,13 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             self.test_apply_with_new_dataframe()
 
     def test_apply_key_handling(self):
-        pdf = pd.DataFrame({'d': [1.0, 1.0, 1.0, 2.0, 2.0, 2.0], 'v': [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]})
-
-        self.assert_eq(
-            pdf.groupby('d').sum(),
-            pdf.groupby('d').apply(sum).drop(['d'], axis=1)
+        pdf = pd.DataFrame(
+            {"d": [1.0, 1.0, 1.0, 2.0, 2.0, 2.0], "v": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]}
         )
+
+        self.assert_eq(pdf.groupby("d").sum(), pdf.groupby("d").apply(sum).drop(["d"], axis=1))
         self.assert_eq(
-            ks.from_pandas(pdf).groupby('d').sum(),
-            ks.from_pandas(pdf).groupby('d').apply(sum)
+            ks.from_pandas(pdf).groupby("d").sum(), ks.from_pandas(pdf).groupby("d").apply(sum)
         )
 
     def test_transform(self):

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -1165,11 +1165,9 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         pdf = pd.DataFrame(
             {"d": [1.0, 1.0, 1.0, 2.0, 2.0, 2.0], "v": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]}
         )
+        kdf = ks.from_pandas(pdf)
 
-        self.assert_eq(pdf.groupby("d").sum(), pdf.groupby("d").apply(sum).drop(["d"], axis=1))
-        self.assert_eq(
-            ks.from_pandas(pdf).groupby("d").sum(), ks.from_pandas(pdf).groupby("d").apply(sum)
-        )
+        self.assert_eq(pdf.groupby("d").apply(sum).drop(["d"], axis=1), kdf.groupby("d").apply(sum))
 
     def test_transform(self):
         pdf = pd.DataFrame(

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -1161,6 +1161,18 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         with option_context("compute.shortcut_limit", 0):
             self.test_apply_with_new_dataframe()
 
+    def test_apply_key_handling(self):
+        pdf = pd.DataFrame({'d': [1.0, 1.0, 1.0, 2.0, 2.0, 2.0], 'v': [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]})
+
+        self.assert_eq(
+            pdf.groupby('d').sum(),
+            pdf.groupby('d').apply(sum).drop(['d'], axis=1)
+        )
+        self.assert_eq(
+            ks.from_pandas(pdf).groupby('d').sum(),
+            ks.from_pandas(pdf).groupby('d').apply(sum)
+        )
+
     def test_transform(self):
         pdf = pd.DataFrame(
             {"a": [1, 2, 3, 4, 5, 6], "b": [1, 1, 2, 3, 5, 8], "c": [1, 4, 9, 16, 25, 36]},


### PR DESCRIPTION
Solves #1361 

When the function to be applied after a `groupby` operation doesn't have type annotations, koalas has to infer the schema of the result. In this context koalas raises an exception due to the duplication between index and column names in `pandas.groupby.apply` [[1]](https://github.com/pandas-dev/pandas/issues/32384).

One option to deal with this issue is get rid of the duplicated columns, getting this results:

```python
>>> df = pd.DataFrame({'d': [1.0, 1.0, 1.0, 2.0, 2.0, 2.0], 'v': [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]})
>>> df
     d    v
0  1.0  1.0
1  1.0  2.0
2  1.0  3.0
3  2.0  4.0
4  2.0  5.0
5  2.0  6.0

>>> df.groupby('d').sum()
        v
d
1.0   6.0
2.0  15.0

>>> df.groupby('d').apply(sum)
       d     v
d
1.0  3.0   6.0
2.0  6.0  15.0

# Before PR
>>> ks.from_pandas(df).groupby('d').apply(sum)
...
ValueError: cannot insert d, already exists

# After PR
>>> ks.from_pandas(df).groupby('d').apply(sum)
       v
d
1.0  6.0
2.0  15.0
```

Another option that come to mind would be to rename the columns used as groupby keys (see below), but either way its still 'inconsistent' with pandas behavior.

```python
>>> ks.from_pandas(df).groupby('d').apply(sum)
       d_dup     v
d
1.0  3.0   6.0
2.0  6.0  15.0
```

how should koalas handle this?