### PR TITLE
Add documentation about non-Koalas APIs

### DIFF
--- a/docs/source/user_guide/best_practices.rst
+++ b/docs/source/user_guide/best_practices.rst
@@ -214,16 +214,16 @@ Therefore, it works seamlessly in pandas as below:
 
    >>> import pandas as pd
    >>> data = []
-   >>> pser = pd.Series([20, 21, 12],
-   ...                  index=['London', 'New York', 'Helsinki'])
+   >>> countries = ['London', 'New York', 'Helsinki']
+   >>> pser = pd.Series([20., 21., 12.], index=countries)
    >>> for temperature in pser:
    ...     data.append(temperature ** 2)
    ...
-   >>> pd.Series(data)
-   0    400
-   1    441
-   2    144
-   dtype: int64
+   >>> pd.Series(data, index=countries)
+   London      400.0
+   New York    441.0
+   Helsinki    144.0
+   dtype: float64
 
 However, for Koalas it does not work as the same reason above.
 The example above can be also changed to directly using Koalas APIs as below:
@@ -231,11 +231,15 @@ The example above can be also changed to directly using Koalas APIs as below:
 .. code-block:: python
 
    >>> import databricks.koalas as ks
-   >>> kser = ks.Series([20, 21, 12],
-   ...                  index=['London', 'New York', 'Helsinki'])
-   >>> kser.apply(lambda x: x ** 2)
-   0    400
-   1    441
-   2    144
-   dtype: int64
+   >>> import numpy as np
+   >>> countries = ['London', 'New York', 'Helsinki']
+   >>> kser = ks.Series([20., 21., 12.], index=countries)
+   >>> def square(x) -> np.float64:
+   ...     return x ** 2
+   ...
+   >>> kser.apply(square)
+   London      400.0
+   New York    441.0
+   Helsinki    144.0
+   Name: 0, dtype: float64
 

--- a/docs/source/user_guide/best_practices.rst
+++ b/docs/source/user_guide/best_practices.rst
@@ -217,6 +217,9 @@ Therefore, it works seamlessly in pandas as below:
    >>> countries = ['London', 'New York', 'Helsinki']
    >>> pser = pd.Series([20., 21., 12.], index=countries)
    >>> for temperature in pser:
+   ...     assert temperature > 0
+   ...     if temperature > 1000:
+   ...             temperature = None
    ...     data.append(temperature ** 2)
    ...
    >>> pd.Series(data, index=countries)

--- a/docs/source/user_guide/best_practices.rst
+++ b/docs/source/user_guide/best_practices.rst
@@ -170,3 +170,69 @@ this operation should be avoided.
 
 See `Operations on different DataFrames <options.rst#operations-on-different-dataframes>`_ for more details.
 
+
+Use Koalas APIs directly whenever possible
+---------------------------------------------------
+
+While Koalas has similar APIs with pandas, some APIs are not explicitly supported. 
+For example, Python built-in functions such as ``min``, ``max``, ``sum``, etc.
+require the given argument to be iterable. 
+Koalas does not implement ``__iter__()`` yet to prevent users to collect
+all data into the client (driver) side from the cluster. 
+See the example below:
+
+.. code-block:: python
+
+   >>> import pandas as pd
+   >>> max(pd.Series([1, 2, 3]))
+   3
+   >>> min(pd.Series([1, 2, 3]))
+   1
+   >>> sum(pd.Series([1, 2, 3]))
+   6
+
+Pandas dataset live in the local and is iterable because the entire dataset is designed
+to be acceptable on a single client machine.
+Koalas performes operation in a distributed manner.
+So with Koalas built-in functions, you can do the same operation on multiple machines.
+
+.. code-block:: python
+
+   >>> import databricks.koalas as ks
+   >>> ks.Series([1, 2, 3]).max()
+   3
+   >>> ks.Series([1, 2, 3]).min()
+   1
+   >>> ks.Series([1, 2, 3]).sum()
+   6
+
+Another common pattern from pandas users is to rely on list or generator comprehensions.
+In Python, any value that can follow the ``in`` keyword in a ``for`` statement is iterable.
+For instance, see below:
+
+.. code-block:: python
+
+   >>> import pandas as pd
+   >>> data = []
+   >>> pser = pd.Series([1, 2, 3])
+   >>> for v in pser:
+   ...     data.append(v + 1)
+   ...
+   >>> pd.Series(data)
+   0    2
+   1    3
+   2    4
+   dtype: int64
+
+In Koalas, you can do it via:
+
+.. code-block:: python
+
+   >>> import databricks.koalas as ks
+   >>> kser = ks.Series([1, 2, 3])
+   >>> kser.apply(lambda x: x + 1)
+   0    2
+   1    3
+   2    4
+   Name: 0, dtype: int64
+

--- a/docs/source/user_guide/best_practices.rst
+++ b/docs/source/user_guide/best_practices.rst
@@ -174,9 +174,9 @@ See `Operations on different DataFrames <options.rst#operations-on-different-dat
 Use Koalas APIs directly whenever possible
 ------------------------------------------
 
-Although Koalas has most of the pandas-equivalent APIs with pandas, there are several APIs not implemented yet or explicitly unsupported.
+Although Koalas has most of the pandas-equivalent APIs, there are several APIs not implemented yet or explicitly unsupported.
 
-As an example, Koalas does not implement ``__iter__()`` to prevent users to collect all data into the client (driver) side from the whole cluster.
+As an example, Koalas does not implement ``__iter__()`` to prevent users from collecting all data into the client (driver) side from the whole cluster.
 Unfortunately, many external APIs such as Python built-in functions such as min, max, sum, etc. require the given argument to be iterable.
 In case of pandas, it works properly out of the box as below:
 
@@ -219,7 +219,7 @@ Therefore, it works seamlessly in pandas as below:
    >>> for temperature in pser:
    ...     assert temperature > 0
    ...     if temperature > 1000:
-   ...             temperature = None
+   ...         temperature = None
    ...     data.append(temperature ** 2)
    ...
    >>> pd.Series(data, index=countries)
@@ -237,8 +237,11 @@ The example above can be also changed to directly using Koalas APIs as below:
    >>> import numpy as np
    >>> countries = ['London', 'New York', 'Helsinki']
    >>> kser = ks.Series([20., 21., 12.], index=countries)
-   >>> def square(x) -> np.float64:
-   ...     return x ** 2
+   >>> def square(temperature) -> np.float64:
+   ...     assert temperature > 0
+   ...     if temperature > 1000:
+   ...         temperature = None
+   ...     return temperature ** 2
    ...
    >>> kser.apply(square)
    London      400.0


### PR DESCRIPTION
Resolves https://github.com/databricks/koalas/issues/1414
I have added a preemptive guide to non-Koalas APIs to `best practeces`.
Please check.