### PR TITLE
Support tuple for as a temp column label in verify_temp_column_name.

### DIFF
--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -36,11 +36,12 @@ from databricks import koalas as ks  # For running doctests and reference resolu
 from databricks.koalas.indexing import AtIndexer, iAtIndexer, iLocIndexer, LocIndexer
 from databricks.koalas.internal import _InternalFrame, NATURAL_ORDER_COLUMN_NAME
 from databricks.koalas.utils import (
-    validate_arguments_and_invoke_function,
-    scol_for,
-    validate_axis,
     align_diff_frames,
     name_like_string,
+    scol_for,
+    validate_arguments_and_invoke_function,
+    validate_axis,
+    verify_temp_column_name,
 )
 from databricks.koalas.window import Rolling, Expanding
 
@@ -1524,12 +1525,14 @@ class _Frame(object):
                         column_labels.append(col_or_s._internal.column_labels[0])
                     else:
                         need_assign.append(True)
-                        column_labels.append(
+                        temp_label = verify_temp_column_name(
+                            kdf,
                             tuple(
                                 ([""] * (column_labels_level - 1))
                                 + ["__tmp_groupkey_{}__".format(i)]
-                            )
+                            ),
                         )
+                        column_labels.append(temp_label)
                 elif isinstance(col_or_s, tuple):
                     kser = kdf[col_or_s]
                     if not isinstance(kser, ks.Series):

--- a/databricks/koalas/utils.py
+++ b/databricks/koalas/utils.py
@@ -486,59 +486,102 @@ def validate_bool_kwarg(value, arg_name):
     return value
 
 
-def verify_temp_column_name(df: Union["DataFrame", spark.DataFrame], column_name: str) -> str:
+def verify_temp_column_name(
+    df: Union["DataFrame", spark.DataFrame], column_name_or_label: Union[str, Tuple[str, ...]]
+) -> Union[str, Tuple[str, ...]]:
     """
     Verify that the given column name does not exist in the given Koalas or Spark DataFrame.
 
-    The temporary column names should start and end with `__`. In addition, `column_name` only
-    expects a single string instead of labels when `df` is a Koalas DataFrame.
+    The temporary column names should start and end with `__`. In addition, `column_name_or_label`
+    expects a single string, or column labels when `df` is a Koalas DataFrame.
 
     >>> kdf = ks.DataFrame({("x", "a"): ['a', 'b', 'c']})
     >>> kdf["__dummy__"] = 0
+    >>> kdf[("", "__dummy__")] = 1
     >>> kdf  # doctest: +NORMALIZE_WHITESPACE
        x __dummy__
-       a
-    0  a         0
-    1  b         0
-    2  c         0
+       a           __dummy__
+    0  a         0         1
+    1  b         0         1
+    2  c         0         1
 
     >>> verify_temp_column_name(kdf, '__tmp__')
-    '__tmp__'
+    ('__tmp__', '')
+    >>> verify_temp_column_name(kdf, ('', '__tmp__'))
+    ('', '__tmp__')
     >>> verify_temp_column_name(kdf, '__dummy__')
     Traceback (most recent call last):
     ...
-    AssertionError: ... `__dummy__` ...
+    AssertionError: ... `(__dummy__, )` ...
+    >>> verify_temp_column_name(kdf, ('', '__dummy__'))
+    Traceback (most recent call last):
+    ...
+    AssertionError: ... `(, __dummy__)` ...
+    >>> verify_temp_column_name(kdf, 'dummy')
+    Traceback (most recent call last):
+    ...
+    AssertionError: ... should be empty or start and end with `__`: ('dummy', '')
+    >>> verify_temp_column_name(kdf, ('', 'dummy'))
+    Traceback (most recent call last):
+    ...
+    AssertionError: ... should be empty or start and end with `__`: ('', 'dummy')
 
     >>> sdf = kdf._internal.spark_frame
     >>> sdf.select(kdf._internal.data_spark_columns).show()  # doctest: +NORMALIZE_WHITESPACE
-    +------+---------+
-    |(x, a)|__dummy__|
-    +------+---------+
-    |     a|        0|
-    |     b|        0|
-    |     c|        0|
-    +------+---------+
+    +------+---------+-------------+
+    |(x, a)|__dummy__|(, __dummy__)|
+    +------+---------+-------------+
+    |     a|        0|            1|
+    |     b|        0|            1|
+    |     c|        0|            1|
+    +------+---------+-------------+
 
     >>> verify_temp_column_name(sdf, '__tmp__')
     '__tmp__'
     >>> verify_temp_column_name(sdf, '__dummy__')
     Traceback (most recent call last):
     ...
-    AssertionError: ... `__dummy__` ... '(x, a)', '__dummy__', ...
+    AssertionError: ... `__dummy__` ... '(x, a)', '__dummy__', '(, __dummy__)', ...
+    >>> verify_temp_column_name(sdf, ('', '__dummy__'))
+    Traceback (most recent call last):
+    ...
+    AssertionError: <class 'tuple'>
+    >>> verify_temp_column_name(sdf, 'dummy')
+    Traceback (most recent call last):
+    ...
+    AssertionError: ... should start and end with `__`: dummy
     """
     from databricks.koalas.frame import DataFrame
 
-    assert column_name.startswith("__") and column_name.endswith(
-        "__"
-    ), "The temporary column name should start and end with `__`."
-
     if isinstance(df, DataFrame):
+        if isinstance(column_name_or_label, str):
+            column_name = column_name_or_label
+
+            level = df._internal.column_labels_level
+            column_name_or_label = tuple([column_name_or_label] + ([""] * (level - 1)))
+        else:
+            column_name = name_like_string(column_name_or_label)
+
+        assert any(len(label) > 0 for label in column_name_or_label) and all(
+            label == "" or (label.startswith("__") and label.endswith("__"))
+            for label in column_name_or_label
+        ), "The temporary column name should be empty or start and end with `__`: {}".format(
+            column_name_or_label
+        )
         assert all(
-            column_name != label[0] for label in df._internal.column_labels
+            column_name_or_label != label for label in df._internal.column_labels
         ), "The given column name `{}` already exists in the Koalas DataFrame: {}".format(
-            column_name, df.columns
+            name_like_string(column_name_or_label), df.columns
         )
         df = df._internal.spark_frame
+    else:
+        assert isinstance(column_name_or_label, str), type(column_name_or_label)
+        assert column_name_or_label.startswith("__") and column_name_or_label.endswith(
+            "__"
+        ), "The temporary column name should start and end with `__`: {}".format(
+            column_name_or_label
+        )
+        column_name = column_name_or_label
 
     assert isinstance(df, spark.DataFrame), type(df)
     assert (
@@ -546,7 +589,8 @@ def verify_temp_column_name(df: Union["DataFrame", spark.DataFrame], column_name
     ), "The given column name `{}` already exists in the Spark DataFrame: {}".format(
         column_name, df.columns
     )
-    return column_name
+
+    return column_name_or_label
 
 
 def compare_null_first(left, right, comp):


### PR DESCRIPTION
Extending `verify_temp_column_name` to support column labels when the `df` is Koalas DataFrame.