### PR TITLE
Fix Series.groupby on the Series from different DataFrames.

### DIFF
--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -36,11 +36,12 @@ from databricks import koalas as ks  # For running doctests and reference resolu
 from databricks.koalas.indexing import AtIndexer, iAtIndexer, iLocIndexer, LocIndexer
 from databricks.koalas.internal import _InternalFrame, NATURAL_ORDER_COLUMN_NAME
 from databricks.koalas.utils import (
-    validate_arguments_and_invoke_function,
-    scol_for,
-    validate_axis,
     align_diff_frames,
     name_like_string,
+    scol_for,
+    validate_arguments_and_invoke_function,
+    validate_axis,
+    verify_temp_column_name,
 )
 from databricks.koalas.window import Rolling, Expanding
 
@@ -1524,12 +1525,14 @@ class _Frame(object):
                         column_labels.append(col_or_s._internal.column_labels[0])
                     else:
                         need_assign.append(True)
-                        column_labels.append(
+                        temp_label = verify_temp_column_name(
+                            kdf,
                             tuple(
                                 ([""] * (column_labels_level - 1))
                                 + ["__tmp_groupkey_{}__".format(i)]
-                            )
+                            ),
                         )
+                        column_labels.append(temp_label)
                 elif isinstance(col_or_s, tuple):
                     kser = kdf[col_or_s]
                     if not isinstance(kser, ks.Series):

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -1970,7 +1970,7 @@ class GroupBy(object):
                             ([""] * (column_labels_level - 1)) + ["__tmp_groupkey_{}__".format(i)]
                         ),
                     )
-                    column_labels.append(temp_label)
+                    column_labels.append(temp_label)  # type: ignore
             elif isinstance(col_or_s, tuple):
                 kser = kdf[col_or_s]
                 if not isinstance(kser, Series):

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -56,7 +56,13 @@ from databricks.koalas.missing.groupby import (
 )
 from databricks.koalas.series import Series, _col
 from databricks.koalas.config import get_option
-from databricks.koalas.utils import column_labels_level, scol_for, name_like_string
+from databricks.koalas.utils import (
+    align_diff_frames,
+    column_labels_level,
+    name_like_string,
+    scol_for,
+    verify_temp_column_name,
+)
 from databricks.koalas.window import RollingGroupby, ExpandingGroupby
 
 # to keep it the same as pandas
@@ -1940,14 +1946,106 @@ class GroupBy(object):
                 kdf = kdf.reset_index()
         return kdf
 
+    @staticmethod
+    def _resolve_grouping_from_diff_dataframes(
+        kdf: DataFrame, by: List[Union[Series, Tuple[str, ...]]]
+    ) -> Tuple[DataFrame, List[Series], List[Tuple[str, ...]]]:
+        column_labels_level = kdf._internal.column_labels_level
+
+        need_assign = []
+        column_labels = []
+        for i, col_or_s in enumerate(by):
+            if isinstance(col_or_s, Series):
+                if any(
+                    col_or_s.spark_column._jc.equals(scol._jc)
+                    for scol in kdf._internal.data_spark_columns
+                ):
+                    need_assign.append(False)
+                    column_labels.append(col_or_s._internal.column_labels[0])
+                else:
+                    need_assign.append(True)
+                    temp_label = verify_temp_column_name(
+                        kdf,
+                        tuple(
+                            ([""] * (column_labels_level - 1)) + ["__tmp_groupkey_{}__".format(i)]
+                        ),
+                    )
+                    column_labels.append(temp_label)
+            elif isinstance(col_or_s, tuple):
+                kser = kdf[col_or_s]
+                if not isinstance(kser, Series):
+                    raise ValueError(name_like_string(col_or_s))
+                need_assign.append(False)
+                column_labels.append(col_or_s)
+            else:
+                raise ValueError(col_or_s)
+
+        def assign_columns(kdf, this_column_labels, that_column_labels):
+            raise NotImplementedError(
+                "Duplicated labels with groupby() and "
+                "'compute.ops_on_diff_frames' option are not supported currently "
+                "Please use unique labels in series and frames."
+            )
+
+        for col_or_s, assign, label in zip(by, need_assign, column_labels):
+            if assign:
+                kser = col_or_s
+                kdf = align_diff_frames(
+                    assign_columns, kdf, kser.rename(label), fillna=False, how="inner",
+                )
+
+        new_by_series = []
+        for col_or_s, assign, label in zip(by, need_assign, column_labels):
+            if assign:
+                kser = col_or_s
+                new_by_series.append(kdf._kser_for(label).rename(kser.name))
+            else:
+                new_by_series.append(kdf._kser_for(label))
+
+        return kdf, new_by_series, column_labels
+
+    @staticmethod
+    def _resolve_grouping(kdf: DataFrame, by: List[Union[Series, Tuple[str, ...]]]) -> List[Series]:
+        new_by_series = []
+        for col_or_s in by:
+            if isinstance(col_or_s, Series):
+                new_by_series.append(col_or_s)
+            elif isinstance(col_or_s, tuple):
+                kser = kdf[col_or_s]
+                if not isinstance(kser, Series):
+                    raise ValueError(name_like_string(col_or_s))
+                new_by_series.append(kser)
+            else:
+                raise ValueError(col_or_s)
+        return new_by_series
+
 
 class DataFrameGroupBy(GroupBy):
+    @staticmethod
+    def _build(
+        kdf: DataFrame, by: List[Union[Series, Tuple[str, ...]]], as_index: bool
+    ) -> "DataFrameGroupBy":
+        if any(isinstance(col_or_s, Series) and kdf is not col_or_s._kdf for col_or_s in by):
+            kdf, new_by_series, column_labels = GroupBy._resolve_grouping_from_diff_dataframes(
+                kdf, by
+            )
+            agg_columns = [
+                label
+                for label in kdf._internal.column_labels
+                if all(not kdf._kser_for(label)._equals(key) for key in new_by_series)
+                and label not in column_labels
+            ]
+        else:
+            new_by_series = GroupBy._resolve_grouping(kdf, by)
+            agg_columns = [
+                label
+                for label in kdf._internal.column_labels
+                if all(not kdf[label]._equals(key) for key in new_by_series)
+            ]
+        return DataFrameGroupBy(kdf, new_by_series, as_index=as_index, agg_columns=agg_columns)
+
     def __init__(
-        self,
-        kdf: DataFrame,
-        by: List[Series],
-        as_index: bool,
-        agg_columns: List[Union[str, Tuple[str, ...]]],
+        self, kdf: DataFrame, by: List[Series], as_index: bool, agg_columns: List[Tuple[str, ...]],
     ):
         self._kdf = kdf
         self._groupkeys = by
@@ -2092,6 +2190,19 @@ class DataFrameGroupBy(GroupBy):
 
 
 class SeriesGroupBy(GroupBy):
+    @staticmethod
+    def _build(
+        kser: Series, by: List[Union[Series, Tuple[str, ...]]], as_index: bool
+    ) -> "SeriesGroupBy":
+        if any(isinstance(col_or_s, Series) and kser._kdf is not col_or_s._kdf for col_or_s in by):
+            kdf, new_by_series, _ = GroupBy._resolve_grouping_from_diff_dataframes(
+                kser.to_frame(), by
+            )
+            return SeriesGroupBy(kdf[kser.name], new_by_series, as_index=as_index)
+        else:
+            new_by_series = GroupBy._resolve_grouping(kser._kdf, by)
+            return SeriesGroupBy(kser, new_by_series, as_index=as_index)
+
     def __init__(self, kser: Series, by: List[Series], as_index: bool = True):
         self._kser = kser
         self._groupkeys = by

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -264,23 +264,24 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
                             almost=almost,
                         )
 
-        for kkey, pkey in [(kdf.b, pdf.b), (kdf.b + 1, pdf.b + 1)]:
-            for almost, func in funcs:
-                self.assert_eq(
-                    getattr(kdf.a.groupby(kkey), func)().sort_index(),
-                    getattr(pdf.a.groupby(pkey), func)().sort_index(),
-                    almost=almost,
-                )
-                self.assert_eq(
-                    getattr((kdf.a + 1).groupby(kkey), func)().sort_index(),
-                    getattr((pdf.a + 1).groupby(pkey), func)().sort_index(),
-                    almost=almost,
-                )
-                self.assert_eq(
-                    getattr((kdf.b + 1).groupby(kkey), func)().sort_index(),
-                    getattr((pdf.b + 1).groupby(pkey), func)().sort_index(),
-                    almost=almost,
-                )
+        for almost, func in funcs:
+            for kkey, pkey in [(kdf.b, pdf.b), (kdf.b + 1, pdf.b + 1)]:
+                with self.subTest(func=func, key=pkey):
+                    self.assert_eq(
+                        getattr(kdf.a.groupby(kkey), func)().sort_index(),
+                        getattr(pdf.a.groupby(pkey), func)().sort_index(),
+                        almost=almost,
+                    )
+                    self.assert_eq(
+                        getattr((kdf.a + 1).groupby(kkey), func)().sort_index(),
+                        getattr((pdf.a + 1).groupby(pkey), func)().sort_index(),
+                        almost=almost,
+                    )
+                    self.assert_eq(
+                        getattr((kdf.b + 1).groupby(kkey), func)().sort_index(),
+                        getattr((pdf.b + 1).groupby(pkey), func)().sort_index(),
+                        almost=almost,
+                    )
 
     def test_aggregate(self):
         pdf = pd.DataFrame(

--- a/databricks/koalas/tests/test_ops_on_diff_frames_groupby.py
+++ b/databricks/koalas/tests/test_ops_on_diff_frames_groupby.py
@@ -96,6 +96,36 @@ class OpsOnDiffFramesGroupByTest(ReusedSQLTestCase, SQLTestUtils):
             pdf1.groupby(pdf2[("x", "a")])[[("y", "c")]].sum().sort_index(),
         )
 
+    def test_split_apply_combine_on_series(self):
+        pdf1 = pd.DataFrame({"C": [0.362, 0.227, 1.267, -0.562], "B": [1, 2, 3, 4]})
+        pdf2 = pd.DataFrame({"A": [1, 1, 2, 2]})
+        kdf1 = ks.from_pandas(pdf1)
+        kdf2 = ks.from_pandas(pdf2)
+
+        for as_index in [True, False]:
+            if as_index:
+                sort = lambda df: df.sort_index()
+            else:
+                sort = lambda df: df.sort_values(list(df.columns)).reset_index(drop=True)
+
+            with self.subTest(as_index=as_index):
+                self.assert_eq(
+                    sort(kdf1.groupby(kdf2.A, as_index=as_index).sum()),
+                    sort(pdf1.groupby(pdf2.A, as_index=as_index).sum()),
+                )
+                self.assert_eq(
+                    sort(kdf1.groupby(kdf2.A, as_index=as_index).B.sum()),
+                    sort(pdf1.groupby(pdf2.A, as_index=as_index).B.sum()),
+                )
+
+        self.assert_eq(
+            kdf1.B.groupby(kdf2.A).sum().sort_index(), pdf1.B.groupby(pdf2.A).sum().sort_index(),
+        )
+        self.assert_eq(
+            (kdf1.B + 1).groupby(kdf2.A).sum().sort_index(),
+            (pdf1.B + 1).groupby(pdf2.A).sum().sort_index(),
+        )
+
     def test_aggregate(self):
         pdf1 = pd.DataFrame({"C": [0.362, 0.227, 1.267, -0.562], "B": [1, 2, 3, 4]})
         pdf2 = pd.DataFrame({"A": [1, 1, 2, 2]})

--- a/databricks/koalas/utils.py
+++ b/databricks/koalas/utils.py
@@ -486,59 +486,102 @@ def validate_bool_kwarg(value, arg_name):
     return value
 
 
-def verify_temp_column_name(df: Union["DataFrame", spark.DataFrame], column_name: str) -> str:
+def verify_temp_column_name(
+    df: Union["DataFrame", spark.DataFrame], column_name_or_label: Union[str, Tuple[str, ...]]
+) -> Union[str, Tuple[str, ...]]:
     """
     Verify that the given column name does not exist in the given Koalas or Spark DataFrame.
 
-    The temporary column names should start and end with `__`. In addition, `column_name` only
-    expects a single string instead of labels when `df` is a Koalas DataFrame.
+    The temporary column names should start and end with `__`. In addition, `column_name_or_label`
+    expects a single string, or column labels when `df` is a Koalas DataFrame.
 
     >>> kdf = ks.DataFrame({("x", "a"): ['a', 'b', 'c']})
     >>> kdf["__dummy__"] = 0
+    >>> kdf[("", "__dummy__")] = 1
     >>> kdf  # doctest: +NORMALIZE_WHITESPACE
        x __dummy__
-       a
-    0  a         0
-    1  b         0
-    2  c         0
+       a           __dummy__
+    0  a         0         1
+    1  b         0         1
+    2  c         0         1
 
     >>> verify_temp_column_name(kdf, '__tmp__')
-    '__tmp__'
+    ('__tmp__', '')
+    >>> verify_temp_column_name(kdf, ('', '__tmp__'))
+    ('', '__tmp__')
     >>> verify_temp_column_name(kdf, '__dummy__')
     Traceback (most recent call last):
     ...
-    AssertionError: ... `__dummy__` ...
+    AssertionError: ... `(__dummy__, )` ...
+    >>> verify_temp_column_name(kdf, ('', '__dummy__'))
+    Traceback (most recent call last):
+    ...
+    AssertionError: ... `(, __dummy__)` ...
+    >>> verify_temp_column_name(kdf, 'dummy')
+    Traceback (most recent call last):
+    ...
+    AssertionError: ... should be empty or start and end with `__`: ('dummy', '')
+    >>> verify_temp_column_name(kdf, ('', 'dummy'))
+    Traceback (most recent call last):
+    ...
+    AssertionError: ... should be empty or start and end with `__`: ('', 'dummy')
 
     >>> sdf = kdf._internal.spark_frame
     >>> sdf.select(kdf._internal.data_spark_columns).show()  # doctest: +NORMALIZE_WHITESPACE
-    +------+---------+
-    |(x, a)|__dummy__|
-    +------+---------+
-    |     a|        0|
-    |     b|        0|
-    |     c|        0|
-    +------+---------+
+    +------+---------+-------------+
+    |(x, a)|__dummy__|(, __dummy__)|
+    +------+---------+-------------+
+    |     a|        0|            1|
+    |     b|        0|            1|
+    |     c|        0|            1|
+    +------+---------+-------------+
 
     >>> verify_temp_column_name(sdf, '__tmp__')
     '__tmp__'
     >>> verify_temp_column_name(sdf, '__dummy__')
     Traceback (most recent call last):
     ...
-    AssertionError: ... `__dummy__` ... '(x, a)', '__dummy__', ...
+    AssertionError: ... `__dummy__` ... '(x, a)', '__dummy__', '(, __dummy__)', ...
+    >>> verify_temp_column_name(sdf, ('', '__dummy__'))
+    Traceback (most recent call last):
+    ...
+    AssertionError: <class 'tuple'>
+    >>> verify_temp_column_name(sdf, 'dummy')
+    Traceback (most recent call last):
+    ...
+    AssertionError: ... should start and end with `__`: dummy
     """
     from databricks.koalas.frame import DataFrame
 
-    assert column_name.startswith("__") and column_name.endswith(
-        "__"
-    ), "The temporary column name should start and end with `__`."
-
     if isinstance(df, DataFrame):
+        if isinstance(column_name_or_label, str):
+            column_name = column_name_or_label
+
+            level = df._internal.column_labels_level
+            column_name_or_label = tuple([column_name_or_label] + ([""] * (level - 1)))
+        else:
+            column_name = name_like_string(column_name_or_label)
+
+        assert any(len(label) > 0 for label in column_name_or_label) and all(
+            label == "" or (label.startswith("__") and label.endswith("__"))
+            for label in column_name_or_label
+        ), "The temporary column name should be empty or start and end with `__`: {}".format(
+            column_name_or_label
+        )
         assert all(
-            column_name != label[0] for label in df._internal.column_labels
+            column_name_or_label != label for label in df._internal.column_labels
         ), "The given column name `{}` already exists in the Koalas DataFrame: {}".format(
-            column_name, df.columns
+            name_like_string(column_name_or_label), df.columns
         )
         df = df._internal.spark_frame
+    else:
+        assert isinstance(column_name_or_label, str), type(column_name_or_label)
+        assert column_name_or_label.startswith("__") and column_name_or_label.endswith(
+            "__"
+        ), "The temporary column name should start and end with `__`: {}".format(
+            column_name_or_label
+        )
+        column_name = column_name_or_label
 
     assert isinstance(df, spark.DataFrame), type(df)
     assert (
@@ -546,7 +589,8 @@ def verify_temp_column_name(df: Union["DataFrame", spark.DataFrame], column_name
     ), "The given column name `{}` already exists in the Spark DataFrame: {}".format(
         column_name, df.columns
     )
-    return column_name
+
+    return column_name_or_label
 
 
 def compare_null_first(left, right, comp):


### PR DESCRIPTION
Fixing `Series.groupby` on the Series from different DataFrames.

```py
>>> import databricks.koalas as ks
>>> kdf1 = ks.DataFrame({"C": [0.362, 0.227, 1.267, -0.562], "B": [1, 2, 3, 4]})
>>> kdf2 = ks.DataFrame({"A": [1, 1, 2, 2]})
>>> ks.options.compute.ops_on_diff_frames = True
>>> kdf1.B.groupby(kdf2.A).sum()
Traceback (most recent call last):
...
pyspark.sql.utils.AnalysisException: 'Resolved attribute(s) __tmp_groupkey_0__#118L missing from ...\n'
```