### PR TITLE
Update the version of pandas up-to-date for CI

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -101,7 +101,7 @@ jobs:
             pyarrow-version: 0.14.1
           - python-version: 3.7
             spark-version: 2.4.5
-            pandas-version: 1.0.2
+            pandas-version: 1.0.3
             pyarrow-version: 0.14.1
     env:
       PYTHON_VERSION: ${{ matrix.python-version }}


### PR DESCRIPTION
As pandas 1.0.3 released, I think It would be better match the version of pandas in our CI.