### PR TITLE
Separate a requirements file for Read the Docs.

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -69,9 +69,6 @@ jobs:
         # as Black only works with Python 3.6+. This is hacky but we will drop
         # Python 3.5 soon so it's fine.
         sed -i '/black/d' requirements-dev.txt
-        # 'install-jdk' does not support Python 3.5. This is hacky but we will remove
-        # once Spark 3.0 is released. See also https://github.com/databricks/koalas/pull/1387
-        sed -i '/install-jdk/d' requirements-dev.txt
         pip install -r requirements-dev.txt
         pip install pandas==$PANDAS_VERSION pyarrow==$PYARROW_VERSION
         pip list
@@ -147,9 +144,6 @@ jobs:
         conda config --env --add pinned_packages pandas==$PANDAS_VERSION
         conda config --env --add pinned_packages pyarrow==$PYARROW_VERSION
         conda install -c conda-forge --yes pandas==$PANDAS_VERSION pyarrow==$PYARROW_VERSION
-        # 'install-jdk' does not exist in Conda. This is hacky but we will remove
-        # once Spark 3.0 is released. See also https://github.com/databricks/koalas/pull/1387
-        sed -i '/install-jdk/d' requirements-dev.txt
         conda install -c conda-forge --yes --freeze-installed --file requirements-dev.txt
         conda list
     - name: Run tests

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -32,8 +32,8 @@ python:
   version: 3.6
   install:
     - requirements: requirements-dev.txt
+    - requirements: docs/requirements-readthedocs.txt
     - method: pip
       path: .
       extra_requirements:
         - spark
-

--- a/docs/requirements-readthedocs.txt
+++ b/docs/requirements-readthedocs.txt
@@ -1,0 +1,2 @@
+# Dependencies for Read the Docs.
+install-jdk

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -30,6 +30,3 @@ pytest-cov
 scikit-learn
 openpyxl
 xlrd
-
-# For Read the docs
-install-jdk


### PR DESCRIPTION
This is a follow-up of #1387.
If there is a dependency which doesn't exist in conda in a requirements file, we can't use it for conda and it takes some steps for contributors to set up their development environment.
We should separate the requirements file for Read the Docs.