### PR TITLE
Support expand parameter if n is a positive integer in Series.str.split/rsplit.

### DIFF
--- a/databricks/koalas/tests/test_series_string.py
+++ b/databricks/koalas/tests/test_series_string.py
@@ -45,9 +45,14 @@ class SeriesStringTest(ReusedSQLTestCase, SQLTestUtils):
     def check_func(self, func):
         self.check_func_on_series(func, self.pser)
 
-    def check_func_on_series(self, func, pser):
+    def check_func_on_series(self, func, pser, result_is_dataframe=False):
         kser = ks.from_pandas(pser)
-        mt.assert_series_equal(func(kser).toPandas(), func(pser), check_names=False)
+        if result_is_dataframe:
+            mt.assert_frame_equal(
+                func(kser).to_pandas(), func(pser).rename(columns=str), check_names=False
+            )
+        else:
+            mt.assert_series_equal(func(kser).to_pandas(), func(pser), check_names=False)
 
     def test_string_add_str_num(self):
         pdf = pd.DataFrame(dict(col1=["a"], col2=[1]))
@@ -291,6 +296,9 @@ class SeriesStringTest(ReusedSQLTestCase, SQLTestUtils):
         pser = pd.Series(["This is a sentence.", "This-is-a-long-word."])
         self.check_func_on_series(lambda x: x.str.split(n=2), pser)
         self.check_func_on_series(lambda x: x.str.split(pat="-", n=2), pser)
+        self.check_func_on_series(
+            lambda x: x.str.split(n=2, expand=True), pser, result_is_dataframe=True,
+        )
         with self.assertRaises(NotImplementedError):
             self.check_func(lambda x: x.str.split(expand=True))
 
@@ -300,6 +308,9 @@ class SeriesStringTest(ReusedSQLTestCase, SQLTestUtils):
         pser = pd.Series(["This is a sentence.", "This-is-a-long-word."])
         self.check_func_on_series(lambda x: x.str.rsplit(n=2), pser)
         self.check_func_on_series(lambda x: x.str.rsplit(pat="-", n=2), pser)
+        self.check_func_on_series(
+            lambda x: x.str.rsplit(n=2, expand=True), pser, result_is_dataframe=True
+        )
         with self.assertRaises(NotImplementedError):
             self.check_func(lambda x: x.str.rsplit(expand=True))
 


### PR DESCRIPTION
Adding `expand` parameter support if `n` is a positive integer in `Series.str.split`/`rsplit` with a couple of restrictions that:

- `n` parameter must be a positive integer
- the number of columns will always be `n + 1`.

E.g.,

```py
>>> kser = ks.Series(['A_1', 'A_2', 'A_3', 'A_4', 'A_5'])
>>> kser
0    A_1
1    A_2
2    A_3
3    A_4
4    A_5
Name: 0, dtype: object
>>> kser.str.split('_', n=1, expand=True)
   0  1
0  A  1
1  A  2
2  A  3
3  A  4
4  A  5
>>> kser.str.split('_', n=2, expand=True)
   0  1     2
0  A  1  None
1  A  2  None
2  A  3  None
3  A  4  None
4  A  5  None
```

The last example is different from pandas'.

```py
>>> kser.to_pandas().str.split('_', n=2, expand=True)
   0  1
0  A  1
1  A  2
2  A  3
3  A  4
4  A  5
```

Resolves #1421.