### PR TITLE
Use mapInPandas in DataFrame.apply

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -2370,6 +2370,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         spec = inspect.getfullargspec(func)
         return_sig = spec.annotations.get("return", None)
         should_infer_schema = return_sig is None
+        should_use_map_in_pandas = LooseVersion(pyspark.__version__) >= "3.0"
 
         def apply_func(pdf):
             pdf_or_pser = pdf.apply(func, axis=axis, args=args, **kwds)
@@ -2393,11 +2394,19 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 should_return_series = True
                 kdf = kser_or_kdf.to_frame()
 
-            return_schema = kdf._internal._sdf.drop(*HIDDEN_COLUMNS).schema
+            return_schema = kdf._internal.to_internal_spark_frame.schema
 
-            sdf = GroupBy._spark_group_map_apply(
-                self, apply_func, (F.spark_partition_id(),), return_schema, retain_index=True
-            )
+            if should_use_map_in_pandas:
+                output_func = GroupBy._make_pandas_df_builder_func(
+                    self, apply_func, return_schema, retain_index=True
+                )
+                sdf = self._internal.to_internal_spark_frame.mapInPandas(
+                    lambda iterator: map(output_func, iterator), schema=return_schema
+                )
+            else:
+                sdf = GroupBy._spark_group_map_apply(
+                    self, apply_func, (F.spark_partition_id(),), return_schema, retain_index=True
+                )
 
             # If schema is inferred, we can restore indexes too.
             internal = kdf._internal.with_new_sdf(sdf)
@@ -2426,9 +2435,17 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 should_return_series = True
                 return_schema = StructType([StructField("0", return_schema)])
 
-            sdf = GroupBy._spark_group_map_apply(
-                self, apply_func, (F.spark_partition_id(),), return_schema, retain_index=False
-            )
+            if should_use_map_in_pandas:
+                output_func = GroupBy._make_pandas_df_builder_func(
+                    self, apply_func, return_schema, retain_index=False
+                )
+                sdf = self._internal.to_internal_spark_frame.mapInPandas(
+                    lambda iterator: map(output_func, iterator), schema=return_schema
+                )
+            else:
+                sdf = GroupBy._spark_group_map_apply(
+                    self, apply_func, (F.spark_partition_id(),), return_schema, retain_index=False
+                )
 
             # Otherwise, it loses index.
             internal = _InternalFrame(spark_frame=sdf, index_map=None)


### PR DESCRIPTION
This PR proposes to use `mapInPandas` which is available from Spark 3.0 at `DataFrame.apply`. I manually ran the existing tests against Apache Spark 3.0.