### PR TITLE
Fix GroupBy functions which need natural orderings to follow the order when opts from different DataFrames.

### DIFF
--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -2170,7 +2170,12 @@ class GroupBy(object):
             if label in tmp_column_labels:
                 kser = col_or_s
                 kdf = align_diff_frames(
-                    assign_columns, kdf, kser.rename(label), fillna=False, how="inner",
+                    assign_columns,
+                    kdf,
+                    kser.rename(label),
+                    fillna=False,
+                    how="inner",
+                    preserve_order_column=True,
                 )
 
         new_by_series = []

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -2181,7 +2181,7 @@ class GroupBy(object):
             else:
                 new_by_series.append(kdf._kser_for(label))
 
-        return kdf, new_by_series, tmp_column_labels
+        return kdf, new_by_series, tmp_column_labels  # type: ignore
 
     @staticmethod
     def _resolve_grouping(kdf: DataFrame, by: List[Union[Series, Tuple[str, ...]]]) -> List[Series]:
@@ -2233,7 +2233,7 @@ class DataFrameGroupBy(GroupBy):
 
         self._agg_columns_selected = agg_columns is not None
         if self._agg_columns_selected:
-            for label in agg_columns:
+            for label in agg_columns:  # type: ignore
                 if label in ignore_column_labels:
                     raise KeyError(label)
         else:
@@ -2243,7 +2243,7 @@ class DataFrameGroupBy(GroupBy):
                 if all(not kdf._kser_for(label)._equals(key) for key in by)
                 and label not in ignore_column_labels
             ]
-        self._agg_columns = [kdf[label] for label in agg_columns]
+        self._agg_columns = [kdf[label] for label in agg_columns]  # type: ignore
         self._agg_columns_scols = [s.spark_column for s in self._agg_columns]
 
     def __getattr__(self, item: str) -> Any:

--- a/databricks/koalas/indexing.py
+++ b/databricks/koalas/indexing.py
@@ -453,7 +453,11 @@ class _LocIndexerLike(_IndexerLike, metaclass=ABCMeta):
                     sdf = sdf.limit(sdf.count() + limit)
 
             data_columns = sdf.select(data_spark_columns).columns
-            sdf = sdf.select(index_scols + data_spark_columns)
+
+            if cond is None:
+                sdf = sdf.select(index_scols + data_spark_columns + [NATURAL_ORDER_COLUMN_NAME])
+            else:
+                sdf = sdf.select(index_scols + data_spark_columns)
         except AnalysisException:
             raise KeyError(
                 "[{}] don't exist in columns".format(

--- a/databricks/koalas/tests/test_ops_on_diff_frames_groupby.py
+++ b/databricks/koalas/tests/test_ops_on_diff_frames_groupby.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import unittest
+
 import pandas as pd
 
 from databricks import koalas as ks
@@ -286,4 +288,287 @@ class OpsOnDiffFramesGroupByTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(
             kdf.groupby(["a", kkey]).filter(lambda x: any(x.a == 2)).sort_index(),
             pdf.groupby(["a", pkey]).filter(lambda x: any(x.a == 2)).sort_index(),
+        )
+
+    def test_head(self):
+        pdf = pd.DataFrame(
+            {
+                "a": [1, 1, 1, 1, 2, 2, 2, 3, 3, 3] * 3,
+                "b": [2, 3, 1, 4, 6, 9, 8, 10, 7, 5] * 3,
+                "c": [3, 5, 2, 5, 1, 2, 6, 4, 3, 6] * 3,
+            },
+        )
+        pkey = pd.Series([1, 1, 1, 1, 2, 2, 2, 3, 3, 3] * 3)
+        kdf = ks.from_pandas(pdf)
+        kkey = ks.from_pandas(pkey)
+
+        self.assert_eq(
+            pdf.groupby(pkey).head(2).sort_index(), kdf.groupby(kkey).head(2).sort_index()
+        )
+        self.assert_eq(
+            pdf.groupby("a")["b"].head(2).sort_index(), kdf.groupby("a")["b"].head(2).sort_index()
+        )
+        self.assert_eq(
+            pdf.groupby("a")[["b"]].head(2).sort_index(),
+            kdf.groupby("a")[["b"]].head(2).sort_index(),
+        )
+        self.assert_eq(
+            pdf.groupby([pkey, "b"]).head(2).sort_index(),
+            kdf.groupby([kkey, "b"]).head(2).sort_index(),
+        )
+
+    def test_cummin(self):
+        pdf = pd.DataFrame(
+            {
+                "a": [1, 2, 3, 4, 5, 6] * 3,
+                "b": [1, 1, 2, 3, 5, 8] * 3,
+                "c": [1, 4, 9, 16, 25, 36] * 3,
+            },
+        )
+        pkey = pd.Series([1, 1, 2, 3, 5, 8] * 3)
+        kdf = ks.from_pandas(pdf)
+        kkey = ks.from_pandas(pkey)
+
+        self.assert_eq(
+            kdf.groupby(kkey).cummin().sort_index(),
+            pdf.groupby(pkey).cummin().sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            kdf.groupby(kkey)["a"].cummin().sort_index(),
+            pdf.groupby(pkey)["a"].cummin().sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            kdf.groupby(kkey)[["a"]].cummin().sort_index(),
+            pdf.groupby(pkey)[["a"]].cummin().sort_index(),
+            almost=True,
+        )
+
+    def test_cummax(self):
+        pdf = pd.DataFrame(
+            {
+                "a": [1, 2, 3, 4, 5, 6] * 3,
+                "b": [1, 1, 2, 3, 5, 8] * 3,
+                "c": [1, 4, 9, 16, 25, 36] * 3,
+            },
+        )
+        pkey = pd.Series([1, 1, 2, 3, 5, 8] * 3)
+        kdf = ks.from_pandas(pdf)
+        kkey = ks.from_pandas(pkey)
+
+        self.assert_eq(
+            kdf.groupby(kkey).cummax().sort_index(),
+            pdf.groupby(pkey).cummax().sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            kdf.groupby(kkey)["a"].cummax().sort_index(),
+            pdf.groupby(pkey)["a"].cummax().sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            kdf.groupby(kkey)[["a"]].cummax().sort_index(),
+            pdf.groupby(pkey)[["a"]].cummax().sort_index(),
+            almost=True,
+        )
+
+    def test_cumsum(self):
+        pdf = pd.DataFrame(
+            {
+                "a": [1, 2, 3, 4, 5, 6] * 3,
+                "b": [1, 1, 2, 3, 5, 8] * 3,
+                "c": [1, 4, 9, 16, 25, 36] * 3,
+            },
+        )
+        pkey = pd.Series([1, 1, 2, 3, 5, 8] * 3)
+        kdf = ks.from_pandas(pdf)
+        kkey = ks.from_pandas(pkey)
+
+        self.assert_eq(
+            kdf.groupby(kkey).cumsum().sort_index(),
+            pdf.groupby(pkey).cumsum().sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            kdf.groupby(kkey)["a"].cumsum().sort_index(),
+            pdf.groupby(pkey)["a"].cumsum().sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            kdf.groupby(kkey)[["a"]].cumsum().sort_index(),
+            pdf.groupby(pkey)[["a"]].cumsum().sort_index(),
+            almost=True,
+        )
+
+    def test_cumprod(self):
+        pdf = pd.DataFrame(
+            {
+                "a": [1, 2, 3, 4, 5, 6] * 3,
+                "b": [1, 1, 2, 3, 5, 8] * 3,
+                "c": [1, 4, 9, 16, 25, 36] * 3,
+            },
+        )
+        pkey = pd.Series([1, 1, 2, 3, 5, 8] * 3)
+        kdf = ks.from_pandas(pdf)
+        kkey = ks.from_pandas(pkey)
+
+        self.assert_eq(
+            kdf.groupby(kkey).cumprod().sort_index(),
+            pdf.groupby(pkey).cumprod().sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            kdf.groupby(kkey)["a"].cumprod().sort_index(),
+            pdf.groupby(pkey)["a"].cumprod().sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            kdf.groupby(kkey)[["a"]].cumprod().sort_index(),
+            pdf.groupby(pkey)[["a"]].cumprod().sort_index(),
+            almost=True,
+        )
+
+    def test_diff(self):
+        pdf = pd.DataFrame(
+            {
+                "a": [1, 2, 3, 4, 5, 6] * 3,
+                "b": [1, 1, 2, 3, 5, 8] * 3,
+                "c": [1, 4, 9, 16, 25, 36] * 3,
+            }
+        )
+        pkey = pd.Series([1, 1, 2, 3, 5, 8] * 3)
+        kdf = ks.from_pandas(pdf)
+        kkey = ks.from_pandas(pkey)
+
+        self.assert_eq(
+            kdf.groupby(kkey).diff().sort_index(),
+            pdf.groupby(pkey).diff().sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            kdf.groupby(kkey)["a"].diff().sort_index(),
+            pdf.groupby(pkey)["a"].diff().sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            kdf.groupby(kkey)[["a"]].diff().sort_index(),
+            pdf.groupby(pkey)[["a"]].diff().sort_index(),
+            almost=True,
+        )
+
+    def test_rank(self):
+        pdf = pd.DataFrame(
+            {
+                "a": [1, 2, 3, 4, 5, 6] * 3,
+                "b": [1, 1, 2, 3, 5, 8] * 3,
+                "c": [1, 4, 9, 16, 25, 36] * 3,
+            },
+        )
+        pkey = pd.Series([1, 1, 2, 3, 5, 8] * 3)
+        kdf = ks.from_pandas(pdf)
+        kkey = ks.from_pandas(pkey)
+
+        self.assert_eq(
+            kdf.groupby(kkey).rank().sort_index(),
+            pdf.groupby(pkey).rank().sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            kdf.groupby(kkey)["a"].rank().sort_index(),
+            pdf.groupby(pkey)["a"].rank().sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            kdf.groupby(kkey)[["a"]].rank().sort_index(),
+            pdf.groupby(pkey)[["a"]].rank().sort_index(),
+            almost=True,
+        )
+
+    @unittest.skipIf(pd.__version__ < "0.24.0", "not supported before pandas 0.24.0")
+    def test_shift(self):
+        pdf = pd.DataFrame(
+            {
+                "a": [1, 1, 2, 2, 3, 3] * 3,
+                "b": [1, 1, 2, 2, 3, 4] * 3,
+                "c": [1, 4, 9, 16, 25, 36] * 3,
+            },
+        )
+        pkey = pd.Series([1, 1, 2, 2, 3, 4] * 3)
+        kdf = ks.from_pandas(pdf)
+        kkey = ks.from_pandas(pkey)
+
+        self.assert_eq(
+            kdf.groupby(kkey).shift().sort_index(),
+            pdf.groupby(pkey).shift().sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            kdf.groupby(kkey)["a"].shift().sort_index(),
+            pdf.groupby(pkey)["a"].shift().sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            kdf.groupby(kkey)[["a"]].shift().sort_index(),
+            pdf.groupby(pkey)[["a"]].shift().sort_index(),
+            almost=True,
+        )
+
+    def test_fillna(self):
+        pdf = pd.DataFrame(
+            {
+                "A": [1, 1, 2, 2] * 3,
+                "B": [2, 4, None, 3] * 3,
+                "C": [None, None, None, 1] * 3,
+                "D": [0, 1, 5, 4] * 3,
+            }
+        )
+        pkey = pd.Series([1, 1, 2, 2] * 3)
+        kdf = ks.from_pandas(pdf)
+        kkey = ks.from_pandas(pkey)
+
+        self.assert_eq(
+            kdf.groupby(kkey).fillna(0).sort_index(),
+            pdf.groupby(pkey).fillna(0).sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            kdf.groupby(kkey)["C"].fillna(0).sort_index(),
+            pdf.groupby(pkey)["C"].fillna(0).sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            kdf.groupby(kkey)[["C"]].fillna(0).sort_index(),
+            pdf.groupby(pkey)[["C"]].fillna(0).sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            kdf.groupby(kkey).fillna(method="bfill").sort_index(),
+            pdf.groupby(pkey).fillna(method="bfill").sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            kdf.groupby(kkey)["C"].fillna(method="bfill").sort_index(),
+            pdf.groupby(pkey)["C"].fillna(method="bfill").sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            kdf.groupby(kkey)[["C"]].fillna(method="bfill").sort_index(),
+            pdf.groupby(pkey)[["C"]].fillna(method="bfill").sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            kdf.groupby(kkey).fillna(method="ffill").sort_index(),
+            pdf.groupby(pkey).fillna(method="ffill").sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            kdf.groupby(kkey)["C"].fillna(method="ffill").sort_index(),
+            pdf.groupby(pkey)["C"].fillna(method="ffill").sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            kdf.groupby(kkey)[["C"]].fillna(method="ffill").sort_index(),
+            pdf.groupby(pkey)[["C"]].fillna(method="ffill").sort_index(),
+            almost=True,
         )

--- a/databricks/koalas/tests/test_ops_on_diff_frames_groupby.py
+++ b/databricks/koalas/tests/test_ops_on_diff_frames_groupby.py
@@ -209,3 +209,81 @@ class OpsOnDiffFramesGroupByTest(ReusedSQLTestCase, SQLTestUtils):
             kdf1.groupby(kdf2.A, as_index=False).sum().sort_values("A").reset_index(drop=True),
             pdf1.groupby(pdf2.A, as_index=False).sum().sort_values("A").reset_index(drop=True),
         )
+
+    def test_apply(self):
+        pdf = pd.DataFrame(
+            {"a": [1, 2, 3, 4, 5, 6], "b": [1, 1, 2, 3, 5, 8], "c": [1, 4, 9, 16, 25, 36]},
+            columns=["a", "b", "c"],
+        )
+        pkey = pd.Series([1, 1, 2, 3, 5, 8])
+        kdf = ks.from_pandas(pdf)
+        kkey = ks.from_pandas(pkey)
+
+        self.assert_eq(
+            kdf.groupby(kkey).apply(lambda x: x + x.min()).sort_index(),
+            pdf.groupby(pkey).apply(lambda x: x + x.min()).sort_index(),
+        )
+        self.assert_eq(
+            kdf.groupby(kkey)["a"].apply(lambda x: x + x.min()).sort_index(),
+            pdf.groupby(pkey)["a"].apply(lambda x: x + x.min()).sort_index(),
+        )
+        self.assert_eq(
+            kdf.groupby(kkey)[["a"]].apply(lambda x: x + x.min()).sort_index(),
+            pdf.groupby(pkey)[["a"]].apply(lambda x: x + x.min()).sort_index(),
+        )
+        self.assert_eq(
+            kdf.groupby(["a", kkey]).apply(lambda x: x + x.min()).sort_index(),
+            pdf.groupby(["a", pkey]).apply(lambda x: x + x.min()).sort_index(),
+        )
+
+    def test_transform(self):
+        pdf = pd.DataFrame(
+            {"a": [1, 2, 3, 4, 5, 6], "b": [1, 1, 2, 3, 5, 8], "c": [1, 4, 9, 16, 25, 36]},
+            columns=["a", "b", "c"],
+        )
+        pkey = pd.Series([1, 1, 2, 3, 5, 8])
+        kdf = ks.from_pandas(pdf)
+        kkey = ks.from_pandas(pkey)
+
+        self.assert_eq(
+            kdf.groupby(kkey).transform(lambda x: x + x.min()).sort_index(),
+            pdf.groupby(pkey).transform(lambda x: x + x.min()).sort_index(),
+        )
+        self.assert_eq(
+            kdf.groupby(kkey)["a"].transform(lambda x: x + x.min()).sort_index(),
+            pdf.groupby(pkey)["a"].transform(lambda x: x + x.min()).sort_index(),
+        )
+        self.assert_eq(
+            kdf.groupby(kkey)[["a"]].transform(lambda x: x + x.min()).sort_index(),
+            pdf.groupby(pkey)[["a"]].transform(lambda x: x + x.min()).sort_index(),
+        )
+        self.assert_eq(
+            kdf.groupby(["a", kkey]).transform(lambda x: x + x.min()).sort_index(),
+            pdf.groupby(["a", pkey]).transform(lambda x: x + x.min()).sort_index(),
+        )
+
+    def test_filter(self):
+        pdf = pd.DataFrame(
+            {"a": [1, 2, 3, 4, 5, 6], "b": [1, 1, 2, 3, 5, 8], "c": [1, 4, 9, 16, 25, 36]},
+            columns=["a", "b", "c"],
+        )
+        pkey = pd.Series([1, 1, 2, 3, 5, 8])
+        kdf = ks.from_pandas(pdf)
+        kkey = ks.from_pandas(pkey)
+
+        self.assert_eq(
+            kdf.groupby(kkey).filter(lambda x: any(x.a == 2)).sort_index(),
+            pdf.groupby(pkey).filter(lambda x: any(x.a == 2)).sort_index(),
+        )
+        self.assert_eq(
+            kdf.groupby(kkey)["a"].filter(lambda x: any(x == 2)).sort_index(),
+            pdf.groupby(pkey)["a"].filter(lambda x: any(x == 2)).sort_index(),
+        )
+        self.assert_eq(
+            kdf.groupby(kkey)[["a"]].filter(lambda x: any(x.a == 2)).sort_index(),
+            pdf.groupby(pkey)[["a"]].filter(lambda x: any(x.a == 2)).sort_index(),
+        )
+        self.assert_eq(
+            kdf.groupby(["a", kkey]).filter(lambda x: any(x.a == 2)).sort_index(),
+            pdf.groupby(["a", pkey]).filter(lambda x: any(x.a == 2)).sort_index(),
+        )

--- a/databricks/koalas/utils.py
+++ b/databricks/koalas/utils.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
     from databricks.koalas.frame import DataFrame
 
 
-def combine_frames(this, *args, how="full"):
+def combine_frames(this, *args, how="full", preserve_order_column=False):
     """
     This method combines `this` DataFrame with a different `that` DataFrame or
     Series from a different DataFrame.
@@ -49,9 +49,10 @@ def combine_frames(this, *args, how="full"):
     So, if `compute.ops_on_diff_frames` option is False,
     this method throws an exception.
     """
-    from databricks.koalas import Series
-    from databricks.koalas import DataFrame
     from databricks.koalas.config import get_option
+    from databricks.koalas.frame import DataFrame
+    from databricks.koalas.internal import NATURAL_ORDER_COLUMN_NAME
+    from databricks.koalas.series import Series
 
     if all(isinstance(arg, Series) for arg in args):
         assert all(
@@ -99,6 +100,11 @@ def combine_frames(this, *args, how="full"):
 
         joined_df = this._sdf.alias("this").join(that._sdf.alias("that"), on=join_scols, how=how)
 
+        if preserve_order_column:
+            order_column = [scol_for(this._sdf, NATURAL_ORDER_COLUMN_NAME)]
+        else:
+            order_column = []
+
         joined_df = joined_df.select(
             merged_index_scols
             + [
@@ -113,10 +119,15 @@ def combine_frames(this, *args, how="full"):
                 )
                 for label in that._internal.column_labels
             ]
+            + order_column
         )
 
         index_columns = set(this._internal.index_spark_column_names)
-        new_data_columns = [c for c in joined_df.columns if c not in index_columns]
+        new_data_columns = [
+            c
+            for c in joined_df.columns
+            if c not in index_columns and c != NATURAL_ORDER_COLUMN_NAME
+        ]
         level = max(this._internal.column_labels_level, that._internal.column_labels_level)
         column_labels = [
             tuple(["this"] + ([""] * (level - len(label))) + list(label))
@@ -148,7 +159,9 @@ def combine_frames(this, *args, how="full"):
         )
 
 
-def align_diff_frames(resolve_func, this, that, fillna=True, how="full"):
+def align_diff_frames(
+    resolve_func, this, that, fillna=True, how="full", preserve_order_column=False
+):
     """
     This method aligns two different DataFrames with a given `func`. Columns are resolved and
     handled within the given `func`.
@@ -210,7 +223,7 @@ def align_diff_frames(resolve_func, this, that, fillna=True, how="full"):
     common_column_labels = set(this_column_labels).intersection(that_column_labels)
 
     # 1. Perform the join given two dataframes.
-    combined = combine_frames(this, that, how=how)
+    combined = combine_frames(this, that, how=how, preserve_order_column=preserve_order_column)
 
     # 2. Apply the given function to transform the columns in a batch and keep the new columns.
     combined_column_labels = combined._internal.column_labels

--- a/databricks/koalas/utils.py
+++ b/databricks/koalas/utils.py
@@ -124,9 +124,9 @@ def combine_frames(this, *args, how="full", preserve_order_column=False):
 
         index_columns = set(this._internal.index_spark_column_names)
         new_data_columns = [
-            c
-            for c in joined_df.columns
-            if c not in index_columns and c != NATURAL_ORDER_COLUMN_NAME
+            col
+            for col in joined_df.columns
+            if col not in index_columns and col != NATURAL_ORDER_COLUMN_NAME
         ]
         level = max(this._internal.column_labels_level, that._internal.column_labels_level)
         column_labels = [


### PR DESCRIPTION
Fixing `GroupBy` functions which need natural orderings, such as `head`, `cumxxx`, etc., to follow the order when opts from different DataFrames, otherwise the result will be non-deterministic because of the shuffle needed to join the group keys.

```py
>>> kdf = ks.DataFrame({"a": [1, 1, 1, 1, 2, 2, 2, 3, 3, 3] * 3, "b": [2, 3, 1, 4, 6, 9, 8, 10, 7, 5] * 3, "c": [3, 5, 2, 5, 1, 2, 6, 4, 3, 6] * 3})
>>> kkey = ks.Series([1, 1, 1, 1, 2, 2, 2, 3, 3, 3] * 3)
>>> kdf.groupby(kkey).head(2)
    a  b  c
0   1  2  3
22  1  1  2
29  3  5  6
19  3  5  6
26  2  8  6
25  2  9  2
```

This should be:

```py
>>> pdf.groupby(pkey).head(2)
   a   b  c
0  1   2  3
1  1   3  5
4  2   6  1
5  2   9  2
7  3  10  4
8  3   7  3
```