### PR TITLE
Specify upperbound for Python version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         'spark': ['pyspark>=2.4.0'],
         'mlflow': ['mlflow>=1.0'],
     },
-    python_requires='>=3.5',
+    python_requires='>=3.5,<3.8',
     install_requires=[
         'pandas>=0.23.2',
         'pyarrow>=0.10',


### PR DESCRIPTION
Koalas currently can't support because Spark 2.x does not support Python 3.8. Python 3.8 is supported from Spark 3.