### PR TITLE
Fix iloc.__setitem__ with the other Series from the same DataFrame.

### DIFF
--- a/databricks/koalas/indexing.py
+++ b/databricks/koalas/indexing.py
@@ -982,16 +982,10 @@ class iLocIndexer(_LocIndexerLike):
     @lazy_property
     def _internal(self):
         internal = super(iLocIndexer, self)._internal
-        if self._is_series:
-            sdf = internal.spark_frame.select(
-                internal.index_spark_columns + [internal.spark_column]
-            )
-            scol = scol_for(sdf, internal.data_spark_column_names[0])
-        else:
-            sdf = internal.spark_frame
-            scol = None
-        sdf = _InternalFrame.attach_distributed_sequence_column(sdf, column_name=self._sequence_col)
-        return internal.copy(spark_frame=sdf.orderBy(NATURAL_ORDER_COLUMN_NAME), spark_column=scol)
+        sdf = _InternalFrame.attach_distributed_sequence_column(
+            internal.spark_frame, column_name=self._sequence_col
+        )
+        return internal.copy(spark_frame=sdf.orderBy(NATURAL_ORDER_COLUMN_NAME))
 
     @lazy_property
     def _sequence_col(self):

--- a/databricks/koalas/tests/test_indexing.py
+++ b/databricks/koalas/tests/test_indexing.py
@@ -959,6 +959,16 @@ class IndexingTest(ReusedSQLTestCase):
         kser1.iloc[0] = 20
         self.assert_eq(kser1, pser1)
 
+        pdf = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+        kdf = ks.from_pandas(pdf)
+
+        pser = pdf.a
+        kser = kdf.a
+
+        pser.iloc[[1]] = -pdf.b
+        kser.iloc[[1]] = -kdf.b
+        self.assert_eq(kser, pser)
+
     def test_iloc_raises(self):
         pdf = pd.DataFrame({"A": [1, 2], "B": [3, 4], "C": [5, 6]})
         kdf = ks.from_pandas(pdf)


### PR DESCRIPTION
Fixing a bug of `iloc.__setitem__` which throws an `AnalysisException` even when the value is the other Series from the same DataFrame.

```py
>>> kdf = ks.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
>>> kser = kdf.a
>>> kser.iloc[[1]] = -kdf.b
Traceback (most recent call last):
...
pyspark.sql.utils.AnalysisException: 'Resolved attribute(s) b#2L missing from __distributed_sequence_column__#44L,__index_level_0__#0L,a#1L,__natural_order__#48L in ...
```