### PR TITLE
Fix explode to use internal methods.

### DIFF
--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -3492,9 +3492,9 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
                 {"A": [-1, np.nan, 0, np.inf, 1, -np.inf], "B": [1, 1, 1, 1, 1, 1]},
                 index=pd.Index([0, 0, 1, 1, 2, 2]),
             )
-            expected_result2 = pdf
             expected_result1.index.name = "index"
             expected_result1.columns.name = "columns"
+            expected_result2 = pdf
 
         self.assert_eq(kdf.explode("A"), expected_result1, almost=True)
         self.assert_eq(repr(kdf.explode("B")), repr(expected_result2))
@@ -3546,6 +3546,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(kdf.explode(("A", "Z")).columns.names, expected_result1.columns.names)
 
         self.assertRaises(ValueError, lambda: kdf.explode(["A", "B"]))
+        self.assertRaises(ValueError, lambda: kdf.explode("A"))
 
     def test_spark_schema(self):
         kdf = ks.DataFrame(


### PR DESCRIPTION
Koalas doesn't guarantee the underlying Spark DataFrame has columns named `name_like_string(column_label)`. We should always retrieve the Spark column, the column name, etc. using internal methods.

E.g.,

```py
>>> kdf = ks.DataFrame({("A", "X"): [[-1.0, np.nan], [0.0, np.inf], [1.0, -np.inf]], ("B", "Y"): 1})
>>> kdf
             A  B
             X  Y
0  [-1.0, nan]  1
1   [0.0, inf]  1
2  [1.0, -inf]  1
>>> kdf.A.explode("X")
Traceback (most recent call last):
...
AttributeError: 'DataFrame' object has no attribute 'explode'
```

Also added a negative test.