### PR TITLE
Fix message for AttributeError properly for Series.

### DIFF
--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -4898,6 +4898,8 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
                 return property_or_func.fget(self)  # type: ignore
             else:
                 return partial(property_or_func, self)
+        elif not hasattr(ks.Series, item):
+            raise AttributeError("'Series' object has no attribute '{}'".format(item))
         return self.getField(item)
 
     def _to_internal_pandas(self):

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -944,17 +944,6 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
             scol = self.spark_column.cast(spark_type)
         return self._with_new_scol(scol)
 
-    def getField(self, name):
-        if not isinstance(self.spark_type, StructType):
-            raise AttributeError("Not a struct: {}".format(self.spark_type))
-        else:
-            fnames = self.spark_type.fieldNames()
-            if name not in fnames:
-                raise AttributeError(
-                    "Field {} not found, possible values are {}".format(name, ", ".join(fnames))
-                )
-            return self._with_new_scol(self.spark_column.getField(name))
-
     def alias(self, name):
         """An alias for :meth:`Series.rename`."""
         return self.rename(name)
@@ -4898,9 +4887,7 @@ class Series(_Frame, IndexOpsMixin, Generic[T]):
                 return property_or_func.fget(self)  # type: ignore
             else:
                 return partial(property_or_func, self)
-        elif not hasattr(ks.Series, item):
-            raise AttributeError("'Series' object has no attribute '{}'".format(item))
-        return self.getField(item)
+        raise AttributeError("'Series' object has no attribute '{}'".format(item))
 
     def _to_internal_pandas(self):
         """


### PR DESCRIPTION
When users try to call the wrong name of property or function with Series,

The existing error message seems not proper like the below.

```python
>>> kser.itholic()  # 'kser' is Series of Koalas
Traceback (most recent call last):
...
AttributeError: Not a struct: LongType
```

Fixed it to:

```python
>>> kser.itholic()  # 'kser' is Series of Koalas
Traceback (most recent call last):
...
AttributeError: 'Series' object has no attribute 'itholic'
```

This way is same as pandas and other APIs (DataFrame, Index ...)