### PR TITLE
Fix GroupBy.transform to follow complex group keys.

### DIFF
--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -1772,10 +1772,11 @@ class GroupBy(object):
         spec = inspect.getfullargspec(func)
         return_sig = spec.annotations.get("return", None)
 
-        if isinstance(self, DataFrameGroupBy):
-            kdf = self._kdf
-        else:
+        if isinstance(self, SeriesGroupBy):
             kdf = self._kser._kdf
+        else:
+            kdf = self._kdf
+
         groupkey_labels = [
             verify_temp_column_name(kdf, "__groupkey_{}__".format(i))
             for i in range(len(self._groupkeys))

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -1771,12 +1771,24 @@ class GroupBy(object):
 
         spec = inspect.getfullargspec(func)
         return_sig = spec.annotations.get("return", None)
-        input_groupnames = [s.name for s in self._groupkeys]
+
+        if isinstance(self, DataFrameGroupBy):
+            kdf = self._kdf
+        else:
+            kdf = self._kser._kdf
+        groupkey_labels = [
+            verify_temp_column_name(kdf, "__groupkey_{}__".format(i))
+            for i in range(len(self._groupkeys))
+        ]
+        kdf = kdf[
+            [s.rename(label) for s, label in zip(self._groupkeys, groupkey_labels)]
+            + self._agg_columns
+        ]
+
+        groupkey_names = [label if len(label) > 1 else label[0] for label in groupkey_labels]
 
         def pandas_transform(pdf):
-            # pandas GroupBy.transform drops grouping columns.
-            pdf = pdf.drop(columns=input_groupnames)
-            return pdf.transform(func)
+            return pdf.groupby(groupkey_names).transform(func)
 
         should_infer_schema = return_sig is None
 
@@ -1784,29 +1796,33 @@ class GroupBy(object):
             # Here we execute with the first 1000 to get the return type.
             # If the records were less than 1000, it uses pandas API directly for a shortcut.
             limit = get_option("compute.shortcut_limit")
-            pdf = self._kdf.head(limit + 1)._to_internal_pandas()
-            pdf = pdf.groupby(input_groupnames).transform(func)
-            kdf = DataFrame(pdf)
-            return_schema = kdf._sdf.drop(*HIDDEN_COLUMNS).schema
+            pdf = kdf.head(limit + 1)._to_internal_pandas()
+            pdf = pdf.groupby(groupkey_names).transform(func)
+            kdf_from_pandas = DataFrame(pdf)
+            return_schema = kdf_from_pandas._sdf.drop(*HIDDEN_COLUMNS).schema
             if len(pdf) <= limit:
-                return kdf
+                return kdf_from_pandas
 
             sdf = GroupBy._spark_group_map_apply(
-                self._kdf, pandas_transform, self._groupkeys_scols, return_schema, retain_index=True
+                kdf,
+                pandas_transform,
+                [kdf._internal.spark_column_for(label) for label in groupkey_labels],
+                return_schema,
+                retain_index=True,
             )
             # If schema is inferred, we can restore indexes too.
-            internal = kdf._internal.with_new_sdf(sdf)
+            internal = kdf.drop(groupkey_labels, axis=1)._internal.with_new_sdf(sdf)
         else:
             return_type = infer_return_type(func).tpe
-            data_columns = self._kdf._internal.data_spark_column_names
+            data_columns = kdf._internal.data_spark_column_names
             return_schema = StructType(
-                [StructField(c, return_type) for c in data_columns if c not in input_groupnames]
+                [StructField(c, return_type) for c in data_columns if c not in groupkey_names]
             )
 
             sdf = GroupBy._spark_group_map_apply(
-                self._kdf,
+                kdf,
                 pandas_transform,
-                self._groupkeys_scols,
+                [kdf._internal.spark_column_for(label) for label in groupkey_labels],
                 return_schema,
                 retain_index=False,
             )

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -1475,12 +1475,32 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             pdf.groupby("b").transform(lambda x: x + 1).sort_index(),
         )
         self.assert_eq(
+            kdf.groupby("b")["a"].transform(lambda x: x + 1).sort_index(),
+            pdf.groupby("b")["a"].transform(lambda x: x + 1).sort_index(),
+        )
+        self.assert_eq(
+            kdf.groupby("b")[["a"]].transform(lambda x: x + 1).sort_index(),
+            pdf.groupby("b")[["a"]].transform(lambda x: x + 1).sort_index(),
+        )
+        self.assert_eq(
             kdf.groupby(["a", "b"]).transform(lambda x: x * x).sort_index(),
             pdf.groupby(["a", "b"]).transform(lambda x: x * x).sort_index(),
         )
         self.assert_eq(
             kdf.groupby(["b"])["c"].transform(lambda x: x).sort_index(),
             pdf.groupby(["b"])["c"].transform(lambda x: x).sort_index(),
+        )
+        self.assert_eq(
+            kdf.groupby(kdf.b // 5).transform(lambda x: x + 1).sort_index(),
+            pdf.groupby(pdf.b // 5).transform(lambda x: x + 1).sort_index(),
+        )
+        self.assert_eq(
+            kdf.groupby(kdf.b // 5)["a"].transform(lambda x: x + 1).sort_index(),
+            pdf.groupby(pdf.b // 5)["a"].transform(lambda x: x + 1).sort_index(),
+        )
+        self.assert_eq(
+            kdf.groupby(kdf.b // 5)[["a"]].transform(lambda x: x + 1).sort_index(),
+            pdf.groupby(pdf.b // 5)[["a"]].transform(lambda x: x + 1).sort_index(),
         )
 
         # multi-index columns

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -1471,36 +1471,36 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         )
         kdf = ks.from_pandas(pdf)
         self.assert_eq(
-            kdf.groupby("b").transform(lambda x: x + 1).sort_index(),
-            pdf.groupby("b").transform(lambda x: x + 1).sort_index(),
+            kdf.groupby("b").transform(lambda x: x + x.min()).sort_index(),
+            pdf.groupby("b").transform(lambda x: x + x.min()).sort_index(),
         )
         self.assert_eq(
-            kdf.groupby("b")["a"].transform(lambda x: x + 1).sort_index(),
-            pdf.groupby("b")["a"].transform(lambda x: x + 1).sort_index(),
+            kdf.groupby("b")["a"].transform(lambda x: x + x.min()).sort_index(),
+            pdf.groupby("b")["a"].transform(lambda x: x + x.min()).sort_index(),
         )
         self.assert_eq(
-            kdf.groupby("b")[["a"]].transform(lambda x: x + 1).sort_index(),
-            pdf.groupby("b")[["a"]].transform(lambda x: x + 1).sort_index(),
+            kdf.groupby("b")[["a"]].transform(lambda x: x + x.min()).sort_index(),
+            pdf.groupby("b")[["a"]].transform(lambda x: x + x.min()).sort_index(),
         )
         self.assert_eq(
-            kdf.groupby(["a", "b"]).transform(lambda x: x * x).sort_index(),
-            pdf.groupby(["a", "b"]).transform(lambda x: x * x).sort_index(),
+            kdf.groupby(["a", "b"]).transform(lambda x: x + x.min()).sort_index(),
+            pdf.groupby(["a", "b"]).transform(lambda x: x + x.min()).sort_index(),
         )
         self.assert_eq(
-            kdf.groupby(["b"])["c"].transform(lambda x: x).sort_index(),
-            pdf.groupby(["b"])["c"].transform(lambda x: x).sort_index(),
+            kdf.groupby(["b"])["c"].transform(lambda x: x + x.min()).sort_index(),
+            pdf.groupby(["b"])["c"].transform(lambda x: x + x.min()).sort_index(),
         )
         self.assert_eq(
-            kdf.groupby(kdf.b // 5).transform(lambda x: x + 1).sort_index(),
-            pdf.groupby(pdf.b // 5).transform(lambda x: x + 1).sort_index(),
+            kdf.groupby(kdf.b // 5).transform(lambda x: x + x.min()).sort_index(),
+            pdf.groupby(pdf.b // 5).transform(lambda x: x + x.min()).sort_index(),
         )
         self.assert_eq(
-            kdf.groupby(kdf.b // 5)["a"].transform(lambda x: x + 1).sort_index(),
-            pdf.groupby(pdf.b // 5)["a"].transform(lambda x: x + 1).sort_index(),
+            kdf.groupby(kdf.b // 5)["a"].transform(lambda x: x + x.min()).sort_index(),
+            pdf.groupby(pdf.b // 5)["a"].transform(lambda x: x + x.min()).sort_index(),
         )
         self.assert_eq(
-            kdf.groupby(kdf.b // 5)[["a"]].transform(lambda x: x + 1).sort_index(),
-            pdf.groupby(pdf.b // 5)[["a"]].transform(lambda x: x + 1).sort_index(),
+            kdf.groupby(kdf.b // 5)[["a"]].transform(lambda x: x + x.min()).sort_index(),
+            pdf.groupby(pdf.b // 5)[["a"]].transform(lambda x: x + x.min()).sort_index(),
         )
 
         # multi-index columns
@@ -1509,12 +1509,12 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         kdf.columns = columns
 
         self.assert_eq(
-            kdf.groupby(("x", "b")).transform(lambda x: x + 1).sort_index(),
-            pdf.groupby(("x", "b")).transform(lambda x: x + 1).sort_index(),
+            kdf.groupby(("x", "b")).transform(lambda x: x + x.min()).sort_index(),
+            pdf.groupby(("x", "b")).transform(lambda x: x + x.min()).sort_index(),
         )
         self.assert_eq(
-            kdf.groupby([("x", "a"), ("x", "b")]).transform(lambda x: x * x).sort_index(),
-            pdf.groupby([("x", "a"), ("x", "b")]).transform(lambda x: x * x).sort_index(),
+            kdf.groupby([("x", "a"), ("x", "b")]).transform(lambda x: x + x.min()).sort_index(),
+            pdf.groupby([("x", "a"), ("x", "b")]).transform(lambda x: x + x.min()).sort_index(),
         )
 
     def test_transform_without_shortcut(self):


### PR DESCRIPTION
Fixing `GroupBy.transform` to follow complex group keys.

```py
>>> kdf = ks.DataFrame({"a": [1, 2, 3, 4, 5, 6], "b": [1, 1, 2, 3, 5, 8], "c": [1, 4, 9, 16, 25, 36]})
>>> kdf.groupby(kdf.b // 5).transform(lambda x: x + x.min())
    a   c
0   2   2
1   3   5
2   6  18
3   8  32
4  10  50
5  12  72
```

This should be:

```py
>>> pdf.groupby(pdf.b // 5).transform(lambda x: x + x.min())
    a   b   c
0   2   2   2
1   3   2   5
2   4   3  10
3   5   4  17
4  10  10  50
5  11  13  61
```

Also fixing handling agg_columns,

```py
>>> kdf.groupby(kdf.b)[['c']].transform(lambda x: x + x.min())
    a   c
0   2   2
1   3   5
2   6  18
3   8  32
4  10  50
5  12  72
>>> pdf.groupby(pdf.b)[['c']].transform(lambda x: x + x.min())
    c
0   2
1   5
2  18
3  32
4  50
5  72
```