### PR TITLE
Fix from_pandas to handle the same index name as a column name.

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -3274,7 +3274,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 idx = []
                 for l in level:
                     try:
-                        i = self._internal.index_spark_column_names.index(l)
+                        i = self._internal.index_names.index((l,))
                         idx.append(i)
                     except ValueError:
                         if multi_index:
@@ -3282,7 +3282,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                         else:
                             raise KeyError(
                                 "Level unknown must be same as name ({})".format(
-                                    self._internal.index_spark_column_names[0]
+                                    name_like_string(self._internal.index_names[0])
                                 )
                             )
             else:

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -1073,32 +1073,10 @@ class GroupBy(object):
                 # https://github.com/databricks/koalas/issues/628.
 
                 # TODO: deduplicate this logic with _InternalFrame.from_pandas
-                columns = pdf.columns
+                new_index_columns = [SPARK_INDEX_NAME_FORMAT(i) for i in range(len(index_names))]
+                new_data_columns = [name_like_string(col) for col in pdf.columns]
 
-                index = pdf.index
-
-                index_map = []
-                if isinstance(index, pd.MultiIndex):
-                    if index.names is None:
-                        index_map = [
-                            (SPARK_INDEX_NAME_FORMAT(i), None) for i in range(len(index.levels))
-                        ]
-                    else:
-                        index_map = [
-                            (SPARK_INDEX_NAME_FORMAT(i) if name is None else name, name)
-                            for i, name in enumerate(index.names)
-                        ]
-                else:
-                    index_map = [
-                        (
-                            index.name if index.name is not None else SPARK_DEFAULT_INDEX_NAME,
-                            index.name,
-                        )
-                    ]
-
-                new_index_columns = [index_column for index_column, _ in index_map]
-                new_data_columns = [str(col) for col in columns]
-
+                pdf.index.names = new_index_columns
                 reset_index = pdf.reset_index()
                 reset_index.columns = new_index_columns + new_data_columns
                 for name, col in reset_index.iteritems():

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -49,7 +49,6 @@ from databricks.koalas.internal import (
     HIDDEN_COLUMNS,
     NATURAL_ORDER_COLUMN_NAME,
     SPARK_INDEX_NAME_FORMAT,
-    SPARK_DEFAULT_INDEX_NAME,
 )
 from databricks.koalas.missing.groupby import (
     _MissingPandasLikeDataFrameGroupBy,

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -1072,7 +1072,9 @@ class GroupBy(object):
                 # https://github.com/databricks/koalas/issues/628.
 
                 # TODO: deduplicate this logic with _InternalFrame.from_pandas
-                new_index_columns = [SPARK_INDEX_NAME_FORMAT(i) for i in range(len(index_names))]
+                new_index_columns = [
+                    SPARK_INDEX_NAME_FORMAT(i) for i in range(len(pdf.index.names))
+                ]
                 new_data_columns = [name_like_string(col) for col in pdf.columns]
 
                 pdf.index.names = new_index_columns

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -1171,6 +1171,11 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             kdf.groupby("d").apply(sum).sort_index(), pdf.groupby("d").apply(sum).sort_index()
         )
 
+        with ks.option_context("compute.shortcut_limit", 1):
+            self.assert_eq(
+                kdf.groupby("d").apply(sum).sort_index(), pdf.groupby("d").apply(sum).sort_index()
+            )
+
     def test_transform(self):
         pdf = pd.DataFrame(
             {"a": [1, 2, 3, 4, 5, 6], "b": [1, 1, 2, 3, 5, 8], "c": [1, 4, 9, 16, 25, 36]},

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -1161,6 +1161,16 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         with option_context("compute.shortcut_limit", 0):
             self.test_apply_with_new_dataframe()
 
+    def test_apply_key_handling(self):
+        pdf = pd.DataFrame(
+            {"d": [1.0, 1.0, 1.0, 2.0, 2.0, 2.0], "v": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]}
+        )
+        kdf = ks.from_pandas(pdf)
+
+        self.assert_eq(
+            kdf.groupby("d").apply(sum).sort_index(), pdf.groupby("d").apply(sum).sort_index()
+        )
+
     def test_transform(self):
         pdf = pd.DataFrame(
             {"a": [1, 2, 3, 4, 5, 6], "b": [1, 1, 2, 3, 5, 8], "c": [1, 4, 9, 16, 25, 36]},

--- a/databricks/koalas/tests/test_internal.py
+++ b/databricks/koalas/tests/test_internal.py
@@ -17,7 +17,11 @@ from collections import OrderedDict
 
 import pandas as pd
 
-from databricks.koalas.internal import _InternalFrame, SPARK_DEFAULT_INDEX_NAME
+from databricks.koalas.internal import (
+    _InternalFrame,
+    SPARK_DEFAULT_INDEX_NAME,
+    SPARK_INDEX_NAME_FORMAT,
+)
 from databricks.koalas.testing.utils import ReusedSQLTestCase, SQLTestUtils
 
 
@@ -43,7 +47,8 @@ class InternalFrameTest(ReusedSQLTestCase, SQLTestUtils):
         sdf = internal.spark_frame
 
         self.assert_eq(
-            internal.index_map, OrderedDict([(SPARK_DEFAULT_INDEX_NAME, None), ("a", ("a",))])
+            internal.index_map,
+            OrderedDict([(SPARK_INDEX_NAME_FORMAT(0), None), (SPARK_INDEX_NAME_FORMAT(1), ("a",))]),
         )
         self.assert_eq(internal.column_labels, [("b",)])
         self.assert_eq(internal.data_spark_column_names, ["b"])
@@ -58,7 +63,8 @@ class InternalFrameTest(ReusedSQLTestCase, SQLTestUtils):
         sdf = internal.spark_frame
 
         self.assert_eq(
-            internal.index_map, OrderedDict([(SPARK_DEFAULT_INDEX_NAME, None), ("a", ("a",))])
+            internal.index_map,
+            OrderedDict([(SPARK_INDEX_NAME_FORMAT(0), None), (SPARK_INDEX_NAME_FORMAT(1), ("a",))]),
         )
         self.assert_eq(internal.column_labels, [("x", "b")])
         self.assert_eq(internal.data_spark_column_names, ["(x, b)"])


### PR DESCRIPTION
When the input pandas DataFrame has the same index name as a column name, `ks.from_pandas()` fails with the following error:

```py
>>> pdf = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
>>> pdf.index.name = "a"
>>> pdf
   a  b
a
0  1  4
1  2  5
2  3  6

>>> kdf = ks.from_pandas(pdf)
Traceback (most recent call last):
...
ValueError: cannot insert a, already exists
```

Resolves #1361, Closes #1375.