### PR TITLE
Make reset_index disallow the same name but allow it when drop=True.

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -3598,6 +3598,13 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
             index_map = OrderedDict(new_index_map_items)
 
+        if drop:
+            new_index_map = []
+
+        for _, name in new_index_map:
+            if name in self._internal.column_labels:
+                raise ValueError("cannot insert {}, already exists".format(name_like_string(name)))
+
         new_data_scols = [
             scol_for(self._sdf, column).alias(name_like_string(name))
             for column, name in new_index_map
@@ -3616,14 +3623,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 new_data_scols + self._internal.data_spark_columns + list(HIDDEN_COLUMNS)
             )
 
-            # Now, new internal Spark columns are named as same as index name.
-            new_index_map = [(column, name) for column, name in new_index_map]
-
             sdf = _InternalFrame.attach_default_index(sdf)
             index_map = OrderedDict({SPARK_DEFAULT_INDEX_NAME: None})
-
-        if drop:
-            new_index_map = []
 
         if self._internal.column_labels_level > 1:
             column_depth = len(self._internal.column_labels[0])

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -170,6 +170,21 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             self.assert_eq(pdf_k, kdf_k)
             self.assert_eq(pdf_v, kdf_v)
 
+    def test_reset_index(self):
+        pdf = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}, index=np.random.rand(3))
+        kdf = ks.from_pandas(pdf)
+
+        self.assert_eq(kdf.reset_index(), pdf.reset_index())
+        self.assert_eq(kdf.reset_index(drop=True), pdf.reset_index(drop=True))
+
+        pdf.index.name = "a"
+        kdf.index.name = "a"
+
+        with self.assertRaisesRegex(ValueError, "cannot insert a, already exists"):
+            kdf.reset_index()
+
+        self.assert_eq(kdf.reset_index(drop=True), pdf.reset_index(drop=True))
+
     def test_reset_index_with_default_index_types(self):
         pdf = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}, index=np.random.rand(3))
         kdf = ks.from_pandas(pdf)


### PR DESCRIPTION
pandas' `DataFrame.reset_index()` raises an error if the index name is the same as one of columns but allow it when `drop=True`.

```py
>>> import pandas as pd
>>> import numpy as np
>>> pdf = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}, index=np.random.rand(3))
>>> pdf.index.name = "a"
>>> pdf.reset_index()
Traceback (most recent call last):
...
ValueError: cannot insert a, already exists
>>> pdf.reset_index(drop=True)
   a  b
0  1  4
1  2  5
2  3  6
```

whereas Koalas raises another error for both cases:

```py
>>> ks.from_pandas(pdf).reset_index()
Traceback (most recent call last):
...
pyspark.sql.utils.AnalysisException: "Reference 'a' is ambiguous, could be: a, a.;"

>>> ks.from_pandas(pdf).reset_index(drop=True)
...
pyspark.sql.utils.AnalysisException: "Reference 'a' is ambiguous, could be: a, a.;"
```