### PR TITLE
Add extra arguments support in DataFrame.apply and DataFrame.apply_batch

### DIFF
--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -2786,9 +2786,26 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(
             kdf.apply(lambda x: x + 1).sort_index(), pdf.apply(lambda x: x + 1).sort_index()
         )
+        self.assert_eq(
+            kdf.apply(lambda x, b: x + b, args=(1,)).sort_index(),
+            pdf.apply(lambda x, b: x + b, args=(1,)).sort_index(),
+        )
+        self.assert_eq(
+            kdf.apply(lambda x, b: x + b, b=1).sort_index(),
+            pdf.apply(lambda x, b: x + b, b=1).sort_index(),
+        )
+
         with option_context("compute.shortcut_limit", 500):
             self.assert_eq(
                 kdf.apply(lambda x: x + 1).sort_index(), pdf.apply(lambda x: x + 1).sort_index()
+            )
+            self.assert_eq(
+                kdf.apply(lambda x, b: x + b, args=(1,)).sort_index(),
+                pdf.apply(lambda x, b: x + b, args=(1,)).sort_index(),
+            )
+            self.assert_eq(
+                kdf.apply(lambda x, b: x + b, b=1).sort_index(),
+                pdf.apply(lambda x, b: x + b, b=1).sort_index(),
             )
 
         # returning a Series
@@ -2796,10 +2813,18 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             kdf.apply(lambda x: len(x), axis=1).sort_index(),
             pdf.apply(lambda x: len(x), axis=1).sort_index(),
         )
+        self.assert_eq(
+            kdf.apply(lambda x, c: len(x) + c, axis=1, c=100).sort_index(),
+            pdf.apply(lambda x, c: len(x) + c, axis=1, c=100).sort_index(),
+        )
         with option_context("compute.shortcut_limit", 500):
             self.assert_eq(
                 kdf.apply(lambda x: len(x), axis=1).sort_index(),
                 pdf.apply(lambda x: len(x), axis=1).sort_index(),
+            )
+            self.assert_eq(
+                kdf.apply(lambda x, c: len(x) + c, axis=1, c=100).sort_index(),
+                pdf.apply(lambda x, c: len(x) + c, axis=1, c=100).sort_index(),
             )
 
         with self.assertRaisesRegex(AssertionError, "the first argument should be a callable"):
@@ -2856,9 +2881,15 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         kdf = ks.DataFrame(pdf)
 
         self.assert_eq(kdf.apply_batch(lambda pdf: pdf + 1).sort_index(), (pdf + 1).sort_index())
+        self.assert_eq(
+            kdf.apply_batch(lambda pdf, a: pdf + a, args=(1,)).sort_index(), (pdf + 1).sort_index()
+        )
         with option_context("compute.shortcut_limit", 500):
             self.assert_eq(
                 kdf.apply_batch(lambda pdf: pdf + 1).sort_index(), (pdf + 1).sort_index()
+            )
+            self.assert_eq(
+                kdf.apply_batch(lambda pdf, b: pdf + b, b=1).sort_index(), (pdf + 1).sort_index()
             )
 
         with self.assertRaisesRegex(AssertionError, "the first argument should be a callable"):


### PR DESCRIPTION
This PR adds extra argument support in Koalas `DataFrame.apply` and `DataFrame.apply_batch` to match with pandas' [`DataFrame.apply`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.apply.html).

```python
import databricks.koalas as ks
ks.range(10).apply(lambda a, b, c: a + b + c, args=(1,), c=3)
```
```
   id
0   4
1   5
2   6
3   7
4   8
5   9
6  10
7  11
8  12
9  13
```

```python
import databricks.koalas as ks

def func(a, b, c, d=123) -> ks.Series[int]:
    return a + b + c + d

ks.range(10).apply(func, args=(1,), c=3)
```
```
    id
0  127
1  128
2  129
3  130
4  131
5  132
6  133
7  134
8  135
9  136
```