### PR TITLE
Fix Series.div when div/floordiv np.inf by zero

### DIFF
--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -180,7 +180,7 @@ class IndexOpsMixin(object):
 
     def __truediv__(self, other):
         def truediv(left, right):
-            return F.when(F.lit(right != 0), left.__div__(right)).otherwise(
+            return F.when(F.lit(right != 0) | F.lit(right).isNull(), left.__div__(right)).otherwise(
                 F.when(F.lit(left == np.inf) | F.lit(left == -np.inf), left).otherwise(
                     F.lit(np.inf).__div__(left)
                 )
@@ -215,7 +215,9 @@ class IndexOpsMixin(object):
     def __floordiv__(self, other):
         def floordiv(left, right):
             return F.when(F.lit(right is np.nan), np.nan).otherwise(
-                F.when(F.lit(right != 0), F.floor(left.__div__(right))).otherwise(
+                F.when(
+                    F.lit(right != 0) | F.lit(right).isNull(), F.floor(left.__div__(right))
+                ).otherwise(
                     F.when(F.lit(left == np.inf) | F.lit(left == -np.inf), left).otherwise(
                         F.lit(np.inf).__div__(left)
                     )

--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -185,6 +185,15 @@ class IndexOpsMixin(object):
         2. When divide positive number by zero, PySpark returns null whereas pandas returns np.inf
         3. When divide -np.inf by zero, PySpark returns null whereas pandas returns -np.inf
         4. When divide negative number by zero, PySpark returns null whereas pandas returns -np.inf
+
+        +-------------------------------------------+
+        | dividend (divisor: 0) | PySpark | pandas  |
+        |-----------------------|---------|---------|
+        |         np.inf        |   null  |  np.inf |
+        |        -np.inf        |   null  | -np.inf |
+        |           10          |   null  |  np.inf |
+        |          -10          |   null  | -np.inf |
+        +-----------------------|---------|---------+
         """
 
         def truediv(left, right):
@@ -227,6 +236,15 @@ class IndexOpsMixin(object):
         2. When divide positive number by zero, PySpark returns null whereas pandas returns np.inf
         3. When divide -np.inf by zero, PySpark returns null whereas pandas returns -np.inf
         4. When divide negative number by zero, PySpark returns null whereas pandas returns -np.inf
+
+        +-------------------------------------------+
+        | dividend (divisor: 0) | PySpark | pandas  |
+        |-----------------------|---------|---------|
+        |         np.inf        |   null  |  np.inf |
+        |        -np.inf        |   null  | -np.inf |
+        |           10          |   null  |  np.inf |
+        |          -10          |   null  | -np.inf |
+        +-----------------------|---------|---------+
         """
 
         def floordiv(left, right):

--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -181,10 +181,10 @@ class IndexOpsMixin(object):
     def __truediv__(self, other):
         """
         __truediv__ has different behaviour between pandas and PySpark for several cases.
-        1. when dividing np.inf by zero, PySpark returns null whereas pandas returns np.inf
-        2. When dividing positive number by zero, PySpark returns null whereas pandas returns np.inf
-        3. When dividing -np.inf by zero, PySpark returns null whereas pandas returns -np.inf
-        4. When dividing negative number by zero, PySpark returns null whereas pandas returns -np.inf
+        1. When divide np.inf by zero, PySpark returns null whereas pandas returns np.inf
+        2. When divide positive number by zero, PySpark returns null whereas pandas returns np.inf
+        3. When divide -np.inf by zero, PySpark returns null whereas pandas returns -np.inf
+        4. When divide negative number by zero, PySpark returns null whereas pandas returns -np.inf
         """
 
         def truediv(left, right):
@@ -223,10 +223,10 @@ class IndexOpsMixin(object):
     def __floordiv__(self, other):
         """
         __floordiv__ has different behaviour between pandas and PySpark for several cases.
-        1. when dividing np.inf by zero, PySpark returns null whereas pandas returns np.inf
-        2. When dividing positive number by zero, PySpark returns null whereas pandas returns np.inf
-        3. When dividing -np.inf by zero, PySpark returns null whereas pandas returns -np.inf
-        4. When dividing negative number by zero, PySpark returns null whereas pandas returns -np.inf
+        1. When divide np.inf by zero, PySpark returns null whereas pandas returns np.inf
+        2. When divide positive number by zero, PySpark returns null whereas pandas returns np.inf
+        3. When divide -np.inf by zero, PySpark returns null whereas pandas returns -np.inf
+        4. When divide negative number by zero, PySpark returns null whereas pandas returns -np.inf
         """
 
         def floordiv(left, right):

--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -184,9 +184,10 @@ class IndexOpsMixin(object):
                 F.lit(right == 0) & (F.lit(left != np.inf) & F.lit(left != -np.inf)),
                 F.lit(np.inf).__div__(left),
             ).otherwise(
-                F.when(F.lit(left == np.inf) | F.lit(left == -np.inf), left).otherwise(
-                    left.__truediv__(right)
-                )
+                F.when(
+                    (F.lit(left == np.inf) | F.lit(left == -np.inf)) & F.lit(right is not np.nan),
+                    left,
+                ).otherwise(left.__truediv__(right))
             )
 
         return _numpy_column_op(truediv)(self, other)
@@ -221,8 +222,14 @@ class IndexOpsMixin(object):
                 F.lit(right == 0) & (F.lit(left != np.inf) & F.lit(left != -np.inf)),
                 F.lit(np.inf).__div__(left),
             ).otherwise(
-                F.when(F.lit(left == np.inf) | F.lit(left == -np.inf), left).otherwise(
-                    F.when(F.lit(right) == np.nan, np.nan).otherwise(F.floor(left.__div__(right)))
+                F.when(
+                    F.lit(right == 0) & (F.lit(left == np.inf) | F.lit(left == -np.inf)), left
+                ).otherwise(
+                    F.when(F.lit(left == np.inf) | F.lit(left == -np.inf), np.nan).otherwise(
+                        F.when(F.lit(right is np.nan), np.nan).otherwise(
+                            F.floor(left.__div__(right))
+                        )
+                    )
                 )
             )
 

--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -179,6 +179,14 @@ class IndexOpsMixin(object):
     __mul__ = _column_op(spark.Column.__mul__)
 
     def __truediv__(self, other):
+        """
+        __truediv__ has different behaviour between pandas and PySpark for several cases.
+        1. when dividing np.inf by zero, PySpark returns null whereas pandas returns np.inf
+        2. When dividing positive number by zero, PySpark returns null whereas pandas returns np.inf
+        3. When dividing -np.inf by zero, PySpark returns null whereas pandas returns -np.inf
+        4. When dividing negative number by zero, PySpark returns null whereas pandas returns -np.inf
+        """
+
         def truediv(left, right):
             return F.when(F.lit(right != 0) | F.lit(right).isNull(), left.__div__(right)).otherwise(
                 F.when(F.lit(left == np.inf) | F.lit(left == -np.inf), left).otherwise(
@@ -213,6 +221,14 @@ class IndexOpsMixin(object):
         return _numpy_column_op(rtruediv)(self, other)
 
     def __floordiv__(self, other):
+        """
+        __floordiv__ has different behaviour between pandas and PySpark for several cases.
+        1. when dividing np.inf by zero, PySpark returns null whereas pandas returns np.inf
+        2. When dividing positive number by zero, PySpark returns null whereas pandas returns np.inf
+        3. When dividing -np.inf by zero, PySpark returns null whereas pandas returns -np.inf
+        4. When dividing negative number by zero, PySpark returns null whereas pandas returns -np.inf
+        """
+
         def floordiv(left, right):
             return F.when(F.lit(right is np.nan), np.nan).otherwise(
                 F.when(

--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -187,7 +187,7 @@ class IndexOpsMixin(object):
         4. When divide negative number by zero, PySpark returns null whereas pandas returns -np.inf
 
         +-------------------------------------------+
-        | dividend (divisor: 0) | PySpark | pandas  |
+        | dividend (divisor: 0) | PySpark |  pandas |
         |-----------------------|---------|---------|
         |         np.inf        |   null  |  np.inf |
         |        -np.inf        |   null  | -np.inf |
@@ -238,7 +238,7 @@ class IndexOpsMixin(object):
         4. When divide negative number by zero, PySpark returns null whereas pandas returns -np.inf
 
         +-------------------------------------------+
-        | dividend (divisor: 0) | PySpark | pandas  |
+        | dividend (divisor: 0) | PySpark |  pandas |
         |-----------------------|---------|---------|
         |         np.inf        |   null  |  np.inf |
         |        -np.inf        |   null  | -np.inf |

--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -180,9 +180,9 @@ class IndexOpsMixin(object):
 
     def __truediv__(self, other):
         def truediv(left, right):
-            return F.when(F.lit(right == 0), F.lit(np.inf).__div__(left)).otherwise(
-                left.__truediv__(right)
-            )
+            return F.when(
+                F.lit(right == 0) & F.lit(left != np.inf), F.lit(np.inf).__div__(left)
+            ).otherwise(F.when(F.lit(left == np.inf), left).otherwise(left.__truediv__(right)))
 
         return _numpy_column_op(truediv)(self, other)
 
@@ -212,8 +212,12 @@ class IndexOpsMixin(object):
 
     def __floordiv__(self, other):
         def floordiv(left, right):
-            return F.when(F.lit(right == 0), F.lit(np.inf).__div__(left)).otherwise(
-                F.when(F.lit(right) == np.nan, np.nan).otherwise(F.floor(left.__div__(right)))
+            return F.when(
+                F.lit(right == 0) & F.lit(left != np.inf), F.lit(np.inf).__div__(left)
+            ).otherwise(
+                F.when(F.lit(left == np.inf), left).otherwise(
+                    F.when(F.lit(right) == np.nan, np.nan).otherwise(F.floor(left.__div__(right)))
+                )
             )
 
         return _numpy_column_op(floordiv)(self, other)

--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -181,8 +181,13 @@ class IndexOpsMixin(object):
     def __truediv__(self, other):
         def truediv(left, right):
             return F.when(
-                F.lit(right == 0) & F.lit(left != np.inf), F.lit(np.inf).__div__(left)
-            ).otherwise(F.when(F.lit(left == np.inf), left).otherwise(left.__truediv__(right)))
+                F.lit(right == 0) & (F.lit(left != np.inf) & F.lit(left != -np.inf)),
+                F.lit(np.inf).__div__(left),
+            ).otherwise(
+                F.when(F.lit(left == np.inf) | F.lit(left == -np.inf), left).otherwise(
+                    left.__truediv__(right)
+                )
+            )
 
         return _numpy_column_op(truediv)(self, other)
 
@@ -213,9 +218,10 @@ class IndexOpsMixin(object):
     def __floordiv__(self, other):
         def floordiv(left, right):
             return F.when(
-                F.lit(right == 0) & F.lit(left != np.inf), F.lit(np.inf).__div__(left)
+                F.lit(right == 0) & (F.lit(left != np.inf) & F.lit(left != -np.inf)),
+                F.lit(np.inf).__div__(left),
             ).otherwise(
-                F.when(F.lit(left == np.inf), left).otherwise(
+                F.when(F.lit(left == np.inf) | F.lit(left == -np.inf), left).otherwise(
                     F.when(F.lit(right) == np.nan, np.nan).otherwise(F.floor(left.__div__(right)))
                 )
             )

--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -180,14 +180,10 @@ class IndexOpsMixin(object):
 
     def __truediv__(self, other):
         def truediv(left, right):
-            return F.when(
-                F.lit(right == 0) & (F.lit(left != np.inf) & F.lit(left != -np.inf)),
-                F.lit(np.inf).__div__(left),
-            ).otherwise(
-                F.when(
-                    (F.lit(left == np.inf) | F.lit(left == -np.inf)) & F.lit(right is not np.nan),
-                    left,
-                ).otherwise(left.__truediv__(right))
+            return F.when(F.lit(right != 0), left.__div__(right)).otherwise(
+                F.when(F.lit(left == np.inf) | F.lit(left == -np.inf), left).otherwise(
+                    F.lit(np.inf).__div__(left)
+                )
             )
 
         return _numpy_column_op(truediv)(self, other)
@@ -218,17 +214,10 @@ class IndexOpsMixin(object):
 
     def __floordiv__(self, other):
         def floordiv(left, right):
-            return F.when(
-                F.lit(right == 0) & (F.lit(left != np.inf) & F.lit(left != -np.inf)),
-                F.lit(np.inf).__div__(left),
-            ).otherwise(
-                F.when(
-                    F.lit(right == 0) & (F.lit(left == np.inf) | F.lit(left == -np.inf)), left
-                ).otherwise(
-                    F.when(F.lit(left == np.inf) | F.lit(left == -np.inf), np.nan).otherwise(
-                        F.when(F.lit(right is np.nan), np.nan).otherwise(
-                            F.floor(left.__div__(right))
-                        )
+            return F.when(F.lit(right is np.nan), np.nan).otherwise(
+                F.when(F.lit(right != 0), F.floor(left.__div__(right))).otherwise(
+                    F.when(F.lit(left == np.inf) | F.lit(left == -np.inf), left).otherwise(
+                        F.lit(np.inf).__div__(left)
                     )
                 )
             )

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -1480,7 +1480,9 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
             self.assert_eq(repr(pser.floordiv(0)), repr(kser.floordiv(0)))
             self.assert_eq(repr(pser // 0), repr(kser // 0))
         else:
-            result = pd.Series([np.inf, np.nan, -np.inf, np.nan, np.inf, -np.inf], name="Koalas")
+            result = pd.Series(
+                [np.inf, np.nan, -np.inf, np.nan, np.inf, -np.inf, np.inf, -np.inf], name="Koalas"
+            )
             self.assert_eq(repr(kser.floordiv(0)), repr(result))
             self.assert_eq(repr(kser // 0), repr(result))
 

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -1468,7 +1468,7 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(kser.squeeze(), pser.squeeze())
 
     def test_div_zero(self):
-        pser = pd.Series([100, None, -300, None, 500, -700, np.inf], name="Koalas")
+        pser = pd.Series([100, None, -300, None, 500, -700, np.inf, -np.inf], name="Koalas")
         kser = ks.from_pandas(pser)
 
         self.assert_eq(repr(pser.div(0)), repr(kser.div(0)))

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -1468,7 +1468,7 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(kser.squeeze(), pser.squeeze())
 
     def test_div_zero(self):
-        pser = pd.Series([100, None, -300, None, 500, -700], name="Koalas")
+        pser = pd.Series([100, None, -300, None, 500, -700, np.inf], name="Koalas")
         kser = ks.from_pandas(pser)
 
         self.assert_eq(repr(pser.div(0)), repr(kser.div(0)))

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -1467,15 +1467,18 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         pser = kser.to_pandas()
         self.assert_eq(kser.squeeze(), pser.squeeze())
 
-    def test_div_zero(self):
+    def test_div_zero_and_nan(self):
         pser = pd.Series([100, None, -300, None, 500, -700, np.inf, -np.inf], name="Koalas")
         kser = ks.from_pandas(pser)
 
         self.assert_eq(repr(pser.div(0)), repr(kser.div(0)))
         self.assert_eq(repr(pser.truediv(0)), repr(kser.truediv(0)))
         self.assert_eq(repr(pser / 0), repr(kser / 0))
+        self.assert_eq(repr(pser.div(np.nan)), repr(kser.div(np.nan)))
+        self.assert_eq(repr(pser.truediv(np.nan)), repr(kser.truediv(np.nan)))
+        self.assert_eq(repr(pser / np.nan), repr(kser / np.nan))
 
-        # floordiv has different behavior in pandas > 1.0.0
+        # floordiv has different behavior in pandas > 1.0.0 when divide by 0
         if LooseVersion(pd.__version__) >= LooseVersion("1.0.0"):
             self.assert_eq(repr(pser.floordiv(0)), repr(kser.floordiv(0)))
             self.assert_eq(repr(pser // 0), repr(kser // 0))
@@ -1485,9 +1488,4 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
             )
             self.assert_eq(repr(kser.floordiv(0)), repr(result))
             self.assert_eq(repr(kser // 0), repr(result))
-
-    def test_floordiv_nan(self):
-        pser = pd.Series([-100, 0, 100, None, np.nan], name="Koalas")
-        kser = ks.from_pandas(pser)
-
         self.assert_eq(repr(pser.floordiv(np.nan)), repr(kser.floordiv(np.nan)))


### PR DESCRIPTION
There is an incompatible hehaviour with pandas when divide `np.inf` by 0

```python
>>> pser
0    0.0
1    NaN
2    inf
Name: 0, dtype: float64
>>> kser
0    0.0
1    NaN
2    inf
Name: 0, dtype: float64

>>> pser.div(0)
0    NaN
1    NaN
2    inf
Name: 0, dtype: float64
>>> kser.div(0)
0   NaN
1   NaN
2   NaN  # Have to be a `inf`
Name: 0, dtype: float64
```

This PR fixed it.