### PR TITLE
Fix groupby when as_index=False.

### DIFF
--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -1493,59 +1493,102 @@ class _Frame(object):
             raise NotImplementedError('axis should be either 0 or "index" currently.')
 
         if isinstance(df_or_s, ks.DataFrame):
-            df = df_or_s  # type: ks.DataFrame
-
-            # This is to match the output with pandas'. Pandas seems returning different results
-            # when given series is from different dataframes. It only applies when as_index is
-            # False.
-            should_drop_index = any(
-                isinstance(col_or_s, ks.Series) and df is not col_or_s._kdf for col_or_s in by
-            )
-
-            kdf, col_by = self._resolve_grouping_series(by)
-            return DataFrameGroupBy(
-                kdf, col_by, as_index=as_index, should_drop_index=should_drop_index
-            )
+            kdf, col_by, agg_columns = self._resolve_grouping_series(by)
+            return DataFrameGroupBy(kdf, col_by, as_index=as_index, agg_columns=agg_columns)
         if isinstance(df_or_s, ks.Series):
             col = df_or_s  # type: ks.Series
-            _, col_by = self._resolve_grouping_series(by)
+            _, col_by, _ = self._resolve_grouping_series(by)
             return SeriesGroupBy(col, col_by, as_index=as_index)
         raise TypeError(
             "Constructor expects DataFrame or Series; however, " "got [%s]" % (df_or_s,)
         )
 
     def _resolve_grouping_series(self, by):
-        should_use_name = False
         if isinstance(self, ks.Series):
             kdf = self._kdf
         else:
             kdf = self
-        for col_or_s in by:
-            if isinstance(col_or_s, ks.Series) and kdf is not col_or_s._kdf:
 
-                def assign_columns(kdf, this_column_labels, that_column_labels):
-                    raise NotImplementedError(
-                        "Duplicated labels with groupby() and "
-                        "'compute.ops_on_diff_frames' option are not supported currently "
-                        "Please use unique labels in series and frames."
+        if any(isinstance(col_or_s, ks.Series) and kdf is not col_or_s._kdf for col_or_s in by):
+            column_labels_level = kdf._internal.column_labels_level
+
+            need_assign = []
+            column_labels = []
+            for i, col_or_s in enumerate(by):
+                if isinstance(col_or_s, ks.Series):
+                    if any(
+                        col_or_s.spark_column._jc.equals(scol._jc)
+                        for scol in kdf._internal.data_spark_columns
+                    ):
+                        need_assign.append(False)
+                        column_labels.append(col_or_s._internal.column_labels[0])
+                    else:
+                        need_assign.append(True)
+                        column_labels.append(
+                            tuple(
+                                ([""] * (column_labels_level - 1))
+                                + ["__tmp_groupkey_{}__".format(i)]
+                            )
+                        )
+                elif isinstance(col_or_s, tuple):
+                    kser = kdf[col_or_s]
+                    if not isinstance(kser, ks.Series):
+                        raise ValueError(name_like_string(col_or_s))
+                    need_assign.append(False)
+                    column_labels.append(col_or_s)
+                else:
+                    raise ValueError(col_or_s)
+
+            def assign_columns(kdf, this_column_labels, that_column_labels):
+                raise NotImplementedError(
+                    "Duplicated labels with groupby() and "
+                    "'compute.ops_on_diff_frames' option are not supported currently "
+                    "Please use unique labels in series and frames."
+                )
+
+            for col_or_s, assign, label in zip(by, need_assign, column_labels):
+
+                if assign:
+                    kdf = align_diff_frames(
+                        assign_columns, kdf, col_or_s.rename(label), fillna=False, how="inner",
                     )
 
-                kdf = align_diff_frames(assign_columns, kdf, col_or_s, fillna=False, how="inner")
-                # Should use name to search series because now the anchor is different
-                should_use_name = True
+            new_by_series = []
+            for col_or_s, assign, label in zip(by, need_assign, column_labels):
+                if assign:
+                    new_by_series.append(kdf._kser_for(label).rename(col_or_s.name))
+                else:
+                    new_by_series.append(kdf._kser_for(label))
 
-        new_by_series = []
-        for col_or_s in by:
-            if isinstance(col_or_s, ks.Series) and should_use_name:
-                new_by_series.append(kdf[col_or_s.name])
-            elif isinstance(col_or_s, ks.Series):
-                new_by_series.append(col_or_s)
-            elif isinstance(col_or_s, tuple):
-                new_by_series.append(kdf[col_or_s])
-            else:
-                raise ValueError(col_or_s)
+            agg_columns = [
+                label
+                for label in kdf._internal.column_labels
+                if all(not kdf._kser_for(label)._equals(key) for key in new_by_series)
+                and label not in column_labels
+            ]
 
-        return kdf, new_by_series
+            return kdf, new_by_series, agg_columns
+
+        else:
+            new_by_series = []
+            for col_or_s in by:
+                if isinstance(col_or_s, ks.Series):
+                    new_by_series.append(col_or_s)
+                elif isinstance(col_or_s, tuple):
+                    kser = kdf[col_or_s]
+                    if not isinstance(kser, ks.Series):
+                        raise ValueError(name_like_string(col_or_s))
+                    new_by_series.append(kser)
+                else:
+                    raise ValueError(col_or_s)
+
+            agg_columns = [
+                label
+                for label in kdf._internal.column_labels
+                if all(not kdf[label]._equals(key) for key in new_by_series)
+            ]
+
+            return kdf, new_by_series, agg_columns
 
     def bool(self):
         """

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -203,47 +203,82 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             (True, ["var", "std"]),
         ]
         funcs = [(almost, f) for almost, fs in funcs for f in fs]
-        for ddkey, pdkey in [("b", "b"), (kdf.b, pdf.b), (kdf.b + 1, pdf.b + 1)]:
-            for almost, func in funcs:
-                self.assert_eq(
-                    getattr(kdf.groupby(ddkey).a, func)().sort_index(),
-                    getattr(pdf.groupby(pdkey).a, func)().sort_index(),
-                    almost=almost,
-                )
-                self.assert_eq(
-                    getattr(kdf.groupby(ddkey), func)().sort_index(),
-                    getattr(pdf.groupby(pdkey), func)().sort_index(),
-                    almost=almost,
-                )
 
-        for ddkey, pdkey in [(kdf.b, pdf.b), (kdf.b + 1, pdf.b + 1)]:
-            for almost, func in funcs:
-                self.assert_eq(
-                    getattr(kdf.a.groupby(ddkey), func)().sort_index(),
-                    getattr(pdf.a.groupby(pdkey), func)().sort_index(),
-                    almost=almost,
-                )
-                self.assert_eq(
-                    getattr((kdf.a + 1).groupby(ddkey), func)().sort_index(),
-                    getattr((pdf.a + 1).groupby(pdkey), func)().sort_index(),
-                    almost=almost,
-                )
-                self.assert_eq(
-                    getattr((kdf.b + 1).groupby(ddkey), func)().sort_index(),
-                    getattr((pdf.b + 1).groupby(pdkey), func)().sort_index(),
-                    almost=almost,
-                )
+        for as_index in [True, False]:
+            if as_index:
+                sort = lambda df: df.sort_index()
+            else:
+                sort = lambda df: df.sort_values(list(df.columns)).reset_index(drop=True)
 
-        for i in [0, 4, 7]:
+            for almost, func in funcs:
+                for kkey, pkey in [("b", "b"), (kdf.b, pdf.b)]:
+                    with self.subTest(as_index=as_index, func=func, key=pkey):
+                        if as_index is True or func != "std":
+                            self.assert_eq(
+                                sort(getattr(kdf.groupby(kkey, as_index=as_index).a, func)()),
+                                sort(getattr(pdf.groupby(pkey, as_index=as_index).a, func)()),
+                                almost=almost,
+                            )
+                            self.assert_eq(
+                                sort(getattr(kdf.groupby(kkey, as_index=as_index), func)()),
+                                sort(getattr(pdf.groupby(pkey, as_index=as_index), func)()),
+                                almost=almost,
+                            )
+                        else:
+                            # seems like a pandas' bug for as_index=False and func == "std"?
+                            self.assert_eq(
+                                sort(getattr(kdf.groupby(kkey, as_index=as_index).a, func)()),
+                                sort(pdf.groupby(pkey, as_index=True).a.std().reset_index()),
+                                almost=almost,
+                            )
+                            self.assert_eq(
+                                sort(getattr(kdf.groupby(kkey, as_index=as_index), func)()),
+                                sort(pdf.groupby(pkey, as_index=True).std().reset_index()),
+                                almost=almost,
+                            )
+
+                kkey, pkey = (kdf.b + 1, pdf.b + 1)
+                with self.subTest(as_index=as_index, func=func, key=pkey):
+                    self.assert_eq(
+                        sort(getattr(kdf.groupby(kkey, as_index=as_index).a, func)()),
+                        sort(getattr(pdf.groupby(pkey, as_index=as_index).a, func)()),
+                        almost=almost,
+                    )
+                    self.assert_eq(
+                        sort(getattr(kdf.groupby(kkey, as_index=as_index), func)()),
+                        sort(getattr(pdf.groupby(pkey, as_index=as_index), func)()),
+                        almost=almost,
+                    )
+
+            for almost, func in funcs:
+                for i in [0, 4, 7]:
+                    with self.subTest(as_index=as_index, func=func, i=i):
+                        self.assert_eq(
+                            sort(getattr(kdf.groupby(kdf.b > i, as_index=as_index).a, func)()),
+                            sort(getattr(pdf.groupby(pdf.b > i, as_index=as_index).a, func)()),
+                            almost=almost,
+                        )
+                        self.assert_eq(
+                            sort(getattr(kdf.groupby(kdf.b > i, as_index=as_index), func)()),
+                            sort(getattr(pdf.groupby(pdf.b > i, as_index=as_index), func)()),
+                            almost=almost,
+                        )
+
+        for kkey, pkey in [(kdf.b, pdf.b), (kdf.b + 1, pdf.b + 1)]:
             for almost, func in funcs:
                 self.assert_eq(
-                    getattr(kdf.groupby(kdf.b > i).a, func)().sort_index(),
-                    getattr(pdf.groupby(pdf.b > i).a, func)().sort_index(),
+                    getattr(kdf.a.groupby(kkey), func)().sort_index(),
+                    getattr(pdf.a.groupby(pkey), func)().sort_index(),
                     almost=almost,
                 )
                 self.assert_eq(
-                    getattr(kdf.groupby(kdf.b > i), func)().sort_index(),
-                    getattr(pdf.groupby(pdf.b > i), func)().sort_index(),
+                    getattr((kdf.a + 1).groupby(kkey), func)().sort_index(),
+                    getattr((pdf.a + 1).groupby(pkey), func)().sort_index(),
+                    almost=almost,
+                )
+                self.assert_eq(
+                    getattr((kdf.b + 1).groupby(kkey), func)().sort_index(),
+                    getattr((pdf.b + 1).groupby(pkey), func)().sort_index(),
                     almost=almost,
                 )
 
@@ -254,23 +289,68 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         kdf = ks.from_pandas(pdf)
 
         for as_index in [True, False]:
-            stats_kdf = kdf.groupby("A", as_index=as_index).agg({"B": "min", "C": "sum"})
-            stats_pdf = pdf.groupby("A", as_index=as_index).agg({"B": "min", "C": "sum"})
-            self.assert_eq(
-                stats_kdf.sort_values(by=["B", "C"]).reset_index(drop=True),
-                stats_pdf.sort_values(by=["B", "C"]).reset_index(drop=True),
-            )
+            if as_index:
+                sort = lambda df: df.sort_index()
+            else:
+                sort = lambda df: df.sort_values(list(df.columns)).reset_index(drop=True)
 
-            stats_kdf = kdf.groupby("A", as_index=as_index).agg({"B": ["min", "max"], "C": "sum"})
-            stats_pdf = pdf.groupby("A", as_index=as_index).agg({"B": ["min", "max"], "C": "sum"})
-            self.assert_eq(
-                stats_kdf.sort_values(by=[("B", "min"), ("B", "max"), ("C", "sum")]).reset_index(
-                    drop=True
-                ),
-                stats_pdf.sort_values(by=[("B", "min"), ("B", "max"), ("C", "sum")]).reset_index(
-                    drop=True
-                ),
-            )
+            for kkey, pkey in [("A", "A"), (kdf.A, pdf.A)]:
+                with self.subTest(as_index=as_index, key=pkey):
+                    self.assert_eq(
+                        sort(kdf.groupby(kkey, as_index=as_index).agg("sum")),
+                        sort(pdf.groupby(pkey, as_index=as_index).agg("sum")),
+                    )
+                    self.assert_eq(
+                        sort(kdf.groupby(kkey, as_index=as_index).agg({"B": "min", "C": "sum"})),
+                        sort(pdf.groupby(pkey, as_index=as_index).agg({"B": "min", "C": "sum"})),
+                    )
+                    self.assert_eq(
+                        sort(
+                            kdf.groupby(kkey, as_index=as_index).agg(
+                                {"B": ["min", "max"], "C": "sum"}
+                            )
+                        ),
+                        sort(
+                            pdf.groupby(pkey, as_index=as_index).agg(
+                                {"B": ["min", "max"], "C": "sum"}
+                            )
+                        ),
+                    )
+
+                    if as_index:
+                        self.assert_eq(
+                            sort(kdf.groupby(kkey, as_index=as_index).agg(["sum"])),
+                            sort(pdf.groupby(pkey, as_index=as_index).agg(["sum"])),
+                        )
+                    else:
+                        # seems like a pandas' bug for as_index=False and func_or_funcs is list?
+                        self.assert_eq(
+                            sort(kdf.groupby(kkey, as_index=as_index).agg(["sum"])),
+                            sort(pdf.groupby(pkey, as_index=True).agg(["sum"]).reset_index()),
+                        )
+
+            kkey, pkey = (kdf.A + 1, pdf.A + 1)
+            with self.subTest(as_index=as_index, key=pkey):
+                self.assert_eq(
+                    sort(kdf.groupby(kkey, as_index=as_index).agg("sum")),
+                    sort(pdf.groupby(pkey, as_index=as_index).agg("sum")),
+                )
+                self.assert_eq(
+                    sort(kdf.groupby(kkey, as_index=as_index).agg({"B": "min", "C": "sum"})),
+                    sort(pdf.groupby(pkey, as_index=as_index).agg({"B": "min", "C": "sum"})),
+                )
+                self.assert_eq(
+                    sort(
+                        kdf.groupby(kkey, as_index=as_index).agg({"B": ["min", "max"], "C": "sum"})
+                    ),
+                    sort(
+                        pdf.groupby(pkey, as_index=as_index).agg({"B": ["min", "max"], "C": "sum"})
+                    ),
+                )
+                self.assert_eq(
+                    sort(kdf.groupby(kkey, as_index=as_index).agg(["sum"])),
+                    sort(pdf.groupby(pkey, as_index=as_index).agg(["sum"])),
+                )
 
         expected_error_message = (
             r"aggs must be a dict mapping from column name \(string or "


### PR DESCRIPTION
When `as_index=False`, the behavior of groupby for statistic functions like `sum`, `min`, `max`, etc. and `aggregate` function is not the same as pandas'.

```py
>>> pdf = pd.DataFrame({"a": [1, 2, 6, 4, 4, 6, 4, 3, 7], "b": [4, 2, 7, 3, 3, 1, 1, 1, 2]}, index=[0, 1, 3, 5, 6, 8, 9, 9, 9])
>>> pdf.groupby(pdf.b, as_index=False).sum()
   b   a
0  1  13
1  2   9
2  3   8
3  4   1
4  7   6
>>> pdf.groupby(pdf.b + 1, as_index=False).sum()
    a  b
0  13  3
1   9  4
2   8  6
3   1  4
4   6  7
```

For Koalas,

```py
>>> kdf.groupby(kdf.b, as_index=False).sum().sort_values('b')
   b   a
1  1  13
3  2   9
2  3   8
4  4   1
0  7   6
>>> kdf.groupby(kdf.b + 1, as_index=False).sum()
Traceback (most recent call last):
...
ValueError: cannot insert b, already exists
```

The first one is fine, but the second one raises `ValueError` because the key name conflicts the existing column name.

Even if renaming the group key,

```py
>>> pdf.groupby((pdf.b + 1).rename('c'), as_index=False).sum()
    a  b
0  13  3
1   9  4
2   8  6
3   1  4
4   6  7
>>> kdf.groupby((kdf.b + 1).rename('c'), as_index=False).sum()
   c   a  b
0  5   1  4
1  3   9  4
2  8   6  7
3  2  13  3
4  4   8  6
```