### PR TITLE
Add extra arguments support in DataFrame.transform, DataFrame.transform_batch and Series.transform_batch

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -2404,7 +2404,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         else:
             return result
 
-    def transform(self, func):
+    def transform(self, func, axis=0, *args, **kwargs):
         """
         Call ``func`` on self producing a Series with transformed values
         and that has the same length as its input.
@@ -2437,6 +2437,12 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         func : function
             Function to use for transforming the data. It must work when pandas Series
             is passed.
+        axis : int, default 0 or 'index'
+            Can only be set to 0 at the moment.
+        *args
+            Positional arguments to pass to func.
+        **kwargs
+            Keyword arguments to pass to func.
 
         Returns
         -------
@@ -2494,8 +2500,23 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         0  0  1
         1  1  4
         2  4  9
+
+        You can also specify extra arguments.
+
+        >>> def calculation(x, y, z) -> ks.Series[int]:
+        ...     return x ** y + z
+        >>> df.transform(calculation, y=10, z=20)  # doctest: +NORMALIZE_WHITESPACE
+              X
+              A      B
+        0    20     21
+        1    21   1044
+        2  1044  59069
         """
         assert callable(func), "the first argument should be a callable function."
+        axis = validate_axis(axis)
+        if axis != 0:
+            raise NotImplementedError('axis should be either 0 or "index" currently.')
+
         spec = inspect.getfullargspec(func)
         return_sig = spec.annotations.get("return", None)
         should_infer_schema = return_sig is None
@@ -2505,7 +2526,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             # If the records were less than 1000, it uses pandas API directly for a shortcut.
             limit = get_option("compute.shortcut_limit")
             pdf = self.head(limit + 1)._to_internal_pandas()
-            transformed = pdf.transform(func)
+            transformed = pdf.transform(func, axis, *args, **kwargs)
             kdf = DataFrame(transformed)
             if len(pdf) <= limit:
                 return kdf
@@ -2515,7 +2536,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 self._internal.column_labels, kdf._internal.column_labels
             ):
                 pudf = pandas_udf(
-                    func,
+                    lambda c: func(c, *args, **kwargs),
                     returnType=kdf._internal.spark_type_for(output_label),
                     functionType=PandasUDFType.SCALAR,
                 )
@@ -2527,9 +2548,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             internal = self._internal.with_new_columns(applied)
             return DataFrame(internal)
         else:
-            return self._apply_series_op(lambda kser: kser.transform_batch(func))
+            return self._apply_series_op(lambda kser: kser.transform_batch(func, *args, **kwargs))
 
-    def transform_batch(self, func):
+    def transform_batch(self, func, *args, **kwargs):
         """
         Transform chunks with a function that takes pandas DataFrame and outputs pandas DataFrame.
         The pandas DataFrame given to the function is of a batch used internally. The length of
@@ -2574,6 +2595,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         ----------
         func : function
             Function to transform each pandas frame.
+        *args
+            Positional arguments to pass to func.
+        **kwargs
+            Keyword arguments to pass to func.
 
         Returns
         -------
@@ -2624,6 +2649,14 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         1    5
         2    7
         Name: B, dtype: int64
+
+        You can also specify extra arguments as below.
+
+        >>> df.transform_batch(lambda pdf, a, b, c: pdf.B + a + b + c, 1, 2, c=3)
+        0     8
+        1    10
+        2    12
+        Name: B, dtype: int64
         """
         from databricks.koalas.groupby import GroupBy
         from databricks.koalas import Series
@@ -2632,6 +2665,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         spec = inspect.getfullargspec(func)
         return_sig = spec.annotations.get("return", None)
         should_infer_schema = return_sig is None
+        original_func = func
+        func = lambda o: original_func(o, *args, **kwargs)
 
         names = self._internal.to_internal_spark_frame.schema.names
         should_by_pass = LooseVersion(pyspark.__version__) >= "3.0"
@@ -2725,7 +2760,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                     sdf = self._internal.spark_frame.select(*applied)
                 return DataFrame(kdf._internal.with_new_sdf(sdf))
         else:
-            return_schema = infer_return_type(func).tpe
+            return_schema = infer_return_type(original_func).tpe
             is_return_dataframe = getattr(return_sig, "__origin__", None) == ks.DataFrame
             is_return_series = getattr(return_sig, "__origin__", None) == ks.Series
             if not is_return_dataframe and not is_return_series:

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -2741,7 +2741,7 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
 
     T = property(transpose)
 
-    def transform(self, func, *args, **kwargs):
+    def transform(self, func, axis=0, *args, **kwargs):
         """
         Call ``func`` producing the same type as `self` with transformed values
         and that has the same axis length as input.
@@ -2761,6 +2761,8 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         ----------
         func : function or list
             A function or a list of functions to use for transforming the data.
+        axis : int, default 0 or 'index'
+            Can only be set to 0 at the moment.
         *args
             Positional arguments to pass to `func`.
         **kwargs
@@ -2813,6 +2815,10 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         1  1.000000  2.718282
         2  1.414214  7.389056
         """
+        axis = validate_axis(axis)
+        if axis != 0:
+            raise NotImplementedError('axis should be either 0 or "index" currently.')
+
         if isinstance(func, list):
             applied = []
             for f in func:
@@ -2823,7 +2829,7 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         else:
             return self.apply(func, args=args, **kwargs)
 
-    def transform_batch(self, func) -> "ks.Series":
+    def transform_batch(self, func, *args, **kwargs) -> "ks.Series":
         """
         Transform the data with the function that takes pandas Series and outputs pandas Series.
         The pandas Series given to the function is of a batch used internally.
@@ -2862,6 +2868,10 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         ----------
         func : function
             Function to apply to each pandas frame.
+        *args
+            Positional arguments to pass to func.
+        **kwargs
+            Keyword arguments to pass to func.
 
         Returns
         -------
@@ -2895,6 +2905,16 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
         1    4
         2    6
         Name: A, dtype: int64
+
+        You can also specify extra arguments.
+
+        >>> def plus_one_func(pser, a, b, c=3) -> ks.Series[np.int64]:
+        ...     return pser + a + b + c
+        >>> df.A.transform_batch(plus_one_func, 1, b=2)
+        0     7
+        1     9
+        2    11
+        Name: A, dtype: int64
         """
 
         assert callable(func), "the first argument should be a callable function."
@@ -2918,6 +2938,8 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
                 )
             return_schema = sig_return.tpe
 
+        ff = func
+        func = lambda o: ff(o, *args, **kwargs)
         return self._transform_batch(func, return_schema)
 
     def _transform_batch(self, func, return_schema):

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -2748,10 +2748,18 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(
             kdf.transform(lambda x: x + 1).sort_index(), pdf.transform(lambda x: x + 1).sort_index()
         )
+        self.assert_eq(
+            kdf.transform(lambda x, y: x + y, y=2).sort_index(),
+            pdf.transform(lambda x, y: x + y, y=2).sort_index(),
+        )
         with option_context("compute.shortcut_limit", 500):
             self.assert_eq(
                 kdf.transform(lambda x: x + 1).sort_index(),
                 pdf.transform(lambda x: x + 1).sort_index(),
+            )
+            self.assert_eq(
+                kdf.transform(lambda x, y: x + y, y=1).sort_index(),
+                pdf.transform(lambda x, y: x + y, y=1).sort_index(),
             )
 
         with self.assertRaisesRegex(AssertionError, "the first argument should be a callable"):
@@ -2901,6 +2909,13 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(
             kdf.transform_batch(lambda pdf: pdf.c + 1).sort_index(), (pdf.c + 1).sort_index()
         )
+        self.assert_eq(
+            kdf.transform_batch(lambda pdf, a: pdf + a, 1).sort_index(), (pdf + 1).sort_index()
+        )
+        self.assert_eq(
+            kdf.transform_batch(lambda pdf, a: pdf.c + a, a=1).sort_index(),
+            (pdf.c + 1).sort_index(),
+        )
 
         with option_context("compute.shortcut_limit", 500):
             self.assert_eq(
@@ -2908,6 +2923,13 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             )
             self.assert_eq(
                 kdf.transform_batch(lambda pdf: pdf.b + 1).sort_index(), (pdf.b + 1).sort_index()
+            )
+            self.assert_eq(
+                kdf.transform_batch(lambda pdf, a: pdf + a, 1).sort_index(), (pdf + 1).sort_index()
+            )
+            self.assert_eq(
+                kdf.transform_batch(lambda pdf, a: pdf.c + a, a=1).sort_index(),
+                (pdf.c + 1).sort_index(),
             )
 
         with self.assertRaisesRegex(AssertionError, "the first argument should be a callable"):


### PR DESCRIPTION
This PR adds extra arguments support in DataFrame.transform, DataFrame.transform_batch and Series.transform_batch.

For example, 

```python
>>> from databricks import koalas as ks
>>> ks.range(10).transform_batch(lambda pdf, a, b, c: pdf.id + a + b + c, 1, 2, c=3)
0     6
1     7
2     8
3     9
4    10
5    11
6    12
7    13
8    14
9    15
Name: id, dtype: int64
```