### PR TITLE
Add storage_level property in _CachedDataFrame.

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -3965,8 +3965,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         Set the StorageLevel to `MEMORY_ONLY`.
 
         >>> with df.persist(pyspark.StorageLevel.MEMORY_ONLY) as cached_df:
+        ...     print(cached_df.storage_level)
         ...     print(cached_df.count())
         ...
+        Memory Serialized 1x Replicated
         dogs    4
         cats    4
         Name: 0, dtype: int64
@@ -3974,8 +3976,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         Set the StorageLevel to `DISK_ONLY`.
 
         >>> with df.persist(pyspark.StorageLevel.DISK_ONLY) as cached_df:
+        ...     print(cached_df.storage_level)
         ...     print(cached_df.count())
         ...
+        Disk Serialized 1x Replicated
         dogs    4
         cats    4
         Name: 0, dtype: int64
@@ -3983,8 +3987,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         If a StorageLevel is not given, it uses `MEMORY_AND_DISK` by default.
 
         >>> with df.persist() as cached_df:
+        ...     print(cached_df.storage_level)
         ...     print(cached_df.count())
         ...
+        Disk Memory Serialized 1x Replicated
         dogs    4
         cats    4
         Name: 0, dtype: int64
@@ -10166,6 +10172,37 @@ class _CachedDataFrame(DataFrame):
 
     def __exit__(self, exception_type, exception_value, traceback):
         self.unpersist()
+
+    @property
+    def storage_level(self):
+        """
+        Return the storage level of this cache.
+
+        Examples
+        --------
+        >>> import pyspark
+        >>> df = ks.DataFrame([(.2, .3), (.0, .6), (.6, .0), (.2, .1)],
+        ...                   columns=['dogs', 'cats'])
+        >>> df
+           dogs  cats
+        0   0.2   0.3
+        1   0.0   0.6
+        2   0.6   0.0
+        3   0.2   0.1
+
+        >>> with df.cache() as cached_df:
+        ...     print(cached_df.storage_level)
+        ...
+        Disk Memory Deserialized 1x Replicated
+
+        Set the StorageLevel to `MEMORY_ONLY`.
+
+        >>> with df.persist(pyspark.StorageLevel.MEMORY_ONLY) as cached_df:
+        ...     print(cached_df.storage_level)
+        ...
+        Memory Serialized 1x Replicated
+        """
+        return self._cached.storageLevel
 
     def unpersist(self):
         """

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -3144,6 +3144,9 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         with kdf.cache() as cached_df:
             self.assert_eq(isinstance(cached_df, _CachedDataFrame), True)
+            self.assert_eq(
+                repr(cached_df.storage_level), repr(StorageLevel(True, True, False, True))
+            )
 
     def test_persist(self):
         pdf = pd.DataFrame(
@@ -3160,5 +3163,6 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         for storage_level in storage_levels:
             with kdf.persist(storage_level) as cached_df:
                 self.assert_eq(isinstance(cached_df, _CachedDataFrame), True)
+                self.assert_eq(repr(cached_df.storage_level), repr(storage_level))
 
         self.assertRaises(TypeError, lambda: kdf.persist("DISK_ONLY"))


### PR DESCRIPTION
Now that we can specify the storage level via caching by `DataFrame.persist()` function.
We should also have `storage_level` property to show the current storage level.