### PR TITLE
Hot-fixing the lack of keyword argument 'deep' for DataFrame.copy()

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -4706,6 +4706,11 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         """
         Make a copy of this object's indices and data.
 
+        Parameters
+        ----------
+        deep : None
+            this parameter is not supported but just dummy parameter to match pandas.
+
         Returns
         -------
         copy : DataFrame

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -4702,7 +4702,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             kdf._to_internal_pandas(), self.to_records, pd.DataFrame.to_records, args
         )
 
-    def copy(self, *args, **kwargs) -> "DataFrame":
+    def copy(self, deep=None) -> "DataFrame":
         """
         Make a copy of this object's indices and data.
 

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -4702,7 +4702,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             kdf._to_internal_pandas(), self.to_records, pd.DataFrame.to_records, args
         )
 
-    def copy(self) -> "DataFrame":
+    def copy(self, *args, **kwargs) -> "DataFrame":
         """
         Make a copy of this object's indices and data.
 

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -2245,9 +2245,35 @@ class MultiIndex(Index):
         raise NotImplementedError("isna is not defined for MultiIndex")
 
     # TODO: add 'name' parameter after pd.MultiIndex.name is implemented
-    def copy(self):
+    def copy(self, deep=None):
         """
         Make a copy of this object.
+
+        Parameters
+        ----------
+        deep : None
+            this parameter is not supported but just dummy parameter to match pandas.
+
+        Examples
+        --------
+        >>> df = ks.DataFrame([(.2, .3), (.0, .6), (.6, .0), (.2, .1)],
+        ...                   columns=['dogs', 'cats'],
+        ...                   index=[list('abcd'), list('efgh')])
+        >>> df['dogs'].index  # doctest: +SKIP
+        MultiIndex([('a', 'e'),
+                    ('b', 'f'),
+                    ('c', 'g'),
+                    ('d', 'h')],
+                   )
+
+        Copy index
+
+        >>> df.index.copy()  # doctest: +SKIP
+        MultiIndex([('a', 'e'),
+                    ('b', 'f'),
+                    ('c', 'g'),
+                    ('d', 'h')],
+                   )
         """
         return MultiIndex(self._kdf.copy())
 

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -961,7 +961,7 @@ class Index(IndexOpsMixin):
                 "Requested level ({}) does not match index name ({})".format(level, self.name)
             )
 
-    def copy(self, name=None):
+    def copy(self, name=None, deep=None):
         """
         Make a copy of this object. name sets those attributes on the new object.
 
@@ -969,6 +969,8 @@ class Index(IndexOpsMixin):
         ----------
         name : string, optional
             to set name of index
+        deep : None
+            this parameter is not supported but just dummy parameter to match pandas.
 
         Examples
         --------

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -3525,9 +3525,14 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
 
         return _col(DataFrame(internal))
 
-    def copy(self) -> "Series":
+    def copy(self, deep=None) -> "Series":
         """
         Make a copy of this object's indices and data.
+
+        Parameters
+        ----------
+        deep : None
+            this parameter is not supported but just dummy parameter to match pandas.
 
         Returns
         -------


### PR DESCRIPTION
Resolves #1422 

Adding a dummy keyword argument `deep` which is doing nothing for `DataFrame.copy()`, since we doesn't support keyword `deep` for the `DataFrame.copy()`.