### PR TITLE
Add new package 'typedef' into setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     name='koalas',
     version=VERSION,
     packages=['databricks', 'databricks.koalas', 'databricks.koalas.missing',
-              'databricks.koalas.usage_logging'],
+              'databricks.koalas.usage_logging', 'databricks.koalas.typedef'],
     extras_require={
         'spark': ['pyspark>=2.4.0'],
         'mlflow': ['mlflow>=1.0'],


### PR DESCRIPTION
Read the docs build seems being failed :

```
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/koalas/envs/latest/lib/python3.6/site-packages/sphinx/config.py", line 319, in eval_config_file
    execfile_(filename, namespace)
  File "/home/docs/checkouts/readthedocs.org/user_builds/koalas/envs/latest/lib/python3.6/site-packages/sphinx/util/pycompat.py", line 81, in execfile_
    exec(code, _globals)
  File "/home/docs/checkouts/readthedocs.org/user_builds/koalas/checkouts/latest/docs/source/conf.py", line 19, in <module>
    from databricks import koalas
  File "/home/docs/checkouts/readthedocs.org/user_builds/koalas/envs/latest/lib/python3.6/site-packages/databricks/koalas/__init__.py", line 73, in <module>
    from databricks.koalas.frame import DataFrame
  File "/home/docs/checkouts/readthedocs.org/user_builds/koalas/envs/latest/lib/python3.6/site-packages/databricks/koalas/frame.py", line 74, in <module>
    from databricks.koalas.generic import _Frame
  File "/home/docs/checkouts/readthedocs.org/user_builds/koalas/envs/latest/lib/python3.6/site-packages/databricks/koalas/generic.py", line 36, in <module>
    from databricks.koalas.indexing import AtIndexer, iAtIndexer, iLocIndexer, LocIndexer
  File "/home/docs/checkouts/readthedocs.org/user_builds/koalas/envs/latest/lib/python3.6/site-packages/databricks/koalas/indexing.py", line 33, in <module>
    from databricks.koalas.internal import _InternalFrame, NATURAL_ORDER_COLUMN_NAME
  File "/home/docs/checkouts/readthedocs.org/user_builds/koalas/envs/latest/lib/python3.6/site-packages/databricks/koalas/internal.py", line 45, in <module>
    from databricks.koalas.typedef import infer_pd_series_spark_type, spark_type_to_pandas_dtype
ModuleNotFoundError: No module named 'databricks.koalas.typedef'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/koalas/envs/latest/lib/python3.6/site-packages/sphinx/cmd/build.py", line 279, in build_main
    args.tags, args.verbosity, args.jobs, args.keep_going)
  File "/home/docs/checkouts/readthedocs.org/user_builds/koalas/envs/latest/lib/python3.6/site-packages/sphinx/application.py", line 218, in __init__
    self.config = Config.read(self.confdir, confoverrides or {}, self.tags)
  File "/home/docs/checkouts/readthedocs.org/user_builds/koalas/envs/latest/lib/python3.6/site-packages/sphinx/config.py", line 174, in read
    namespace = eval_config_file(filename, tags)
  File "/home/docs/checkouts/readthedocs.org/user_builds/koalas/envs/latest/lib/python3.6/site-packages/sphinx/config.py", line 332, in eval_config_file
    raise ConfigError(msg % traceback.format_exc())
sphinx.errors.ConfigError: There is a programmable error in your configuration file:

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/koalas/envs/latest/lib/python3.6/site-packages/sphinx/config.py", line 319, in eval_config_file
    execfile_(filename, namespace)
  File "/home/docs/checkouts/readthedocs.org/user_builds/koalas/envs/latest/lib/python3.6/site-packages/sphinx/util/pycompat.py", line 81, in execfile_
    exec(code, _globals)
  File "/home/docs/checkouts/readthedocs.org/user_builds/koalas/checkouts/latest/docs/source/conf.py", line 19, in <module>
    from databricks import koalas
  File "/home/docs/checkouts/readthedocs.org/user_builds/koalas/envs/latest/lib/python3.6/site-packages/databricks/koalas/__init__.py", line 73, in <module>
    from databricks.koalas.frame import DataFrame
  File "/home/docs/checkouts/readthedocs.org/user_builds/koalas/envs/latest/lib/python3.6/site-packages/databricks/koalas/frame.py", line 74, in <module>
    from databricks.koalas.generic import _Frame
  File "/home/docs/checkouts/readthedocs.org/user_builds/koalas/envs/latest/lib/python3.6/site-packages/databricks/koalas/generic.py", line 36, in <module>
    from databricks.koalas.indexing import AtIndexer, iAtIndexer, iLocIndexer, LocIndexer
  File "/home/docs/checkouts/readthedocs.org/user_builds/koalas/envs/latest/lib/python3.6/site-packages/databricks/koalas/indexing.py", line 33, in <module>
    from databricks.koalas.internal import _InternalFrame, NATURAL_ORDER_COLUMN_NAME
  File "/home/docs/checkouts/readthedocs.org/user_builds/koalas/envs/latest/lib/python3.6/site-packages/databricks/koalas/internal.py", line 45, in <module>
    from databricks.koalas.typedef import infer_pd_series_spark_type, spark_type_to_pandas_dtype
ModuleNotFoundError: No module named 'databricks.koalas.typedef'

```

becuase `typedef` package is missing. It became a proper pakcage as of https://github.com/databricks/koalas/commit/59ba781ed27e137378808d578efbd0e4ef7029ee