### PR TITLE
Make groupby.apply in pandas<0.25 run the function only once per group.

### DIFF
--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -977,7 +977,7 @@ class GroupBy(object):
         def pandas_groupby_apply(pdf):
 
             if not is_series_groupby and LooseVersion(pd.__version__) < LooseVersion("0.25"):
-                # `groupby.apply` in pandas<2.5 runs the functions twice for the first group.
+                # `groupby.apply` in pandas<0.25 runs the functions twice for the first group.
                 # https://github.com/pandas-dev/pandas/pull/24748
                 from pandas.core.base import SelectionMixin
 

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -983,26 +983,26 @@ class GroupBy(object):
 
                 f = SelectionMixin._builtin_table.get(func, func)
 
-                dummy_value = None
+                should_skip_first_call = True
 
-                def _func(df):
-                    nonlocal dummy_value
-                    if dummy_value is None:
+                def wrapped_func(df):
+                    nonlocal should_skip_first_call
+                    if should_skip_first_call:
+                        should_skip_first_call = False
                         if should_return_series:
-                            dummy_value = pd.Series()
+                            return pd.Series()
                         else:
-                            dummy_value = pd.DataFrame()
-                        return dummy_value
+                            return pd.DataFrame()
                     else:
                         return f(df)
 
             else:
-                _func = func
+                wrapped_func = func
 
             if is_series_groupby:
-                pdf_or_ser = pdf.groupby(input_groupnames)[name].apply(_func)
+                pdf_or_ser = pdf.groupby(input_groupnames)[name].apply(wrapped_func)
             else:
-                pdf_or_ser = pdf.groupby(input_groupnames).apply(_func)
+                pdf_or_ser = pdf.groupby(input_groupnames).apply(wrapped_func)
 
             if not isinstance(pdf_or_ser, pd.DataFrame):
                 return pd.DataFrame(pdf_or_ser)

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -1330,6 +1330,35 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
                 kdf.groupby("d").apply(sum).sort_index(), pdf.groupby("d").apply(sum).sort_index()
             )
 
+    def test_apply_with_side_effect(self):
+        pdf = pd.DataFrame(
+            {"d": [1.0, 1.0, 1.0, 2.0, 2.0, 2.0], "v": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]}
+        )
+        kdf = ks.from_pandas(pdf)
+
+        acc = ks.utils.default_session().sparkContext.accumulator(0)
+
+        def sum_with_acc_frame(x) -> ks.DataFrame[np.float64, np.float64]:
+            nonlocal acc
+            acc += 1
+            return np.sum(x)
+
+        actual = kdf.groupby("d").apply(sum_with_acc_frame).sort_index()
+        actual.columns = ["d", "v"]
+        self.assert_eq(actual, pdf.groupby("d").apply(sum).sort_index().reset_index(drop=True))
+        self.assert_eq(acc.value, 2)
+
+        def sum_with_acc_series(x) -> np.float64:
+            nonlocal acc
+            acc += 1
+            return np.sum(x)
+
+        self.assert_eq(
+            kdf.groupby("d")["v"].apply(sum_with_acc_series).sort_index(),
+            pdf.groupby("d")["v"].apply(sum).sort_index().reset_index(drop=True),
+        )
+        self.assert_eq(acc.value, 4)
+
     def test_transform(self):
         pdf = pd.DataFrame(
             {"a": [1, 2, 3, 4, 5, 6], "b": [1, 1, 2, 3, 5, 8], "c": [1, 4, 9, 16, 25, 36]},


### PR DESCRIPTION
`groupby.apply` in pandas<0.25 runs the functions twice for the first group, so if the function has a side effect, it could cause an unexpected behavior.

```py
>>> import pandas as pd
>>> pd.__version__
'0.24.2'

>>> kdf = ks.DataFrame({"d": [1.0, 1.0, 1.0, 2.0, 2.0, 2.0], "v": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]})
>>> acc = ks.utils.default_session().sparkContext.accumulator(0)
>>> def sum_with_acc_frame(x) -> ks.DataFrame[np.float64, np.float64]:
...   global acc
...   acc += 1
...   return np.sum(x)
...
>>> kdf.groupby("d").apply(sum_with_acc_frame)
    c0    c1
0  3.0   6.0
1  6.0  15.0
>>> acc.value
4
```

whereas:

```py
>>> import pandas as pd
>>> pd.__version__
'0.25.3'

...

>>> acc.value
2
```

The `acc.value` should be `2` since there are only 2 groups and the function should be called twice.
