### PR TITLE
Add missing docs in series.rst & frame.rst

### DIFF
--- a/docs/source/reference/frame.rst
+++ b/docs/source/reference/frame.rst
@@ -285,7 +285,6 @@ specific plotting methods of the form ``DataFrame.plot.<kind>``.
    DataFrame.plot.line
    DataFrame.plot.pie
    DataFrame.plot.scatter
-   DataFrame.plot.kde
    DataFrame.plot.density
    DataFrame.hist
    DataFrame.kde

--- a/docs/source/reference/frame.rst
+++ b/docs/source/reference/frame.rst
@@ -70,6 +70,7 @@ Indexing, iteration
    DataFrame.iteritems
    DataFrame.iterrows
    DataFrame.keys
+   DataFrame.pop
    DataFrame.xs
    DataFrame.get
    DataFrame.where
@@ -116,6 +117,8 @@ Function application, GroupBy & Window
    DataFrame.agg
    DataFrame.aggregate
    DataFrame.groupby
+   DataFrame.rolling
+   DataFrame.expanding
    DataFrame.transform
    DataFrame.transform_batch
    DataFrame.map_in_pandas
@@ -165,8 +168,10 @@ Reindexing / Selection / Label manipulation
    DataFrame.drop
    DataFrame.drop_duplicates
    DataFrame.duplicated
+   DataFrame.equals
    DataFrame.filter
    DataFrame.head
+   DataFrame.rename
    DataFrame.reset_index
    DataFrame.set_index
    DataFrame.take
@@ -183,6 +188,7 @@ Missing data handling
 
    DataFrame.dropna
    DataFrame.fillna
+   DataFrame.replace
    DataFrame.bfill
    DataFrame.ffill
 
@@ -282,3 +288,4 @@ specific plotting methods of the form ``DataFrame.plot.<kind>``.
    DataFrame.plot.kde
    DataFrame.plot.density
    DataFrame.hist
+   DataFrame.kde

--- a/docs/source/reference/series.rst
+++ b/docs/source/reference/series.rst
@@ -19,12 +19,9 @@ Attributes
    :toctree: api/
 
    Series.index
-
-.. autosummary::
-   :toctree: api/
-
    Series.dtype
    Series.dtypes
+   Series.ndim
    Series.name
    Series.spark_type
    Series.shape
@@ -102,6 +99,8 @@ Function application, GroupBy & Window
    Series.transform_batch
    Series.map
    Series.groupby
+   Series.rolling
+   Series.expanding
    Series.pipe
 
 .. _api.series.stats:
@@ -132,6 +131,7 @@ Computations / Descriptive Stats
    Series.nsmallest
    Series.pct_change
    Series.nunique
+   Series.is_unique
    Series.quantile
    Series.rank
    Series.skew
@@ -154,6 +154,8 @@ Reindexing / Selection / Label manipulation
    :toctree: api/
 
    Series.drop
+   Series.drop_duplicates
+   Series.equals
    Series.add_prefix
    Series.add_suffix
    Series.head


### PR DESCRIPTION
Since several APIs are missing in the docs, just added them.

<img width="805" alt="스크린샷 2020-05-17 오후 1 23 08" src="https://user-images.githubusercontent.com/44108233/82135805-964ac480-9841-11ea-9096-6c11ab72ab65.png">
