### PR TITLE
Add spark namespace in DataFrame, Series, Index and MultiIndex

### DIFF
--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -20,12 +20,13 @@ Base and utility classes for Koalas objects.
 from collections import OrderedDict
 from functools import wraps, partial
 from typing import Union, Callable, Any
+import warnings
 
 import numpy as np
 import pandas as pd
 from pandas.api.types import is_list_like
-from pyspark import sql as spark
-from pyspark.sql import functions as F, Window
+from pandas.core.accessor import CachedAccessor
+from pyspark.sql import functions as F, Window, Column
 from pyspark.sql.types import DateType, DoubleType, FloatType, LongType, StringType, TimestampType
 
 from databricks import koalas as ks  # For running doctests and reference resolution in PyCharm.
@@ -35,6 +36,7 @@ from databricks.koalas.internal import (
     NATURAL_ORDER_COLUMN_NAME,
     SPARK_DEFAULT_INDEX_NAME,
 )
+from databricks.koalas.spark import SparkIndexOpsMethods
 from databricks.koalas.typedef import spark_type_to_pandas_dtype
 from databricks.koalas.utils import align_diff_series, same_anchor, scol_for, validate_axis
 from databricks.koalas.frame import DataFrame
@@ -45,19 +47,19 @@ def booleanize_null(left_scol, scol, f):
     Booleanize Null in Spark Column
     """
     comp_ops = [
-        getattr(spark.Column, "__{}__".format(comp_op))
+        getattr(Column, "__{}__".format(comp_op))
         for comp_op in ["eq", "ne", "lt", "le", "ge", "gt"]
     ]
 
     if f in comp_ops:
         # if `f` is "!=", fill null with True otherwise False
-        filler = f == spark.Column.__ne__
+        filler = f == Column.__ne__
         scol = F.when(scol.isNull(), filler).otherwise(scol)
 
-    elif f == spark.Column.__or__:
+    elif f == Column.__or__:
         scol = F.when(left_scol.isNull() | scol.isNull(), False).otherwise(scol)
 
-    elif f == spark.Column.__and__:
+    elif f == Column.__and__:
         scol = F.when(scol.isNull(), False).otherwise(scol)
 
     return scol
@@ -83,9 +85,9 @@ def column_op(f):
         cols = [arg for arg in args if isinstance(arg, IndexOpsMixin)]
         if all(same_anchor(self, col) for col in cols):
             # Same DataFrame anchors
-            args = [arg.spark_column if isinstance(arg, IndexOpsMixin) else arg for arg in args]
-            scol = f(self.spark_column, *args)
-            scol = booleanize_null(self.spark_column, scol, f)
+            args = [arg.spark.column if isinstance(arg, IndexOpsMixin) else arg for arg in args]
+            scol = f(self.spark.column, *args)
+            scol = booleanize_null(self.spark.column, scol, f)
 
             return self._with_new_scol(scol)
         else:
@@ -107,7 +109,7 @@ def numpy_column_op(f):
         new_args = []
         for arg in args:
             # TODO: This is a quick hack to support NumPy type. We should revisit this.
-            if isinstance(self.spark_type, LongType) and isinstance(arg, np.timedelta64):
+            if isinstance(self.spark.type, LongType) and isinstance(arg, np.timedelta64):
                 new_args.append(float(arg / np.timedelta64(1, "s")))
             else:
                 new_args.append(arg)
@@ -121,13 +123,10 @@ class IndexOpsMixin(object):
 
     Assuming there are following attributes or properties and function.
 
-    :ivar _scol: Spark Column instance
-    :type _scol: pyspark.Column
     :ivar _kdf: Parent's Koalas DataFrame
     :type _kdf: ks.DataFrame
-
-    :ivar spark_type: Spark data type
-    :type spark_type: spark.types.DataType
+    :ivar spark: Spark-related features
+    :type spark: SparkIndexOpsMethods
     """
 
     def __init__(self, internal: InternalFrame, kdf):
@@ -136,23 +135,26 @@ class IndexOpsMixin(object):
         self._internal = internal  # type: InternalFrame
         self._kdf = kdf
 
+    spark = CachedAccessor("spark", SparkIndexOpsMethods)
+
     @property
     def spark_column(self):
-        """
-        Spark Column object representing the Series/Index.
+        warnings.warn(
+            "Series.spark_column is deprecated as of Series.spark.column. "
+            "Please use the API instead.",
+            FutureWarning,
+        )
+        return self.spark.column
 
-        .. note:: This Spark Column object is strictly stick to its base DataFrame the Series/Index
-            was derived from.
-        """
-        return self._internal.spark_column
+    spark_column.__doc__ = SparkIndexOpsMethods.column.__doc__
 
     # arithmetic operators
-    __neg__ = column_op(spark.Column.__neg__)
+    __neg__ = column_op(Column.__neg__)
 
     def __add__(self, other):
-        if isinstance(self.spark_type, StringType):
+        if isinstance(self.spark.type, StringType):
             # Concatenate string columns
-            if isinstance(other, IndexOpsMixin) and isinstance(other.spark_type, StringType):
+            if isinstance(other, IndexOpsMixin) and isinstance(other.spark.type, StringType):
                 return column_op(F.concat)(self, other)
             # Handle df['col'] + 'literal'
             elif isinstance(other, str):
@@ -160,23 +162,23 @@ class IndexOpsMixin(object):
             else:
                 raise TypeError("string addition can only be applied to string series or literals.")
         else:
-            return column_op(spark.Column.__add__)(self, other)
+            return column_op(Column.__add__)(self, other)
 
     def __sub__(self, other):
         # Note that timestamp subtraction casts arguments to integer. This is to mimic Pandas's
         # behaviors. Pandas returns 'timedelta64[ns]' from 'datetime64[ns]'s subtraction.
-        if isinstance(other, IndexOpsMixin) and isinstance(self.spark_type, TimestampType):
-            if not isinstance(other.spark_type, TimestampType):
+        if isinstance(other, IndexOpsMixin) and isinstance(self.spark.type, TimestampType):
+            if not isinstance(other.spark.type, TimestampType):
                 raise TypeError("datetime subtraction can only be applied to datetime series.")
             return self.astype("bigint") - other.astype("bigint")
-        elif isinstance(other, IndexOpsMixin) and isinstance(self.spark_type, DateType):
-            if not isinstance(other.spark_type, DateType):
+        elif isinstance(other, IndexOpsMixin) and isinstance(self.spark.type, DateType):
+            if not isinstance(other.spark.type, DateType):
                 raise TypeError("date subtraction can only be applied to date series.")
             return column_op(F.datediff)(self, other)
         else:
-            return column_op(spark.Column.__sub__)(self, other)
+            return column_op(Column.__sub__)(self, other)
 
-    __mul__ = column_op(spark.Column.__mul__)
+    __mul__ = column_op(Column.__mul__)
 
     def __truediv__(self, other):
         """
@@ -213,13 +215,13 @@ class IndexOpsMixin(object):
 
     def __radd__(self, other):
         # Handle 'literal' + df['col']
-        if isinstance(self.spark_type, StringType) and isinstance(other, str):
-            return self._with_new_scol(F.concat(F.lit(other), self.spark_column))
+        if isinstance(self.spark.type, StringType) and isinstance(other, str):
+            return self._with_new_scol(F.concat(F.lit(other), self.spark.column))
         else:
-            return column_op(spark.Column.__radd__)(self, other)
+            return column_op(Column.__radd__)(self, other)
 
-    __rsub__ = column_op(spark.Column.__rsub__)
-    __rmul__ = column_op(spark.Column.__rmul__)
+    __rsub__ = column_op(Column.__rsub__)
+    __rmul__ = column_op(Column.__rmul__)
 
     def __rtruediv__(self, other):
         def rtruediv(left, right):
@@ -274,24 +276,24 @@ class IndexOpsMixin(object):
 
         return column_op(rmod)(self, other)
 
-    __pow__ = column_op(spark.Column.__pow__)
-    __rpow__ = column_op(spark.Column.__rpow__)
+    __pow__ = column_op(Column.__pow__)
+    __rpow__ = column_op(Column.__rpow__)
 
     # comparison operators
-    __eq__ = column_op(spark.Column.__eq__)
-    __ne__ = column_op(spark.Column.__ne__)
-    __lt__ = column_op(spark.Column.__lt__)
-    __le__ = column_op(spark.Column.__le__)
-    __ge__ = column_op(spark.Column.__ge__)
-    __gt__ = column_op(spark.Column.__gt__)
+    __eq__ = column_op(Column.__eq__)
+    __ne__ = column_op(Column.__ne__)
+    __lt__ = column_op(Column.__lt__)
+    __le__ = column_op(Column.__le__)
+    __ge__ = column_op(Column.__ge__)
+    __gt__ = column_op(Column.__gt__)
 
     # `and`, `or`, `not` cannot be overloaded in Python,
     # so use bitwise operators as boolean operators
-    __and__ = column_op(spark.Column.__and__)
-    __or__ = column_op(spark.Column.__or__)
-    __invert__ = column_op(spark.Column.__invert__)
-    __rand__ = column_op(spark.Column.__rand__)
-    __ror__ = column_op(spark.Column.__ror__)
+    __and__ = column_op(Column.__and__)
+    __or__ = column_op(Column.__or__)
+    __invert__ = column_op(Column.__invert__)
+    __rand__ = column_op(Column.__rand__)
+    __ror__ = column_op(Column.__ror__)
 
     # NDArray Compat
     def __array_ufunc__(self, ufunc: Callable, method: str, *inputs: Any, **kwargs: Any):
@@ -333,7 +335,7 @@ class IndexOpsMixin(object):
         >>> s.rename("a").to_frame().set_index("a").index.dtype
         dtype('<M8[ns]')
         """
-        return spark_type_to_pandas_dtype(self.spark_type)
+        return spark_type_to_pandas_dtype(self.spark.type)
 
     @property
     def empty(self):
@@ -371,8 +373,8 @@ class IndexOpsMixin(object):
         >>> ks.Series([1, 2, 3]).rename("a").to_frame().set_index("a").index.hasnans
         False
         """
-        sdf = self._internal._sdf.select(self.spark_column)
-        col = self.spark_column
+        sdf = self._internal._sdf.select(self.spark.column)
+        col = self.spark.column
 
         ret = sdf.select(F.max(col.isNull() | F.isnan(col))).collect()[0][0]
         return ret
@@ -552,7 +554,7 @@ class IndexOpsMixin(object):
                     "__partition_id"
                 ),  # Make sure we use the same partition id in the whole job.
                 F.col(NATURAL_ORDER_COLUMN_NAME),
-                self.spark_column.alias("__origin"),
+                self.spark.column.alias("__origin"),
             )
             .select(
                 F.col("__partition_id"),
@@ -670,7 +672,7 @@ class IndexOpsMixin(object):
         spark_type = as_spark_type(dtype)
         if not spark_type:
             raise ValueError("Type {} not understood".format(dtype))
-        return self._with_new_scol(self.spark_column.cast(spark_type))
+        return self._with_new_scol(self.spark.column.cast(spark_type))
 
     def isin(self, values):
         """
@@ -722,7 +724,7 @@ class IndexOpsMixin(object):
                 " to isin(), you passed a [{values_type}]".format(values_type=type(values).__name__)
             )
 
-        return self._with_new_scol(self.spark_column.isin(list(values))).rename(self.name)
+        return self._with_new_scol(self.spark.column.isin(list(values))).rename(self.name)
 
     def isnull(self):
         """
@@ -757,10 +759,10 @@ class IndexOpsMixin(object):
             raise NotImplementedError("isna is not defined for MultiIndex")
         if isinstance(self.spark_type, (FloatType, DoubleType)):
             return self._with_new_scol(
-                self.spark_column.isNull() | F.isnan(self.spark_column)
+                self.spark.column.isNull() | F.isnan(self.spark.column)
             ).rename(self.name)
         else:
-            return self._with_new_scol(self.spark_column.isNull()).rename(self.name)
+            return self._with_new_scol(self.spark.column.isNull()).rename(self.name)
 
     isna = isnull
 
@@ -856,7 +858,7 @@ class IndexOpsMixin(object):
         if axis != 0:
             raise NotImplementedError('axis should be either 0 or "index" currently.')
 
-        sdf = self._internal._sdf.select(self.spark_column)
+        sdf = self._internal._sdf.select(self.spark.column)
         col = scol_for(sdf, sdf.columns[0])
 
         # Note that we're ignoring `None`s here for now.
@@ -919,7 +921,7 @@ class IndexOpsMixin(object):
         if axis != 0:
             raise NotImplementedError('axis should be either 0 or "index" currently.')
 
-        sdf = self._internal._sdf.select(self.spark_column)
+        sdf = self._internal._sdf.select(self.spark.column)
         col = scol_for(sdf, sdf.columns[0])
 
         # Note that we're ignoring `None`s here for now.
@@ -986,7 +988,7 @@ class IndexOpsMixin(object):
         if not isinstance(periods, int):
             raise ValueError("periods should be an int; however, got [%s]" % type(periods))
 
-        col = self.spark_column
+        col = self.spark.column
         window = (
             Window.partitionBy(*part_cols)
             .orderBy(NATURAL_ORDER_COLUMN_NAME)
@@ -1152,9 +1154,9 @@ class IndexOpsMixin(object):
             raise NotImplementedError("value_counts currently does not support bins")
 
         if dropna:
-            sdf_dropna = self._internal._sdf.select(self.spark_column).dropna()
+            sdf_dropna = self._internal._sdf.select(self.spark.column).dropna()
         else:
-            sdf_dropna = self._internal._sdf.select(self.spark_column)
+            sdf_dropna = self._internal._sdf.select(self.spark.column)
         index_name = SPARK_DEFAULT_INDEX_NAME
         column_name = self._internal.data_spark_column_names[0]
         sdf = sdf_dropna.groupby(scol_for(sdf_dropna, column_name).alias(index_name)).count()
@@ -1244,12 +1246,12 @@ class IndexOpsMixin(object):
         colname = self._internal.data_spark_column_names[0]
         count_fn = partial(F.approx_count_distinct, rsd=rsd) if approx else F.countDistinct
         if dropna:
-            return count_fn(self.spark_column).alias(colname)
+            return count_fn(self.spark.column).alias(colname)
         else:
             return (
-                count_fn(self.spark_column)
+                count_fn(self.spark.column)
                 + F.when(
-                    F.count(F.when(self.spark_column.isNull(), 1).otherwise(None)) >= 1, 1
+                    F.count(F.when(self.spark.column.isNull(), 1).otherwise(None)) >= 1, 1
                 ).otherwise(0)
             ).alias(colname)
 

--- a/databricks/koalas/datetimes.py
+++ b/databricks/koalas/datetimes.py
@@ -34,8 +34,10 @@ class DatetimeMethods(object):
     """Date/Time methods for Koalas Series"""
 
     def __init__(self, series: "ks.Series"):
-        if not isinstance(series.spark.type, (DateType, TimestampType)):
-            raise ValueError("Cannot call DatetimeMethods on type {}".format(series.spark.type))
+        if not isinstance(series.spark.data_type, (DateType, TimestampType)):
+            raise ValueError(
+                "Cannot call DatetimeMethods on type {}".format(series.spark.data_type)
+            )
         self._data = series
 
     # Properties

--- a/databricks/koalas/datetimes.py
+++ b/databricks/koalas/datetimes.py
@@ -34,8 +34,8 @@ class DatetimeMethods(object):
     """Date/Time methods for Koalas Series"""
 
     def __init__(self, series: "ks.Series"):
-        if not isinstance(series.spark_type, (DateType, TimestampType)):
-            raise ValueError("Cannot call DatetimeMethods on type {}".format(series.spark_type))
+        if not isinstance(series.spark.type, (DateType, TimestampType)):
+            raise ValueError("Cannot call DatetimeMethods on type {}".format(series.spark.type))
         self._data = series
 
     # Properties

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -2742,7 +2742,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 kser = kdf_or_kser
                 pudf = pandas_udf(
                     func if should_by_pass else pandas_series_func(func),
-                    returnType=kser.spark.type,
+                    returnType=kser.spark.data_type,
                     functionType=PandasUDFType.SCALAR,
                 )
                 columns = self._internal.spark_columns

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -1395,7 +1395,7 @@ class Frame(object):
         """
         # TODO: The first example above should not have "Name: 0".
         return self._apply_series_op(
-            lambda kser: kser._with_new_scol(F.abs(kser.spark_column)).rename(kser.name)
+            lambda kser: kser._with_new_scol(F.abs(kser.spark.column)).rename(kser.name)
         )
 
     # TODO: by argument only support the grouping name and as_index only for now. Documentation

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -2067,7 +2067,7 @@ class GroupBy(object):
         if len(agg_columns) > 0:
             stat_exprs = []
             for kser, c in zip(agg_columns, agg_columns_scols):
-                spark_type = kser.spark.type
+                spark_type = kser.spark.data_type
                 name = kser._internal.data_spark_column_names[0]
                 label = kser._internal.column_labels[0]
                 # TODO: we should have a function that takes dataframes and converts the numeric
@@ -2330,7 +2330,7 @@ class DataFrameGroupBy(GroupBy):
 
         """
         for col in self._agg_columns:
-            if isinstance(col.spark.type, StringType):
+            if isinstance(col.spark.data_type, StringType):
                 raise NotImplementedError(
                     "DataFrameGroupBy.describe() doesn't support for string type for now"
                 )

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -81,11 +81,11 @@ class GroupBy(object):
 
     @property
     def _groupkeys_scols(self):
-        return [s.spark_column for s in self._groupkeys]
+        return [s.spark.column for s in self._groupkeys]
 
     @property
     def _agg_columns_scols(self):
-        return [s.spark_column for s in self._agg_columns]
+        return [s.spark.column for s in self._agg_columns]
 
     # TODO: Series support is not implemented yet.
     # TODO: not all arguments are implemented comparing to Pandas' for now.
@@ -242,7 +242,7 @@ class GroupBy(object):
     def _spark_groupby(kdf, func, groupkeys=()):
         sdf = kdf._sdf
         groupkey_scols = [
-            s.spark_column.alias(SPARK_INDEX_NAME_FORMAT(i)) for i, s in enumerate(groupkeys)
+            s.spark.column.alias(SPARK_INDEX_NAME_FORMAT(i)) for i, s in enumerate(groupkeys)
         ]
         multi_aggs = any(isinstance(v, list) for v in func.values())
         reordered = []
@@ -2067,7 +2067,7 @@ class GroupBy(object):
         if len(agg_columns) > 0:
             stat_exprs = []
             for kser, c in zip(agg_columns, agg_columns_scols):
-                spark_type = kser.spark_type
+                spark_type = kser.spark.type
                 name = kser._internal.data_spark_column_names[0]
                 label = kser._internal.column_labels[0]
                 # TODO: we should have a function that takes dataframes and converts the numeric
@@ -2122,7 +2122,7 @@ class GroupBy(object):
         for i, col_or_s in enumerate(by):
             if isinstance(col_or_s, Series):
                 if any(
-                    col_or_s.spark_column._jc.equals(scol._jc)
+                    col_or_s.spark.column._jc.equals(scol._jc)
                     for scol in kdf._internal.data_spark_columns
                 ):
                     column_labels.append(col_or_s._internal.column_labels[0])
@@ -2330,7 +2330,7 @@ class DataFrameGroupBy(GroupBy):
 
         """
         for col in self._agg_columns:
-            if isinstance(col.spark_type, StringType):
+            if isinstance(col.spark.type, StringType):
                 raise NotImplementedError(
                     "DataFrameGroupBy.describe() doesn't support for string type for now"
                 )

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -143,7 +143,7 @@ class Index(IndexOpsMixin):
         String with a summarized representation of the index
         """
         head, tail, total_count = self._kdf._sdf.select(
-            F.first(self.spark_column), F.last(self.spark_column), F.count(F.expr("*"))
+            F.first(self.spark.column), F.last(self.spark.column), F.count(F.expr("*"))
         ).first()
 
         if total_count > 0:
@@ -420,7 +420,7 @@ class Index(IndexOpsMixin):
     @property
     def spark_type(self):
         """ Returns the data type as defined by Spark, as a Spark DataType object."""
-        return self.to_series().spark_type
+        return self.to_series().spark.type
 
     @property
     def has_duplicates(self) -> bool:
@@ -441,7 +441,7 @@ class Index(IndexOpsMixin):
         >>> kdf.index.has_duplicates
         True
         """
-        df = self._kdf._sdf.select(self.spark_column)
+        df = self._kdf._sdf.select(self.spark.column)
         col = df.columns[0]
 
         return df.select(F.count(col) != F.countDistinct(col)).first()[0]
@@ -555,7 +555,7 @@ class Index(IndexOpsMixin):
         )
 
         idx = kdf.index
-        idx._internal = idx._internal.copy(spark_column=self.spark_column)
+        idx._internal = idx._internal.copy(spark_column=self.spark.column)
         if inplace:
             self._internal = idx._internal
         else:
@@ -665,7 +665,7 @@ class Index(IndexOpsMixin):
         Name: 0, dtype: object
         """
         kdf = self._kdf
-        scol = self.spark_column
+        scol = self.spark.column
         if name is not None:
             scol = scol.alias(name_like_string(name))
         column_labels = [None] if len(kdf._internal.index_map) > 1 else kdf._internal.index_names
@@ -732,7 +732,7 @@ class Index(IndexOpsMixin):
                 name = self._internal.index_names[0]
         elif isinstance(name, str):
             name = (name,)
-        scol = self.spark_column.alias(name_like_string(name))
+        scol = self.spark.column.alias(name_like_string(name))
 
         sdf = self._internal.spark_frame.select(scol, NATURAL_ORDER_COLUMN_NAME)
 
@@ -1371,7 +1371,7 @@ class Index(IndexOpsMixin):
         >>> kidx.argmax()
         4
         """
-        sdf = self._internal.spark_frame.select(self.spark_column)
+        sdf = self._internal.spark_frame.select(self.spark.column)
         sequence_col = verify_temp_column_name(sdf, "__distributed_sequence_column__")
         sdf = InternalFrame.attach_distributed_sequence_column(sdf, column_name=sequence_col)
         # spark_frame here looks like below
@@ -1389,7 +1389,7 @@ class Index(IndexOpsMixin):
         # |                1|              9|
         # +-----------------+---------------+
 
-        return sdf.orderBy(self.spark_column.desc(), F.col(sequence_col).asc()).first()[0]
+        return sdf.orderBy(self.spark.column.desc(), F.col(sequence_col).asc()).first()[0]
 
     def argmin(self):
         """
@@ -1412,11 +1412,11 @@ class Index(IndexOpsMixin):
         >>> kidx.argmin()
         7
         """
-        sdf = self._internal.spark_frame.select(self.spark_column)
+        sdf = self._internal.spark_frame.select(self.spark.column)
         sequence_col = verify_temp_column_name(sdf, "__distributed_sequence_column__")
         sdf = InternalFrame.attach_distributed_sequence_column(sdf, column_name=sequence_col)
 
-        return sdf.orderBy(self.spark_column.asc(), F.col(sequence_col).asc()).first()[0]
+        return sdf.orderBy(self.spark.column.asc(), F.col(sequence_col).asc()).first()[0]
 
     def set_names(self, names, level=None, inplace=False):
         """
@@ -1690,9 +1690,9 @@ class Index(IndexOpsMixin):
         """
         sdf = self._internal._sdf
         if self.is_monotonic_increasing:
-            sdf = sdf.where(self.spark_column <= label).select(F.max(self.spark_column))
+            sdf = sdf.where(self.spark.column <= label).select(F.max(self.spark.column))
         elif self.is_monotonic_decreasing:
-            sdf = sdf.where(self.spark_column >= label).select(F.min(self.spark_column))
+            sdf = sdf.where(self.spark.column >= label).select(F.min(self.spark.column))
         else:
             raise ValueError("index must be monotonic increasing or decreasing")
         result = sdf.head()[0]
@@ -1783,7 +1783,7 @@ class Index(IndexOpsMixin):
 
         pindex = (
             self._kdf.head(max_display_count + 1)
-            .index._with_new_scol(self.spark_column)
+            .index._with_new_scol(self.spark.column)
             .to_pandas()
         )
 
@@ -2083,7 +2083,7 @@ class MultiIndex(Index):
             return self._is_monotonic_decreasing().all()
 
     def _is_monotonic_increasing(self):
-        scol = self.spark_column
+        scol = self.spark.column
         window = Window.orderBy(NATURAL_ORDER_COLUMN_NAME).rowsBetween(-1, -1)
         prev = F.lag(scol, 1).over(window)
 
@@ -2119,7 +2119,7 @@ class MultiIndex(Index):
             return compare_null_first
 
     def _is_monotonic_decreasing(self):
-        scol = self.spark_column
+        scol = self.spark.column
         window = Window.orderBy(NATURAL_ORDER_COLUMN_NAME).rowsBetween(-1, -1)
         prev = F.lag(scol, 1).over(window)
 

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -420,7 +420,7 @@ class Index(IndexOpsMixin):
     @property
     def spark_type(self):
         """ Returns the data type as defined by Spark, as a Spark DataType object."""
-        return self.to_series().spark.type
+        return self.to_series().spark.data_type
 
     @property
     def has_duplicates(self) -> bool:

--- a/databricks/koalas/indexing.py
+++ b/databricks/koalas/indexing.py
@@ -834,7 +834,7 @@ class LocIndexer(LocIndexerLike):
     def _select_rows_by_series(
         self, rows_sel: "Series"
     ) -> Tuple[Optional[spark.Column], Optional[int], Optional[int]]:
-        assert isinstance(rows_sel.spark.type, BooleanType), rows_sel.spark.type
+        assert isinstance(rows_sel.spark.data_type, BooleanType), rows_sel.spark.data_type
         return rows_sel.spark.column, None, None
 
     def _select_rows_by_spark_column(
@@ -855,7 +855,7 @@ class LocIndexer(LocIndexerLike):
             sdf = self._internal.spark_frame
             index = self._kdf_or_kser.index
             index_column = index.to_series()
-            index_data_type = index_column.spark.type
+            index_data_type = index_column.spark.data_type
             start = rows_sel.start
             stop = rows_sel.stop
 
@@ -912,7 +912,7 @@ class LocIndexer(LocIndexerLike):
             return reduce(lambda x, y: x & y, cond), None, None
         else:
             index = self._kdf_or_kser.index
-            index_data_type = [f.dataType for f in index.to_series().spark.type]
+            index_data_type = [f.dataType for f in index.to_series().spark.data_type]
 
             start = rows_sel.start
             if start is not None:
@@ -974,7 +974,7 @@ class LocIndexer(LocIndexerLike):
             return F.lit(False), None, None
         elif len(self._internal.index_spark_column_names) == 1:
             index_column = self._kdf_or_kser.index.to_series()
-            index_data_type = index_column.spark.type
+            index_data_type = index_column.spark.data_type
             if len(rows_sel) == 1:
                 return (
                     index_column.spark.column == F.lit(rows_sel[0]).cast(index_data_type),

--- a/databricks/koalas/internal.py
+++ b/databricks/koalas/internal.py
@@ -889,7 +889,7 @@ class InternalFrame(object):
         from databricks.koalas.series import Series
 
         if isinstance(pred, Series):
-            assert isinstance(pred.spark.type, BooleanType), pred.spark.type
+            assert isinstance(pred.spark.data_type, BooleanType), pred.spark.data_type
             pred = pred.spark.column
         else:
             spark_type = self.spark_frame.select(pred).schema[0].dataType

--- a/databricks/koalas/internal.py
+++ b/databricks/koalas/internal.py
@@ -889,8 +889,8 @@ class InternalFrame(object):
         from databricks.koalas.series import Series
 
         if isinstance(pred, Series):
-            assert isinstance(pred.spark_type, BooleanType), pred.spark_type
-            pred = pred.spark_column
+            assert isinstance(pred.spark.type, BooleanType), pred.spark.type
+            pred = pred.spark.column
         else:
             spark_type = self.spark_frame.select(pred).schema[0].dataType
             assert isinstance(spark_type, BooleanType), spark_type

--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -2324,7 +2324,7 @@ def broadcast(obj):
     ...                     'value': [5, 6, 7, 8]},
     ...                    columns=['rkey', 'value'])
     >>> merged = df1.merge(ks.broadcast(df2), left_on='lkey', right_on='rkey')
-    >>> merged.explain()  # doctest: +ELLIPSIS
+    >>> merged.spark.explain()  # doctest: +ELLIPSIS
     == Physical Plan ==
     ...
     ...BroadcastHashJoin...

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -19,6 +19,7 @@ A wrapper class for Spark Column to behave similar to pandas Series.
 """
 import re
 import inspect
+import warnings
 from collections import Iterable, OrderedDict
 from functools import partial, wraps, reduce
 from typing import Any, Generic, List, Optional, Tuple, TypeVar, Union
@@ -29,6 +30,7 @@ from pandas.core.accessor import CachedAccessor
 from pandas.io.formats.printing import pprint_thing
 from pandas.api.types import is_list_like
 
+from databricks.koalas.spark import SparkIndexOpsMethods
 from databricks.koalas.typedef import infer_return_type, SeriesType, ScalarType
 from pyspark import sql as spark
 from pyspark.sql import functions as F, Column
@@ -301,6 +303,10 @@ T = TypeVar("T")
 str_type = str
 
 
+class SparkMethods(object):
+    pass
+
+
 class Series(Frame, IndexOpsMixin, Generic[T]):
     """
     Koalas Series that corresponds to Pandas Series logically. This holds Spark Column
@@ -392,10 +398,14 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
     @property
     def spark_type(self):
-        """ Returns the data type as defined by Spark, as a Spark DataType object."""
-        return self._internal.spark_type_for(self._internal.column_labels[0])
+        warnings.warn(
+            "Series.spark_type is deprecated as of Series.spark.type. "
+            "Please use the API instead.",
+            FutureWarning,
+        )
+        return self.spark.type
 
-    plot = CachedAccessor("plot", KoalasSeriesPlotMethods)
+    spark_type.__doc__ = SparkIndexOpsMethods.type.__doc__
 
     # Arithmetic Operators
     def add(self, other):
@@ -914,21 +924,21 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         if isinstance(arg, dict):
             is_start = True
             # In case dictionary is empty.
-            current = F.when(F.lit(False), F.lit(None).cast(self.spark_type))
+            current = F.when(F.lit(False), F.lit(None).cast(self.spark.type))
 
             for to_replace, value in arg.items():
                 if is_start:
-                    current = F.when(self.spark_column == F.lit(to_replace), value)
+                    current = F.when(self.spark.column == F.lit(to_replace), value)
                     is_start = False
                 else:
-                    current = current.when(self.spark_column == F.lit(to_replace), value)
+                    current = current.when(self.spark.column == F.lit(to_replace), value)
 
             if hasattr(arg, "__missing__"):
                 tmp_val = arg[np._NoValue]
                 del arg[np._NoValue]  # Remove in case it's set in defaultdict.
                 current = current.otherwise(F.lit(tmp_val))
             else:
-                current = current.otherwise(F.lit(None).cast(self.spark_type))
+                current = current.otherwise(F.lit(None).cast(self.spark.type))
             return self._with_new_scol(current).rename(self.name)
         else:
             return self.apply(arg)
@@ -970,20 +980,20 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         if not spark_type:
             raise ValueError("Type {} not understood".format(dtype))
         if isinstance(spark_type, BooleanType):
-            if isinstance(self.spark_type, StringType):
-                scol = F.when(self.spark_column.isNull(), F.lit(False)).otherwise(
-                    F.length(self.spark_column) > 0
+            if isinstance(self.spark.type, StringType):
+                scol = F.when(self.spark.column.isNull(), F.lit(False)).otherwise(
+                    F.length(self.spark.column) > 0
                 )
-            elif isinstance(self.spark_type, (FloatType, DoubleType)):
+            elif isinstance(self.spark.type, (FloatType, DoubleType)):
                 scol = F.when(
-                    self.spark_column.isNull() | F.isnan(self.spark_column), F.lit(True)
-                ).otherwise(self.spark_column.cast(spark_type))
+                    self.spark.column.isNull() | F.isnan(self.spark.column), F.lit(True)
+                ).otherwise(self.spark.column.cast(spark_type))
             else:
-                scol = F.when(self.spark_column.isNull(), F.lit(False)).otherwise(
-                    self.spark_column.cast(spark_type)
+                scol = F.when(self.spark.column.isNull(), F.lit(False)).otherwise(
+                    self.spark.column.cast(spark_type)
                 )
         else:
-            scol = self.spark_column.cast(spark_type)
+            scol = self.spark.column.cast(spark_type)
         return self._with_new_scol(scol)
 
     def alias(self, name):
@@ -1045,9 +1055,9 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         Name: my_name, dtype: int64
         """
         if index is None:
-            scol = self.spark_column
+            scol = self.spark.column
         else:
-            scol = self.spark_column.alias(name_like_string(index))
+            scol = self.spark.column.alias(name_like_string(index))
         internal = self._internal.copy(  # type: ignore
             spark_column=scol,
             column_labels=[index if index is None or isinstance(index, tuple) else (index,)],
@@ -1084,7 +1094,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         >>> ks.Series([1, 2, 3, None]).is_unique
         True
         """
-        scol = self.spark_column
+        scol = self.spark.column
 
         # Here we check:
         #   1. the distinct count without nulls and count without nulls for non-null values
@@ -1606,7 +1616,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
                 return self
 
         column_name = self.name
-        scol = self.spark_column
+        scol = self.spark.column
 
         if value is not None:
             if not isinstance(value, (float, int, str, bool)):
@@ -1735,8 +1745,8 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         if lower is None and upper is None:
             return self
 
-        if isinstance(self.spark_type, NumericType):
-            scol = self.spark_column
+        if isinstance(self.spark.type, NumericType):
+            scol = self.spark.column
             if lower is not None:
                 scol = F.when(scol < lower, lower).otherwise(scol)
             if upper is not None:
@@ -1985,7 +1995,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         ...  3
         Name: (x, a), dtype: int64
         """
-        sdf = self._internal.spark_frame.select(self.spark_column).distinct()
+        sdf = self._internal.spark_frame.select(self.spark.column).distinct()
         internal = InternalFrame(
             spark_frame=sdf,
             index_map=None,
@@ -2704,7 +2714,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             pser = self.head(limit)._to_internal_pandas()
             transformed = pser.apply(func, *args, **kwds)
             kser = Series(transformed)
-            return self._transform_batch(apply_each, kser.spark_type)
+            return self._transform_batch(apply_each, kser.spark.type)
         else:
             sig_return = infer_return_type(func)
             if not isinstance(sig_return, ScalarType):
@@ -3011,12 +3021,12 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             pser = self.head(limit)._to_internal_pandas()
             transformed = pser.transform(func)
             kser = Series(transformed)
-            spark_return_type = kser.spark_type
+            spark_return_type = kser.spark.type
         else:
             spark_return_type = return_schema
 
         pudf = pandas_udf(func, returnType=spark_return_type, functionType=PandasUDFType.SCALAR)
-        return self._with_new_scol(scol=pudf(self.spark_column)).rename(self.name)
+        return self._with_new_scol(scol=pudf(self.spark.column)).rename(self.name)
 
     def round(self, decimals=0):
         """
@@ -3055,7 +3065,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         if not isinstance(decimals, int):
             raise ValueError("decimals must be an integer")
         column_name = self.name
-        scol = F.round(self.spark_column, decimals)
+        scol = F.round(self.spark.column, decimals)
         return self._with_new_scol(scol).rename(column_name)
 
     # TODO: add 'interpolation' parameter.
@@ -3377,7 +3387,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             .orderBy(NATURAL_ORDER_COLUMN_NAME)
             .rowsBetween(-periods, -periods)
         )
-        scol = self.spark_column - F.lag(self.spark_column, periods).over(window)
+        scol = self.spark.column - F.lag(self.spark.column, periods).over(window)
         return self._with_new_scol(scol).rename(self.name)
 
     def idxmax(self, skipna=True):
@@ -3462,7 +3472,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         3
         """
         sdf = self._internal.spark_frame
-        scol = self.spark_column
+        scol = self.spark.column
         index_scols = self._internal.index_spark_columns
         # desc_nulls_(last|first) is used via Py4J directly because
         # it's not supported in Spark 2.3.
@@ -3570,7 +3580,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         10
         """
         sdf = self._internal._sdf
-        scol = self.spark_column
+        scol = self.spark.column
         index_scols = self._internal.index_spark_columns
         # asc_nulls_(last|first)is used via Py4J directly because
         # it's not supported in Spark 2.3.
@@ -4075,17 +4085,17 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         if isinstance(to_replace, dict):
             is_start = True
             if len(to_replace) == 0:
-                current = self.spark_column
+                current = self.spark.column
             else:
                 for to_replace_, value in to_replace.items():
                     if is_start:
-                        current = F.when(self.spark_column == F.lit(to_replace_), value)
+                        current = F.when(self.spark.column == F.lit(to_replace_), value)
                         is_start = False
                     else:
-                        current = current.when(self.spark_column == F.lit(to_replace_), value)
-                current = current.otherwise(self.spark_column)
+                        current = current.when(self.spark.column == F.lit(to_replace_), value)
+                current = current.otherwise(self.spark.column)
         else:
-            current = F.when(self.spark_column.isin(to_replace), value).otherwise(self.spark_column)
+            current = F.when(self.spark.column.isin(to_replace), value).otherwise(self.spark.column)
 
         return self._with_new_scol(current)
 
@@ -4270,10 +4280,10 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             # +-----------------+---+----------------+-----------------+
             condition = (
                 F.when(
-                    kdf[tmp_cond_col].spark_column,
-                    kdf[self._internal.column_labels[0]].spark_column,
+                    kdf[tmp_cond_col].spark.column,
+                    kdf[self._internal.column_labels[0]].spark.column,
                 )
-                .otherwise(kdf[tmp_other_col].spark_column)
+                .otherwise(kdf[tmp_other_col].spark.column)
                 .alias(self._internal.data_spark_column_names[0])
             )
 
@@ -4283,9 +4293,9 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             return first_series(DataFrame(internal))
         else:
             if isinstance(other, Series):
-                other = other.spark_column
+                other = other.spark.column
             condition = (
-                F.when(cond.spark_column, self.spark_column)
+                F.when(cond.spark.column, self.spark.column)
                 .otherwise(other)
                 .alias(self._internal.data_spark_column_names[0])
             )
@@ -4760,7 +4770,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             where = [where]
         sdf = self._internal._sdf
         index_scol = self._internal.index_spark_columns[0]
-        cond = [F.max(F.when(index_scol <= index, self.spark_column)) for index in where]
+        cond = [F.max(F.when(index_scol <= index, self.spark.column)) for index in where]
         sdf = sdf.select(cond)
         if not should_return_series:
             result = sdf.head()[0]
@@ -4931,9 +4941,9 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
             scol = F.when(
                 # Manually sets nulls given the column defined above.
-                self.spark_column.isNull(),
+                self.spark.column.isNull(),
                 F.lit(None),
-            ).otherwise(func(self.spark_column).over(window))
+            ).otherwise(func(self.spark.column).over(window))
         else:
             # Here, we use two Windows.
             # One for real data.
@@ -4966,10 +4976,10 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             # 4  5.0  9.0
             scol = F.when(
                 # By going through with max, it sets True after the first time it meets null.
-                F.max(self.spark_column.isNull()).over(window),
+                F.max(self.spark.column.isNull()).over(window),
                 # Manually sets nulls given the column defined above.
                 F.lit(None),
-            ).otherwise(func(self.spark_column).over(window))
+            ).otherwise(func(self.spark.column).over(window))
 
         return self._with_new_scol(scol).rename(self.name)
 
@@ -4977,7 +4987,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         from pyspark.sql.functions import pandas_udf
 
         def cumprod(scol):
-            @pandas_udf(returnType=self.spark_type)
+            @pandas_udf(returnType=self.spark.type)
             def negative_check(s):
                 assert len(s) == 0 or ((s > 0) | (s.isnull())).all(), (
                     "values should be bigger than 0: %s" % s
@@ -4987,13 +4997,14 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             return F.sum(F.log(negative_check(scol)))
 
         kser = self._cum(cumprod, skipna, part_cols)
-        return kser._with_new_scol(F.exp(kser.spark_column)).rename(self.name)
+        return kser._with_new_scol(F.exp(kser.spark.column)).rename(self.name)
 
     # ----------------------------------------------------------------------
     # Accessor Methods
     # ----------------------------------------------------------------------
     dt = CachedAccessor("dt", DatetimeMethods)
     str = CachedAccessor("str", StringMethods)
+    plot = CachedAccessor("plot", KoalasSeriesPlotMethods)
 
     # ----------------------------------------------------------------------
 
@@ -5017,8 +5028,8 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         if axis == 1:
             raise ValueError("Series does not support columns axis.")
         num_args = len(signature(sfun).parameters)
-        col_sdf = self.spark_column
-        col_type = self.spark_type
+        col_sdf = self.spark.column
+        col_type = self.spark.type
         if isinstance(col_type, BooleanType) and sfun.__name__ not in ("min", "max"):
             # Stat functions cannot be used with boolean values by default
             # Thus, cast to integer (true to 1 and false to 0)
@@ -5039,7 +5050,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
     def __getitem__(self, key):
         try:
             if (isinstance(key, slice) and any(type(n) == int for n in [key.start, key.stop])) or (
-                type(key) == int and not isinstance(self.index.spark_type, (IntegerType, LongType))
+                type(key) == int and not isinstance(self.index.spark.type, (IntegerType, LongType))
             ):
                 # Seems like pandas Series always uses int as positional search when slicing
                 # with ints, searches based on index values when the value is int.
@@ -5093,17 +5104,17 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         return pser.to_string(name=self.name, dtype=self.dtype)
 
     def __dir__(self):
-        if not isinstance(self.spark_type, StructType):
+        if not isinstance(self.spark.type, StructType):
             fields = []
         else:
-            fields = [f for f in self.spark_type.fieldNames() if " " not in f]
+            fields = [f for f in self.spark.type.fieldNames() if " " not in f]
         return super(Series, self).__dir__() + fields
 
     def __iter__(self):
         return MissingPandasLikeSeries.__iter__(self)
 
     def _equals(self, other: "Series") -> bool:
-        return self.spark_column._jc.equals(other.spark_column._jc)
+        return self.spark.column._jc.equals(other.spark.column._jc)
 
 
 def unpack_scalar(sdf):

--- a/databricks/koalas/spark.py
+++ b/databricks/koalas/spark.py
@@ -1,0 +1,731 @@
+#
+# Copyright (C) 2019 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Spark related features. Usually, the features here are missing in pandas
+but Spark has it.
+"""
+from distutils.version import LooseVersion
+from typing import TYPE_CHECKING, Optional, Union, List
+
+import pyspark
+from pyspark import StorageLevel
+from pyspark.sql import Column
+
+if TYPE_CHECKING:
+    import databricks.koalas as ks
+    from databricks.koalas.base import IndexOpsMixin
+    from databricks.koalas.frame import CachedDataFrame
+
+
+class SparkIndexOpsMethods(object):
+    """Spark related features. Usually, the features here are missing in pandas
+    but Spark has it."""
+
+    def __init__(self, data: Union["IndexOpsMixin"]):
+        self._data = data
+
+    @property
+    def type(self):
+        """ Returns the data type as defined by Spark, as a Spark DataType object."""
+        return self._data._internal.spark_type_for(self._data._internal.column_labels[0])
+
+    @property
+    def column(self):
+        """
+        Spark Column object representing the Series/Index.
+
+        .. note:: This Spark Column object is strictly stick to its base DataFrame the Series/Index
+            was derived from.
+        """
+        return self._data._internal.spark_column
+
+    def transform(self, func):
+        """
+        Applies a function that takes and returns a Spark column. It allows natively
+        apply a Spark function and column APIs with the Spark column internally used
+        in Series or Index.
+
+        .. note:: It requires to have the same input and output length; therefore,
+            the aggregate Spark functions such as count does not work.
+
+        Parameters
+        ----------
+        func : function
+            Function to use for transforming the data by using Spark columns.
+
+        Returns
+        -------
+        Series or Index
+
+        Raises
+        ------
+        ValueError : If the output from the function is not a Spark column.
+
+        Examples
+        --------
+        >>> from pyspark.sql.functions import log
+        >>> df = ks.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}, columns=["a", "b"])
+        >>> df
+           a  b
+        0  1  4
+        1  2  5
+        2  3  6
+
+        >>> df.a.spark.transform(lambda c: log(c))
+        0    0.000000
+        1    0.693147
+        2    1.098612
+        Name: a, dtype: float64
+
+        >>> df.index.spark.transform(lambda c: c + 10)
+        Int64Index([10, 11, 12], dtype='int64')
+
+        >>> df.a.spark.transform(lambda c: c + df.b.spark.column)
+        0    5
+        1    7
+        2    9
+        Name: a, dtype: int64
+        """
+        from databricks.koalas import MultiIndex
+
+        if isinstance(self._data, MultiIndex):
+            raise NotImplementedError("MultiIndex does not support spark.transform yet.")
+        output = func(self._data.spark.column)
+        if not isinstance(output, Column):
+            raise ValueError(
+                "The output of the function [%s] should be of a "
+                "pyspark.sql.Column; however, got [%s]." % (func, type(output))
+            )
+        return self._data._with_new_scol(scol=func(self._data.spark.column)).rename(self._data.name)
+
+
+class SparkFrameMethods(object):
+    """Spark related features. Usually, the features here are missing in pandas
+    but Spark has it."""
+
+    def __init__(self, frame: "ks.DataFrame"):
+        self._kdf = frame
+
+    def schema(self, index_col=None):
+        """
+        Returns the underlying Spark schema.
+
+        Returns
+        -------
+        pyspark.sql.types.StructType
+            The underlying Spark schema.
+
+        Parameters
+        ----------
+        index_col: str or list of str, optional, default: None
+            Column names to be used in Spark to represent Koalas' index. The index name
+            in Koalas is ignored. By default, the index is always lost.
+
+        Examples
+        --------
+        >>> df = ks.DataFrame({'a': list('abc'),
+        ...                    'b': list(range(1, 4)),
+        ...                    'c': np.arange(3, 6).astype('i1'),
+        ...                    'd': np.arange(4.0, 7.0, dtype='float64'),
+        ...                    'e': [True, False, True],
+        ...                    'f': pd.date_range('20130101', periods=3)},
+        ...                   columns=['a', 'b', 'c', 'd', 'e', 'f'])
+        >>> df.spark.schema().simpleString()
+        'struct<a:string,b:bigint,c:tinyint,d:double,e:boolean,f:timestamp>'
+        >>> df.spark.schema(index_col='index').simpleString()
+        'struct<index:bigint,a:string,b:bigint,c:tinyint,d:double,e:boolean,f:timestamp>'
+        """
+        return self.frame(index_col).schema
+
+    def print_schema(self, index_col: Optional[Union[str, List[str]]] = None):
+        """
+        Prints out the underlying Spark schema in the tree format.
+
+        Parameters
+        ----------
+        index_col: str or list of str, optional, default: None
+            Column names to be used in Spark to represent Koalas' index. The index name
+            in Koalas is ignored. By default, the index is always lost.
+
+        Examples
+        --------
+        >>> df = ks.DataFrame({'a': list('abc'),
+        ...                    'b': list(range(1, 4)),
+        ...                    'c': np.arange(3, 6).astype('i1'),
+        ...                    'd': np.arange(4.0, 7.0, dtype='float64'),
+        ...                    'e': [True, False, True],
+        ...                    'f': pd.date_range('20130101', periods=3)},
+        ...                   columns=['a', 'b', 'c', 'd', 'e', 'f'])
+        >>> df.spark.print_schema()  # doctest: +NORMALIZE_WHITESPACE
+        root
+         |-- a: string (nullable = false)
+         |-- b: long (nullable = false)
+         |-- c: byte (nullable = false)
+         |-- d: double (nullable = false)
+         |-- e: boolean (nullable = false)
+         |-- f: timestamp (nullable = false)
+        >>> df.spark.print_schema(index_col='index')  # doctest: +NORMALIZE_WHITESPACE
+        root
+         |-- index: long (nullable = false)
+         |-- a: string (nullable = false)
+         |-- b: long (nullable = false)
+         |-- c: byte (nullable = false)
+         |-- d: double (nullable = false)
+         |-- e: boolean (nullable = false)
+         |-- f: timestamp (nullable = false)
+        """
+        self.frame(index_col).printSchema()
+
+    def frame(self, index_col=None):
+        """
+        Return the current DataFrame as a Spark DataFrame.  :meth:`DataFrame.spark.frame` is an
+        alias of  :meth:`DataFrame.to_spark`.
+
+        Parameters
+        ----------
+        index_col: str or list of str, optional, default: None
+            Column names to be used in Spark to represent Koalas' index. The index name
+            in Koalas is ignored. By default, the index is always lost.
+
+        See Also
+        --------
+        DataFrame.to_spark
+        DataFrame.to_koalas
+        DataFrame.spark.frame
+
+        Examples
+        --------
+        By default, this method loses the index as below.
+
+        >>> df = ks.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6], 'c': [7, 8, 9]})
+        >>> df.to_spark().show()  # doctest: +NORMALIZE_WHITESPACE
+        +---+---+---+
+        |  a|  b|  c|
+        +---+---+---+
+        |  1|  4|  7|
+        |  2|  5|  8|
+        |  3|  6|  9|
+        +---+---+---+
+
+        >>> df = ks.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6], 'c': [7, 8, 9]})
+        >>> df.spark.frame().show()  # doctest: +NORMALIZE_WHITESPACE
+        +---+---+---+
+        |  a|  b|  c|
+        +---+---+---+
+        |  1|  4|  7|
+        |  2|  5|  8|
+        |  3|  6|  9|
+        +---+---+---+
+
+        If `index_col` is set, it keeps the index column as specified.
+
+        >>> df.to_spark(index_col="index").show()  # doctest: +NORMALIZE_WHITESPACE
+        +-----+---+---+---+
+        |index|  a|  b|  c|
+        +-----+---+---+---+
+        |    0|  1|  4|  7|
+        |    1|  2|  5|  8|
+        |    2|  3|  6|  9|
+        +-----+---+---+---+
+
+        Keeping index column is useful when you want to call some Spark APIs and
+        convert it back to Koalas DataFrame without creating a default index, which
+        can affect performance.
+
+        >>> spark_df = df.to_spark(index_col="index")
+        >>> spark_df = spark_df.filter("a == 2")
+        >>> spark_df.to_koalas(index_col="index")  # doctest: +NORMALIZE_WHITESPACE
+               a  b  c
+        index
+        1      2  5  8
+
+        In case of multi-index, specify a list to `index_col`.
+
+        >>> new_df = df.set_index("a", append=True)
+        >>> new_spark_df = new_df.to_spark(index_col=["index_1", "index_2"])
+        >>> new_spark_df.show()  # doctest: +NORMALIZE_WHITESPACE
+        +-------+-------+---+---+
+        |index_1|index_2|  b|  c|
+        +-------+-------+---+---+
+        |      0|      1|  4|  7|
+        |      1|      2|  5|  8|
+        |      2|      3|  6|  9|
+        +-------+-------+---+---+
+
+        Likewise, can be converted to back to Koalas DataFrame.
+
+        >>> new_spark_df.to_koalas(
+        ...     index_col=["index_1", "index_2"])  # doctest: +NORMALIZE_WHITESPACE
+                         b  c
+        index_1 index_2
+        0       1        4  7
+        1       2        5  8
+        2       3        6  9
+        """
+        from databricks.koalas.utils import name_like_string
+
+        kdf = self._kdf
+
+        data_column_names = []
+        data_columns = []
+        for i, (label, spark_column, column_name) in enumerate(
+            zip(
+                kdf._internal.column_labels,
+                kdf._internal.data_spark_columns,
+                kdf._internal.data_spark_column_names,
+            )
+        ):
+            name = str(i) if label is None else name_like_string(label)
+            data_column_names.append(name)
+            if column_name != name:
+                spark_column = spark_column.alias(name)
+            data_columns.append(spark_column)
+
+        if index_col is None:
+            return kdf._internal.spark_frame.select(data_columns)
+        else:
+            if isinstance(index_col, str):
+                index_col = [index_col]
+
+            old_index_scols = kdf._internal.index_spark_columns
+
+            if len(index_col) != len(old_index_scols):
+                raise ValueError(
+                    "length of index columns is %s; however, the length of the given "
+                    "'index_col' is %s." % (len(old_index_scols), len(index_col))
+                )
+
+            if any(col in data_column_names for col in index_col):
+                raise ValueError("'index_col' cannot be overlapped with other columns.")
+
+            new_index_scols = [
+                index_scol.alias(col) for index_scol, col in zip(old_index_scols, index_col)
+            ]
+            return kdf._internal.spark_frame.select(new_index_scols + data_columns)
+
+    def cache(self):
+        """
+        Yields and caches the current DataFrame.
+
+        The Koalas DataFrame is yielded as a protected resource and its corresponding
+        data is cached which gets uncached after execution goes of the context.
+
+        If you want to specify the StorageLevel manually, use :meth:`DataFrame.spark.persist`
+
+        See Also
+        --------
+        DataFrame.spark.persist
+
+        Examples
+        --------
+        >>> df = ks.DataFrame([(.2, .3), (.0, .6), (.6, .0), (.2, .1)],
+        ...                   columns=['dogs', 'cats'])
+        >>> df
+           dogs  cats
+        0   0.2   0.3
+        1   0.0   0.6
+        2   0.6   0.0
+        3   0.2   0.1
+
+        >>> with df.spark.cache() as cached_df:
+        ...     print(cached_df.count())
+        ...
+        dogs    4
+        cats    4
+        Name: 0, dtype: int64
+
+        >>> df = df.spark.cache()
+        >>> df.to_pandas().mean(axis=1)
+        0    0.25
+        1    0.30
+        2    0.30
+        3    0.15
+        dtype: float64
+
+        To uncache the dataframe, use `unpersist` function
+
+        >>> df.spark.unpersist()
+        """
+        from databricks.koalas.frame import CachedDataFrame
+
+        return CachedDataFrame(self._kdf._internal)
+
+    def persist(self, storage_level=StorageLevel.MEMORY_AND_DISK):
+        """
+        Yields and caches the current DataFrame with a specific StorageLevel.
+        If a StogeLevel is not given, the `MEMORY_AND_DISK` level is used by default like PySpark.
+
+        The Koalas DataFrame is yielded as a protected resource and its corresponding
+        data is cached which gets uncached after execution goes of the context.
+
+        See Also
+        --------
+        DataFrame.spark.cache
+
+        Examples
+        --------
+        >>> import pyspark
+        >>> df = ks.DataFrame([(.2, .3), (.0, .6), (.6, .0), (.2, .1)],
+        ...                   columns=['dogs', 'cats'])
+        >>> df
+           dogs  cats
+        0   0.2   0.3
+        1   0.0   0.6
+        2   0.6   0.0
+        3   0.2   0.1
+
+        Set the StorageLevel to `MEMORY_ONLY`.
+
+        >>> with df.spark.persist(pyspark.StorageLevel.MEMORY_ONLY) as cached_df:
+        ...     print(cached_df.spark.storage_level)
+        ...     print(cached_df.count())
+        ...
+        Memory Serialized 1x Replicated
+        dogs    4
+        cats    4
+        Name: 0, dtype: int64
+
+        Set the StorageLevel to `DISK_ONLY`.
+
+        >>> with df.spark.persist(pyspark.StorageLevel.DISK_ONLY) as cached_df:
+        ...     print(cached_df.spark.storage_level)
+        ...     print(cached_df.count())
+        ...
+        Disk Serialized 1x Replicated
+        dogs    4
+        cats    4
+        Name: 0, dtype: int64
+
+        If a StorageLevel is not given, it uses `MEMORY_AND_DISK` by default.
+
+        >>> with df.spark.persist() as cached_df:
+        ...     print(cached_df.spark.storage_level)
+        ...     print(cached_df.count())
+        ...
+        Disk Memory Serialized 1x Replicated
+        dogs    4
+        cats    4
+        Name: 0, dtype: int64
+
+        >>> df = df.spark.persist()
+        >>> df.to_pandas().mean(axis=1)
+        0    0.25
+        1    0.30
+        2    0.30
+        3    0.15
+        dtype: float64
+
+        To uncache the dataframe, use `unpersist` function
+
+        >>> df.spark.unpersist()
+        """
+        from databricks.koalas.frame import CachedDataFrame
+
+        return CachedDataFrame(self._kdf._internal, storage_level=storage_level)
+
+    def hint(self, name: str, *parameters) -> "ks.DataFrame":
+        """
+        Specifies some hint on the current DataFrame.
+
+        Parameters
+        ----------
+        name : A name of the hint.
+        parameters : Optional parameters.
+
+        Returns
+        -------
+        ret : DataFrame with the hint.
+
+        See Also
+        --------
+        broadcast : Marks a DataFrame as small enough for use in broadcast joins.
+
+        Examples
+        --------
+        >>> df1 = ks.DataFrame({'lkey': ['foo', 'bar', 'baz', 'foo'],
+        ...                     'value': [1, 2, 3, 5]},
+        ...                    columns=['lkey', 'value'])
+        >>> df2 = ks.DataFrame({'rkey': ['foo', 'bar', 'baz', 'foo'],
+        ...                     'value': [5, 6, 7, 8]},
+        ...                    columns=['rkey', 'value'])
+        >>> merged = df1.merge(df2.spark.hint("broadcast"), left_on='lkey', right_on='rkey')
+        >>> merged.spark.explain()  # doctest: +ELLIPSIS
+        == Physical Plan ==
+        ...
+        ...BroadcastHashJoin...
+        ...
+        """
+        from databricks.koalas.frame import DataFrame
+
+        return DataFrame(self._kdf._internal.with_new_sdf(self._kdf._sdf.hint(name, *parameters)))
+
+    def to_table(
+        self,
+        name: str,
+        format: Optional[str] = None,
+        mode: str = "overwrite",
+        partition_cols: Union[str, List[str], None] = None,
+        index_col: Optional[Union[str, List[str]]] = None,
+        **options
+    ):
+        """
+        Write the DataFrame into a Spark table. :meth:`DataFrame.spark.to_table`
+        is an alias of :meth:`DataFrame.to_table`.
+
+        Parameters
+        ----------
+        name : str, required
+            Table name in Spark.
+        format : string, optional
+            Specifies the output data source format. Some common ones are:
+
+            - 'delta'
+            - 'parquet'
+            - 'orc'
+            - 'json'
+            - 'csv'
+
+        mode : str {'append', 'overwrite', 'ignore', 'error', 'errorifexists'}, default
+            'overwrite'. Specifies the behavior of the save operation when the table exists
+            already.
+
+            - 'append': Append the new data to existing data.
+            - 'overwrite': Overwrite existing data.
+            - 'ignore': Silently ignore this operation if data already exists.
+            - 'error' or 'errorifexists': Throw an exception if data already exists.
+
+        partition_cols : str or list of str, optional, default None
+            Names of partitioning columns
+        index_col: str or list of str, optional, default: None
+            Column names to be used in Spark to represent Koalas' index. The index name
+            in Koalas is ignored. By default, the index is always lost.
+        options
+            Additional options passed directly to Spark.
+
+        See Also
+        --------
+        read_table
+        DataFrame.to_spark_io
+        DataFrame.spark.to_spark_io
+        DataFrame.to_parquet
+
+        Examples
+        --------
+        >>> df = ks.DataFrame(dict(
+        ...    date=list(pd.date_range('2012-1-1 12:00:00', periods=3, freq='M')),
+        ...    country=['KR', 'US', 'JP'],
+        ...    code=[1, 2 ,3]), columns=['date', 'country', 'code'])
+        >>> df
+                         date country  code
+        0 2012-01-31 12:00:00      KR     1
+        1 2012-02-29 12:00:00      US     2
+        2 2012-03-31 12:00:00      JP     3
+
+        >>> df.to_table('%s.my_table' % db, partition_cols='date')
+        """
+        if "options" in options and isinstance(options.get("options"), dict) and len(options) == 1:
+            options = options.get("options")  # type: ignore
+
+        self._kdf.spark.frame(index_col=index_col).write.saveAsTable(
+            name=name, format=format, mode=mode, partitionBy=partition_cols, **options
+        )
+
+    def to_spark_io(
+        self,
+        path: Optional[str] = None,
+        format: Optional[str] = None,
+        mode: str = "overwrite",
+        partition_cols: Union[str, List[str], None] = None,
+        index_col: Optional[Union[str, List[str]]] = None,
+        **options
+    ):
+        """Write the DataFrame out to a Spark data source. :meth:`DataFrame.spark.to_spark_io`
+        is an alias of :meth:`DataFrame.to_spark_io`.
+
+        Parameters
+        ----------
+        path : string, optional
+            Path to the data source.
+        format : string, optional
+            Specifies the output data source format. Some common ones are:
+
+            - 'delta'
+            - 'parquet'
+            - 'orc'
+            - 'json'
+            - 'csv'
+        mode : str {'append', 'overwrite', 'ignore', 'error', 'errorifexists'}, default
+            'overwrite'. Specifies the behavior of the save operation when data already.
+
+            - 'append': Append the new data to existing data.
+            - 'overwrite': Overwrite existing data.
+            - 'ignore': Silently ignore this operation if data already exists.
+            - 'error' or 'errorifexists': Throw an exception if data already exists.
+        partition_cols : str or list of str, optional
+            Names of partitioning columns
+        index_col: str or list of str, optional, default: None
+            Column names to be used in Spark to represent Koalas' index. The index name
+            in Koalas is ignored. By default, the index is always lost.
+        options : dict
+            All other options passed directly into Spark's data source.
+
+        See Also
+        --------
+        read_spark_io
+        DataFrame.to_delta
+        DataFrame.to_parquet
+        DataFrame.to_table
+        DataFrame.to_spark_io
+        DataFrame.spark.to_spark_io
+
+
+        Examples
+        --------
+        >>> df = ks.DataFrame(dict(
+        ...    date=list(pd.date_range('2012-1-1 12:00:00', periods=3, freq='M')),
+        ...    country=['KR', 'US', 'JP'],
+        ...    code=[1, 2 ,3]), columns=['date', 'country', 'code'])
+        >>> df
+                         date country  code
+        0 2012-01-31 12:00:00      KR     1
+        1 2012-02-29 12:00:00      US     2
+        2 2012-03-31 12:00:00      JP     3
+
+        >>> df.to_spark_io(path='%s/to_spark_io/foo.json' % path, format='json')
+        """
+        if "options" in options and isinstance(options.get("options"), dict) and len(options) == 1:
+            options = options.get("options")  # type: ignore
+
+        self._kdf.spark.frame(index_col=index_col).write.save(
+            path=path, format=format, mode=mode, partitionBy=partition_cols, **options
+        )
+
+    def explain(self, extended: Optional[bool] = None, mode: Optional[str] = None):
+        """
+        Prints the underlying (logical and physical) Spark plans to the console for debugging
+        purpose.
+
+        Parameters
+        ----------
+        extended : boolean, default ``False``.
+            If ``False``, prints only the physical plan.
+        mode : string, default ``None``.
+            The expected output format of plans.
+
+        Examples
+        --------
+        >>> df = ks.DataFrame({'id': range(10)})
+        >>> df.spark.explain()  # doctest: +ELLIPSIS
+        == Physical Plan ==
+        ...
+
+        >>> df.spark.explain(True)  # doctest: +ELLIPSIS
+        == Parsed Logical Plan ==
+        ...
+        == Analyzed Logical Plan ==
+        ...
+        == Optimized Logical Plan ==
+        ...
+        == Physical Plan ==
+        ...
+
+        >>> df.spark.explain(mode="extended")  # doctest: +ELLIPSIS
+        == Parsed Logical Plan ==
+        ...
+        == Analyzed Logical Plan ==
+        ...
+        == Optimized Logical Plan ==
+        ...
+        == Physical Plan ==
+        ...
+        """
+        if LooseVersion(pyspark.__version__) < LooseVersion("3.0"):
+            if mode is not None:
+                if extended is not None:
+                    raise Exception("extended and mode can not be specified simultaneously")
+                elif mode == "simple":
+                    extended = False
+                elif mode == "extended":
+                    extended = True
+                else:
+                    raise ValueError(
+                        "Unknown spark.explain mode: {}. Accepted spark.explain modes are "
+                        "'simple', 'extended'.".format(mode)
+                    )
+            if extended is None:
+                extended = False
+            self._kdf._internal.to_internal_spark_frame.explain(extended)
+        else:
+            self._kdf._internal.to_internal_spark_frame.explain(extended, mode)
+
+
+class CachedSparkFrameMethods(SparkFrameMethods):
+    """Spark related features for cached DataFrame. This is usually created via
+    `df.spark.cache()`."""
+
+    def __init__(self, frame: "CachedDataFrame"):
+        super().__init__(frame)
+
+    @property
+    def storage_level(self):
+        """
+        Return the storage level of this cache.
+
+        Examples
+        --------
+        >>> import databricks.koalas as ks
+        >>> import pyspark
+        >>> df = ks.DataFrame([(.2, .3), (.0, .6), (.6, .0), (.2, .1)],
+        ...                   columns=['dogs', 'cats'])
+        >>> df
+           dogs  cats
+        0   0.2   0.3
+        1   0.0   0.6
+        2   0.6   0.0
+        3   0.2   0.1
+
+        >>> with df.spark.cache() as cached_df:
+        ...     print(cached_df.spark.storage_level)
+        ...
+        Disk Memory Deserialized 1x Replicated
+
+        Set the StorageLevel to `MEMORY_ONLY`.
+
+        >>> with df.spark.persist(pyspark.StorageLevel.MEMORY_ONLY) as cached_df:
+        ...     print(cached_df.spark.storage_level)
+        ...
+        Memory Serialized 1x Replicated
+        """
+        return self._kdf._cached.storageLevel
+
+    def unpersist(self):
+        """
+        The `unpersist` function is used to uncache the Koalas DataFrame when it
+        is not used with `with` statement.
+
+        Examples
+        --------
+        >>> df = ks.DataFrame([(.2, .3), (.0, .6), (.6, .0), (.2, .1)],
+        ...                   columns=['dogs', 'cats'])
+        >>> df = df.spark.cache()
+
+        To uncache the dataframe, use `unpersist` function
+
+        >>> df.spark.unpersist()
+        """
+        if self._kdf._cached.is_cached:
+            self._kdf._cached.unpersist()

--- a/databricks/koalas/spark.py
+++ b/databricks/koalas/spark.py
@@ -39,7 +39,7 @@ class SparkIndexOpsMethods(object):
         self._data = data
 
     @property
-    def type(self):
+    def data_type(self):
         """ Returns the data type as defined by Spark, as a Spark DataType object."""
         return self._data._internal.spark_type_for(self._data._internal.column_labels[0])
 
@@ -110,7 +110,12 @@ class SparkIndexOpsMethods(object):
                 "The output of the function [%s] should be of a "
                 "pyspark.sql.Column; however, got [%s]." % (func, type(output))
             )
-        return self._data._with_new_scol(scol=func(self._data.spark.column)).rename(self._data.name)
+        new_ser = self._data._with_new_scol(scol=output).rename(self._data.name)
+        # Trigger the resolution so it throws an exception if anything does wrong
+        # within the function, for example,
+        # `df1.a.spark.transform(lambda _: F.col("non-existent"))`.
+        new_ser._internal.to_internal_spark_frame
+        return new_ser
 
 
 class SparkFrameMethods(object):

--- a/databricks/koalas/strings.py
+++ b/databricks/koalas/strings.py
@@ -35,8 +35,8 @@ class StringMethods(object):
     """String methods for Koalas Series"""
 
     def __init__(self, series: "ks.Series"):
-        if not isinstance(series.spark.type, (StringType, BinaryType, ArrayType)):
-            raise ValueError("Cannot call StringMethods on type {}".format(series.spark.type))
+        if not isinstance(series.spark.data_type, (StringType, BinaryType, ArrayType)):
+            raise ValueError("Cannot call StringMethods on type {}".format(series.spark.data_type))
         self._data = series
         self.name = self._data.name
 
@@ -1271,7 +1271,7 @@ class StringMethods(object):
         1    0
         Name: 0, dtype: int64
         """
-        if isinstance(self._data.spark.type, (ArrayType, MapType)):
+        if isinstance(self._data.spark.data_type, (ArrayType, MapType)):
             return column_op(lambda c: F.size(c).cast(LongType()))(self._data).alias(
                 self._data.name
             )

--- a/databricks/koalas/strings.py
+++ b/databricks/koalas/strings.py
@@ -35,8 +35,8 @@ class StringMethods(object):
     """String methods for Koalas Series"""
 
     def __init__(self, series: "ks.Series"):
-        if not isinstance(series.spark_type, (StringType, BinaryType, ArrayType)):
-            raise ValueError("Cannot call StringMethods on type {}".format(series.spark_type))
+        if not isinstance(series.spark.type, (StringType, BinaryType, ArrayType)):
+            raise ValueError("Cannot call StringMethods on type {}".format(series.spark.type))
         self._data = series
         self.name = self._data.name
 
@@ -1148,7 +1148,7 @@ class StringMethods(object):
             returnType=ArrayType(StringType(), containsNull=True),
             functionType=PandasUDFType.SCALAR,
         )
-        return self._data._with_new_scol(scol=pudf(self._data.spark_column)).rename(self.name)
+        return self._data._with_new_scol(scol=pudf(self._data.spark.column)).rename(self.name)
 
     def index(self, sub, start=0, end=None) -> "ks.Series":
         """
@@ -1271,7 +1271,7 @@ class StringMethods(object):
         1    0
         Name: 0, dtype: int64
         """
-        if isinstance(self._data.spark_type, (ArrayType, MapType)):
+        if isinstance(self._data.spark.type, (ArrayType, MapType)):
             return column_op(lambda c: F.size(c).cast(LongType()))(self._data).alias(
                 self._data.name
             )
@@ -2001,7 +2001,7 @@ class StringMethods(object):
             returnType=ArrayType(StringType(), containsNull=True),
             functionType=PandasUDFType.SCALAR,
         )
-        kser = self._data._with_new_scol(scol=pudf(self._data.spark_column)).rename(self.name)
+        kser = self._data._with_new_scol(scol=pudf(self._data.spark.column)).rename(self.name)
 
         if expand:
             kdf = kser.to_frame()
@@ -2135,7 +2135,7 @@ class StringMethods(object):
             returnType=ArrayType(StringType(), containsNull=True),
             functionType=PandasUDFType.SCALAR,
         )
-        kser = self._data._with_new_scol(scol=pudf(self._data.spark_column)).rename(self.name)
+        kser = self._data._with_new_scol(scol=pudf(self._data.spark.column)).rename(self.name)
 
         if expand:
             kdf = kser.to_frame()

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -13,12 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 from datetime import datetime
 from distutils.version import LooseVersion
 import inspect
 import sys
 import unittest
+from io import StringIO
 
 import numpy as np
 import pandas as pd
@@ -3477,3 +3477,64 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         msg = "Truncate: B must be after C"
         with self.assertRaisesRegex(ValueError, msg):
             kdf.truncate("C", "B", axis=1)
+
+    def test_spark_schema(self):
+        kdf = ks.DataFrame(
+            {
+                "a": list("abc"),
+                "b": list(range(1, 4)),
+                "c": np.arange(3, 6).astype("i1"),
+                "d": np.arange(4.0, 7.0, dtype="float64"),
+                "e": [True, False, True],
+                "f": pd.date_range("20130101", periods=3),
+            },
+            columns=["a", "b", "c", "d", "e", "f"],
+        )
+        self.assertEqual(kdf.spark_schema(), kdf.spark.schema())
+        self.assertEqual(kdf.spark_schema("index"), kdf.spark.schema("index"))
+
+    def test_print_schema(self):
+        kdf = ks.DataFrame(
+            {"a": list("abc"), "b": list(range(1, 4)), "c": np.arange(3, 6).astype("i1")},
+            columns=["a", "b", "c"],
+        )
+
+        prev = sys.stdout
+        try:
+            out = StringIO()
+            sys.stdout = out
+            kdf.print_schema()
+            actual = out.getvalue().strip()
+
+            out = StringIO()
+            sys.stdout = out
+            kdf.spark.print_schema()
+            expected = out.getvalue().strip()
+
+            self.assertEqual(actual, expected)
+        finally:
+            sys.stdout = prev
+
+    def test_explain_hint(self):
+        kdf1 = ks.DataFrame(
+            {"lkey": ["foo", "bar", "baz", "foo"], "value": [1, 2, 3, 5]}, columns=["lkey", "value"]
+        )
+        kdf2 = ks.DataFrame(
+            {"rkey": ["foo", "bar", "baz", "foo"], "value": [5, 6, 7, 8]}, columns=["rkey", "value"]
+        )
+        merged = kdf1.merge(kdf2.hint("broadcast"), left_on="lkey", right_on="rkey")
+        prev = sys.stdout
+        try:
+            out = StringIO()
+            sys.stdout = out
+            merged.explain()
+            actual = out.getvalue().strip()
+
+            out = StringIO()
+            sys.stdout = out
+            merged.spark.explain()
+            expected = out.getvalue().strip()
+
+            self.assertEqual(actual, expected)
+        finally:
+            sys.stdout = prev

--- a/databricks/koalas/tests/test_dataframe_spark_io.py
+++ b/databricks/koalas/tests/test_dataframe_spark_io.py
@@ -116,7 +116,7 @@ class DataFrameSparkIOTest(ReusedSQLTestCase, TestUtils):
             expected = ks.DataFrame(pdf)
 
             # Write out partitioned by one column
-            expected.to_table("test_table", mode="overwrite", partition_cols="i32")
+            expected.spark.to_table("test_table", mode="overwrite", partition_cols="i32")
             # Reset column order, as once the data is written out, Spark rearranges partition
             # columns to appear first.
             actual = ks.read_table("test_table")[self.test_column_order]

--- a/databricks/koalas/tests/test_indexops_spark.py
+++ b/databricks/koalas/tests/test_indexops_spark.py
@@ -15,6 +15,8 @@
 #
 
 import pandas as pd
+from pyspark.sql.utils import AnalysisException
+from pyspark.sql import functions as F
 
 from databricks import koalas as ks
 from databricks.koalas.testing.utils import ReusedSQLTestCase, SQLTestUtils
@@ -34,6 +36,9 @@ class SparkIndexOpsMethodsTest(ReusedSQLTestCase, SQLTestUtils):
             ValueError, "The output of the function.* pyspark.sql.Column.*int"
         ):
             self.kser.spark.transform(lambda scol: 1)
+
+        with self.assertRaisesRegex(AnalysisException, "cannot resolve.*non-existent.*"):
+            self.kser.spark.transform(lambda scol: F.col("non-existent"))
 
     def test_multiindex_transform_negative(self):
         with self.assertRaisesRegex(

--- a/databricks/koalas/tests/test_indexops_spark.py
+++ b/databricks/koalas/tests/test_indexops_spark.py
@@ -1,0 +1,47 @@
+#
+# Copyright (C) 2019 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pandas as pd
+
+from databricks import koalas as ks
+from databricks.koalas.testing.utils import ReusedSQLTestCase, SQLTestUtils
+
+
+class SparkIndexOpsMethodsTest(ReusedSQLTestCase, SQLTestUtils):
+    @property
+    def pser(self):
+        return pd.Series([1, 2, 3, 4, 5, 6, 7], name="x")
+
+    @property
+    def kser(self):
+        return ks.from_pandas(self.pser)
+
+    def test_series_transform_negative(self):
+        with self.assertRaisesRegex(
+            ValueError, "The output of the function.* pyspark.sql.Column.*int"
+        ):
+            self.kser.spark.transform(lambda scol: 1)
+
+    def test_multiindex_transform_negative(self):
+        with self.assertRaisesRegex(
+            NotImplementedError, "MultiIndex does not support spark.transform yet"
+        ):
+            midx = pd.MultiIndex(
+                [["lama", "cow", "falcon"], ["speed", "weight", "length"]],
+                [[0, 0, 0, 1, 1, 1, 2, 2, 2], [1, 1, 1, 1, 1, 2, 1, 2, 2]],
+            )
+            s = ks.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3], index=midx)
+            s.index.spark.transform(lambda scol: scol)

--- a/databricks/koalas/utils.py
+++ b/databricks/koalas/utils.py
@@ -130,13 +130,13 @@ def combine_frames(this, *args, how="full", preserve_order_column=False):
         joined_df = joined_df.select(
             merged_index_scols
             + [
-                this[label].spark_column.alias(
+                this[label].spark.column.alias(
                     "__this_%s" % this._internal.spark_column_name_for(label)
                 )
                 for label in this._internal.column_labels
             ]
             + [
-                that[label].spark_column.alias(
+                that[label].spark.column.alias(
                     "__that_%s" % that._internal.spark_column_name_for(label)
                 )
                 for label in that._internal.column_labels
@@ -288,7 +288,7 @@ def align_diff_frames(
         kser_set, column_labels_applied = zip(
             *resolve_func(combined, this_columns_to_apply, that_columns_to_apply)
         )
-        columns_applied = [c.spark_column for c in kser_set]
+        columns_applied = [c.spark.column for c in kser_set]
         column_labels_applied = list(column_labels_applied)
     else:
         columns_applied = []

--- a/databricks/koalas/window.py
+++ b/databricks/koalas/window.py
@@ -152,7 +152,7 @@ class Rolling(RollingAndExpanding):
 
     def _apply_as_series_or_frame(self, func):
         return self.kdf_or_kser._apply_series_op(
-            lambda kser: kser._with_new_scol(func(kser.spark_column)).rename(kser.name)
+            lambda kser: kser._with_new_scol(func(kser.spark.column)).rename(kser.name)
         )
 
     def count(self):
@@ -633,7 +633,7 @@ class RollingGroupby(Rolling):
 
         super(RollingGroupby, self).__init__(kdf, window, min_periods)
         self._groupby = groupby
-        # NOTE THAT this code intentionally uses `F.col` instead of `spark_column` in
+        # NOTE THAT this code intentionally uses `F.col` instead of `spark.column` in
         # given series. This is because, in case of series, we convert it into
         # DataFrame. So, if the given `groupkeys` is a series, they end up with
         # being a different series.
@@ -675,7 +675,7 @@ class RollingGroupby(Rolling):
         new_index_map = OrderedDict()
         for groupkey in self._groupkeys:
             new_index_scols.append(
-                # NOTE THAT this code intentionally uses `F.col` instead of `spark_column` in
+                # NOTE THAT this code intentionally uses `F.col` instead of `spark.column` in
                 # given series. This is because, in case of series, we convert it into
                 # DataFrame. So, if the given `groupkeys` is a series, they end up with
                 # being a different series.
@@ -698,14 +698,14 @@ class RollingGroupby(Rolling):
         applied = []
         for column in kdf.columns:
             applied.append(
-                kdf[column]._with_new_scol(func(kdf[column].spark_column)).rename(kdf[column].name)
+                kdf[column]._with_new_scol(func(kdf[column].spark.column)).rename(kdf[column].name)
             )
 
         # Seems like pandas filters out when grouped key is NA.
-        cond = self._groupkeys[0].spark_column.isNotNull()
+        cond = self._groupkeys[0].spark.column.isNotNull()
         for c in self._groupkeys:
-            cond = cond | c.spark_column.isNotNull()
-        sdf = sdf.select(new_index_scols + [c.spark_column for c in applied]).filter(cond)
+            cond = cond | c.spark.column.isNotNull()
+        sdf = sdf.select(new_index_scols + [c.spark.column for c in applied]).filter(cond)
 
         internal = kdf._internal.copy(
             spark_frame=sdf,
@@ -1399,7 +1399,7 @@ class ExpandingGroupby(Expanding):
 
         super(ExpandingGroupby, self).__init__(kdf, min_periods)
         self._groupby = groupby
-        # NOTE THAT this code intentionally uses `F.col` instead of `spark_column` in
+        # NOTE THAT this code intentionally uses `F.col` instead of `spark.column` in
         # given series. This is because, in case of series, we convert it into
         # DataFrame. So, if the given `groupkeys` is a series, they end up with
         # being a different series.

--- a/docs/source/reference/frame.rst
+++ b/docs/source/reference/frame.rst
@@ -33,14 +33,6 @@ Attributes and underlying data
    DataFrame.select_dtypes
    DataFrame.values
 
-Underlying Spark schema
------------------------
-.. autosummary::
-   :toctree: api/
-
-   DataFrame.spark_schema
-   DataFrame.print_schema
-
 Conversion
 ----------
 .. autosummary::
@@ -231,14 +223,6 @@ Time series-related
    DataFrame.shift
    DataFrame.first_valid_index
 
-Cache
--------------------------------
-.. autosummary::
-   :toctree: api/
-
-   DataFrame.cache
-   DataFrame.persist
-
 Serialization / IO / Conversion
 -------------------------------
 .. autosummary::
@@ -268,12 +252,29 @@ Serialization / IO / Conversion
 
 .. _api.dataframe.plot:
 
+Spark-related
+-------------
+``DataFrame.spark`` provides features that does not exist in pandas but
+in Spark. These can be accessed by ``DataFrame.spark.<function/property>``.
+
+.. autosummary::
+   :toctree: api/
+
+   DataFrame.spark.schema
+   DataFrame.spark.print_schema
+   DataFrame.spark.frame
+   DataFrame.spark.cache
+   DataFrame.spark.persist
+   DataFrame.spark.hint
+   DataFrame.spark.to_table
+   DataFrame.spark.to_spark_io
+   DataFrame.spark.explain
+
 Plotting
 -------------------------------
 ``DataFrame.plot`` is both a callable method and a namespace attribute for
 specific plotting methods of the form ``DataFrame.plot.<kind>``.
 
-.. currentmodule:: databricks.koalas.frame
 .. autosummary::
    :toctree: api/
 

--- a/docs/source/reference/indexing.rst
+++ b/docs/source/reference/indexing.rst
@@ -109,7 +109,7 @@ in Spark. These can be accessed by ``Index.spark.<function/property>``.
 .. autosummary::
    :toctree: api/
 
-   Index.spark.type
+   Index.spark.data_type
    Index.spark.column
    Index.spark.transform
 
@@ -248,7 +248,7 @@ in Spark. These can be accessed by ``MultiIndex.spark.<function/property>``.
 .. autosummary::
    :toctree: api/
 
-   MultiIndex.spark.type
+   MultiIndex.spark.data_type
    MultiIndex.spark.column
    MultiIndex.spark.transform
 

--- a/docs/source/reference/indexing.rst
+++ b/docs/source/reference/indexing.rst
@@ -34,7 +34,6 @@ Properties
    Index.empty
    Index.T
    Index.values
-   Index.spark_column
 
 Modifying and computations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -101,6 +100,18 @@ Conversion
    Index.to_series
    Index.to_frame
    Index.to_numpy
+
+Spark-related
+-------------
+``Index.spark`` provides features that does not exist in pandas but
+in Spark. These can be accessed by ``Index.spark.<function/property>``.
+
+.. autosummary::
+   :toctree: api/
+
+   Index.spark.type
+   Index.spark.column
+   Index.spark.transform
 
 Sorting
 ~~~~~~~
@@ -169,7 +180,6 @@ MultiIndex Properties
    MultiIndex.nlevels
    MultiIndex.levshape
    MultiIndex.values
-   MultiIndex.spark_column
 
 MultiIndex components
 ~~~~~~~~~~~~~~~~~~~~~
@@ -229,6 +239,18 @@ MultiIndex Conversion
    MultiIndex.to_series
    MultiIndex.to_frame
    MultiIndex.to_numpy
+
+MultiIndex Spark-related
+------------------------
+``MultiIndex.spark`` provides features that does not exist in pandas but
+in Spark. These can be accessed by ``MultiIndex.spark.<function/property>``.
+
+.. autosummary::
+   :toctree: api/
+
+   MultiIndex.spark.type
+   MultiIndex.spark.column
+   MultiIndex.spark.transform
 
 MultiIndex Sorting
 ~~~~~~~~~~~~~~~~~~

--- a/docs/source/reference/series.rst
+++ b/docs/source/reference/series.rst
@@ -23,7 +23,6 @@ Attributes
    Series.dtypes
    Series.ndim
    Series.name
-   Series.spark_type
    Series.shape
    Series.axes
    Series.size
@@ -31,7 +30,6 @@ Attributes
    Series.T
    Series.hasnans
    Series.values
-   Series.spark_column
 
 Conversion
 ----------
@@ -216,6 +214,18 @@ Time series-related
    Series.shift
    Series.first_valid_index
 
+Spark-related
+-------------
+``Series.spark`` provides features that does not exist in pandas but
+in Spark. These can be accessed by ``Series.spark.<function/property>``.
+
+.. autosummary::
+   :toctree: api/
+
+   Series.spark.type
+   Series.spark.column
+   Series.spark.transform
+
 Accessors
 ---------
 
@@ -228,7 +238,6 @@ Data Type                    Accessor
 ========= ===========================
 Datetime  :ref:`dt <api.series.dt>`
 String    :ref:`str <api.series.str>`
-Plot      :ref:`plot <api.series.plot>`
 ========= ===========================
 
 .. _api.series.dt:
@@ -243,7 +252,6 @@ These can be accessed like ``Series.dt.<property>``.
 Datetime Properties
 ~~~~~~~~~~~~~~~~~~~
 
-.. currentmodule:: databricks.koalas.series
 .. autosummary::
    :toctree: api/
 
@@ -274,7 +282,6 @@ Datetime Properties
 Datetime Methods
 ~~~~~~~~~~~~~~~~
 
-.. currentmodule:: databricks.koalas.series
 .. autosummary::
    :toctree: api/
 
@@ -295,7 +302,6 @@ String Handling
 strings and apply several methods to it. These can be accessed
 like ``Series.str.<function/property>``.
 
-.. currentmodule:: databricks.koalas.series
 .. autosummary::
    :toctree: api/
 
@@ -352,14 +358,11 @@ like ``Series.str.<function/property>``.
    Series.str.wrap
    Series.str.zfill
 
-.. _api.series.plot:
-
 Plotting
 -------------------------------
 ``Series.plot`` is both a callable method and a namespace attribute for
 specific plotting methods of the form ``Series.plot.<kind>``.
 
-.. currentmodule:: databricks.koalas.series
 .. autosummary::
    :toctree: api/
 
@@ -373,11 +376,6 @@ specific plotting methods of the form ``Series.plot.<kind>``.
    Series.plot.line
    Series.plot.pie
    Series.plot.kde
-
-.. currentmodule:: databricks.koalas
-.. autosummary::
-   :toctree: api/
-
    Series.hist
 
 Serialization / IO / Conversion

--- a/docs/source/reference/series.rst
+++ b/docs/source/reference/series.rst
@@ -222,7 +222,7 @@ in Spark. These can be accessed by ``Series.spark.<function/property>``.
 .. autosummary::
    :toctree: api/
 
-   Series.spark.type
+   Series.spark.data_type
    Series.spark.column
    Series.spark.transform
 

--- a/docs/source/user_guide/best_practices.rst
+++ b/docs/source/user_guide/best_practices.rst
@@ -48,7 +48,7 @@ If you are interested in performance tuning, please see also `Tuning Spark <http
 Check execution plans
 ---------------------
 
-Expensive operations can be predicted by leveraging PySpark API `DataFrame.explain()`
+Expensive operations can be predicted by leveraging PySpark API `DataFrame.spark.explain()`
 before the actual computation since Koalas is based on lazy execution. For example, see below.
 
 .. code-block:: python
@@ -56,7 +56,7 @@ before the actual computation since Koalas is based on lazy execution. For examp
    >>> import databricks.koalas as ks
    >>> kdf = ks.DataFrame({'id': range(10)})
    >>> kdf = kdf[kdf.id > 5]
-   >>> kdf.explain()
+   >>> kdf.spark.explain()
    == Physical Plan ==
    *(1) Filter (id#1L > 5)
    +- *(1) Scan ExistingRDD[__index_level_0__#0L,id#1L]
@@ -80,7 +80,7 @@ and exchange the data across multiple nodes via networks. See the example below.
 
    >>> import databricks.koalas as ks
    >>> kdf = ks.DataFrame({'id': range(10)}).sort_values(by="id")
-   >>> kdf.explain()
+   >>> kdf.spark.explain()
    == Physical Plan ==
    *(2) Sort [id#9L ASC NULLS LAST], true, 0
    +- Exchange rangepartitioning(id#9L ASC NULLS LAST, 200), true, [id=#18]
@@ -102,7 +102,7 @@ Such APIs should be avoided very large dataset.
 
    >>> import databricks.koalas as ks
    >>> kdf = ks.DataFrame({'id': range(10)})
-   >>> kdf.rank().explain()
+   >>> kdf.rank().spark.explain()
    == Physical Plan ==
    *(4) Project [__index_level_0__#16L, id#24]
    +- Window [avg(cast(_w0#26 as bigint)) windowspecdefinition(id#17L, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS id#24], [id#17L]


### PR DESCRIPTION
This PR proposes to have `spark` namespace in `DataFrame`, `Series`, `Index` and `MultiIndex`.
Spark related features are placed under this namespace.

- `(Series|Index|MultiIndex).spark_type` -> `(Series|Index|MultiIndex).spark.data_type`
    `spark_type` is deprecated

- `(Series|Index|MultiIndex).spark_column` -> `(Series|Index|MultiIndex).spark.column`
    `spark_column` is deprecated

- New API `(Series|Index).transform`
    ```python
    >>> import databricks.koalas as ks
    >>> import pyspark.sql.functions as F
    >>> kss = ks.Series(["example"])
    >>> kss.spark.transform(lambda s: F.trim(F.upper(s)))
    0    EXAMPLE
    Name: 0, dtype: object
    ```
    I intentionally named it `transform` because it needs to have the same length.

- `DataFrame.spark_schema` -> `DataFrame.spark.schema`
    `DataFrame.spark_schema` is deprecated

- `DataFrame.print_schema` -> `DataFrame.spark.print_schema`
    `DataFrame.print_schema` is deprecated

- `DataFrame.to_spark` -> `DataFrame.spark.frame`
    `DataFrame.to_spark` is NOT deprecated to keep the semantic between `to_koalas` <> `to_spark`. It's just an alias of `DataFrame.spark.frame`

- `DataFrame.cache` -> `DataFrame.spark.cache`
    `DataFrame.cache` is deprecated

- `DataFrame.persist` -> `DataFrame.spark.persist`
    `DataFrame.persist` is deprecated

- `DataFrame.hint` -> `DataFrame.spark.hint`
    `DataFrame.hint` is deprecated

- `DataFrame.unpersist` -> `DataFrame.spark.unpersist`
    `DataFrame.unpersist` is deprecated

- `DataFrame.storage_level` -> `DataFrame.spark.storage_level`
    `DataFrame.storage_level` is deprecated

- `DataFrame.to_table` -> `DataFrame.spark.to_table`
    `DataFrame.to_table` is NOT deprecated to keep the semantic between `ks.read_table` <> `to_table`. It's just an alias of `DataFrame.spark.to_table`. It's also similar with `DataFrame.to_parquet`, `DataFrame.to_csv`, etc.

- `DataFrame.to_spark_io` -> `DataFrame.spark.to_spark_io`
    `DataFrame.to_spark_io` is NOT deprecated to keep the semantic between `ks.read_spark_io` <> `to_spark_io`. It's just an alias of `DataFrame.spark.to_spark_io`. It's also similar with `DataFrame.to_parquet`, `DataFrame.to_csv`, etc.

- `DataFrame.explain` -> `DataFrame.spark.explain`
    `DataFrame.explain` is deprecated