### PR TITLE
Fix get dummies when uses the prefix parameter whose type is dict

### DIFF
--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -1505,6 +1505,8 @@ def get_dummies(
             raise NotImplementedError(
                 "get_dummies currently does not support prefix as string types"
             )
+        elif isinstance(prefix, dict):
+            prefix = list(prefix.values())
         kdf = data.copy()
 
         if columns is None:

--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -1505,8 +1505,6 @@ def get_dummies(
             raise NotImplementedError(
                 "get_dummies currently does not support prefix as string types"
             )
-        elif isinstance(prefix, dict):
-            prefix = list(prefix.values())
         kdf = data.copy()
 
         if columns is None:
@@ -1578,6 +1576,8 @@ def get_dummies(
             "Length of 'prefix' ({}) did not match the length of "
             "the columns being encoded ({}).".format(len(prefix), len(column_labels))
         )
+    elif isinstance(prefix, dict):
+        prefix = [prefix[column_label[0]] for column_label in column_labels]
 
     all_values = _reduce_spark_multi(
         kdf._sdf, [F.collect_set(kdf._internal.spark_column_for(label)) for label in column_labels]

--- a/databricks/koalas/tests/test_reshape.py
+++ b/databricks/koalas/tests/test_reshape.py
@@ -153,6 +153,18 @@ class ReshapeTest(ReusedSQLTestCase):
             almost=True,
         )
 
+        self.assert_eq(
+            ks.get_dummies(kdf, prefix={"A": "foo", "B": "bar"}),
+            pd.get_dummies(pdf, prefix={"A": "foo", "B": "bar"}),
+            almost=True,
+        )
+
+        self.assert_eq(
+            ks.get_dummies(kdf, prefix={"A": "foo", "B": "bar"}, columns=["A", "B"]),
+            pd.get_dummies(pdf, prefix={"A": "foo", "B": "bar"}, columns=["A", "B"]),
+            almost=True,
+        )
+
         with self.assertRaisesRegex(NotImplementedError, "string types"):
             ks.get_dummies(kdf, prefix="foo")
         with self.assertRaisesRegex(ValueError, "Length of 'prefix' \\(1\\) .* \\(2\\)"):

--- a/databricks/koalas/tests/test_reshape.py
+++ b/databricks/koalas/tests/test_reshape.py
@@ -160,6 +160,12 @@ class ReshapeTest(ReusedSQLTestCase):
         )
 
         self.assert_eq(
+            ks.get_dummies(kdf, prefix={"B": "foo", "A": "bar"}),
+            pd.get_dummies(pdf, prefix={"B": "foo", "A": "bar"}),
+            almost=True,
+        )
+
+        self.assert_eq(
             ks.get_dummies(kdf, prefix={"A": "foo", "B": "bar"}, columns=["A", "B"]),
             pd.get_dummies(pdf, prefix={"A": "foo", "B": "bar"}, columns=["A", "B"]),
             almost=True,


### PR DESCRIPTION
Resolves #1469 

```python
>>> df = ks.DataFrame({'A': ['a', 'b', 'a'], 'B': ['b', 'a', 'c'], 'C': [1, 2, 3]}, columns=['A', 'B', 'C'])

>>> ks.get_dummies(df, prefix={'B': 'ohe_B', 'C': 'ohe_C'}, columns=['B', 'C'])
   A  ohe_B_a  ohe_B_b  ohe_B_c  ohe_C_1  ohe_C_2  ohe_C_3
0  a        0        1        0        1        0        0
1  b        1        0        0        0        1        0
2  a        0        0        1        0        0        1

>>> pd.get_dummies(df.to_pandas(), prefix={'B': 'ohe_B', 'C': 'ohe_C'}, columns=['B', 'C'])
   A  ohe_B_a  ohe_B_b  ohe_B_c  ohe_C_1  ohe_C_2  ohe_C_3
0  a        0        1        0        1        0        0
1  b        1        0        0        0        1        0
2  a        0        0        1        0        0        1
```