### PR TITLE
Add unique function to SeriesGroupBy.

### DIFF
--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -2161,16 +2161,15 @@ class SeriesGroupBy(GroupBy):
 
         See Also
         --------
-        Series.nsmallest
-        DataFrame.nsmallest
         databricks.koalas.Series.nsmallest
+        databricks.koalas.DataFrame.nsmallest
 
         Examples
         --------
         >>> df = ks.DataFrame({'a': [1, 1, 1, 2, 2, 2, 3, 3, 3],
         ...                    'b': [1, 2, 2, 2, 3, 3, 3, 4, 4]}, columns=['a', 'b'])
 
-        >>> df.groupby(['a'])['b'].nsmallest(1).sort_index() # doctest: +NORMALIZE_WHITESPACE
+        >>> df.groupby(['a'])['b'].nsmallest(1).sort_index()  # doctest: +NORMALIZE_WHITESPACE
         a
         1  0    1
         2  3    2
@@ -2213,16 +2212,15 @@ class SeriesGroupBy(GroupBy):
 
         See Also
         --------
-        Series.nlargest
-        DataFrame.nlargest
         databricks.koalas.Series.nlargest
+        databricks.koalas.DataFrame.nlargest
 
         Examples
         --------
         >>> df = ks.DataFrame({'a': [1, 1, 1, 2, 2, 2, 3, 3, 3],
         ...                    'b': [1, 2, 2, 2, 3, 3, 3, 4, 4]}, columns=['a', 'b'])
 
-        >>> df.groupby(['a'])['b'].nlargest(1).sort_index() # doctest: +NORMALIZE_WHITESPACE
+        >>> df.groupby(['a'])['b'].nlargest(1).sort_index()  # doctest: +NORMALIZE_WHITESPACE
         a
         1  1    2
         2  4    3
@@ -2315,6 +2313,31 @@ class SeriesGroupBy(GroupBy):
             data_spark_columns=[scol_for(sdf, agg_column)],
         )
         return _col(DataFrame(internal))
+
+    def unique(self):
+        """
+        Return unique values in group.
+
+        Uniques are returned in order of unknown. It does NOT sort.
+
+        See Also
+        --------
+        databricks.koalas.Series.unique
+        databricks.koalas.Index.unique
+
+        Examples
+        --------
+        >>> df = ks.DataFrame({'a': [1, 1, 1, 2, 2, 2, 3, 3, 3],
+        ...                    'b': [1, 2, 2, 2, 3, 3, 3, 4, 4]}, columns=['a', 'b'])
+
+        >>> df.groupby(['a'])['b'].unique().sort_index()  # doctest: +SKIP
+        a
+        1    [1, 2]
+        2    [2, 3]
+        3    [3, 4]
+        Name: b, dtype: object
+        """
+        return self._reduce_for_stat_function(F.collect_set, only_numeric=False)
 
 
 def _is_multi_agg_with_relabel(**kwargs):

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -882,10 +882,21 @@ class Index(IndexOpsMixin):
     def unique(self, level=None):
         """
         Return unique values in the index.
+
         Be aware the order of unique values might be different than pandas.Index.unique
 
-        :param level: int or str, optional, default is None
-        :return: Index without deuplicates
+        Parameters
+        ----------
+        level : int or str, optional, default is None
+
+        Returns
+        -------
+        Index without deuplicates
+
+        See Also
+        --------
+        Series.unique
+        groupby.SeriesGroupBy.unique
 
         Examples
         --------

--- a/databricks/koalas/missing/groupby.py
+++ b/databricks/koalas/missing/groupby.py
@@ -88,7 +88,6 @@ class _MissingPandasLikeSeriesGroupBy(object):
     quantile = unsupported_property("quantile")
     skew = unsupported_property("skew")
     tshift = unsupported_property("tshift")
-    unique = unsupported_property("unique")
 
     # Deprecated properties
     take = unsupported_property("take", deprecated=True)

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -1887,7 +1887,10 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         -------
         Returns the unique values as a Series.
 
-        See Examples section.
+        See Also
+        --------
+        Index.unique
+        groupby.SeriesGroupBy.unique
 
         Examples
         --------

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -552,6 +552,27 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             pdf.groupby(("x", "a")).nunique(dropna=False).sort_index(),
         )
 
+    def test_unique(self):
+        for pdf in [
+            pd.DataFrame(
+                {"a": [1, 1, 1, 1, 1, 0, 0, 0, 0, 0], "b": [2, 2, 2, 3, 3, 4, 4, 5, 5, 5]}
+            ),
+            pd.DataFrame(
+                {
+                    "a": [1, 1, 1, 1, 1, 0, 0, 0, 0, 0],
+                    "b": ["w", "w", "w", "x", "x", "y", "y", "z", "z", "z"],
+                }
+            ),
+        ]:
+            with self.subTest(pdf=pdf):
+                kdf = ks.from_pandas(pdf)
+
+                actual = kdf.groupby("a")["b"].unique().sort_index().to_pandas()
+                expect = pdf.groupby("a")["b"].unique().sort_index()
+                self.assert_eq(len(actual), len(expect))
+                for act, exp in zip(actual, expect):
+                    self.assertTrue(sorted(act) == sorted(exp))
+
     def test_value_counts(self):
         pdf = pd.DataFrame({"A": [1, 2, 2, 3, 3, 3], "B": [1, 1, 2, 3, 3, 3]}, columns=["A", "B"])
         kdf = ks.from_pandas(pdf)

--- a/docs/source/reference/groupby.rst
+++ b/docs/source/reference/groupby.rst
@@ -66,6 +66,7 @@ The following methods are available only for `SeriesGroupBy` objects.
    SeriesGroupBy.nsmallest
    SeriesGroupBy.nlargest
    SeriesGroupBy.value_counts
+   SeriesGroupBy.unique
 
 The following methods are available only for `DataFrameGroupBy` objects.
 


### PR DESCRIPTION
Adding `unique` function to `SeriesGroupBy`.

E.g.,

```py
>>> df = ks.DataFrame({'a': [1, 1, 1, 2, 2, 2, 3, 3, 3],
...                    'b': [1, 2, 2, 2, 3, 3, 3, 4, 4]}, columns=['a', 'b'])
>>> df.groupby(['a'])['b'].unique().sort_index()  # doctest: +SKIP
a
1    [1, 2]
2    [2, 3]
3    [3, 4]
Name: b, dtype: object
```

Resolves #875.