### PR TITLE
Add support Series from different DataFrames for `loc/iloc.__setitem__`.

### DIFF
--- a/databricks/koalas/indexing.py
+++ b/databricks/koalas/indexing.py
@@ -1213,6 +1213,5 @@ class iLocIndexer(_LocIndexerLike):
             # TODO: support DataFrame.
 
         # Clean up implicitly cached properties to be able to reuse the indexer.
-        for attr in ["_lazy__internal", "_lazy__sequence_col"]:
-            if hasattr(self, attr):
-                delattr(self, attr)
+        del self._internal
+        del self._sequence_col

--- a/databricks/koalas/indexing.py
+++ b/databricks/koalas/indexing.py
@@ -341,7 +341,7 @@ class _LocIndexerLike(_IndexerLike):
                     kdf["__temp_key_col__"] = key
                 if isinstance(value, Series):
                     kdf["__temp_value_col__"] = value
-                kdf = kdf.sort_values("__temp_natural_order__")
+                kdf = kdf.sort_values("__temp_natural_order__").drop("__temp_natural_order__")
 
                 kser = kdf[self._kdf_or_kser.name]
                 if isinstance(key, Series):

--- a/databricks/koalas/tests/test_indexing.py
+++ b/databricks/koalas/tests/test_indexing.py
@@ -923,6 +923,9 @@ class IndexingTest(ReusedSQLTestCase):
         pser = pd.Series([1, 2, 3], index=["cobra", "viper", "sidewinder"])
         kser = ks.from_pandas(pser)
 
+        piloc = pser.iloc
+        kiloc = kser.iloc
+
         pser1 = pser + 1
         kser1 = kser + 1
 
@@ -936,6 +939,10 @@ class IndexingTest(ReusedSQLTestCase):
             with self.subTest(key=key, value=value):
                 pser.iloc[key] = value
                 kser.iloc[key] = value
+                self.assert_eq(kser, pser)
+
+                piloc[key] = -value
+                kiloc[key] = -value
                 self.assert_eq(kser, pser)
 
                 pser1.iloc[key] = value

--- a/databricks/koalas/tests/test_ops_on_diff_frames.py
+++ b/databricks/koalas/tests/test_ops_on_diff_frames.py
@@ -623,9 +623,27 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
         pser.iloc[[1, 2]] = -pser_another
         self.assert_eq(kser.sort_index(), pser.sort_index())
 
+        kser.iloc[[0]] = 10 * kser_another
+        pser.iloc[[0]] = 10 * pser_another
+        self.assert_eq(kser.sort_index(), pser.sort_index())
+
         kser1.iloc[[1, 2]] = -kser_another
         pser1.iloc[[1, 2]] = -pser_another
         self.assert_eq(kser1.sort_index(), pser1.sort_index())
+
+        pser = pd.Series([1, 2, 3], index=["cobra", "viper", "sidewinder"])
+        kser = ks.from_pandas(pser)
+
+        piloc = pser.iloc
+        kiloc = kser.iloc
+
+        kiloc[[1, 2]] = -kser_another
+        piloc[[1, 2]] = -pser_another
+        self.assert_eq(kser.sort_index(), pser.sort_index())
+
+        kiloc[[0]] = 10 * kser_another
+        piloc[[0]] = 10 * pser_another
+        self.assert_eq(kser.sort_index(), pser.sort_index())
 
     def test_where(self):
         pdf1 = pd.DataFrame({"A": [0, 1, 2, 3, 4], "B": [100, 200, 300, 400, 500]})

--- a/databricks/koalas/tests/test_ops_on_diff_frames.py
+++ b/databricks/koalas/tests/test_ops_on_diff_frames.py
@@ -554,7 +554,7 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
 
         self.assert_eq(kdf.sort_index(), pdf.sort_index())
 
-    def test_loc_setitem(self):
+    def test_frame_loc_setitem(self):
         pdf = pd.DataFrame(
             [[1, 2], [4, 5], [7, 8]],
             index=["cobra", "viper", "sidewinder"],
@@ -567,6 +567,65 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
         pdf.loc[["viper", "sidewinder"], ["shield"]] = pdf.max_speed
 
         self.assert_eq(kdf.sort_index(), pdf.sort_index())
+
+    def test_series_loc_setitem(self):
+        pser = pd.Series([1, 2, 3], index=["cobra", "viper", "sidewinder"])
+        kser = ks.from_pandas(pser)
+
+        pser_another = pd.Series([1, 2, 3], index=["cobra", "viper", "sidewinder"])
+        kser_another = ks.from_pandas(pser_another)
+
+        kser.loc[kser % 2 == 1] = -kser_another
+        pser.loc[pser % 2 == 1] = -pser_another
+        self.assert_eq(kser.sort_index(), pser.sort_index())
+
+        pser = pd.Series([1, 2, 3], index=["cobra", "viper", "sidewinder"])
+        kser = ks.from_pandas(pser)
+        kser.loc[kser_another % 2 == 1] = -kser
+        pser.loc[pser_another % 2 == 1] = -pser
+        self.assert_eq(kser.sort_index(), pser.sort_index())
+
+        pser = pd.Series([1, 2, 3], index=["cobra", "viper", "sidewinder"])
+        kser = ks.from_pandas(pser)
+        kser.loc[kser_another % 2 == 1] = -kser
+        pser.loc[pser_another % 2 == 1] = -pser
+        self.assert_eq(kser.sort_index(), pser.sort_index())
+
+        pser = pd.Series([1, 2, 3], index=["cobra", "viper", "sidewinder"])
+        kser = ks.from_pandas(pser)
+        kser.loc[kser_another % 2 == 1] = -kser_another
+        pser.loc[pser_another % 2 == 1] = -pser_another
+        self.assert_eq(kser.sort_index(), pser.sort_index())
+
+        pser = pd.Series([1, 2, 3], index=["cobra", "viper", "sidewinder"])
+        kser = ks.from_pandas(pser)
+        kser.loc[["viper", "sidewinder"]] = -kser_another
+        pser.loc[["viper", "sidewinder"]] = -pser_another
+        self.assert_eq(kser.sort_index(), pser.sort_index())
+
+        pser = pd.Series([1, 2, 3], index=["cobra", "viper", "sidewinder"])
+        kser = ks.from_pandas(pser)
+        kser.loc[kser_another % 2 == 1] = 10
+        pser.loc[pser_another % 2 == 1] = 10
+        self.assert_eq(kser.sort_index(), pser.sort_index())
+
+    def test_series_iloc_setitem(self):
+        pser = pd.Series([1, 2, 3], index=["cobra", "viper", "sidewinder"])
+        kser = ks.from_pandas(pser)
+
+        pser1 = pser + 1
+        kser1 = kser + 1
+
+        pser_another = pd.Series([1, 2, 3], index=["cobra", "viper", "sidewinder"])
+        kser_another = ks.from_pandas(pser_another)
+
+        kser.iloc[[1, 2]] = -kser_another
+        pser.iloc[[1, 2]] = -pser_another
+        self.assert_eq(kser.sort_index(), pser.sort_index())
+
+        kser1.iloc[[1, 2]] = -kser_another
+        pser1.iloc[[1, 2]] = -pser_another
+        self.assert_eq(kser1.sort_index(), pser1.sort_index())
 
     def test_where(self):
         pdf1 = pd.DataFrame({"A": [0, 1, 2, 3, 4], "B": [100, 200, 300, 400, 500]})
@@ -747,7 +806,7 @@ class OpsOnDiffFramesDisabledTest(ReusedSQLTestCase, SQLTestUtils):
             kdf = ks.from_pandas(self.pdf1)
             kdf["c"] = self.kdf1.a
 
-    def test_loc_setitem(self):
+    def test_frame_loc_setitem(self):
         pdf = pd.DataFrame(
             [[1, 2], [4, 5], [7, 8]],
             index=["cobra", "viper", "sidewinder"],
@@ -758,6 +817,32 @@ class OpsOnDiffFramesDisabledTest(ReusedSQLTestCase, SQLTestUtils):
 
         with self.assertRaisesRegex(ValueError, "Cannot combine the series or dataframe"):
             kdf.loc[["viper", "sidewinder"], ["shield"]] = another_kdf.max_speed
+
+    def test_series_loc_setitem(self):
+        pser = pd.Series([1, 2, 3], index=["cobra", "viper", "sidewinder"])
+        kser = ks.from_pandas(pser)
+
+        pser_another = pd.Series([1, 2, 3], index=["cobra", "viper", "sidewinder"])
+        kser_another = ks.from_pandas(pser_another)
+
+        with self.assertRaisesRegex(ValueError, "Cannot combine the series or dataframe"):
+            kser.loc[kser % 2 == 1] = -kser_another
+
+        with self.assertRaisesRegex(ValueError, "Cannot combine the series or dataframe"):
+            kser.loc[kser_another % 2 == 1] = -kser
+
+        with self.assertRaisesRegex(ValueError, "Cannot combine the series or dataframe"):
+            kser.loc[kser_another % 2 == 1] = -kser_another
+
+    def test_series_iloc_setitem(self):
+        pser = pd.Series([1, 2, 3], index=["cobra", "viper", "sidewinder"])
+        kser = ks.from_pandas(pser)
+
+        pser_another = pd.Series([1, 2, 3], index=["cobra", "viper", "sidewinder"])
+        kser_another = ks.from_pandas(pser_another)
+
+        with self.assertRaisesRegex(ValueError, "Cannot combine the series or dataframe"):
+            kser.iloc[[1]] = -kser_another
 
     def test_where(self):
         pdf1 = pd.DataFrame({"A": [0, 1, 2, 3, 4], "B": [100, 200, 300, 400, 500]})

--- a/databricks/koalas/tests/test_ops_on_diff_frames.py
+++ b/databricks/koalas/tests/test_ops_on_diff_frames.py
@@ -577,37 +577,37 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
 
         kser.loc[kser % 2 == 1] = -kser_another
         pser.loc[pser % 2 == 1] = -pser_another
-        self.assert_eq(kser.sort_index(), pser.sort_index())
+        self.assert_eq(kser, pser)
 
         pser = pd.Series([1, 2, 3], index=["cobra", "viper", "sidewinder"])
         kser = ks.from_pandas(pser)
         kser.loc[kser_another % 2 == 1] = -kser
         pser.loc[pser_another % 2 == 1] = -pser
-        self.assert_eq(kser.sort_index(), pser.sort_index())
+        self.assert_eq(kser, pser)
 
         pser = pd.Series([1, 2, 3], index=["cobra", "viper", "sidewinder"])
         kser = ks.from_pandas(pser)
         kser.loc[kser_another % 2 == 1] = -kser
         pser.loc[pser_another % 2 == 1] = -pser
-        self.assert_eq(kser.sort_index(), pser.sort_index())
+        self.assert_eq(kser, pser)
 
         pser = pd.Series([1, 2, 3], index=["cobra", "viper", "sidewinder"])
         kser = ks.from_pandas(pser)
         kser.loc[kser_another % 2 == 1] = -kser_another
         pser.loc[pser_another % 2 == 1] = -pser_another
-        self.assert_eq(kser.sort_index(), pser.sort_index())
+        self.assert_eq(kser, pser)
 
         pser = pd.Series([1, 2, 3], index=["cobra", "viper", "sidewinder"])
         kser = ks.from_pandas(pser)
         kser.loc[["viper", "sidewinder"]] = -kser_another
         pser.loc[["viper", "sidewinder"]] = -pser_another
-        self.assert_eq(kser.sort_index(), pser.sort_index())
+        self.assert_eq(kser, pser)
 
         pser = pd.Series([1, 2, 3], index=["cobra", "viper", "sidewinder"])
         kser = ks.from_pandas(pser)
         kser.loc[kser_another % 2 == 1] = 10
         pser.loc[pser_another % 2 == 1] = 10
-        self.assert_eq(kser.sort_index(), pser.sort_index())
+        self.assert_eq(kser, pser)
 
     def test_series_iloc_setitem(self):
         pser = pd.Series([1, 2, 3], index=["cobra", "viper", "sidewinder"])
@@ -621,15 +621,15 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
 
         kser.iloc[[1, 2]] = -kser_another
         pser.iloc[[1, 2]] = -pser_another
-        self.assert_eq(kser.sort_index(), pser.sort_index())
+        self.assert_eq(kser, pser)
 
         kser.iloc[[0]] = 10 * kser_another
         pser.iloc[[0]] = 10 * pser_another
-        self.assert_eq(kser.sort_index(), pser.sort_index())
+        self.assert_eq(kser, pser)
 
         kser1.iloc[[1, 2]] = -kser_another
         pser1.iloc[[1, 2]] = -pser_another
-        self.assert_eq(kser1.sort_index(), pser1.sort_index())
+        self.assert_eq(kser1, pser1)
 
         pser = pd.Series([1, 2, 3], index=["cobra", "viper", "sidewinder"])
         kser = ks.from_pandas(pser)
@@ -639,11 +639,11 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
 
         kiloc[[1, 2]] = -kser_another
         piloc[[1, 2]] = -pser_another
-        self.assert_eq(kser.sort_index(), pser.sort_index())
+        self.assert_eq(kser, pser)
 
         kiloc[[0]] = 10 * kser_another
         piloc[[0]] = 10 * pser_another
-        self.assert_eq(kser.sort_index(), pser.sort_index())
+        self.assert_eq(kser, pser)
 
     def test_where(self):
         pdf1 = pd.DataFrame({"A": [0, 1, 2, 3, 4], "B": [100, 200, 300, 400, 500]})

--- a/databricks/koalas/utils.py
+++ b/databricks/koalas/utils.py
@@ -388,6 +388,12 @@ def lazy_property(fn):
             setattr(self, attr_name, fn(self))
         return getattr(self, attr_name)
 
+    def deleter(self):
+        if hasattr(self, attr_name):
+            delattr(self, attr_name)
+
+    _lazy_property = _lazy_property.deleter(deleter)
+
     return _lazy_property
 
 


### PR DESCRIPTION
E.g.,

```py
>>> import databricks.koalas as ks
>>> ks.options.compute.ops_on_diff_frames = True
>>> kser = ks.Series([1, 2, 3], index=["cobra", "viper", "sidewinder"])
>>> kser.loc[["cobra", "viper"]] = ks.Series([4, 5], index=["cobra", "viper"])
>>> kser
cobra         4
viper         5
sidewinder    3
Name: 0, dtype: int64
```