### PR TITLE
Add __bool__ function.

### DIFF
--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -2140,6 +2140,12 @@ class Frame(object):
         """Alias of `to_pandas()` to mimic dask for easily porting tests."""
         return self.toPandas()
 
+    def __bool__(self):
+        raise ValueError(
+            "The truth value of a {0} is ambiguous. "
+            "Use a.empty, a.bool(), a.item(), a.any() or a.all().".format(self.__class__.__name__)
+        )
+
     @staticmethod
     def _count_expr(col: spark.Column, spark_type: DataType) -> spark.Column:
         # Special handle floating point types because Spark's count treats nan as a valid value,

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -1804,6 +1804,12 @@ class Index(IndexOpsMixin):
     def __len__(self):
         return self.size
 
+    def __bool__(self):
+        raise ValueError(
+            "The truth value of a {0} is ambiguous. "
+            "Use a.empty, a.bool(), a.item(), a.any() or a.all().".format(self.__class__.__name__)
+        )
+
 
 class MultiIndex(Index):
     """

--- a/databricks/koalas/utils.py
+++ b/databricks/koalas/utils.py
@@ -504,10 +504,11 @@ def name_like_string(name: Union[str, Tuple]) -> str:
 
 def validate_axis(axis=0, none_axis=0):
     """ Check the given axis is valid. """
-    if axis not in (0, 1, "index", "columns", None):
-        raise ValueError("No axis named {0}".format(axis))
     # convert to numeric axis
-    return {None: none_axis, "index": 0, "columns": 1}.get(axis, axis)
+    axis = {None: none_axis, "index": 0, "columns": 1}.get(axis, axis)
+    if axis not in (none_axis, 0, 1):
+        raise ValueError("No axis named {0}".format(axis))
+    return axis
 
 
 def validate_bool_kwarg(value, arg_name):


### PR DESCRIPTION
Adding `__bool__` function explicitly to raise an error when `DataFrame`, `Series`, and `Index` are used as bool, otherwise they might be used mistakenly.