### PR TITLE
Remove an unnecessary instance variable.

### DIFF
--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -597,6 +597,9 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             kdf.groupby("A")["B"].size().sort_index(), pdf.groupby("A")["B"].size().sort_index()
         )
         self.assert_eq(
+            kdf.groupby("A")[["B"]].size().sort_index(), pdf.groupby("A")[["B"]].size().sort_index()
+        )
+        self.assert_eq(
             kdf.groupby(["A", "B"]).size().sort_index(), pdf.groupby(["A", "B"]).size().sort_index()
         )
 


### PR DESCRIPTION
We need to manage the name in the result Series only when it's from a `SeriesGroupBy`.

```py
>>> pdf = pd.DataFrame({"A": [1, 2, 2, 3, 3, 3], "B": [1, 1, 2, 3, 3, 3]})
>>> pdf.groupby("A").size()
A
1    1
2    2
3    3
dtype: int64
>>> pdf.groupby("A")["B"].size()
A
1    1
2    2
3    3
Name: B, dtype: int64
>>> pdf.groupby("A")[["B"]].size()
A
1    1
2    2
3    3
dtype: int64
```
