### PR TITLE
Use the latest Sphinx in requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,7 +11,7 @@ mlflow>=1.0
 protobuf<3.9.0
 
 # Documentation build
-sphinx==2.0.1
+sphinx
 nbsphinx
 numpydoc==0.8
 pypandoc


### PR DESCRIPTION
Seems we don't face the warnings from Sphinx (see https://github.com/databricks/koalas/pull/417). It seems fixed in the upstream Sphinx. This PR use the latest Sphinx in requirements-dev.txt 