### PR TITLE
Fix incompatible behaviour with pandas for floordiv with np.nan

### DIFF
--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -220,7 +220,7 @@ class IndexOpsMixin(object):
     def __floordiv__(self, other):
         def floordiv(left, right):
             return F.when(F.lit(right == 0), F.lit(np.inf).__div__(left)).otherwise(
-                F.floor(left.__div__(right))
+                F.when(F.lit(right) == "NaN", np.nan).otherwise(F.floor(left.__div__(right)))
             )
 
         return _numpy_column_op(floordiv)(self, other)
@@ -228,7 +228,7 @@ class IndexOpsMixin(object):
     def __rfloordiv__(self, other):
         def rfloordiv(left, right):
             return F.when(F.lit(left == 0), F.lit(np.inf).__div__(right)).otherwise(
-                F.floor(F.lit(right).__div__(left))
+                F.when(F.lit(left) == "NaN", np.nan).otherwise(F.floor(F.lit(right).__div__(left)))
             )
 
         return _numpy_column_op(rfloordiv)(self, other)

--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -220,7 +220,7 @@ class IndexOpsMixin(object):
     def __floordiv__(self, other):
         def floordiv(left, right):
             return F.when(F.lit(right == 0), F.lit(np.inf).__div__(left)).otherwise(
-                F.when(F.lit(right) == "NaN", np.nan).otherwise(F.floor(left.__div__(right)))
+                F.when(F.lit(right) == np.nan, np.nan).otherwise(F.floor(left.__div__(right)))
             )
 
         return _numpy_column_op(floordiv)(self, other)
@@ -228,7 +228,7 @@ class IndexOpsMixin(object):
     def __rfloordiv__(self, other):
         def rfloordiv(left, right):
             return F.when(F.lit(left == 0), F.lit(np.inf).__div__(right)).otherwise(
-                F.when(F.lit(left) == "NaN", np.nan).otherwise(F.floor(F.lit(right).__div__(left)))
+                F.when(F.lit(left) == np.nan, np.nan).otherwise(F.floor(F.lit(right).__div__(left)))
             )
 
         return _numpy_column_op(rfloordiv)(self, other)

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -1463,3 +1463,9 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
             result = pd.Series([np.inf, np.nan, -np.inf, np.nan, np.inf, -np.inf], name="Koalas")
             self.assert_eq(repr(kser.floordiv(0)), repr(result))
             self.assert_eq(repr(kser // 0), repr(result))
+
+    def test_floordiv_nan(self):
+        pser = pd.Series([-100, 0, 100, None, np.nan], name="Koalas")
+        kser = ks.from_pandas(pser)
+
+        self.assert_eq(repr(pser.floordiv(np.nan)), repr(kser.floordiv(np.nan)))


### PR DESCRIPTION
Resolves #1428 

```python
>>> pser = pd.Series([-100, 0, 100, None, np.nan], name="Koalas")
>>> kser = ks.from_pandas(pser)

>>> pser // np.nan
0   NaN
1   NaN
2   NaN
3   NaN
4   NaN
Name: Koalas, dtype: float64

>>> kser // np.nan                                                                                                                
0   NaN
1   NaN
2   NaN
3   NaN
4   NaN
Name: Koalas, dtype: float64
```