### PR TITLE
Fix LocIndexer.setitem when the Series is a part of DataFrame

### DIFF
--- a/databricks/koalas/indexing.py
+++ b/databricks/koalas/indexing.py
@@ -1128,18 +1128,18 @@ class LocIndexer(_LocIndexerLike):
                 value = F.lit(value)
 
             # For overwrite internal DataFrame
-            _kdf = self._kdf_or_kser._kdf
+            kdf = self._kdf_or_kser._kdf
             col_name = self._kdf_or_kser.name or "0"
-            sdf = _kdf._internal._sdf
+            sdf = kdf._internal._sdf
             cond = F.when(cond, value).otherwise(scol_for(sdf, col_name))
             sdf = sdf.withColumn(col_name, cond)
             data_scols = [
-                scol_for(sdf, scol_name) for scol_name in _kdf._internal.data_spark_column_names
+                scol_for(sdf, scol_name) for scol_name in kdf._internal.data_spark_column_names
             ]
 
-            internal = _kdf._internal.copy(spark_frame=sdf, data_spark_columns=data_scols)
+            internal = kdf._internal.copy(spark_frame=sdf, data_spark_columns=data_scols)
 
-            self._kdf_or_kser._kdf._internal = internal
+            kdf._internal = internal
 
 
 class iLocIndexer(_LocIndexerLike):

--- a/databricks/koalas/tests/test_indexing.py
+++ b/databricks/koalas/tests/test_indexing.py
@@ -1038,6 +1038,20 @@ class IndexingTest(ReusedSQLTestCase):
         with self.assertRaisesRegex(ValueError, "Incompatible indexer with DataFrame"):
             kser.iloc[1] = kdf[["b"]]
 
+    def test_series_in_frame_loc_setitem(self):
+        pdf = pd.DataFrame(
+            [[0, 2, 3], [0, 4, 1], [10, 20, 30]], index=[4, 5, 5], columns=["A", "B", "C"]
+        )
+        kdf = ks.from_pandas(pdf)
+
+        pdf["C"].loc[(pdf["A"] <= pdf["B"])] = 10
+        kdf["C"].loc[(kdf["A"] <= kdf["B"])] = 10
+        self.assert_eq(kdf, pdf)
+
+        pdf["C"].loc[(pdf["A"] <= pdf["B"])] = -pdf["C"]
+        kdf["C"].loc[(kdf["A"] <= kdf["B"])] = -kdf["C"]
+        self.assert_eq(kdf, pdf)
+
     def test_iloc_raises(self):
         pdf = pd.DataFrame({"A": [1, 2], "B": [3, 4], "C": [5, 6]})
         kdf = ks.from_pandas(pdf)


### PR DESCRIPTION
Resolves #1378 

```python
>>> kdf = ks.DataFrame([[0, 2, 3], [0, 4, 1], [10, 20, 30]],index=[4, 5, 5], columns=['A', 'B', 'C'])
>>> kdf                                                        
    A   B   C
4   0   2   3
5   0   4   1
5  10  20  30

>>> kdf['C'].loc[(kdf["A"] <= kdf["B"])] = 10
>>> kdf
    A   B   C
4   0   2  10
5   0   4  10
5  10  20  10
```