### PR TITLE
Fix GroupBy apply, filter, and head to ignore temp columns when ops from different DataFrames.

### DIFF
--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -2181,7 +2181,7 @@ class GroupBy(object):
             else:
                 new_by_series.append(kdf._kser_for(label))
 
-        return kdf, new_by_series, tmp_column_labels
+        return kdf, new_by_series, tmp_column_labels  # type: ignore
 
     @staticmethod
     def _resolve_grouping(kdf: DataFrame, by: List[Union[Series, Tuple[str, ...]]]) -> List[Series]:
@@ -2233,7 +2233,7 @@ class DataFrameGroupBy(GroupBy):
 
         self._agg_columns_selected = agg_columns is not None
         if self._agg_columns_selected:
-            for label in agg_columns:
+            for label in agg_columns:  # type: ignore
                 if label in ignore_column_labels:
                     raise KeyError(label)
         else:
@@ -2243,7 +2243,7 @@ class DataFrameGroupBy(GroupBy):
                 if all(not kdf._kser_for(label)._equals(key) for key in by)
                 and label not in ignore_column_labels
             ]
-        self._agg_columns = [kdf[label] for label in agg_columns]
+        self._agg_columns = [kdf[label] for label in agg_columns]  # type: ignore
         self._agg_columns_scols = [s.spark_column for s in self._agg_columns]
 
     def __getattr__(self, item: str) -> Any:

--- a/databricks/koalas/tests/test_ops_on_diff_frames_groupby.py
+++ b/databricks/koalas/tests/test_ops_on_diff_frames_groupby.py
@@ -209,3 +209,81 @@ class OpsOnDiffFramesGroupByTest(ReusedSQLTestCase, SQLTestUtils):
             kdf1.groupby(kdf2.A, as_index=False).sum().sort_values("A").reset_index(drop=True),
             pdf1.groupby(pdf2.A, as_index=False).sum().sort_values("A").reset_index(drop=True),
         )
+
+    def test_apply(self):
+        pdf = pd.DataFrame(
+            {"a": [1, 2, 3, 4, 5, 6], "b": [1, 1, 2, 3, 5, 8], "c": [1, 4, 9, 16, 25, 36]},
+            columns=["a", "b", "c"],
+        )
+        pkey = pd.Series([1, 1, 2, 3, 5, 8])
+        kdf = ks.from_pandas(pdf)
+        kkey = ks.from_pandas(pkey)
+
+        self.assert_eq(
+            kdf.groupby(kkey).apply(lambda x: x + x.min()).sort_index(),
+            pdf.groupby(pkey).apply(lambda x: x + x.min()).sort_index(),
+        )
+        self.assert_eq(
+            kdf.groupby(kkey)["a"].apply(lambda x: x + x.min()).sort_index(),
+            pdf.groupby(pkey)["a"].apply(lambda x: x + x.min()).sort_index(),
+        )
+        self.assert_eq(
+            kdf.groupby(kkey)[["a"]].apply(lambda x: x + x.min()).sort_index(),
+            pdf.groupby(pkey)[["a"]].apply(lambda x: x + x.min()).sort_index(),
+        )
+        self.assert_eq(
+            kdf.groupby(["a", kkey]).apply(lambda x: x + x.min()).sort_index(),
+            pdf.groupby(["a", pkey]).apply(lambda x: x + x.min()).sort_index(),
+        )
+
+    def test_transform(self):
+        pdf = pd.DataFrame(
+            {"a": [1, 2, 3, 4, 5, 6], "b": [1, 1, 2, 3, 5, 8], "c": [1, 4, 9, 16, 25, 36]},
+            columns=["a", "b", "c"],
+        )
+        pkey = pd.Series([1, 1, 2, 3, 5, 8])
+        kdf = ks.from_pandas(pdf)
+        kkey = ks.from_pandas(pkey)
+
+        self.assert_eq(
+            kdf.groupby(kkey).transform(lambda x: x + x.min()).sort_index(),
+            pdf.groupby(pkey).transform(lambda x: x + x.min()).sort_index(),
+        )
+        self.assert_eq(
+            kdf.groupby(kkey)["a"].transform(lambda x: x + x.min()).sort_index(),
+            pdf.groupby(pkey)["a"].transform(lambda x: x + x.min()).sort_index(),
+        )
+        self.assert_eq(
+            kdf.groupby(kkey)[["a"]].transform(lambda x: x + x.min()).sort_index(),
+            pdf.groupby(pkey)[["a"]].transform(lambda x: x + x.min()).sort_index(),
+        )
+        self.assert_eq(
+            kdf.groupby(["a", kkey]).transform(lambda x: x + x.min()).sort_index(),
+            pdf.groupby(["a", pkey]).transform(lambda x: x + x.min()).sort_index(),
+        )
+
+    def test_filter(self):
+        pdf = pd.DataFrame(
+            {"a": [1, 2, 3, 4, 5, 6], "b": [1, 1, 2, 3, 5, 8], "c": [1, 4, 9, 16, 25, 36]},
+            columns=["a", "b", "c"],
+        )
+        pkey = pd.Series([1, 1, 2, 3, 5, 8])
+        kdf = ks.from_pandas(pdf)
+        kkey = ks.from_pandas(pkey)
+
+        self.assert_eq(
+            kdf.groupby(kkey).filter(lambda x: any(x.a == 2)).sort_index(),
+            pdf.groupby(pkey).filter(lambda x: any(x.a == 2)).sort_index(),
+        )
+        self.assert_eq(
+            kdf.groupby(kkey)["a"].filter(lambda x: any(x == 2)).sort_index(),
+            pdf.groupby(pkey)["a"].filter(lambda x: any(x == 2)).sort_index(),
+        )
+        self.assert_eq(
+            kdf.groupby(kkey)[["a"]].filter(lambda x: any(x.a == 2)).sort_index(),
+            pdf.groupby(pkey)[["a"]].filter(lambda x: any(x.a == 2)).sort_index(),
+        )
+        self.assert_eq(
+            kdf.groupby(["a", kkey]).filter(lambda x: any(x.a == 2)).sort_index(),
+            pdf.groupby(["a", pkey]).filter(lambda x: any(x.a == 2)).sort_index(),
+        )


### PR DESCRIPTION
Fixing `GroupBy.apply`, `filter`, and `head` to ignore temp columns when ops from different DataFrames, otherwise the result includes the temp columns.

```py
>>> kdf = ks.DataFrame({"a": [1, 2, 3, 4, 5, 6], "b": [1, 1, 2, 3, 5, 8], "c": [1, 4, 9, 16, 25, 36]})
>>> kkey = ks.Series([1, 1, 2, 3, 5, 8])
>>> kdf.groupby(kkey).apply(lambda x: x + x.min())
    a   b   c  __tmp_groupkey_0__
0   2   2   2                   2
5  12  16  72                  16
1   3   2   5                   2
3   8   6  32                   6
2   6   4  18                   4
4  10  10  50                  10
```