### PR TITLE
Fix functions using GroupBy._apply_series_op.

### DIFF
--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -626,7 +626,7 @@ class GroupBy(object):
         Name: a, dtype: float64
         """
         return self._apply_series_op(
-            lambda sg: sg._kser._diff(periods, part_cols=sg._groupkeys_scols)
+            lambda sg: sg._kser._diff(periods, part_cols=[s.spark_column for s in sg._groupkeys])
         )
 
     def cummax(self):
@@ -674,7 +674,7 @@ class GroupBy(object):
 
         """
         return self._apply_series_op(
-            lambda sg: sg._kser._cum(F.max, True, part_cols=sg._groupkeys_scols)
+            lambda sg: sg._kser._cum(F.max, True, part_cols=[s.spark_column for s in sg._groupkeys])
         )
 
     def cummin(self):
@@ -721,7 +721,7 @@ class GroupBy(object):
         Name: B, dtype: float64
         """
         return self._apply_series_op(
-            lambda sg: sg._kser._cum(F.min, True, part_cols=sg._groupkeys_scols)
+            lambda sg: sg._kser._cum(F.min, True, part_cols=[s.spark_column for s in sg._groupkeys])
         )
 
     def cumprod(self):
@@ -769,7 +769,7 @@ class GroupBy(object):
 
         """
         return self._apply_series_op(
-            lambda sg: sg._kser._cumprod(True, part_cols=sg._groupkeys_scols)
+            lambda sg: sg._kser._cumprod(True, part_cols=[s.spark_column for s in sg._groupkeys])
         )
 
     def cumsum(self):
@@ -817,7 +817,7 @@ class GroupBy(object):
 
         """
         return self._apply_series_op(
-            lambda sg: sg._kser._cum(F.sum, True, part_cols=sg._groupkeys_scols)
+            lambda sg: sg._kser._cum(F.sum, True, part_cols=[s.spark_column for s in sg._groupkeys])
         )
 
     def apply(self, func):
@@ -1224,7 +1224,9 @@ class GroupBy(object):
 
         """
         return self._apply_series_op(
-            lambda sg: sg._kser._rank(method, ascending, part_cols=sg._groupkeys_scols)
+            lambda sg: sg._kser._rank(
+                method, ascending, part_cols=[s.spark_column for s in sg._groupkeys]
+            )
         )
 
     # TODO: add axis parameter
@@ -1662,7 +1664,9 @@ class GroupBy(object):
         8  0
         """
         return self._apply_series_op(
-            lambda sg: sg._kser._shift(periods, fill_value, part_cols=sg._groupkeys_scols)
+            lambda sg: sg._kser._shift(
+                periods, fill_value, part_cols=[s.spark_column for s in sg._groupkeys]
+            )
         )
 
     def transform(self, func):
@@ -2261,7 +2265,9 @@ class SeriesGroupBy(GroupBy):
         return op(self)
 
     def _fillna(self, *args, **kwargs):
-        return Series._fillna(self._kser, *args, **kwargs, part_cols=self._groupkeys_scols)
+        return self._kser._fillna(
+            *args, **kwargs, part_cols=[s.spark_column for s in self._groupkeys]
+        )
 
     @property
     def _kdf(self) -> DataFrame:

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -771,6 +771,16 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             pdf.groupby(["b"])[["a", "b"]].diff().sort_index(),
             almost=True,
         )
+        self.assert_eq(
+            kdf.groupby(kdf.b // 5).diff().sort_index(),
+            pdf.groupby(pdf.b // 5).diff().sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            kdf.groupby(kdf.b // 5)["a"].diff().sort_index(),
+            pdf.groupby(pdf.b // 5)["a"].diff().sort_index(),
+            almost=True,
+        )
 
         # multi-index columns
         columns = pd.MultiIndex.from_tuples([("x", "a"), ("x", "b"), ("y", "c")])
@@ -808,6 +818,16 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         self.assert_eq(
             kdf.groupby(["b"])[["a", "c"]].rank().sort_index(),
             pdf.groupby(["b"])[["a", "c"]].rank().sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            kdf.groupby(kdf.b // 5).rank().sort_index(),
+            pdf.groupby(pdf.b // 5).rank().sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            kdf.groupby(kdf.b // 5)["a"].rank().sort_index(),
+            pdf.groupby(pdf.b // 5)["a"].rank().sort_index(),
             almost=True,
         )
 
@@ -850,6 +870,16 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         self.assert_eq(
             kdf.groupby(["b"])[["a", "c"]].cummin().sort_index(),
             pdf.groupby(["b"])[["a", "c"]].cummin().sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            kdf.groupby(kdf.b // 5).cummin().sort_index(),
+            pdf.groupby(pdf.b // 5).cummin().sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            kdf.groupby(kdf.b // 5)["a"].cummin().sort_index(),
+            pdf.groupby(pdf.b // 5)["a"].cummin().sort_index(),
             almost=True,
         )
 
@@ -895,6 +925,16 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             pdf.groupby(["b"])[["a", "c"]].cummax().sort_index(),
             almost=True,
         )
+        self.assert_eq(
+            kdf.groupby(kdf.b // 5).cummax().sort_index(),
+            pdf.groupby(pdf.b // 5).cummax().sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            kdf.groupby(kdf.b // 5)["a"].cummax().sort_index(),
+            pdf.groupby(pdf.b // 5)["a"].cummax().sort_index(),
+            almost=True,
+        )
 
         # multi-index columns
         columns = pd.MultiIndex.from_tuples([("x", "a"), ("x", "b"), ("y", "c")])
@@ -936,6 +976,16 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         self.assert_eq(
             kdf.groupby(["b"])[["a", "c"]].cumsum().sort_index(),
             pdf.groupby(["b"])[["a", "c"]].cumsum().sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            kdf.groupby(kdf.b // 5).cumsum().sort_index(),
+            pdf.groupby(pdf.b // 5).cumsum().sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            kdf.groupby(kdf.b // 5)["a"].cumsum().sort_index(),
+            pdf.groupby(pdf.b // 5)["a"].cumsum().sort_index(),
             almost=True,
         )
 
@@ -982,6 +1032,16 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         self.assert_eq(
             kdf.groupby(["b"])[["a", "c"]].cumprod().sort_index(),
             pdf.groupby(["b"])[["a", "c"]].cumprod().sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            kdf.groupby(kdf.b // 3).cumprod().sort_index(),
+            pdf.groupby(pdf.b // 3).cumprod().sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            kdf.groupby(kdf.b // 3)["a"].cumprod().sort_index(),
+            pdf.groupby(pdf.b // 3)["a"].cumprod().sort_index(),
             almost=True,
         )
 
@@ -1062,12 +1122,46 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             kdf.groupby("A").fillna(0).sort_index(), pdf.groupby("A").fillna(0).sort_index()
         )
         self.assert_eq(
+            kdf.groupby("A")["C"].fillna(0).sort_index(),
+            pdf.groupby("A")["C"].fillna(0).sort_index(),
+        )
+        self.assert_eq(
             kdf.groupby("A").fillna(method="bfill").sort_index(),
             pdf.groupby("A").fillna(method="bfill").sort_index(),
         )
         self.assert_eq(
+            kdf.groupby("A")["C"].fillna(method="bfill").sort_index(),
+            pdf.groupby("A")["C"].fillna(method="bfill").sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
             kdf.groupby("A").fillna(method="ffill").sort_index(),
             pdf.groupby("A").fillna(method="ffill").sort_index(),
+        )
+        self.assert_eq(
+            kdf.groupby("A")["C"].fillna(method="ffill").sort_index(),
+            pdf.groupby("A")["C"].fillna(method="ffill").sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            kdf.groupby(kdf.A // 5).fillna(method="bfill").sort_index(),
+            pdf.groupby(pdf.A // 5).fillna(method="bfill").sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            kdf.groupby(kdf.A // 5)["C"].fillna(method="bfill").sort_index(),
+            pdf.groupby(pdf.A // 5)["C"].fillna(method="bfill").sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            kdf.groupby(kdf.A // 5).fillna(method="ffill").sort_index(),
+            pdf.groupby(pdf.A // 5).fillna(method="ffill").sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            kdf.groupby(kdf.A // 5)["C"].fillna(method="ffill").sort_index(),
+            pdf.groupby(pdf.A // 5)["C"].fillna(method="ffill").sort_index(),
+            almost=True,
         )
 
         # multi-index columns
@@ -1196,6 +1290,16 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         self.assert_eq(
             kdf.groupby(["a", "b"])["c"].shift().sort_index(),
             pdf.groupby(["a", "b"])["c"].shift().sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            kdf.groupby(kdf.b // 5).shift().sort_index(),
+            pdf.groupby(pdf.b // 5).shift().sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            kdf.groupby(kdf.b // 5)["a"].shift().sort_index(),
+            pdf.groupby(pdf.b // 5)["a"].shift().sort_index(),
             almost=True,
         )
         # TODO: known pandas' bug when fill_value is not None pandas>=1.0.0


### PR DESCRIPTION
Fixing groupby functions using `GroupBy._apply_series_op`, such as `cumxxx`, `diff`, `shift`, etc to use the original group keys since `Series` doesn't know the modified group keys in `SeriesGroupBy`, otherwise it doesn't follow the actual group keys.

```py
>>> kdf = ks.DataFrame({"a": [1, 2, 3, 4, 5, 6], "b": [1, 1, 2, 3, 5, 8], "c": [1, 4, 9, 16, 25, 36]})
>>> kdf
   a  b   c
0  1  1   1
1  2  1   4
2  3  2   9
3  4  3  16
4  5  5  25
5  6  8  36
>>> kdf.groupby((kdf.b // 5).rename('b')).cumsum().sort_index()
   a  b   c
0  1  1   1
1  3  2   5
2  3  2   9
3  4  3  16
4  5  5  25
5  6  8  36
```

This should be:

```py
>>> pdf.groupby((pdf.b // 5).rename('b')).cumsum().sort_index()
    a   b   c
0   1   1   1
1   3   2   5
2   6   4  14
3  10   7  30
4   5   5  25
5  11  13  61
```

Or even raises an error:

```py
>>> kdf.groupby(kdf.b // 5).cumsum().sort_index()
Traceback (most recent call last):

...

pyspark.sql.utils.AnalysisException: "cannot resolve '`CASE WHEN false THEN (Infinity / b) ELSE CASE WHEN (5 = NaN) THEN NaN ELSE FLOOR((b / 5)) END END`' given input columns: ...
```
