### PR TITLE
Fix documentations style in DataFrame.pop

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -2845,13 +2845,16 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
     def pop(self, item):
         """
         Return item and drop from frame. Raise KeyError if not found.
+
         Parameters
         ----------
         item : str
             Label of column to be popped.
+
         Returns
         -------
         Series
+
         Examples
         --------
         >>> df = ks.DataFrame([('falcon', 'bird', 389.0),
@@ -2859,18 +2862,21 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         ...                    ('lion', 'mammal', 80.5),
         ...                    ('monkey','mammal', np.nan)],
         ...                   columns=('name', 'class', 'max_speed'))
+
         >>> df
              name   class  max_speed
         0  falcon    bird      389.0
         1  parrot    bird       24.0
         2    lion  mammal       80.5
         3  monkey  mammal        NaN
+
         >>> df.pop('class')
         0      bird
         1      bird
         2    mammal
         3    mammal
         Name: class, dtype: object
+
         >>> df
              name  max_speed
         0  falcon      389.0
@@ -2894,12 +2900,14 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         1  parrot    bird      24.0
         2    lion  mammal      80.5
         3  monkey  mammal       NaN
+
         >>> df.pop('a')
              name   class
         0  falcon    bird
         1  parrot    bird
         2    lion  mammal
         3  monkey  mammal
+
         >>> df
                   b
           max_speed


### PR DESCRIPTION
```
Warning, treated as error:
/.../koalas/databricks/koalas/frame.py:docstring of databricks.koalas.DataFrame.pop:6:Unexpected indentation.
```

Similar with https://github.com/databricks/koalas/pull/1509. For some reasons, it didn't fail before but after new more changes in the current master, it started to fail as above. We should fix the style mistakes anyway ..