### PR TITLE
Permissively run all tests in Github Actions

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -13,6 +13,7 @@ jobs:
     name: PIP (Python, Spark, pandas, PyArrow)
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         include:
           - python-version: 3.5
@@ -82,6 +83,7 @@ jobs:
     name: Conda (Python, Spark, pandas, PyArrow)
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         include:
           - python-version: 3.6


### PR DESCRIPTION
Github Actions fails fast by default. This PR targets to permissively run all tests.