### PR TITLE
Implements DataFrame.persist() with additional tests for DataFrame.cache()

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -3905,6 +3905,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         See Also
         --------
         DataFrame.persist
+        DataFrame.unpersist
 
         Examples
         --------
@@ -3949,6 +3950,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         See Also
         --------
         DataFrame.cache
+        DataFrame.unpersist
 
         Examples
         --------
@@ -10171,6 +10173,11 @@ class _CachedDataFrame(DataFrame):
         """
         The `unpersist` function is used to uncache the Koalas DataFrame when it
         is not used with `with` statement.
+
+        See Also
+        --------
+        DataFrame.cache
+        DataFrame.persist
 
         Examples
         --------

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -3905,7 +3905,6 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         See Also
         --------
         DataFrame.persist
-        DataFrame.unpersist
 
         Examples
         --------
@@ -3950,7 +3949,6 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         See Also
         --------
         DataFrame.cache
-        DataFrame.unpersist
 
         Examples
         --------
@@ -10173,11 +10171,6 @@ class _CachedDataFrame(DataFrame):
         """
         The `unpersist` function is used to uncache the Koalas DataFrame when it
         is not used with `with` statement.
-
-        See Also
-        --------
-        DataFrame.cache
-        DataFrame.persist
 
         Examples
         --------

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -31,7 +31,7 @@ from databricks.koalas.config import option_context
 from databricks.koalas.testing.utils import ReusedSQLTestCase, SQLTestUtils
 from databricks.koalas.exceptions import PandasNotImplementedError
 from databricks.koalas.missing.frame import _MissingPandasLikeDataFrame
-from databricks.koalas.frame import DataFrame, _CachedDataFrame
+from databricks.koalas.frame import _CachedDataFrame
 
 
 class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):

--- a/docs/source/reference/frame.rst
+++ b/docs/source/reference/frame.rst
@@ -219,6 +219,7 @@ Cache
    :toctree: api/
 
    DataFrame.cache
+   DataFrame.persist
 
 Serialization / IO / Conversion
 -------------------------------

--- a/docs/source/reference/frame.rst
+++ b/docs/source/reference/frame.rst
@@ -220,6 +220,7 @@ Cache
 
    DataFrame.cache
    DataFrame.persist
+   DataFrame.unpersist
 
 Serialization / IO / Conversion
 -------------------------------

--- a/docs/source/reference/frame.rst
+++ b/docs/source/reference/frame.rst
@@ -220,7 +220,6 @@ Cache
 
    DataFrame.cache
    DataFrame.persist
-   DataFrame.unpersist
 
 Serialization / IO / Conversion
 -------------------------------


### PR DESCRIPTION
Resolves #1373 


Here, we have a `DataFrame` named `df`

```python
>>> import pyspark
>>> df = ks.DataFrame([(.2, .3), (.0, .6), (.6, .0), (.2, .1)],
...                   columns=['dogs', 'cats'])
>>> df
   dogs  cats
0   0.2   0.3
1   0.0   0.6
2   0.6   0.0
3   0.2   0.1
```

Set the StorageLevel to `MEMORY_ONLY`.

```python
>>> with df.persist(pyspark.StorageLevel.MEMORY_ONLY) as cached_df:
...     print(cached_df.count())
...
dogs    4
cats    4
Name: 0, dtype: int64
```

Set the StorageLevel to `DISK_ONLY`.

```python
>>> with df.persist(pyspark.StorageLevel.DISK_ONLY) as cached_df:
...     print(cached_df.count())
...
dogs    4
cats    4
Name: 0, dtype: int64
```

If a StorageLevel is not given, it uses `MEMORY_AND_DISK` by default.

```python
>>> with df.persist() as cached_df:
...     print(cached_df.count())
...
dogs    4
cats    4
Name: 0, dtype: int64
```