### PR TITLE
Add apt-get update in Pyhon 3.5 + PIP build

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -50,6 +50,8 @@ jobs:
     - name: Setup Python 3.5
       run: |
         sudo add-apt-repository ppa:deadsnakes/ppa
+        # To avoid error such as "Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?"
+        sudo apt-get update
         sudo apt-get install tk-dev python3.5-tk python3.5
         sudo rm /usr/bin/python
         sudo ln -s /usr/bin/python3.5 /usr/bin/python


### PR DESCRIPTION
```
...
Get:9 http://ppa.launchpad.net/deadsnakes/ppa/ubuntu bionic/main amd64 python3.5-minimal amd64 3.5.9-1+bionic1 [1274 kB]
Get:10 http://ppa.launchpad.net/deadsnakes/ppa/ubuntu bionic/main amd64 libpython3.5-stdlib amd64 3.5.9-1+bionic1 [2106 kB]
Get:11 http://ppa.launchpad.net/deadsnakes/ppa/ubuntu bionic/main amd64 libpython3.5-tk amd64 3.5.9-1+bionic1 [60.8 kB]
Get:12 http://ppa.launchpad.net/deadsnakes/ppa/ubuntu bionic/main amd64 python3.5 amd64 3.5.9-1+bionic1 [212 kB]
Get:13 http://ppa.launchpad.net/deadsnakes/ppa/ubuntu bionic/main amd64 python3.5-tk all 3.5.9-1+bionic1 [41.6 kB]
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/b/blt/tk8.6-blt2.5_2.5.3+dfsg-4_amd64.deb  503  Service Unavailable [IP: 52.165.132.12 80]
Fetched 4236 kB in 4s (1032 kB/s)
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/x/xorgproto/x11proto-scrnsaver-dev_2018.4-4_all.deb  503  Service Unavailable [IP: 52.165.132.12 80]
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/libx/libxss/libxss-dev_1.2.2-1_amd64.deb  503  Service Unavailable [IP: 52.165.132.12 80]
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/t/tcl8.6/tcl8.6-dev_8.6.8+dfsg-3_amd64.deb  503  Service Unavailable [IP: 52.165.132.12 80]
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/universe/t/tcltk-defaults/tcl-dev_8.6.0+9_amd64.deb  503  Service Unavailable [IP: 52.165.132.12 80]
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/t/tk8.6/tk8.6-dev_8.6.8-4_amd64.deb  503  Service Unavailable [IP: 52.165.132.12 80]
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/universe/t/tcltk-defaults/tk-dev_8.6.0+9_amd64.deb  503  Service Unavailable [IP: 52.165.132.12 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```

This PR adds `apt-get update` to recover Python 3.5 + PIP build