### PR TITLE
Implements DataFrame.to_markdown

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -1791,12 +1791,17 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         >>> df = ks.DataFrame(
         ...     data={"animal_1": ["elk", "pig"], "animal_2": ["dog", "quetzal"]}
         ... )
-        >>> print(df.to_markdown())
+        >>> print(df.to_markdown())  # doctest: +SKIP
         |    | animal_1   | animal_2   |
         |---:|:-----------|:-----------|
         |  0 | elk        | dog        |
         |  1 | pig        | quetzal    |
         """
+        # `to_markdown` is supported in pandas >= 1.0.0 since it's newly added in pandas 1.0.0.
+        if LooseVersion(pd.__version__) < LooseVersion("1.0.0"):
+            raise NotImplementedError(
+                "`to_markdown()` only supported in Kaoals with pandas >= 1.0.0"
+            )
         # Make sure locals() call is at the top of the function so we don't capture local variables.
         args = locals()
         if max_rows is not None:

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -1762,6 +1762,51 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             kdf._to_internal_pandas(), self.to_latex, pd.DataFrame.to_latex, args
         )
 
+    def to_markdown(self, buf=None, mode=None, max_rows=None):
+        """
+        Print DataFrame in Markdown-friendly format.
+
+        .. note:: This method should only be used if the resulting Pandas object is expected
+                  to be small, as all the data is loaded into the driver's memory. If the input
+                  is large, set max_rows parameter.
+
+        Parameters
+        ----------
+        buf : writable buffer, defaults to sys.stdout
+            Where to send the output. By default, the output is printed to
+            sys.stdout. Pass a writable buffer if you need to further process
+            the output.
+        mode : str, optional
+            Mode in which file is opened.
+        **kwargs
+            These parameters will be passed to `tabulate`.
+
+        Returns
+        -------
+        str
+            DataFrame in Markdown-friendly format.
+
+        Examples
+        --------
+        >>> df = ks.DataFrame(
+        ...     data={"animal_1": ["elk", "pig"], "animal_2": ["dog", "quetzal"]}
+        ... )
+        >>> print(df.to_markdown())
+        |    | animal_1   | animal_2   |
+        |---:|:-----------|:-----------|
+        |  0 | elk        | dog        |
+        |  1 | pig        | quetzal    |
+        """
+        # Make sure locals() call is at the top of the function so we don't capture local variables.
+        args = locals()
+        if max_rows is not None:
+            kdf = self.head(max_rows)
+        else:
+            kdf = self
+        return validate_arguments_and_invoke_function(
+            kdf._to_internal_pandas(), self.to_markdown, pd.DataFrame.to_markdown, args
+        )
+
     # TODO: enable doctests once we drop Spark 2.3.x (due to type coercion logic
     #  when creating arrays)
     def transpose(self):

--- a/databricks/koalas/missing/frame.py
+++ b/databricks/koalas/missing/frame.py
@@ -78,7 +78,6 @@ class _MissingPandasLikeDataFrame(object):
     to_sql = unsupported_function("to_sql")
     to_stata = unsupported_function("to_stata")
     to_timestamp = unsupported_function("to_timestamp")
-    to_markdown = unsupported_function("to_markdown")
     truncate = unsupported_function("truncate")
     tshift = unsupported_function("tshift")
     tz_convert = unsupported_function("tz_convert")

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -3123,3 +3123,9 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         columns = pd.MultiIndex.from_tuples([("x", "a"), ("y", "b"), ("z", "c")])
         kdf.columns = columns
         self.assertRaises(ValueError, lambda: kdf.eval("x.a + y.b"))
+
+    def test_to_markdown(self):
+        pdf = pd.DataFrame(data={"animal_1": ["elk", "pig"], "animal_2": ["dog", "quetzal"]})
+        kdf = ks.from_pandas(pdf)
+
+        self.assert_eq(pdf.to_markdown(), kdf.to_markdown())

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -3128,4 +3128,8 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         pdf = pd.DataFrame(data={"animal_1": ["elk", "pig"], "animal_2": ["dog", "quetzal"]})
         kdf = ks.from_pandas(pdf)
 
-        self.assert_eq(pdf.to_markdown(), kdf.to_markdown())
+        # `to_markdown()` is supported in pandas >= 1.0.0 since it's newly added in pandas 1.0.0.
+        if LooseVersion(pd.__version__) < LooseVersion("1.0.0"):
+            self.assertRaises(NotImplementedError, lambda: kdf.to_markdown())
+        else:
+            self.assert_eq(pdf.to_markdown(), kdf.to_markdown())

--- a/docs/source/reference/frame.rst
+++ b/docs/source/reference/frame.rst
@@ -242,6 +242,7 @@ Serialization / IO / Conversion
    DataFrame.to_dict
    DataFrame.to_excel
    DataFrame.to_clipboard
+   DataFrame.to_markdown
    DataFrame.to_records
    DataFrame.to_latex
    DataFrame.style


### PR DESCRIPTION
This PR proposes `DataFrame.markdown()` which is newly added in pandas > 1.0.0.
(https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_markdown.html#pandas.DataFrame.to_markdown)

```
>>> kdf = ks.DataFrame(data={"animal_1": ["elk", "pig"], "animal_2": ["dog", "quetzal"]})
>>> print(kdf.to_markdown())
|    | animal_1   | animal_2   |
|---:|:-----------|:-----------|
|  0 | elk        | dog        |
|  1 | pig        | quetzal    |
```