### PR TITLE
Add DataFrame.spark.apply

### DIFF
--- a/databricks/koalas/spark.py
+++ b/databricks/koalas/spark.py
@@ -727,11 +727,11 @@ class SparkFrameMethods(object):
         The case below ends up with using the default index, which should be avoided
         if possible.
 
-        >>> kdf.spark.apply(lambda sdf: sdf.groupby("a").count())
+        >>> kdf.spark.apply(lambda sdf: sdf.groupby("a").count().sort("a"))
            a  count
         0  1      1
-        1  3      1
-        2  2      1
+        1  2      1
+        2  3      1
         """
         output = func(self.frame(index_col))
         if not isinstance(output, SparkDataFrame):

--- a/databricks/koalas/tests/test_frame_spark.py
+++ b/databricks/koalas/tests/test_frame_spark.py
@@ -1,0 +1,25 @@
+#
+# Copyright (C) 2019 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from databricks import koalas as ks
+from databricks.koalas.testing.utils import ReusedSQLTestCase, SQLTestUtils
+
+
+class SparkFrameMethodsTest(ReusedSQLTestCase, SQLTestUtils):
+    def test_frame_apply_negative(self):
+        with self.assertRaisesRegex(
+            ValueError, "The output of the function.* pyspark.sql.DataFrame.*int"
+        ):
+            ks.range(10).spark.apply(lambda scol: 1)

--- a/docs/source/reference/frame.rst
+++ b/docs/source/reference/frame.rst
@@ -269,6 +269,7 @@ in Spark. These can be accessed by ``DataFrame.spark.<function/property>``.
    DataFrame.spark.to_table
    DataFrame.spark.to_spark_io
    DataFrame.spark.explain
+   DataFrame.spark.apply
 
 Plotting
 -------------------------------


### PR DESCRIPTION
This PR adds `DataFrame.spark.apply`:

```python
import databricks.koalas as ks
ks.range(10).spark.apply(lambda sdf: sdf.selectExpr("id + 1"))
```

```
   (id + 1)
0         1
1         2
2         3
3         4
4         5
5         6
6         7
7         8
8         9
9        10
```