### PR TITLE
Expose spark_column from Series/Index to make it easier to work with Spark Columns.

### DIFF
--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -83,9 +83,9 @@ def _column_op(f):
         cols = [arg for arg in args if isinstance(arg, IndexOpsMixin)]
         if all(self._kdf is col._kdf for col in cols):
             # Same DataFrame anchors
-            args = [arg._scol if isinstance(arg, IndexOpsMixin) else arg for arg in args]
-            scol = f(self._scol, *args)
-            scol = booleanize_null(self._scol, scol, f)
+            args = [arg.spark_column if isinstance(arg, IndexOpsMixin) else arg for arg in args]
+            scol = f(self.spark_column, *args)
+            scol = booleanize_null(self.spark_column, scol, f)
 
             return self._with_new_scol(scol)
         else:
@@ -154,7 +154,13 @@ class IndexOpsMixin(object):
         self._kdf = kdf
 
     @property
-    def _scol(self):
+    def spark_column(self):
+        """
+        Spark Column object representing the Series/Index.
+
+        .. note:: This Spark Column object is strictly stick to its base DataFrame the Series/Index
+            was derived from.
+        """
         return self._internal.spark_column
 
     # arithmetic operators
@@ -202,7 +208,7 @@ class IndexOpsMixin(object):
     def __radd__(self, other):
         # Handle 'literal' + df['col']
         if isinstance(self.spark_type, StringType) and isinstance(other, str):
-            return self._with_new_scol(F.concat(F.lit(other), self._scol))
+            return self._with_new_scol(F.concat(F.lit(other), self.spark_column))
         else:
             return _column_op(spark.Column.__radd__)(self, other)
 
@@ -336,8 +342,8 @@ class IndexOpsMixin(object):
         >>> ks.Series([1, 2, 3]).rename("a").to_frame().set_index("a").index.hasnans
         False
         """
-        sdf = self._internal._sdf.select(self._scol)
-        col = self._scol
+        sdf = self._internal._sdf.select(self.spark_column)
+        col = self.spark_column
 
         ret = sdf.select(F.max(col.isNull() | F.isnan(col))).collect()[0][0]
         return ret
@@ -517,7 +523,7 @@ class IndexOpsMixin(object):
                     "__partition_id"
                 ),  # Make sure we use the same partition id in the whole job.
                 F.col(NATURAL_ORDER_COLUMN_NAME),
-                self._scol.alias("__origin"),
+                self.spark_column.alias("__origin"),
             )
             .select(
                 F.col("__partition_id"),
@@ -635,7 +641,7 @@ class IndexOpsMixin(object):
         spark_type = as_spark_type(dtype)
         if not spark_type:
             raise ValueError("Type {} not understood".format(dtype))
-        return self._with_new_scol(self._scol.cast(spark_type))
+        return self._with_new_scol(self.spark_column.cast(spark_type))
 
     def isin(self, values):
         """
@@ -687,7 +693,7 @@ class IndexOpsMixin(object):
                 " to isin(), you passed a [{values_type}]".format(values_type=type(values).__name__)
             )
 
-        return self._with_new_scol(self._scol.isin(list(values))).rename(self.name)
+        return self._with_new_scol(self.spark_column.isin(list(values))).rename(self.name)
 
     def isnull(self):
         """
@@ -721,9 +727,11 @@ class IndexOpsMixin(object):
         if isinstance(self, MultiIndex):
             raise NotImplementedError("isna is not defined for MultiIndex")
         if isinstance(self.spark_type, (FloatType, DoubleType)):
-            return self._with_new_scol(self._scol.isNull() | F.isnan(self._scol)).rename(self.name)
+            return self._with_new_scol(
+                self.spark_column.isNull() | F.isnan(self.spark_column)
+            ).rename(self.name)
         else:
-            return self._with_new_scol(self._scol.isNull()).rename(self.name)
+            return self._with_new_scol(self.spark_column.isNull()).rename(self.name)
 
     isna = isnull
 
@@ -819,7 +827,7 @@ class IndexOpsMixin(object):
         if axis != 0:
             raise NotImplementedError('axis should be either 0 or "index" currently.')
 
-        sdf = self._internal._sdf.select(self._scol)
+        sdf = self._internal._sdf.select(self.spark_column)
         col = scol_for(sdf, sdf.columns[0])
 
         # Note that we're ignoring `None`s here for now.
@@ -882,7 +890,7 @@ class IndexOpsMixin(object):
         if axis != 0:
             raise NotImplementedError('axis should be either 0 or "index" currently.')
 
-        sdf = self._internal._sdf.select(self._scol)
+        sdf = self._internal._sdf.select(self.spark_column)
         col = scol_for(sdf, sdf.columns[0])
 
         # Note that we're ignoring `None`s here for now.
@@ -949,7 +957,7 @@ class IndexOpsMixin(object):
         if not isinstance(periods, int):
             raise ValueError("periods should be an int; however, got [%s]" % type(periods))
 
-        col = self._scol
+        col = self.spark_column
         window = (
             Window.partitionBy(*part_cols)
             .orderBy(NATURAL_ORDER_COLUMN_NAME)
@@ -1115,9 +1123,9 @@ class IndexOpsMixin(object):
             raise NotImplementedError("value_counts currently does not support bins")
 
         if dropna:
-            sdf_dropna = self._internal._sdf.select(self._scol).dropna()
+            sdf_dropna = self._internal._sdf.select(self.spark_column).dropna()
         else:
-            sdf_dropna = self._internal._sdf.select(self._scol)
+            sdf_dropna = self._internal._sdf.select(self.spark_column)
         index_name = SPARK_DEFAULT_INDEX_NAME
         column_name = self._internal.data_spark_column_names[0]
         sdf = sdf_dropna.groupby(scol_for(sdf_dropna, column_name).alias(index_name)).count()
@@ -1207,13 +1215,13 @@ class IndexOpsMixin(object):
         colname = self._internal.data_spark_column_names[0]
         count_fn = partial(F.approx_count_distinct, rsd=rsd) if approx else F.countDistinct
         if dropna:
-            return count_fn(self._scol).alias(colname)
+            return count_fn(self.spark_column).alias(colname)
         else:
             return (
-                count_fn(self._scol)
-                + F.when(F.count(F.when(self._scol.isNull(), 1).otherwise(None)) >= 1, 1).otherwise(
-                    0
-                )
+                count_fn(self.spark_column)
+                + F.when(
+                    F.count(F.when(self.spark_column.isNull(), 1).otherwise(None)) >= 1, 1
+                ).otherwise(0)
             ).alias(colname)
 
     def take(self, indices):

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -1395,7 +1395,7 @@ class _Frame(object):
         """
         # TODO: The first example above should not have "Name: 0".
         return self._apply_series_op(
-            lambda kser: kser._with_new_scol(F.abs(kser._scol)).rename(kser.name)
+            lambda kser: kser._with_new_scol(F.abs(kser.spark_column)).rename(kser.name)
         )
 
     # TODO: by argument only support the grouping name and as_index only for now. Documentation

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -1912,7 +1912,7 @@ class DataFrameGroupBy(GroupBy):
     ):
         self._kdf = kdf
         self._groupkeys = by
-        self._groupkeys_scols = [s._scol for s in self._groupkeys]
+        self._groupkeys_scols = [s.spark_column for s in self._groupkeys]
         self._as_index = as_index
         self._should_drop_index = should_drop_index
         self._have_agg_columns = True
@@ -1925,7 +1925,7 @@ class DataFrameGroupBy(GroupBy):
             ]
             self._have_agg_columns = False
         self._agg_columns = [kdf[label] for label in agg_columns]
-        self._agg_columns_scols = [s._scol for s in self._agg_columns]
+        self._agg_columns_scols = [s.spark_column for s in self._agg_columns]
 
     def __getattr__(self, item: str) -> Any:
         if hasattr(_MissingPandasLikeDataFrameGroupBy, item):

--- a/databricks/koalas/indexing.py
+++ b/databricks/koalas/indexing.py
@@ -533,7 +533,7 @@ class _LocIndexerLike(_IndexerLike, metaclass=ABCMeta):
             if isinstance(value, Series):
                 if remaining_index is not None and remaining_index == 0:
                     raise ValueError("No axis named {} for object type {}".format(key, type(value)))
-                value = value._scol
+                value = value.spark_column
             else:
                 value = F.lit(value)
             scol = (
@@ -599,7 +599,7 @@ class _LocIndexerLike(_IndexerLike, metaclass=ABCMeta):
                     raise ValueError("Incompatible indexer with Series")
                 if len(data_spark_columns) > 1:
                     raise ValueError("shape mismatch")
-                value = value._scol
+                value = value.spark_column
             else:
                 value = F.lit(value)
 
@@ -830,7 +830,7 @@ class LocIndexer(_LocIndexerLike):
         self, rows_sel: "Series"
     ) -> Tuple[Optional[spark.Column], Optional[int], Optional[int]]:
         assert isinstance(rows_sel.spark_type, BooleanType), rows_sel.spark_type
-        return rows_sel._scol, None, None
+        return rows_sel.spark_column, None, None
 
     def _select_rows_by_spark_column(
         self, rows_sel: spark.Column
@@ -857,10 +857,10 @@ class LocIndexer(_LocIndexerLike):
             # get natural order from '__natural_order__' from start to stop
             # to keep natural order.
             start_and_stop = (
-                sdf.select(index_column._scol, NATURAL_ORDER_COLUMN_NAME)
+                sdf.select(index_column.spark_column, NATURAL_ORDER_COLUMN_NAME)
                 .where(
-                    (index_column._scol == F.lit(start).cast(index_data_type))
-                    | (index_column._scol == F.lit(stop).cast(index_data_type))
+                    (index_column.spark_column == F.lit(start).cast(index_data_type))
+                    | (index_column.spark_column == F.lit(stop).cast(index_data_type))
                 )
                 .collect()
             )
@@ -890,17 +890,17 @@ class LocIndexer(_LocIndexerLike):
                 if start is None and rows_sel.start is not None:
                     start = rows_sel.start
                     if inc is not False:
-                        cond.append(index_column._scol >= F.lit(start).cast(index_data_type))
+                        cond.append(index_column.spark_column >= F.lit(start).cast(index_data_type))
                     elif dec is not False:
-                        cond.append(index_column._scol <= F.lit(start).cast(index_data_type))
+                        cond.append(index_column.spark_column <= F.lit(start).cast(index_data_type))
                     else:
                         raise KeyError(rows_sel.start)
                 if stop is None and rows_sel.stop is not None:
                     stop = rows_sel.stop
                     if inc is not False:
-                        cond.append(index_column._scol <= F.lit(stop).cast(index_data_type))
+                        cond.append(index_column.spark_column <= F.lit(stop).cast(index_data_type))
                     elif dec is not False:
-                        cond.append(index_column._scol >= F.lit(stop).cast(index_data_type))
+                        cond.append(index_column.spark_column >= F.lit(stop).cast(index_data_type))
                     else:
                         raise KeyError(rows_sel.stop)
 
@@ -972,13 +972,15 @@ class LocIndexer(_LocIndexerLike):
             index_data_type = index_column.spark_type
             if len(rows_sel) == 1:
                 return (
-                    index_column._scol == F.lit(rows_sel[0]).cast(index_data_type),
+                    index_column.spark_column == F.lit(rows_sel[0]).cast(index_data_type),
                     None,
                     None,
                 )
             else:
                 return (
-                    index_column._scol.isin([F.lit(r).cast(index_data_type) for r in rows_sel]),
+                    index_column.spark_column.isin(
+                        [F.lit(r).cast(index_data_type) for r in rows_sel]
+                    ),
                     None,
                     None,
                 )
@@ -1038,7 +1040,7 @@ class LocIndexer(_LocIndexerLike):
         self, cols_sel: "Series", missing_keys: Optional[List[Tuple[str, ...]]]
     ) -> Tuple[List[Tuple[str, ...]], Optional[List[spark.Column]], bool]:
         column_labels = [cols_sel._internal.column_labels[0]]
-        data_spark_columns = [cols_sel._scol]
+        data_spark_columns = [cols_sel.spark_column]
         return column_labels, data_spark_columns, True
 
     def _select_cols_by_spark_column(
@@ -1065,7 +1067,7 @@ class LocIndexer(_LocIndexerLike):
 
         if all(isinstance(key, Series) for key in cols_sel):
             column_labels = [key._internal.column_labels[0] for key in cols_sel]
-            data_spark_columns = [key._scol for key in cols_sel]
+            data_spark_columns = [key.spark_column for key in cols_sel]
         elif all(isinstance(key, spark.Column) for key in cols_sel):
             column_labels = [
                 (self._internal.spark_frame.select(col).columns[0],) for col in cols_sel

--- a/databricks/koalas/internal.py
+++ b/databricks/koalas/internal.py
@@ -468,7 +468,7 @@ class _InternalFrame(object):
         >>> list(internal._column_label_names)
         ['column_labels_a', 'column_labels_b']
 
-        >>> internal._scol
+        >>> internal.spark_column
         Column<b'(a, y)'>
         """
 
@@ -509,7 +509,7 @@ class _InternalFrame(object):
 
         self._sdf = spark_frame  # type: spark.DataFrame
         self._index_map = index_map  # type: Dict[str, Optional[Tuple[str, ...]]]
-        self._scol = spark_column  # type: Optional[spark.Column]
+        self._spark_column = spark_column  # type: Optional[spark.Column]
         if spark_column is not None:
             self._data_spark_columns = [spark_column]
         elif data_spark_columns is None:
@@ -697,7 +697,7 @@ class _InternalFrame(object):
     @property
     def spark_column(self) -> Optional[spark.Column]:
         """ Return the managed Spark Column. """
-        return self._scol
+        return self._spark_column
 
     @lazy_property
     def data_spark_column_names(self) -> List[str]:
@@ -930,7 +930,7 @@ class _InternalFrame(object):
 
         if isinstance(pred, Series):
             assert isinstance(pred.spark_type, BooleanType), pred.spark_type
-            pred = pred._scol
+            pred = pred.spark_column
         else:
             spark_type = self._sdf.select(pred).schema[0].dataType
             assert isinstance(spark_type, BooleanType), spark_type
@@ -967,7 +967,7 @@ class _InternalFrame(object):
         if column_label_names is _NoValue:
             column_label_names = self._column_label_names
         if spark_column is _NoValue:
-            spark_column = self._scol
+            spark_column = self.spark_column
         return _InternalFrame(
             spark_frame,
             index_map=index_map,

--- a/databricks/koalas/typedef.py
+++ b/databricks/koalas/typedef.py
@@ -270,11 +270,11 @@ def _make_fun(f: typing.Callable, return_type: types.DataType, *args, **kwargs) 
     spark_col_args = []
     for col in col_args:
         if col is not None:
-            spark_col_args.append(col._scol)
+            spark_col_args.append(col.spark_column)
             name_tokens.append(str(col.name))
     kw_name_tokens = []
     for (key, col) in col_kwargs:
-        spark_col_args.append(col._scol)
+        spark_col_args.append(col.spark_column)
         kw_name_tokens.append("{}={}".format(key, col.name))
     col = wrapped_udf(*spark_col_args)
     series = kser._with_new_scol(scol=col)  # type: 'ks.Series'

--- a/databricks/koalas/utils.py
+++ b/databricks/koalas/utils.py
@@ -102,11 +102,15 @@ def combine_frames(this, *args, how="full"):
         joined_df = joined_df.select(
             merged_index_scols
             + [
-                this[label]._scol.alias("__this_%s" % this._internal.spark_column_name_for(label))
+                this[label].spark_column.alias(
+                    "__this_%s" % this._internal.spark_column_name_for(label)
+                )
                 for label in this._internal.column_labels
             ]
             + [
-                that[label]._scol.alias("__that_%s" % that._internal.spark_column_name_for(label))
+                that[label].spark_column.alias(
+                    "__that_%s" % that._internal.spark_column_name_for(label)
+                )
                 for label in that._internal.column_labels
             ]
         )
@@ -249,7 +253,7 @@ def align_diff_frames(resolve_func, this, that, fillna=True, how="full"):
         kser_set, column_labels_applied = zip(
             *resolve_func(combined, this_columns_to_apply, that_columns_to_apply)
         )
-        columns_applied = [c._scol for c in kser_set]
+        columns_applied = [c.spark_column for c in kser_set]
         column_labels_applied = list(column_labels_applied)
     else:
         columns_applied = []

--- a/databricks/koalas/window.py
+++ b/databricks/koalas/window.py
@@ -152,7 +152,7 @@ class Rolling(_RollingAndExpanding):
 
     def _apply_as_series_or_frame(self, func):
         return self.kdf_or_kser._apply_series_op(
-            lambda kser: kser._with_new_scol(func(kser._scol)).rename(kser.name)
+            lambda kser: kser._with_new_scol(func(kser.spark_column)).rename(kser.name)
         )
 
     def count(self):
@@ -698,14 +698,14 @@ class RollingGroupby(Rolling):
         applied = []
         for column in kdf.columns:
             applied.append(
-                kdf[column]._with_new_scol(func(kdf[column]._scol)).rename(kdf[column].name)
+                kdf[column]._with_new_scol(func(kdf[column].spark_column)).rename(kdf[column].name)
             )
 
         # Seems like pandas filters out when grouped key is NA.
-        cond = self._groupkeys[0]._scol.isNotNull()
+        cond = self._groupkeys[0].spark_column.isNotNull()
         for c in self._groupkeys:
-            cond = cond | c._scol.isNotNull()
-        sdf = sdf.select(new_index_scols + [c._scol for c in applied]).filter(cond)
+            cond = cond | c.spark_column.isNotNull()
+        sdf = sdf.select(new_index_scols + [c.spark_column for c in applied]).filter(cond)
 
         internal = kdf._internal.copy(
             spark_frame=sdf,

--- a/docs/source/reference/indexing.rst
+++ b/docs/source/reference/indexing.rst
@@ -34,6 +34,7 @@ Properties
    Index.empty
    Index.T
    Index.values
+   Index.spark_column
 
 Modifying and computations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -168,6 +169,7 @@ MultiIndex Properties
    MultiIndex.nlevels
    MultiIndex.levshape
    MultiIndex.values
+   MultiIndex.spark_column
 
 MultiIndex components
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/reference/series.rst
+++ b/docs/source/reference/series.rst
@@ -34,6 +34,7 @@ Attributes
    Series.T
    Series.hasnans
    Series.values
+   Series.spark_column
 
 Conversion
 ----------


### PR DESCRIPTION
This PR is exposing `spark_column` property representing the Series/Index for users who are familiar with Spark functions to make it easier to work with them.

E.g.:

```py
>>> kdf = ks.DataFrame({'a': [1.0, 1.0, 1.0, 2.0, 2.0, 2.0], 'b': [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]})

>>> from pyspark.sql import functions as F
>>> kdf['greatest'] = F.greatest(kdf.a.spark_column, kdf.b.spark_column)
>>> kdf['least'] = F.least(kdf.a.spark_column, kdf.b.spark_column)
>>> kdf
     a    b  greatest  least
0  1.0  1.0       1.0    1.0
1  1.0  2.0       2.0    1.0
2  1.0  3.0       3.0    1.0
3  2.0  4.0       4.0    2.0
4  2.0  5.0       5.0    2.0
5  2.0  6.0       6.0    2.0
```