### PR TITLE
Add (DataFrame|Series).transform_batch and DataFrame.apply_batch

### DIFF
--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -35,7 +35,7 @@ from databricks.koalas.internal import (
     NATURAL_ORDER_COLUMN_NAME,
     SPARK_DEFAULT_INDEX_NAME,
 )
-from databricks.koalas.typedef import pandas_wraps, spark_type_to_pandas_dtype
+from databricks.koalas.typedef import spark_type_to_pandas_dtype
 from databricks.koalas.utils import align_diff_series, scol_for, validate_axis
 from databricks.koalas.frame import DataFrame
 
@@ -114,23 +114,6 @@ def _numpy_column_op(f):
         return _column_op(f)(self, *new_args)
 
     return wrapper
-
-
-def _wrap_accessor_spark(accessor, fn, return_type=None):
-    """
-    Wrap an accessor property or method, e.g., Series.dt.date with a spark function.
-    """
-    if return_type:
-        return _column_op(lambda col: fn(col).cast(return_type))(accessor._data)
-    else:
-        return _column_op(fn)(accessor._data)
-
-
-def _wrap_accessor_pandas(accessor, fn, return_type):
-    """
-    Wrap an accessor property or method, e.g, Series.dt.date with a pandas function.
-    """
-    return pandas_wraps(fn, return_col=return_type)(accessor._data)
 
 
 class IndexOpsMixin(object):

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -2495,7 +2495,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                     functionType=PandasUDFType.SCALAR,
                 )
                 kser = self._kser_for(input_label)
-                applied.append(kser._with_new_scol(scol=pudf(kser._scol)).rename(input_label))
+                applied.append(
+                    kser._with_new_scol(scol=pudf(kser.spark_column)).rename(input_label)
+                )
 
             internal = self._internal.with_new_columns(applied)
             return DataFrame(internal)

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -1103,7 +1103,7 @@ class GroupBy(object):
                 pdf = reset_index
 
             # Just positionally map the column names to given schema's.
-            pdf = pdf.rename(columns=OrderedDict(zip(pdf.columns, return_schema.fieldNames())))
+            pdf = pdf.rename(columns=dict(zip(pdf.columns, return_schema.fieldNames())))
 
             return pdf
 

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -1103,7 +1103,7 @@ class GroupBy(object):
                 pdf = reset_index
 
             # Just positionally map the column names to given schema's.
-            pdf = pdf.rename(columns=dict(zip(pdf.columns, return_schema.fieldNames())))
+            pdf = pdf.rename(columns=OrderedDict(zip(pdf.columns, return_schema.fieldNames())))
 
             return pdf
 

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -121,9 +121,10 @@ class Index(IndexOpsMixin):
         :param scol: the new Spark Column
         :return: the copied Index
         """
-        sdf = self._internal.spark_frame.select(scol)
+        sdf = self._internal.spark_frame.select(scol)  # type: ignore
         internal = _InternalFrame(
-            spark_frame=sdf, index_map=OrderedDict(zip(sdf.columns, self._internal.index_names))
+            spark_frame=sdf,
+            index_map=OrderedDict(zip(sdf.columns, self._internal.index_names)),  # type: ignore
         )
         return DataFrame(internal).index
 
@@ -355,7 +356,7 @@ class Index(IndexOpsMixin):
         >>> df['dogs'].index.to_pandas()
         Index(['a', 'b', 'c', 'd'], dtype='object')
         """
-        return self._internal.to_pandas_frame.index
+        return self._internal.to_pandas_frame.index  # type: ignore
 
     toPandas = to_pandas
 
@@ -459,7 +460,7 @@ class Index(IndexOpsMixin):
         """Return names of the Index."""
         return [
             name if name is None or len(name) > 1 else name[0]
-            for name in self._internal.index_names
+            for name in self._internal.index_names  # type: ignore
         ]
 
     @names.setter

--- a/databricks/koalas/strings.py
+++ b/databricks/koalas/strings.py
@@ -21,9 +21,11 @@ from typing import Union, TYPE_CHECKING
 
 import numpy as np
 
-from pyspark.sql.types import StringType, BinaryType, BooleanType, IntegerType, ArrayType, LongType
+from pyspark.sql.types import StringType, BinaryType, ArrayType, LongType, MapType
+from pyspark.sql import functions as F
+from pyspark.sql.functions import pandas_udf, PandasUDFType
 
-from databricks.koalas.base import _wrap_accessor_pandas
+from databricks.koalas.base import _column_op
 
 if TYPE_CHECKING:
     import databricks.koalas as ks
@@ -60,9 +62,11 @@ class StringMethods(object):
         3              Swapcase
         Name: 0, dtype: object
         """
-        return _wrap_accessor_pandas(self, lambda x: x.str.capitalize(), StringType()).alias(
-            self.name
-        )
+
+        def pandas_capitalize(s) -> "ks.Series[str]":
+            return s.str.capitalize()
+
+        return self._data.transform_batch(pandas_capitalize)
 
     def title(self) -> "ks.Series":
         """
@@ -85,7 +89,11 @@ class StringMethods(object):
         3              Swapcase
         Name: 0, dtype: object
         """
-        return _wrap_accessor_pandas(self, lambda x: x.str.title(), StringType()).alias(self.name)
+
+        def pandas_title(s) -> "ks.Series[str]":
+            return s.str.title()
+
+        return self._data.transform_batch(pandas_title)
 
     def lower(self) -> "ks.Series":
         """
@@ -108,7 +116,7 @@ class StringMethods(object):
         3              swapcase
         Name: 0, dtype: object
         """
-        return _wrap_accessor_pandas(self, lambda x: x.str.lower(), StringType()).alias(self.name)
+        return _column_op(lambda c: F.lower(c))(self._data).alias(self._data.name)
 
     def upper(self) -> "ks.Series":
         """
@@ -131,7 +139,7 @@ class StringMethods(object):
         3              SWAPCASE
         Name: 0, dtype: object
         """
-        return _wrap_accessor_pandas(self, lambda x: x.str.upper(), StringType()).alias(self.name)
+        return _column_op(lambda c: F.upper(c))(self._data).alias(self._data.name)
 
     def swapcase(self) -> "ks.Series":
         """
@@ -154,9 +162,11 @@ class StringMethods(object):
         3              sWaPcAsE
         Name: 0, dtype: object
         """
-        return _wrap_accessor_pandas(self, lambda x: x.str.swapcase(), StringType()).alias(
-            self.name
-        )
+
+        def pandas_swapcase(s) -> "ks.Series[str]":
+            return s.str.swapcase()
+
+        return self._data.transform_batch(pandas_swapcase)
 
     def startswith(self, pattern, na=None) -> "ks.Series":
         """
@@ -203,9 +213,11 @@ class StringMethods(object):
         3    False
         Name: 0, dtype: bool
         """
-        return _wrap_accessor_pandas(
-            self, lambda x: x.str.startswith(pattern, na), BooleanType()
-        ).alias(self.name)
+
+        def pandas_startswith(s) -> "ks.Series[bool]":
+            return s.str.startswith(pattern, na)
+
+        return self._data.transform_batch(pandas_startswith)
 
     def endswith(self, pattern, na=None) -> "ks.Series":
         """
@@ -252,9 +264,11 @@ class StringMethods(object):
         3    False
         Name: 0, dtype: bool
         """
-        return _wrap_accessor_pandas(
-            self, lambda x: x.str.endswith(pattern, na), BooleanType()
-        ).alias(self.name)
+
+        def pandas_endswith(s) -> "ks.Series[bool]":
+            return s.str.endswith(pattern, na)
+
+        return self._data.transform_batch(pandas_endswith)
 
     def strip(self, to_strip=None) -> "ks.Series":
         """
@@ -302,9 +316,11 @@ class StringMethods(object):
         2      None
         Name: 0, dtype: object
         """
-        return _wrap_accessor_pandas(self, lambda x: x.str.strip(to_strip), StringType()).alias(
-            self.name
-        )
+
+        def pandas_strip(s) -> "ks.Series[str]":
+            return s.str.strip(to_strip)
+
+        return self._data.transform_batch(pandas_strip)
 
     def lstrip(self, to_strip=None) -> "ks.Series":
         """
@@ -340,9 +356,11 @@ class StringMethods(object):
         2       None
         Name: 0, dtype: object
         """
-        return _wrap_accessor_pandas(self, lambda x: x.str.lstrip(to_strip), StringType()).alias(
-            self.name
-        )
+
+        def pandas_lstrip(s) -> "ks.Series[str]":
+            return s.str.lstrip(to_strip)
+
+        return self._data.transform_batch(pandas_lstrip)
 
     def rstrip(self, to_strip=None) -> "ks.Series":
         """
@@ -378,9 +396,11 @@ class StringMethods(object):
         2      None
         Name: 0, dtype: object
         """
-        return _wrap_accessor_pandas(self, lambda x: x.str.rstrip(to_strip), StringType()).alias(
-            self.name
-        )
+
+        def pandas_rstrip(s) -> "ks.Series[str]":
+            return s.str.rstrip(to_strip)
+
+        return self._data.transform_batch(pandas_rstrip)
 
     def get(self, i) -> "ks.Series":
         """
@@ -430,7 +450,11 @@ class StringMethods(object):
         1    None
         Name: 0, dtype: object
         """
-        return _wrap_accessor_pandas(self, lambda x: x.str.get(i), StringType()).alias(self.name)
+
+        def pandas_get(s) -> "ks.Series[str]":
+            return s.str.get(i)
+
+        return self._data.transform_batch(pandas_get)
 
     def isalnum(self) -> "ks.Series":
         """
@@ -462,9 +486,11 @@ class StringMethods(object):
         2    False
         Name: 0, dtype: bool
         """
-        return _wrap_accessor_pandas(self, lambda x: x.str.isalnum(), BooleanType()).alias(
-            self.name
-        )
+
+        def pandas_isalnum(s) -> "ks.Series[bool]":
+            return s.str.isalnum()
+
+        return self._data.transform_batch(pandas_isalnum)
 
     def isalpha(self) -> "ks.Series":
         """
@@ -485,9 +511,11 @@ class StringMethods(object):
         3    False
         Name: 0, dtype: bool
         """
-        return _wrap_accessor_pandas(self, lambda x: x.str.isalpha(), BooleanType()).alias(
-            self.name
-        )
+
+        def pandas_isalpha(s) -> "ks.Series[bool]":
+            return s.str.isalpha()
+
+        return self._data.transform_batch(pandas_isalpha)
 
     def isdigit(self) -> "ks.Series":
         """
@@ -533,9 +561,11 @@ class StringMethods(object):
         3    False
         Name: 0, dtype: bool
         """
-        return _wrap_accessor_pandas(self, lambda x: x.str.isdigit(), BooleanType()).alias(
-            self.name
-        )
+
+        def pandas_isdigit(s) -> "ks.Series[bool]":
+            return s.str.isdigit()
+
+        return self._data.transform_batch(pandas_isdigit)
 
     def isspace(self) -> "ks.Series":
         """
@@ -554,9 +584,11 @@ class StringMethods(object):
         2    False
         Name: 0, dtype: bool
         """
-        return _wrap_accessor_pandas(self, lambda x: x.str.isspace(), BooleanType()).alias(
-            self.name
-        )
+
+        def pandas_isspace(s) -> "ks.Series[bool]":
+            return s.str.isspace()
+
+        return self._data.transform_batch(pandas_isspace)
 
     def islower(self) -> "ks.Series":
         """
@@ -576,9 +608,11 @@ class StringMethods(object):
         3    False
         Name: 0, dtype: bool
         """
-        return _wrap_accessor_pandas(self, lambda x: x.str.islower(), BooleanType()).alias(
-            self.name
-        )
+
+        def pandas_isspace(s) -> "ks.Series[bool]":
+            return s.str.islower()
+
+        return self._data.transform_batch(pandas_isspace)
 
     def isupper(self) -> "ks.Series":
         """
@@ -598,9 +632,11 @@ class StringMethods(object):
         3    False
         Name: 0, dtype: bool
         """
-        return _wrap_accessor_pandas(self, lambda x: x.str.isupper(), BooleanType()).alias(
-            self.name
-        )
+
+        def pandas_isspace(s) -> "ks.Series[bool]":
+            return s.str.isupper()
+
+        return self._data.transform_batch(pandas_isspace)
 
     def istitle(self) -> "ks.Series":
         """
@@ -626,9 +662,11 @@ class StringMethods(object):
         3    False
         Name: 0, dtype: bool
         """
-        return _wrap_accessor_pandas(self, lambda x: x.str.istitle(), BooleanType()).alias(
-            self.name
-        )
+
+        def pandas_istitle(s) -> "ks.Series[bool]":
+            return s.str.istitle()
+
+        return self._data.transform_batch(pandas_istitle)
 
     def isnumeric(self) -> "ks.Series":
         """
@@ -682,9 +720,11 @@ class StringMethods(object):
         3    False
         Name: 0, dtype: bool
         """
-        return _wrap_accessor_pandas(self, lambda x: x.str.isnumeric(), BooleanType()).alias(
-            self.name
-        )
+
+        def pandas_isnumeric(s) -> "ks.Series[bool]":
+            return s.str.isnumeric()
+
+        return self._data.transform_batch(pandas_isnumeric)
 
     def isdecimal(self) -> "ks.Series":
         """
@@ -730,9 +770,11 @@ class StringMethods(object):
         3    False
         Name: 0, dtype: bool
         """
-        return _wrap_accessor_pandas(self, lambda x: x.str.isdecimal(), BooleanType()).alias(
-            self.name
-        )
+
+        def pandas_isdecimal(s) -> "ks.Series[bool]":
+            return s.str.isdecimal()
+
+        return self._data.transform_batch(pandas_isdecimal)
 
     def cat(self, others=None, sep=None, na_rep=None, join=None) -> "ks.Series":
         """
@@ -770,9 +812,11 @@ class StringMethods(object):
         1    --tiger---
         Name: 0, dtype: object
         """
-        return _wrap_accessor_pandas(
-            self, lambda x: x.str.center(width, fillchar), StringType()
-        ).alias(self.name)
+
+        def pandas_center(s) -> "ks.Series[str]":
+            return s.str.center(width, fillchar)
+
+        return self._data.transform_batch(pandas_center)
 
     def contains(self, pat, case=True, flags=0, na=None, regex=True) -> "ks.Series":
         """
@@ -885,9 +929,11 @@ class StringMethods(object):
         4    False
         Name: 0, dtype: bool
         """
-        return _wrap_accessor_pandas(
-            self, lambda x: x.str.contains(pat, case, flags, na, regex), BooleanType()
-        ).alias(self.name)
+
+        def pandas_contains(s) -> "ks.Series[bool]":
+            return s.str.contains(pat, case, flags, na, regex)
+
+        return self._data.transform_batch(pandas_contains)
 
     def count(self, pat, flags=0) -> "ks.Series":
         """
@@ -933,9 +979,11 @@ class StringMethods(object):
         5    0
         Name: 0, dtype: int32
         """
-        return _wrap_accessor_pandas(self, lambda x: x.str.count(pat, flags), IntegerType()).alias(
-            self.name
-        )
+
+        def pandas_count(s) -> "ks.Series[int]":
+            return s.str.count(pat, flags)
+
+        return self._data.transform_batch(pandas_count)
 
     def decode(self, encoding, errors="strict") -> "ks.Series":
         """
@@ -1010,9 +1058,11 @@ class StringMethods(object):
         2   -1
         Name: 0, dtype: int32
         """
-        return _wrap_accessor_pandas(
-            self, lambda x: x.str.find(sub, start, end), IntegerType()
-        ).alias(self.name)
+
+        def pandas_find(s) -> "ks.Series[int]":
+            return s.str.find(sub, start, end)
+
+        return self._data.transform_batch(pandas_find)
 
     def findall(self, pat, flags=0) -> "ks.Series":
         """
@@ -1092,9 +1142,13 @@ class StringMethods(object):
         2    [b, b]
         Name: 0, dtype: object
         """
-        return _wrap_accessor_pandas(
-            self, lambda x: x.str.findall(pat, flags), ArrayType(StringType(), containsNull=True)
-        ).alias(self.name)
+        # type hint does not support to specify array type yet.
+        pudf = pandas_udf(
+            lambda s: s.str.findall(pat, flags),
+            returnType=ArrayType(StringType(), containsNull=True),
+            functionType=PandasUDFType.SCALAR,
+        )
+        return self._data._with_new_scol(scol=pudf(self._data.spark_column)).rename(self.name)
 
     def index(self, sub, start=0, end=None) -> "ks.Series":
         """
@@ -1133,9 +1187,11 @@ class StringMethods(object):
 
         >>> s.str.index('a', start=2) # doctest: +SKIP
         """
-        return _wrap_accessor_pandas(
-            self, lambda x: x.str.index(sub, start, end), LongType()
-        ).alias(self.name)
+
+        def pandas_index(s) -> "ks.Series[np.int64]":
+            return s.str.index(sub, start, end)
+
+        return self._data.transform_batch(pandas_index)
 
     def join(self, sep) -> "ks.Series":
         """
@@ -1180,7 +1236,11 @@ class StringMethods(object):
         1                   None
         Name: 0, dtype: object
         """
-        return _wrap_accessor_pandas(self, lambda x: x.str.join(sep), StringType()).alias(self.name)
+
+        def pandas_join(s) -> "ks.Series[str]":
+            return s.str.join(sep)
+
+        return self._data.transform_batch(pandas_join)
 
     def len(self) -> "ks.Series":
         """
@@ -1211,7 +1271,14 @@ class StringMethods(object):
         1    0
         Name: 0, dtype: int64
         """
-        return _wrap_accessor_pandas(self, lambda x: x.str.len(), LongType()).alias(self.name)
+        if isinstance(self._data.spark_type, (ArrayType, MapType)):
+            return _column_op(lambda c: F.size(c).cast(LongType()))(self._data).alias(
+                self._data.name
+            )
+        else:
+            return _column_op(lambda c: F.length(c).cast(LongType()))(self._data).alias(
+                self._data.name
+            )
 
     def ljust(self, width, fillchar=" ") -> "ks.Series":
         """
@@ -1243,9 +1310,11 @@ class StringMethods(object):
         1    tiger-----
         Name: 0, dtype: object
         """
-        return _wrap_accessor_pandas(
-            self, lambda x: x.str.ljust(width, fillchar), StringType()
-        ).alias(self.name)
+
+        def pandas_ljust(s) -> "ks.Series[str]":
+            return s.str.ljust(width, fillchar)
+
+        return self._data.transform_batch(pandas_ljust)
 
     def match(self, pat, case=True, flags=0, na=np.NaN) -> "ks.Series":
         """
@@ -1307,9 +1376,11 @@ class StringMethods(object):
         4     None
         Name: 0, dtype: object
         """
-        return _wrap_accessor_pandas(
-            self, lambda x: x.str.match(pat, case, flags, na), BooleanType()
-        ).alias(self.name)
+
+        def pandas_match(s) -> "ks.Series[bool]":
+            return s.str.match(pat, case, flags, na)
+
+        return self._data.transform_batch(pandas_match)
 
     def normalize(self, form) -> "ks.Series":
         """
@@ -1328,9 +1399,11 @@ class StringMethods(object):
         Series of objects
             A Series of normalized strings.
         """
-        return _wrap_accessor_pandas(self, lambda x: x.str.normalize(form), StringType()).alias(
-            self.name
-        )
+
+        def pandas_normalize(s) -> "ks.Series[str]":
+            return s.str.normalize(form)
+
+        return self._data.transform_batch(pandas_normalize)
 
     def pad(self, width, side="left", fillchar=" ") -> "ks.Series":
         """
@@ -1374,9 +1447,11 @@ class StringMethods(object):
         1    --tiger---
         Name: 0, dtype: object
         """
-        return _wrap_accessor_pandas(
-            self, lambda x: x.str.pad(width, side, fillchar), StringType()
-        ).alias(self.name)
+
+        def pandas_pad(s) -> "ks.Series[str]":
+            return s.str.pad(width, side, fillchar)
+
+        return self._data.transform_batch(pandas_pad)
 
     def partition(self, sep=" ", expand=True) -> "ks.Series":
         """
@@ -1420,9 +1495,10 @@ class StringMethods(object):
         if not isinstance(repeats, int):
             raise ValueError("repeats expects an int parameter")
 
-        return _wrap_accessor_pandas(
-            self, lambda x: x.str.repeat(repeats=repeats), StringType()
-        ).alias(self.name)
+        def pandas_repeat(s) -> "ks.Series[str]":
+            return s.str.repeat(repeats=repeats)
+
+        return self._data.transform_batch(pandas_repeat)
 
     def replace(self, pat, repl, n=-1, case=None, flags=0, regex=True) -> "ks.Series":
         """
@@ -1512,11 +1588,11 @@ class StringMethods(object):
         2    None
         Name: 0, dtype: object
         """
-        return _wrap_accessor_pandas(
-            self,
-            lambda x: x.str.replace(pat, repl, n=n, case=case, flags=flags, regex=regex),
-            StringType(),
-        ).alias(self.name)
+
+        def pandas_replace(s) -> "ks.Series[str]":
+            return s.str.replace(pat, repl, n=n, case=case, flags=flags, regex=regex)
+
+        return self._data.transform_batch(pandas_replace)
 
     def rfind(self, sub, start=0, end=None) -> "ks.Series":
         """
@@ -1567,9 +1643,11 @@ class StringMethods(object):
         2   -1
         Name: 0, dtype: int32
         """
-        return _wrap_accessor_pandas(
-            self, lambda x: x.str.rfind(sub, start, end), IntegerType()
-        ).alias(self.name)
+
+        def pandas_rfind(s) -> "ks.Series[int]":
+            return s.str.rfind(sub, start, end)
+
+        return self._data.transform_batch(pandas_rfind)
 
     def rindex(self, sub, start=0, end=None) -> "ks.Series":
         """
@@ -1608,9 +1686,11 @@ class StringMethods(object):
 
         >>> s.str.rindex('a', start=2) # doctest: +SKIP
         """
-        return _wrap_accessor_pandas(
-            self, lambda x: x.str.rindex(sub, start, end), LongType()
-        ).alias(self.name)
+
+        def pandas_rindex(s) -> "ks.Series[np.int64]":
+            return s.str.rindex(sub, start, end)
+
+        return self._data.transform_batch(pandas_rindex)
 
     def rjust(self, width, fillchar=" ") -> "ks.Series":
         """
@@ -1647,9 +1727,11 @@ class StringMethods(object):
         1    -----tiger
         Name: 0, dtype: object
         """
-        return _wrap_accessor_pandas(
-            self, lambda x: x.str.rjust(width, fillchar), StringType()
-        ).alias(self.name)
+
+        def pandas_rjust(s) -> "ks.Series[str]":
+            return s.str.rjust(width, fillchar)
+
+        return self._data.transform_batch(pandas_rjust)
 
     def rpartition(self, sep=" ", expand=True) -> "ks.Series":
         """
@@ -1708,9 +1790,11 @@ class StringMethods(object):
         2    cm
         Name: 0, dtype: object
         """
-        return _wrap_accessor_pandas(
-            self, lambda x: x.str.slice(start, stop, step), StringType()
-        ).alias(self.name)
+
+        def pandas_slice(s) -> "ks.Series[str]":
+            return s.str.slice(start, stop, step)
+
+        return self._data.transform_batch(pandas_slice)
 
     def slice_replace(self, start=None, stop=None, repl=None) -> "ks.Series":
         """
@@ -1780,9 +1864,11 @@ class StringMethods(object):
         4    aXde
         Name: 0, dtype: object
         """
-        return _wrap_accessor_pandas(
-            self, lambda x: x.str.slice_replace(start, stop, repl), StringType()
-        ).alias(self.name)
+
+        def pandas_slice_replace(s) -> "ks.Series[str]":
+            return s.str.slice_replace(start, stop, repl)
+
+        return self._data.transform_batch(pandas_slice_replace)
 
     def split(self, pat=None, n=-1, expand=False) -> Union["ks.Series", "ks.DataFrame"]:
         """
@@ -1899,7 +1985,7 @@ class StringMethods(object):
         Remember to escape special characters when explicitly using regular
         expressions.
 
-        >>> s = pd.Series(["1+1=2"])
+        >>> s = ks.Series(["1+1=2"])
         >>> s.str.split(r"\\+|=", n=2, expand=True)
            0  1  2
         0  1  1  2
@@ -1909,9 +1995,13 @@ class StringMethods(object):
         if expand and n <= 0:
             raise NotImplementedError("expand=True is currently only supported with n > 0.")
 
-        kser = _wrap_accessor_pandas(
-            self, lambda x: x.str.split(pat, n), ArrayType(StringType(), containsNull=True)
-        ).alias(self.name)
+        # type hint does not support to specify array type yet.
+        pudf = pandas_udf(
+            lambda s: s.str.split(pat, n),
+            returnType=ArrayType(StringType(), containsNull=True),
+            functionType=PandasUDFType.SCALAR,
+        )
+        kser = self._data._with_new_scol(scol=pudf(self._data.spark_column)).rename(self.name)
 
         if expand:
             kdf = kser.to_frame()
@@ -2029,7 +2119,7 @@ class StringMethods(object):
         Remember to escape special characters when explicitly using regular
         expressions.
 
-        >>> s = pd.Series(["1+1=2"])
+        >>> s = ks.Series(["1+1=2"])
         >>> s.str.split(r"\\+|=", n=2, expand=True)
            0  1  2
         0  1  1  2
@@ -2039,9 +2129,13 @@ class StringMethods(object):
         if expand and n <= 0:
             raise NotImplementedError("expand=True is currently only supported with n > 0.")
 
-        kser = _wrap_accessor_pandas(
-            self, lambda x: x.str.rsplit(pat, n), ArrayType(StringType(), containsNull=True)
-        ).alias(self.name)
+        # type hint does not support to specify array type yet.
+        pudf = pandas_udf(
+            lambda s: s.str.rsplit(pat, n),
+            returnType=ArrayType(StringType(), containsNull=True),
+            functionType=PandasUDFType.SCALAR,
+        )
+        kser = self._data._with_new_scol(scol=pudf(self._data.spark_column)).rename(self.name)
 
         if expand:
             kdf = kser.to_frame()
@@ -2081,9 +2175,11 @@ class StringMethods(object):
         2    bYrd
         Name: 0, dtype: object
         """
-        return _wrap_accessor_pandas(self, lambda x: x.str.translate(table), StringType()).alias(
-            self.name
-        )
+
+        def pandas_translate(s) -> "ks.Series[str]":
+            return s.str.translate(table)
+
+        return self._data.transform_batch(pandas_translate)
 
     def wrap(self, width, **kwargs) -> "ks.Series":
         """
@@ -2130,9 +2226,11 @@ class StringMethods(object):
         1    another line\\nto be\\nwrapped
         Name: 0, dtype: object
         """
-        return _wrap_accessor_pandas(
-            self, lambda x: x.str.wrap(width, **kwargs), StringType()
-        ).alias(self.name)
+
+        def pandas_wrap(s) -> "ks.Series[str]":
+            return s.str.wrap(width, **kwargs)
+
+        return self._data.transform_batch(pandas_wrap)
 
     def zfill(self, width) -> "ks.Series":
         """
@@ -2178,9 +2276,11 @@ class StringMethods(object):
         3    None
         Name: 0, dtype: object
         """
-        return _wrap_accessor_pandas(self, lambda x: x.str.zfill(width), StringType()).alias(
-            self.name
-        )
+
+        def pandas_zfill(s) -> "ks.Series[str]":
+            return s.str.zfill(width)
+
+        return self._data.transform_batch(pandas_zfill)
 
     def get_dummies(self, sep="|"):
         """

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -2920,11 +2920,15 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
     def test_transform_batch_same_anchor(self):
         kdf = ks.range(10)
         kdf["d"] = kdf.transform_batch(lambda pdf: pdf.id + 1)
-        self.assert_eq(kdf, pd.DataFrame({"id": list(range(10)), "d": list(range(1, 11))}))
+        self.assert_eq(
+            kdf, pd.DataFrame({"id": list(range(10)), "d": list(range(1, 11))}, columns=["id", "d"])
+        )
 
         kdf = ks.range(10)
         kdf["d"] = kdf.id.transform_batch(lambda ser: ser + 1)
-        self.assert_eq(kdf, pd.DataFrame({"id": list(range(10)), "d": list(range(1, 11))}))
+        self.assert_eq(
+            kdf, pd.DataFrame({"id": list(range(10)), "d": list(range(1, 11))}, columns=["id", "d"])
+        )
 
         kdf = ks.range(10)
 
@@ -2932,7 +2936,9 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             return pdf.id + 1
 
         kdf["d"] = kdf.transform_batch(plus_one)
-        self.assert_eq(kdf, pd.DataFrame({"id": list(range(10)), "d": list(range(1, 11))}))
+        self.assert_eq(
+            kdf, pd.DataFrame({"id": list(range(10)), "d": list(range(1, 11))}, columns=["id", "d"])
+        )
 
         kdf = ks.range(10)
 
@@ -2940,7 +2946,9 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             return ser + 1
 
         kdf["d"] = kdf.id.transform_batch(plus_one)
-        self.assert_eq(kdf, pd.DataFrame({"id": list(range(10)), "d": list(range(1, 11))}))
+        self.assert_eq(
+            kdf, pd.DataFrame({"id": list(range(10)), "d": list(range(1, 11))}, columns=["id", "d"])
+        )
 
     def test_empty_timestamp(self):
         pdf = pd.DataFrame(

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -2828,7 +2828,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
                 pdf.apply(lambda x: len(x), axis=1).sort_index(),
             )
 
-    def test_map_in_pandas(self):
+    def test_apply_batch(self):
         pdf = pd.DataFrame(
             {
                 "a": [1, 2, 3, 4, 5, 6] * 100,
@@ -2840,33 +2840,107 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         )
         kdf = ks.DataFrame(pdf)
 
-        self.assert_eq(kdf.map_in_pandas(lambda pdf: pdf + 1).sort_index(), (pdf + 1).sort_index())
+        self.assert_eq(kdf.apply_batch(lambda pdf: pdf + 1).sort_index(), (pdf + 1).sort_index())
         with option_context("compute.shortcut_limit", 500):
             self.assert_eq(
-                kdf.map_in_pandas(lambda pdf: pdf + 1).sort_index(), (pdf + 1).sort_index()
+                kdf.apply_batch(lambda pdf: pdf + 1).sort_index(), (pdf + 1).sort_index()
             )
 
         with self.assertRaisesRegex(AssertionError, "the first argument should be a callable"):
-            kdf.map_in_pandas(1)
+            kdf.apply_batch(1)
 
         with self.assertRaisesRegex(TypeError, "The given function.*frame as its type hints"):
 
             def f2(_) -> ks.Series[int]:
                 pass
 
-            kdf.map_in_pandas(f2)
+            kdf.apply_batch(f2)
 
         with self.assertRaisesRegex(ValueError, "The given function should return a frame"):
-            kdf.map_in_pandas(lambda pdf: 1)
+            kdf.apply_batch(lambda pdf: 1)
 
         # multi-index columns
         columns = pd.MultiIndex.from_tuples([("x", "a"), ("x", "b"), ("y", "c")])
         pdf.columns = columns
         kdf.columns = columns
 
-        self.assert_eq(kdf.map_in_pandas(lambda x: x + 1).sort_index(), (pdf + 1).sort_index())
+        self.assert_eq(kdf.apply_batch(lambda x: x + 1).sort_index(), (pdf + 1).sort_index())
         with option_context("compute.shortcut_limit", 500):
-            self.assert_eq(kdf.map_in_pandas(lambda x: x + 1).sort_index(), (pdf + 1).sort_index())
+            self.assert_eq(kdf.apply_batch(lambda x: x + 1).sort_index(), (pdf + 1).sort_index())
+
+    def test_transform_batch(self):
+        pdf = pd.DataFrame(
+            {
+                "a": [1, 2, 3, 4, 5, 6] * 100,
+                "b": [1.0, 1.0, 2.0, 3.0, 5.0, 8.0] * 100,
+                "c": [1, 4, 9, 16, 25, 36] * 100,
+            },
+            columns=["a", "b", "c"],
+            index=np.random.rand(600),
+        )
+        kdf = ks.DataFrame(pdf)
+
+        self.assert_eq(
+            kdf.transform_batch(lambda pdf: pdf + 1).sort_index(), (pdf + 1).sort_index()
+        )
+        self.assert_eq(
+            kdf.transform_batch(lambda pdf: pdf.c + 1).sort_index(), (pdf.c + 1).sort_index()
+        )
+
+        with option_context("compute.shortcut_limit", 500):
+            self.assert_eq(
+                kdf.transform_batch(lambda pdf: pdf + 1).sort_index(), (pdf + 1).sort_index()
+            )
+            self.assert_eq(
+                kdf.transform_batch(lambda pdf: pdf.b + 1).sort_index(), (pdf.b + 1).sort_index()
+            )
+
+        with self.assertRaisesRegex(AssertionError, "the first argument should be a callable"):
+            kdf.transform_batch(1)
+
+        with self.assertRaisesRegex(ValueError, "The given function should return a frame"):
+            kdf.transform_batch(lambda pdf: 1)
+
+        with self.assertRaisesRegex(
+            ValueError, "transform_batch cannot produce aggregated results"
+        ):
+            kdf.transform_batch(lambda pdf: pd.Series(1))
+
+        # multi-index columns
+        columns = pd.MultiIndex.from_tuples([("x", "a"), ("x", "b"), ("y", "c")])
+        pdf.columns = columns
+        kdf.columns = columns
+
+        self.assert_eq(kdf.transform_batch(lambda x: x + 1).sort_index(), (pdf + 1).sort_index())
+        with option_context("compute.shortcut_limit", 500):
+            self.assert_eq(
+                kdf.transform_batch(lambda x: x + 1).sort_index(), (pdf + 1).sort_index()
+            )
+
+    def test_transform_batch_same_anchor(self):
+        kdf = ks.range(10)
+        kdf["d"] = kdf.transform_batch(lambda pdf: pdf.id + 1)
+        self.assert_eq(kdf, pd.DataFrame({"id": list(range(10)), "d": list(range(1, 11))}))
+
+        kdf = ks.range(10)
+        kdf["d"] = kdf.id.transform_batch(lambda ser: ser + 1)
+        self.assert_eq(kdf, pd.DataFrame({"id": list(range(10)), "d": list(range(1, 11))}))
+
+        kdf = ks.range(10)
+
+        def plus_one(pdf) -> ks.Series[np.int64]:
+            return pdf.id + 1
+
+        kdf["d"] = kdf.transform_batch(plus_one)
+        self.assert_eq(kdf, pd.DataFrame({"id": list(range(10)), "d": list(range(1, 11))}))
+
+        kdf = ks.range(10)
+
+        def plus_one(ser) -> ks.Series[np.int64]:
+            return ser + 1
+
+        kdf["d"] = kdf.id.transform_batch(plus_one)
+        self.assert_eq(kdf, pd.DataFrame({"id": list(range(10)), "d": list(range(1, 11))}))
 
     def test_empty_timestamp(self):
         pdf = pd.DataFrame(

--- a/databricks/koalas/typedef/string_typehints.py
+++ b/databricks/koalas/typedef/string_typehints.py
@@ -1,0 +1,30 @@
+#
+# Copyright (C) 2019 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import numpy as np
+import pandas as pd
+from numpy import *
+from pandas import *
+from inspect import getfullargspec
+
+
+def resolve_string_type_hint(tpe):
+    import databricks.koalas as ks
+    from databricks.koalas import DataFrame, Series
+
+    locs = {"ks": ks, "DataFrame": DataFrame, "Series": Series}
+    # This is a hack to resolve the forward reference string.
+    exec("def func() -> %s: pass\narg_spec = getfullargspec(func)" % tpe, globals(), locs)
+    return locs["arg_spec"].annotations.get("return", None)

--- a/databricks/koalas/typedef/typehints.py
+++ b/databricks/koalas/typedef/typehints.py
@@ -1,0 +1,235 @@
+#
+# Copyright (C) 2019 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Utilities to deal with types. This is mostly focused on python3.
+"""
+import typing
+import datetime
+from inspect import getfullargspec
+
+import numpy as np
+import pandas as pd
+from pandas.api.types import is_datetime64_dtype, is_datetime64tz_dtype
+import pyarrow as pa
+import pyspark.sql.types as types
+from pyspark.sql.types import UserDefinedType
+
+try:
+    from pyspark.sql.types import to_arrow_type, from_arrow_type
+except ImportError:
+    from pyspark.sql.pandas.types import to_arrow_type, from_arrow_type
+
+from databricks import koalas as ks  # For running doctests and reference resolution in PyCharm.
+from databricks.koalas.typedef.string_typehints import resolve_string_type_hint
+
+
+# A column of data, with the data type.
+class SeriesType(object):
+    def __init__(self, tpe):
+        self.tpe = tpe  # type: types.DataType
+
+    def __repr__(self):
+        return "SeriesType[{}]".format(self.tpe)
+
+
+class DataFrameType(object):
+    def __init__(self, tpe):
+        # Seems we cannot specify field names. I currently gave some default names
+        # `c0, c1, ... cn`.
+        self.tpe = types.StructType(
+            [types.StructField("c%s" % i, tpe[i]) for i in range(len(tpe))]
+        )  # type: types.StructType
+
+    def __repr__(self):
+        return "DataFrameType[{}]".format(self.tpe)
+
+
+# The type is a scalar type that is furthermore understood by Spark.
+class ScalarType(object):
+    def __init__(self, tpe):
+        self.tpe = tpe  # type: types.DataType
+
+    def __repr__(self):
+        return "ScalarType[{}]".format(self.tpe)
+
+
+# The type is left unspecified or we do not know about this type.
+class UnknownType(object):
+    def __init__(self, tpe):
+        self.tpe = tpe
+
+    def __repr__(self):
+        return "UnknownType[{}]".format(self.tpe)
+
+
+def _to_stype(tpe) -> typing.Union[SeriesType, DataFrameType, ScalarType, UnknownType]:
+    if isinstance(tpe, str):
+        # This type hint can happen when given hints are string to avoid forward reference.
+        tpe = resolve_string_type_hint(tpe)
+    if hasattr(tpe, "__origin__") and tpe.__origin__ == ks.Series:
+        inner = as_spark_type(tpe.__args__[0])
+        return SeriesType(inner)
+    if hasattr(tpe, "__origin__") and tpe.__origin__ == ks.DataFrame:
+        tuple_type = tpe.__args__[0]
+        if hasattr(tuple_type, "__tuple_params__"):
+            # Python 3.5.0 to 3.5.2 has '__tuple_params__' instead.
+            # See https://github.com/python/cpython/blob/v3.5.2/Lib/typing.py
+            parameters = getattr(tuple_type, "__tuple_params__")
+        else:
+            parameters = getattr(tuple_type, "__args__")
+        return DataFrameType([as_spark_type(t) for t in parameters])
+    inner = as_spark_type(tpe)
+    if inner is None:
+        return UnknownType(tpe)
+    else:
+        return ScalarType(inner)
+
+
+def as_spark_type(tpe) -> types.DataType:
+    """
+    Given a python type, returns the equivalent spark type.
+    Accepts:
+    - the built-in types in python
+    - the built-in types in numpy
+    - list of pairs of (field_name, type)
+    - dictionaries of field_name -> type
+    - python3's typing system
+    """
+    if tpe in (str, "str", "string"):
+        return types.StringType()
+    elif tpe in (bytes,):
+        return types.BinaryType()
+    elif tpe in (np.int8, "int8", "byte"):
+        return types.ByteType()
+    elif tpe in (np.int16, "int16", "short"):
+        return types.ShortType()
+    elif tpe in (int, "int", np.int, np.int32):
+        return types.IntegerType()
+    elif tpe in (np.int64, "int64", "long", "bigint"):
+        return types.LongType()
+    elif tpe in (float, "float", np.float):
+        return types.FloatType()
+    elif tpe in (np.float64, "float64", "double"):
+        return types.DoubleType()
+    elif tpe in (datetime.datetime, np.datetime64):
+        return types.TimestampType()
+    elif tpe in (datetime.date,):
+        return types.DateType()
+    elif tpe in (bool, "boolean", "bool", np.bool):
+        return types.BooleanType()
+    elif tpe in ():
+        return types.ArrayType(types.StringType())
+
+
+def spark_type_to_pandas_dtype(spark_type):
+    """ Return the given Spark DataType to pandas dtype. """
+    if isinstance(spark_type, UserDefinedType):
+        return np.dtype("object")
+    elif isinstance(spark_type, types.TimestampType):
+        return np.dtype("datetime64[ns]")
+    else:
+        return np.dtype(to_arrow_type(spark_type).to_pandas_dtype())
+
+
+def infer_pd_series_spark_type(s: pd.Series) -> types.DataType:
+    """Infer Spark DataType from pandas Series dtype.
+
+    :param s: :class:`pandas.Series` to be inferred
+    :return: the inferred Spark data type
+    """
+    dt = s.dtype
+    if dt == np.dtype("object"):
+        if len(s) == 0 or s.isnull().all():
+            raise ValueError("can not infer schema from empty or null dataset")
+        elif hasattr(s[0], "__UDT__"):
+            return s[0].__UDT__
+        else:
+            return from_arrow_type(pa.Array.from_pandas(s).type)
+    elif is_datetime64_dtype(dt) or is_datetime64tz_dtype(dt):
+        return types.TimestampType()
+    else:
+        return from_arrow_type(pa.from_numpy_dtype(dt))
+
+
+def infer_return_type(
+    f, return_col=None, return_scalar=None
+) -> typing.Union[SeriesType, DataFrameType, ScalarType, UnknownType]:
+    """
+    >>> def func() -> int:
+    ...    pass
+    >>> infer_return_type(func).tpe
+    IntegerType
+
+    >>> def func() -> ks.Series[int]:
+    ...    pass
+    >>> infer_return_type(func).tpe
+    IntegerType
+
+    >>> def func() -> ks.DataFrame[np.float, str]:
+    ...    pass
+    >>> infer_return_type(func).tpe
+    StructType(List(StructField(c0,FloatType,true),StructField(c1,StringType,true)))
+
+    >>> def func() -> ks.DataFrame[np.float]:
+    ...    pass
+    >>> infer_return_type(func).tpe
+    StructType(List(StructField(c0,FloatType,true)))
+
+    >>> def func() -> 'int':
+    ...    pass
+    >>> infer_return_type(func).tpe
+    IntegerType
+
+    >>> def func() -> 'ks.Series[int]':
+    ...    pass
+    >>> infer_return_type(func).tpe
+    IntegerType
+
+    >>> def func() -> 'ks.DataFrame[np.float, str]':
+    ...    pass
+    >>> infer_return_type(func).tpe
+    StructType(List(StructField(c0,FloatType,true),StructField(c1,StringType,true)))
+
+    >>> def func() -> 'ks.DataFrame[np.float]':
+    ...    pass
+    >>> infer_return_type(func).tpe
+    StructType(List(StructField(c0,FloatType,true)))
+    """
+    spec = getfullargspec(f)
+    return_sig = spec.annotations.get("return", None)
+
+    if not (return_col or return_sig or return_scalar):
+        raise ValueError(
+            "Missing type information. It should either be provided as an argument to "
+            "pandas_wraps, or as a python typing hint"
+        )
+    if return_col is not None:
+        if isinstance(return_col, ks.Series):
+            return _to_stype(return_col)
+        inner = as_spark_type(return_col)
+        return SeriesType(inner)
+    if return_scalar is not None:
+        if isinstance(return_scalar, ks.Series):
+            raise ValueError(
+                "Column return type {}, you should use 'return_col' to specify"
+                " it.".format(return_scalar)
+            )
+        inner = as_spark_type(return_scalar)
+        return ScalarType(inner)
+    if return_sig is not None:
+        return _to_stype(return_sig)
+    assert False

--- a/docs/source/reference/frame.rst
+++ b/docs/source/reference/frame.rst
@@ -103,11 +103,13 @@ Function application, GroupBy & Window
 
    DataFrame.apply
    DataFrame.applymap
+   DataFrame.apply_batch
    DataFrame.pipe
    DataFrame.agg
    DataFrame.aggregate
    DataFrame.groupby
    DataFrame.transform
+   DataFrame.transform_batch
    DataFrame.map_in_pandas
 
 .. _api.dataframe.stats:

--- a/docs/source/reference/series.rst
+++ b/docs/source/reference/series.rst
@@ -99,6 +99,7 @@ Function application, GroupBy & Window
    Series.agg
    Series.aggregate
    Series.transform
+   Series.transform_batch
    Series.map
    Series.groupby
    Series.pipe


### PR DESCRIPTION
This PR adds:

- `DataFrame.transform_batch()` (previously `pandas_wraps`)
- `Series.transform_batch()` (previously `pandas_wraps`)
- `DataFrame.apply_batch()` (previously `DataFrame.map_in_pandas`)

also deprecates:

- `ks.pandas_wraps` (now `DataFrame.transform_batch` and `Series.transform_batch`)
- `DataFrame.map_in_pandas` (now `DataFrame.apply_batch()`)

In addition, this PR adds a support of type inference for string literal type hint expressions. It's a bit hacky but works. (see `string_literal_typehints.py`).

<br/>

For `pandas_wraps`, the codes can be converted as below:

Before:

```python
import databricks.koalas as ks
kdf = ks.DataFrame({'a': [1,2,3], 'b':[4,5,6]})
@ks.pandas_wraps
def pandas_plus_one(col1, col2) -> ks.Series[int]:
    return col1 + col2

pandas_plus_one(kdf.a, kdf.b)
```

```python
import databricks.koalas as ks
kdf = ks.DataFrame({'a': [1,2,3], 'b':[4,5,6]})
@ks.pandas_wraps
def pandas_plus_one(col1) -> ks.Series[int]:
    return col1 * col1

pandas_plus_one(kdf.a)
```


After:

```python
import databricks.koalas as ks
kdf = ks.DataFrame({'a': [1,2,3], 'b':[4,5,6]})
def pandas_plus_one(kdf) -> ks.Series[int]:
    return kdf.a + kdf.b

kdf[['a', 'b']].transform_batch(pandas_plus_one)
```

```python
import databricks.koalas as ks
kdf = ks.DataFrame({'a': [1,2,3], 'b':[4,5,6]})
def pandas_plus_one(col1) -> ks.Series[int]:
    return col1 * col1

kdf.a.transform_batch(pandas_plus_one)

import databricks.koalas as ks
kdf = ks.DataFrame({'a': [1,2,3], 'b':[4,5,6]})
def pandas_plus_one(pdf) -> ks.Series[int]:
    return pdf.a * pdf.a

kdf[['a']].transform_batch(pandas_plus_one)
```

Of course, these does not require `compute.ops_on_diff_frames` if it doesn't create new dataframe:

```python
import databricks.koalas as ks
kdf = ks.DataFrame({'a': [1,2,3], 'b':[4,5,6]})
def pandas_plus_one(col1) -> ks.Series[int]:
    return col1 * col1

kdf['abc'] = kdf.a.transform_batch(pandas_plus_one)
kdf
```

```python
import databricks.koalas as ks
kdf = ks.DataFrame({'a': [1,2,3], 'b':[4,5,6]})
def pandas_plus_one(pdf) -> ks.Series[int]:
    return pdf.a * pdf.a

kdf['abc'] = kdf.transform_batch(pandas_plus_one)
kdf
```
