### PR TITLE
Add test for Series.fillna - considering series does not have NA/NaN …

### DIFF
--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -215,6 +215,11 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         pser.fillna(0, inplace=True)
         self.assert_eq(kser, pser)
 
+        # test considering series does not have NA/NaN values
+        kser.fillna(0, inplace=True)
+        pser.fillna(0, inplace=True)
+        self.assert_eq(kser, pser)
+
     def test_dropna(self):
         pser = pd.Series([np.nan, 2, 3, 4, np.nan, 6], name="x")
 


### PR DESCRIPTION
Adding missing test for Series.fillna

<img width="603" alt="스크린샷 2020-05-13 오전 1 09 55" src="https://user-images.githubusercontent.com/7010554/81720135-f1369180-94b8-11ea-9550-908bd4e306df.png">

I added a test to call `fillna` once again in a filled series.