### PR TITLE
Fix GroupBy.apply to follow complex group keys.

### DIFF
--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -1333,17 +1333,39 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         )
         kdf = ks.from_pandas(pdf)
         self.assert_eq(
-            kdf.groupby("b").apply(lambda x: x + 1).sort_index(),
-            pdf.groupby("b").apply(lambda x: x + 1).sort_index(),
+            kdf.groupby("b").apply(lambda x: x + x.min()).sort_index(),
+            pdf.groupby("b").apply(lambda x: x + x.min()).sort_index(),
         )
         self.assert_eq(
-            kdf.groupby(["a", "b"]).apply(lambda x: x * x).sort_index(),
-            pdf.groupby(["a", "b"]).apply(lambda x: x * x).sort_index(),
+            kdf.groupby("b")["a"].apply(lambda x: x + x.min()).sort_index(),
+            pdf.groupby("b")["a"].apply(lambda x: x + x.min()).sort_index(),
+        )
+        # TODO: handle agg_columns.
+        # self.assert_eq(
+        #     kdf.groupby("b")[["a"]].apply(lambda x: x + x.min()).sort_index(),
+        #     pdf.groupby("b")[["a"]].apply(lambda x: x + x.min()).sort_index(),
+        # )
+        self.assert_eq(
+            kdf.groupby(["a", "b"]).apply(lambda x: x + x.min()).sort_index(),
+            pdf.groupby(["a", "b"]).apply(lambda x: x + x.min()).sort_index(),
         )
         self.assert_eq(
             kdf.groupby(["b"])["c"].apply(lambda x: 1).sort_index(),
             pdf.groupby(["b"])["c"].apply(lambda x: 1).sort_index(),
         )
+        self.assert_eq(
+            kdf.groupby(kdf.b // 5).apply(lambda x: x + x.min()).sort_index(),
+            pdf.groupby(pdf.b // 5).apply(lambda x: x + x.min()).sort_index(),
+        )
+        self.assert_eq(
+            kdf.groupby(kdf.b // 5)["a"].apply(lambda x: x + x.min()).sort_index(),
+            pdf.groupby(pdf.b // 5)["a"].apply(lambda x: x + x.min()).sort_index(),
+        )
+        # TODO: handle agg_columns.
+        # self.assert_eq(
+        #     kdf.groupby(kdf.b // 5)[["a"]].apply(lambda x: x + x.min()).sort_index(),
+        #     pdf.groupby(pdf.b // 5)[["a"]].apply(lambda x: x + x.min()).sort_index(),
+        # )
 
         with self.assertRaisesRegex(TypeError, "<class 'int'> object is not callable"):
             kdf.groupby("b").apply(1)
@@ -1358,8 +1380,8 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             pdf.groupby(("x", "b")).apply(lambda x: 1).sort_index(),
         )
         self.assert_eq(
-            kdf.groupby([("x", "a"), ("x", "b")]).apply(lambda x: x * x).sort_index(),
-            pdf.groupby([("x", "a"), ("x", "b")]).apply(lambda x: x * x).sort_index(),
+            kdf.groupby([("x", "a"), ("x", "b")]).apply(lambda x: x + x.min()).sort_index(),
+            pdf.groupby([("x", "a"), ("x", "b")]).apply(lambda x: x + x.min()).sort_index(),
         )
 
     def test_apply_without_shortcut(self):


### PR DESCRIPTION
Fixing `GroupBy.apply` to follow complex group keys.

```py
>>> kdf = ks.DataFrame({"a": [1, 2, 3, 4, 5, 6], "b": [1, 1, 2, 3, 5, 8], "c": [1, 4, 9, 16, 25, 36]})
>>> kdf.groupby(kdf.b // 5).apply(lambda x: x + x.min())
    a   b   c
0   2   2   2
1   3   2   5
2   6   4  18
3   8   6  32
4  10  10  50
5  12  16  72
```

This should be:

```py
>>> pdf.groupby(pdf.b // 5).apply(lambda x: x + x.min())
    a   b   c
0   2   2   2
1   3   2   5
2   4   3  10
3   5   4  17
4  10  10  50
5  11  13  61
```