### PR TITLE
Fix build failure due to scikit-learn upgrade.

### DIFF
--- a/databricks/koalas/mlflow.py
+++ b/databricks/koalas/mlflow.py
@@ -143,8 +143,8 @@ def load_model(model_uri, predict_type="infer") -> PythonModelWrapper:
     >>> with mlflow.start_run():
     ...     lr = LinearRegression()
     ...     lr.fit(train_x, train_y)
-    ...     mlflow.sklearn.log_model(lr, "model")  # doctest: +NORMALIZE_WHITESPACE
-    LinearRegression(copy_X=True, fit_intercept=True, n_jobs=None, normalize=False)
+    ...     mlflow.sklearn.log_model(lr, "model")
+    LinearRegression(...)
 
     Now that our model is logged using MLflow, we load it back and apply it on a Koalas dataframe:
 


### PR DESCRIPTION
The build came to fail due to scikit-learn upgrade.
The output string seems changed since scikit-learn 0.23.0 which was just released on May 12, 2020.

```
134     >>> mlflow.set_experiment("my_experiment")
135
136     We aim at learning this numerical function using a simple linear regressor.
137
138     >>> from sklearn.linear_model import LinearRegression
139     >>> train = pd.DataFrame({"x1": np.arange(8), "x2": np.arange(8)**2,
140     ...                       "y": np.log(2 + np.arange(8))})
141     >>> train_x = train[["x1", "x2"]]
142     >>> train_y = train[["y"]]
143     >>> with mlflow.start_run():
Expected:
    LinearRegression(copy_X=True, fit_intercept=True, n_jobs=None, normalize=False)
Got:
    LinearRegression()
```