### PR TITLE
Fix GroupBy.filter to follow complex group keys.

### DIFF
--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -1512,10 +1512,24 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             kdf.groupby("b").filter(lambda x: x.b.mean() < 4).sort_index(),
             pdf.groupby("b").filter(lambda x: x.b.mean() < 4).sort_index(),
         )
+        # TODO: handle agg_columns.
+        # self.assert_eq(
+        #     kdf.groupby("b")[["b"]].filter(lambda x: x.b.mean() < 4).sort_index(),
+        #     pdf.groupby("b")[["b"]].filter(lambda x: x.b.mean() < 4).sort_index(),
+        # )
         self.assert_eq(
             kdf.groupby(["a", "b"]).filter(lambda x: any(x.a == 2)).sort_index(),
             pdf.groupby(["a", "b"]).filter(lambda x: any(x.a == 2)).sort_index(),
         )
+        self.assert_eq(
+            kdf.groupby(kdf["b"] // 5).filter(lambda x: any(x.a == 2)).sort_index(),
+            pdf.groupby(pdf["b"] // 5).filter(lambda x: any(x.a == 2)).sort_index(),
+        )
+        # TODO: handle agg_columns.
+        # self.assert_eq(
+        #     kdf.groupby(kdf["b"] // 5)[["a"]].filter(lambda x: any(x == 2)).sort_index(),
+        #     pdf.groupby(pdf["b"] // 5)[["a"]].filter(lambda x: any(x == 2)).sort_index(),
+        # )
 
         with self.assertRaisesRegex(TypeError, "<class 'int'> object is not callable"):
             kdf.groupby("b").filter(1)

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -1509,13 +1509,13 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         kdf = ks.from_pandas(pdf)
 
         self.assert_eq(
-            kdf.groupby("b").filter(lambda x: x.b.mean() < 4).sort_index(),
-            pdf.groupby("b").filter(lambda x: x.b.mean() < 4).sort_index(),
+            kdf.groupby("b").filter(lambda x: any(x.a == 2)).sort_index(),
+            pdf.groupby("b").filter(lambda x: any(x.a == 2)).sort_index(),
         )
         # TODO: handle agg_columns.
         # self.assert_eq(
-        #     kdf.groupby("b")[["b"]].filter(lambda x: x.b.mean() < 4).sort_index(),
-        #     pdf.groupby("b")[["b"]].filter(lambda x: x.b.mean() < 4).sort_index(),
+        #     kdf.groupby("b")[["a"]].filter(lambda x: any(x.a == 2)).sort_index(),
+        #     pdf.groupby("b")[["a"]].filter(lambda x: any(x.a == 2)).sort_index(),
         # )
         self.assert_eq(
             kdf.groupby(["a", "b"]).filter(lambda x: any(x.a == 2)).sort_index(),
@@ -1527,8 +1527,8 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         )
         # TODO: handle agg_columns.
         # self.assert_eq(
-        #     kdf.groupby(kdf["b"] // 5)[["a"]].filter(lambda x: any(x == 2)).sort_index(),
-        #     pdf.groupby(pdf["b"] // 5)[["a"]].filter(lambda x: any(x == 2)).sort_index(),
+        #     kdf.groupby(kdf["b"] // 5)[["a"]].filter(lambda x: any(x.a == 2)).sort_index(),
+        #     pdf.groupby(pdf["b"] // 5)[["a"]].filter(lambda x: any(x.a == 2)).sort_index(),
         # )
 
         with self.assertRaisesRegex(TypeError, "<class 'int'> object is not callable"):
@@ -1540,8 +1540,8 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         kdf.columns = columns
 
         self.assert_eq(
-            kdf.groupby(("x", "b")).filter(lambda x: x[("x", "b")].mean() < 4).sort_index(),
-            pdf.groupby(("x", "b")).filter(lambda x: x[("x", "b")].mean() < 4).sort_index(),
+            kdf.groupby(("x", "b")).filter(lambda x: any(x[("x", "a")] == 2)).sort_index(),
+            pdf.groupby(("x", "b")).filter(lambda x: any(x[("x", "a")] == 2)).sort_index(),
         )
         self.assert_eq(
             kdf.groupby([("x", "a"), ("x", "b")])


### PR DESCRIPTION
Fixing `GroupBy.filter` to follow complex group keys.

```py
>>> kdf = ks.DataFrame({"a": [1, 2, 3, 4, 5, 6], "b": [1, 1, 2, 3, 5, 8], "c": [1, 4, 9, 16, 25, 36]})
>>> kdf.groupby(kdf["b"] // 5).filter(lambda x: any(x.a == 2))
   a  b  c
0  1  1  1
1  2  1  4
```

This should be:

```py
>>> pdf.groupby(pdf["b"] // 5).filter(lambda x: any(x.a == 2))
   a  b   c
0  1  1   1
1  2  1   4
2  3  2   9
3  4  3  16
```