### PR TITLE
Fix Series.item to run a Spark job once

### DIFF
--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -4873,10 +4873,11 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         >>> kser.item()
         10
         """
-        item_top_two = self[:2]
+        scol = self.spark_column
+        item_top_two = self._internal._sdf.select(scol).head(2)
         if len(item_top_two) != 1:
             raise ValueError("can only convert an array of size 1 to a Python scalar")
-        return item_top_two[0]
+        return item_top_two[0][0]
 
     def _cum(self, func, skipna, part_cols=()):
         # This is used to cummin, cummax, cumsum, etc.

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -4873,11 +4873,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         >>> kser.item()
         10
         """
-        scol = self.spark_column
-        item_top_two = self._internal._sdf.select(scol).head(2)
-        if len(item_top_two) != 1:
-            raise ValueError("can only convert an array of size 1 to a Python scalar")
-        return item_top_two[0][0]
+        return self.head(2).to_pandas().item()
 
     def _cum(self, func, skipna, part_cols=()):
         # This is used to cummin, cummax, cumsum, etc.

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -1595,3 +1595,7 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         # Only support for MultiIndex
         kser = ks.Series([10, -2, 4, 7])
         self.assertRaises(ValueError, lambda: kser.unstack())
+
+    def test_item(self):
+        kser = ks.Series([10, 20])
+        self.assertRaises(ValueError, lambda: kser.item())

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -1595,7 +1595,3 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         # Only support for MultiIndex
         kser = ks.Series([10, -2, 4, 7])
         self.assertRaises(ValueError, lambda: kser.unstack())
-
-    def test_item(self):
-        kser = ks.Series([10, 20])
-        self.assertRaises(ValueError, lambda: kser.item())


### PR DESCRIPTION
According to the comment https://github.com/databricks/koalas/pull/1502#discussion_r427560507, fixed `Series.item` to run a Spark job not twice, once.