### PR TITLE
Fix Series.clip not to create a new DataFrame.

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -46,14 +46,9 @@ from pyspark.sql.functions import pandas_udf, PandasUDFType
 from pyspark.sql.readwriter import OptionUtils
 from pyspark.sql.types import (
     BooleanType,
-    ByteType,
-    DecimalType,
     DoubleType,
     FloatType,
-    IntegerType,
-    LongType,
     NumericType,
-    ShortType,
     StructType,
     StructField,
 )
@@ -5708,28 +5703,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         if lower is None and upper is None:
             return self
 
-        numeric_types = (
-            DecimalType,
-            DoubleType,
-            FloatType,
-            ByteType,
-            IntegerType,
-            LongType,
-            ShortType,
-        )
-
-        def op(kser):
-            if isinstance(kser.spark_type, numeric_types):
-                scol = kser.spark_column
-                if lower is not None:
-                    scol = F.when(scol < lower, lower).otherwise(scol)
-                if upper is not None:
-                    scol = F.when(scol > upper, upper).otherwise(scol)
-                return scol.alias(kser._internal.data_spark_column_names[0])
-            else:
-                return kser
-
-        return self._apply_series_op(op)
+        return self._apply_series_op(lambda kser: kser.clip(lower=lower, upper=upper))
 
     def head(self, n: int = 5) -> "DataFrame":
         """

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -40,6 +40,7 @@ from pyspark.sql.types import (
     IntegerType,
     LongType,
     NumericType,
+    StringType,
     StructType,
 )
 from pyspark.sql.window import Window

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -1387,6 +1387,10 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         # Assert lower and upper
         self.assert_eq(kdf.clip(1, 3), pdf.clip(1, 3))
 
+        pdf["clip"] = pdf.A.clip(lower=1, upper=3)
+        kdf["clip"] = kdf.A.clip(lower=1, upper=3)
+        self.assert_eq(kdf, pdf)
+
         # Assert behavior on string values
         str_kdf = ks.DataFrame({"A": ["a", "b", "c"]}, index=np.random.rand(3))
         self.assert_eq(str_kdf.clip(1, 3), str_kdf)


### PR DESCRIPTION
Currently `Series.clip` creates a new DataFrame, so assigning back to the anchor DataFrame can't be executed without the option "compute.ops_on_diff_frames":

```py
>>> kdf = ks.DataFrame({"a": [1, 2, 6, 4, 4, 6, 4, 3, 7]})
>>> kdf['clip'] = kdf.a.clip(3, 6)
Traceback (most recent call last):
...
ValueError: Cannot combine the series or dataframe because it comes from a different dataframe. In order to allow this operation, enable 'compute.ops_on_diff_frames' option.
```