### PR TITLE
Use F.datediff() for subtraction of dates as a workaround.

### DIFF
--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -26,7 +26,7 @@ import pandas as pd
 from pandas.api.types import is_list_like
 from pyspark import sql as spark
 from pyspark.sql import functions as F, Window
-from pyspark.sql.types import DoubleType, FloatType, LongType, StringType, TimestampType
+from pyspark.sql.types import DateType, DoubleType, FloatType, LongType, StringType, TimestampType
 
 from databricks import koalas as ks  # For running doctests and reference resolution in PyCharm.
 from databricks.koalas import numpy_compat
@@ -186,6 +186,10 @@ class IndexOpsMixin(object):
             if not isinstance(other.spark_type, TimestampType):
                 raise TypeError("datetime subtraction can only be applied to datetime series.")
             return self.astype("bigint") - other.astype("bigint")
+        elif isinstance(other, IndexOpsMixin) and isinstance(self.spark_type, DateType):
+            if not isinstance(other.spark_type, DateType):
+                raise TypeError("date subtraction can only be applied to date series.")
+            return _column_op(F.datediff)(self, other)
         else:
             return _column_op(spark.Column.__sub__)(self, other)
 

--- a/databricks/koalas/tests/test_series_datetime.py
+++ b/databricks/koalas/tests/test_series_datetime.py
@@ -48,21 +48,33 @@ class SeriesDateTimeTest(ReusedSQLTestCase, SQLTestUtils):
         "It fails in certain OSs presumably due to different "
         "timezone behaviours inherited from C library."
     )
-    def test_subtraction(self):
+    def test_timestamp_subtraction(self):
         pdf = self.pdf1
         kdf = ks.from_pandas(pdf)
         kdf["diff_seconds"] = kdf["end_date"] - kdf["start_date"] - 1
 
         self.assertEqual(list(kdf["diff_seconds"].toPandas()), [35545499, 33644699, 31571099])
 
-        kdf = ks.from_pandas(
-            pd.DataFrame(
-                {"a": pd.date_range("2016-12-31", "2017-01-08", freq="D"), "b": pd.Series(range(9))}
-            )
+        kdf = ks.DataFrame(
+            {"a": pd.date_range("2016-12-31", "2017-01-08", freq="D"), "b": pd.Series(range(9))}
         )
         expected_error_message = "datetime subtraction can only be applied to datetime series."
         with self.assertRaisesRegex(TypeError, expected_error_message):
             kdf["a"] - kdf["b"]
+
+    def test_date_subtraction(self):
+        pdf = self.pdf1
+        kdf = ks.from_pandas(pdf)
+        kdf["diff_days"] = kdf["end_date"].dt.date - kdf["start_date"].dt.date
+
+        self.assert_eq(list(kdf["diff_days"].toPandas()), [411, 389, 365])
+
+        kdf = ks.DataFrame(
+            {"a": pd.date_range("2016-12-31", "2017-01-08", freq="D"), "b": pd.Series(range(9))}
+        )
+        expected_error_message = "date subtraction can only be applied to date series."
+        with self.assertRaisesRegex(TypeError, expected_error_message):
+            kdf["a"].dt.date - kdf["b"]
 
     @unittest.skip(
         "It fails in certain OSs presumably due to different "


### PR DESCRIPTION
Since currently we don't support `timedelta` type in pandas, we haven't support subtraction of dates, but we already have a workaround for subtraction of timestamps returning long instead of `timedelta`. We can also support subtraction of dates returning int.
We should revisit after we support `timedelta` type.