### PR TITLE
Simplify DataFrame.columns setter.

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -6182,29 +6182,6 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                     % (len(old_names), len(column_labels))
                 )
             column_label_names = columns.names
-            data_columns = [name_like_string(label) for label in column_labels]
-            data_spark_columns = [
-                self._internal.spark_column_for(label).alias(name)
-                for label, name in zip(self._internal.column_labels, data_columns)
-            ]
-            self._internal = self._internal.with_new_columns(
-                data_spark_columns, column_labels=column_labels
-            )
-            sdf = self._sdf.select(
-                self._internal.index_spark_columns
-                + [
-                    self._internal.spark_column_for(label).alias(name)
-                    for label, name in zip(self._internal.column_labels, data_columns)
-                ]
-                + list(HIDDEN_COLUMNS)
-            )
-            data_spark_columns = [scol_for(sdf, col) for col in data_columns]
-            self._internal = self._internal.copy(
-                spark_frame=sdf,
-                column_labels=column_labels,
-                data_spark_columns=data_spark_columns,
-                column_label_names=column_label_names,
-            )
         else:
             old_names = self._internal.column_labels
             if len(old_names) != len(columns):
@@ -6217,22 +6194,14 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 column_label_names = columns.names
             else:
                 column_label_names = None
-            data_columns = [name_like_string(label) for label in column_labels]
-            sdf = self._sdf.select(
-                self._internal.index_spark_columns
-                + [
-                    self._internal.spark_column_for(label).alias(name)
-                    for label, name in zip(self._internal.column_labels, data_columns)
-                ]
-                + list(HIDDEN_COLUMNS)
-            )
-            data_spark_columns = [scol_for(sdf, col) for col in data_columns]
-            self._internal = self._internal.copy(
-                spark_frame=sdf,
-                column_labels=column_labels,
-                data_spark_columns=data_spark_columns,
-                column_label_names=column_label_names,
-            )
+        data_columns = [name_like_string(label) for label in column_labels]
+        data_spark_columns = [
+            self._internal.spark_column_for(label).alias(name)
+            for label, name in zip(self._internal.column_labels, data_columns)
+        ]
+        self._internal = self._internal.with_new_columns(
+            data_spark_columns, column_labels=column_labels, column_label_names=column_label_names
+        )
 
     @property
     def dtypes(self):

--- a/databricks/koalas/internal.py
+++ b/databricks/koalas/internal.py
@@ -864,6 +864,7 @@ class _InternalFrame(object):
         self,
         scols_or_ksers: List[Union[spark.Column, "Series"]],
         column_labels: Optional[List[Tuple[str, ...]]] = None,
+        column_label_names: Optional[Union[List[str], _NoValueType]] = _NoValue,
         keep_order: bool = True,
     ) -> "_InternalFrame":
         """
@@ -911,12 +912,16 @@ class _InternalFrame(object):
 
         sdf = self._sdf.select(self.index_spark_columns + data_spark_columns + hidden_columns)
 
+        if column_label_names is _NoValue:
+            column_label_names = self._column_label_names
+
         return self.copy(
             spark_frame=sdf,
             column_labels=column_labels,
             data_spark_columns=[
                 scol_for(sdf, col) for col in self._sdf.select(data_spark_columns).columns
             ],
+            column_label_names=column_label_names,
             spark_column=None,
         )
 


### PR DESCRIPTION
We can simplify `DataFrame.columns` setter using `_InternalFrame.with_new_columns`.