### PR TITLE
Fix GroupBy.head to recognize agg_columns.

### DIFF
--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -1630,6 +1630,32 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             kdf.groupby("a")["b"].head(100000).sort_index(),
         )
 
+        self.assert_eq(
+            pdf.groupby("a")[["b"]].head(2).sort_index(),
+            kdf.groupby("a")[["b"]].head(2).sort_index(),
+        )
+        self.assert_eq(
+            pdf.groupby("a")[["b"]].head(-2).sort_index(),
+            kdf.groupby("a")[["b"]].head(-2).sort_index(),
+        )
+        self.assert_eq(
+            pdf.groupby("a")[["b"]].head(100000).sort_index(),
+            kdf.groupby("a")[["b"]].head(100000).sort_index(),
+        )
+
+        self.assert_eq(
+            pdf.groupby(pdf.a // 2).head(2).sort_index(),
+            kdf.groupby(kdf.a // 2).head(2).sort_index(),
+        )
+        self.assert_eq(
+            pdf.groupby(pdf.a // 2)["b"].head(2).sort_index(),
+            kdf.groupby(kdf.a // 2)["b"].head(2).sort_index(),
+        )
+        self.assert_eq(
+            pdf.groupby(pdf.a // 2)[["b"]].head(2).sort_index(),
+            kdf.groupby(kdf.a // 2)[["b"]].head(2).sort_index(),
+        )
+
         # multi-index
         midx = pd.MultiIndex(
             [["x", "y"], ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"]],


### PR DESCRIPTION
Fixing `GroupBy.head` to recognize `agg_columns`.

```py
>>> kdf = ks.DataFrame({"a": [1, 1, 1, 1, 2, 2, 2, 3, 3, 3] * 3, "b": [2, 3, 1, 4, 6, 9, 8, 10, 7, 5] * 3, "c": [3, 5, 2, 5, 1, 2, 6, 4, 3, 6] * 3})
>>> kdf.groupby("a")[["b"]].head(2).sort_index()
   a   b  c
0  1   2  3
1  1   3  5
4  2   6  1
5  2   9  2
7  3  10  4
8  3   7  3
```

This should be:

```py
>>> pdf.groupby("a")[["b"]].head(2).sort_index()
    b
0   2
1   3
4   6
5   9
7  10
8   7
```