### PR TITLE
Fix RollingGroupby and ExpandingGroupby to handle agg_columns.

### DIFF
--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -2024,7 +2024,7 @@ class GroupBy(object):
         Series.groupby
         DataFrame.groupby
         """
-        return RollingGroupby(self, self._groupkeys, window, min_periods=min_periods)
+        return RollingGroupby(self, window, min_periods=min_periods)
 
     def expanding(self, min_periods=1):
         """
@@ -2046,7 +2046,7 @@ class GroupBy(object):
         Series.groupby
         DataFrame.groupby
         """
-        return ExpandingGroupby(self, self._groupkeys, min_periods=min_periods)
+        return ExpandingGroupby(self, min_periods=min_periods)
 
     def _reduce_for_stat_function(self, sfun, only_numeric, should_include_groupkeys=False):
         if should_include_groupkeys:

--- a/databricks/koalas/tests/test_expanding.py
+++ b/databricks/koalas/tests/test_expanding.py
@@ -155,6 +155,11 @@ class ExpandingTest(ReusedSQLTestCase, TestUtils):
             almost=True,
         )
         self.assert_eq(
+            getattr(kdf.b.groupby(kdf.a).expanding(2), f)().sort_index(),
+            getattr(pdf.b.groupby(pdf.a).expanding(2), f)().sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
             getattr(kdf.groupby(kdf.a)["b"].expanding(2), f)().sort_index(),
             getattr(pdf.groupby(pdf.a)["b"].expanding(2), f)().sort_index(),
             almost=True,
@@ -232,6 +237,11 @@ class ExpandingTest(ReusedSQLTestCase, TestUtils):
                 almost=True,
             )
             expected_result = pd.Series([None, None, 2.0, None], index=midx, name="b")
+            self.assert_eq(
+                kdf.b.groupby(kdf.a).expanding(2).count().sort_index(),
+                expected_result.sort_index(),
+                almost=True,
+            )
             self.assert_eq(
                 kdf.groupby(kdf.a)["b"].expanding(2).count().sort_index(),
                 expected_result.sort_index(),

--- a/databricks/koalas/tests/test_expanding.py
+++ b/databricks/koalas/tests/test_expanding.py
@@ -26,26 +26,30 @@ from databricks.koalas.window import Expanding
 
 class ExpandingTest(ReusedSQLTestCase, TestUtils):
     def _test_expanding_func(self, f):
-        kser = ks.Series([1, 2, 3], index=np.random.rand(3))
-        pser = kser.to_pandas()
-        self.assert_eq(repr(getattr(kser.expanding(2), f)()), repr(getattr(pser.expanding(2), f)()))
+        pser = pd.Series([1, 2, 3], index=np.random.rand(3))
+        kser = ks.from_pandas(pser)
+        self.assert_eq(
+            getattr(kser.expanding(2), f)(), getattr(pser.expanding(2), f)(), almost=True
+        )
 
         # Multiindex
-        kser = ks.Series(
+        pser = pd.Series(
             [1, 2, 3], index=pd.MultiIndex.from_tuples([("a", "x"), ("a", "y"), ("b", "z")])
         )
-        pser = kser.to_pandas()
-        self.assert_eq(repr(getattr(kser.expanding(2), f)()), repr(getattr(pser.expanding(2), f)()))
+        kser = ks.from_pandas(pser)
+        self.assert_eq(
+            getattr(kser.expanding(2), f)(), getattr(pser.expanding(2), f)(), almost=True
+        )
 
-        kdf = ks.DataFrame({"a": [1, 2, 3, 2], "b": [4.0, 2.0, 3.0, 1.0]})
-        pdf = kdf.to_pandas()
-        self.assert_eq(repr(getattr(kdf.expanding(2), f)()), repr(getattr(pdf.expanding(2), f)()))
+        pdf = pd.DataFrame({"a": [1, 2, 3, 2], "b": [4.0, 2.0, 3.0, 1.0]}, index=np.random.rand(4))
+        kdf = ks.from_pandas(pdf)
+        self.assert_eq(getattr(kdf.expanding(2), f)(), getattr(pdf.expanding(2), f)(), almost=True)
 
         # Multiindex column
-        kdf = ks.DataFrame({"a": [1, 2, 3, 2], "b": [4.0, 2.0, 3.0, 1.0]}, index=np.random.rand(4))
-        kdf.columns = pd.MultiIndex.from_tuples([("a", "x"), ("a", "y")])
-        pdf = kdf.to_pandas()
-        self.assert_eq(repr(getattr(kdf.expanding(2), f)()), repr(getattr(pdf.expanding(2), f)()))
+        columns = pd.MultiIndex.from_tuples([("a", "x"), ("a", "y")])
+        pdf.columns = columns
+        kdf.columns = columns
+        self.assert_eq(getattr(kdf.expanding(2), f)(), getattr(pdf.expanding(2), f)(), almost=True)
 
     def test_expanding_error(self):
         with self.assertRaisesRegex(ValueError, "min_periods must be >= 0"):
@@ -66,39 +70,36 @@ class ExpandingTest(ReusedSQLTestCase, TestUtils):
             self._test_expanding_func("count")
         else:
             # Series
-            kser = ks.Series([1, 2, 3], index=np.random.rand(3))
-            expected_result = ks.Series([None, 2.0, 3.0], index=kser.index.to_pandas())
+            idx = np.random.rand(3)
+            kser = ks.Series([1, 2, 3], index=idx, name="a")
+            expected_result = pd.Series([None, 2.0, 3.0], index=idx, name="a")
             self.assert_eq(
-                repr(kser.expanding(2).count().sort_index()), repr(expected_result.sort_index())
+                kser.expanding(2).count().sort_index(), expected_result.sort_index(), almost=True
             )
             # MultiIndex
-            kser = ks.Series(
-                [1, 2, 3], index=pd.MultiIndex.from_tuples([("a", "x"), ("a", "y"), ("b", "z")])
-            )
-            expected_result = ks.Series([None, 2.0, 3.0], index=kser.index.to_pandas())
+            midx = pd.MultiIndex.from_tuples([("a", "x"), ("a", "y"), ("b", "z")])
+            kser = ks.Series([1, 2, 3], index=midx, name="a")
+            expected_result = pd.Series([None, 2.0, 3.0], index=midx, name="a")
             self.assert_eq(
-                repr(kser.expanding(2).count().sort_index()), repr(expected_result.sort_index())
+                kser.expanding(2).count().sort_index(), expected_result.sort_index(), almost=True
             )
 
             # DataFrame
             kdf = ks.DataFrame({"a": [1, 2, 3, 2], "b": [4.0, 2.0, 3.0, 1.0]})
-            expected_result = ks.DataFrame({"a": [None, 2.0, 3.0, 4.0], "b": [None, 2.0, 3.0, 4.0]})
+            expected_result = pd.DataFrame({"a": [None, 2.0, 3.0, 4.0], "b": [None, 2.0, 3.0, 4.0]})
             self.assert_eq(
-                repr(kdf.expanding(2).count().sort_index()), repr(expected_result.sort_index())
+                kdf.expanding(2).count().sort_index(), expected_result.sort_index(), almost=True
             )
 
             # MultiIndex columns
-            kdf = ks.DataFrame(
-                {"a": [1, 2, 3, 2], "b": [4.0, 2.0, 3.0, 1.0]}, index=np.random.rand(4)
-            )
+            idx = np.random.rand(4)
+            kdf = ks.DataFrame({"a": [1, 2, 3, 2], "b": [4.0, 2.0, 3.0, 1.0]}, index=idx)
             kdf.columns = pd.MultiIndex.from_tuples([("a", "x"), ("a", "y")])
-            expected_result = ks.DataFrame(
-                {"a": [None, 2.0, 3.0, 4.0], "b": [None, 2.0, 3.0, 4.0]},
-                index=kdf.index.to_pandas(),
+            expected_result = pd.DataFrame(
+                {("a", "x"): [None, 2.0, 3.0, 4.0], ("a", "y"): [None, 2.0, 3.0, 4.0]}, index=idx,
             )
-            expected_result.columns = pd.MultiIndex.from_tuples([("a", "x"), ("a", "y")])
             self.assert_eq(
-                repr(kdf.expanding(2).count().sort_index()), repr(expected_result.sort_index())
+                kdf.expanding(2).count().sort_index(), expected_result.sort_index(), almost=True
             )
 
     def test_expanding_min(self):
@@ -120,42 +121,64 @@ class ExpandingTest(ReusedSQLTestCase, TestUtils):
         self._test_expanding_func("var")
 
     def _test_groupby_expanding_func(self, f):
-        kser = ks.Series([1, 2, 3], index=np.random.rand(3))
-        pser = kser.to_pandas()
+        pser = pd.Series([1, 2, 3], index=np.random.rand(3), name="a")
+        kser = ks.from_pandas(pser)
         self.assert_eq(
-            repr(getattr(kser.groupby(kser).expanding(2), f)().sort_index()),
-            repr(getattr(pser.groupby(pser).expanding(2), f)().sort_index()),
+            getattr(kser.groupby(kser).expanding(2), f)().sort_index(),
+            getattr(pser.groupby(pser).expanding(2), f)().sort_index(),
+            almost=True,
         )
 
         # Multiindex
-        kser = ks.Series(
-            [1, 2, 3], index=pd.MultiIndex.from_tuples([("a", "x"), ("a", "y"), ("b", "z")])
+        pser = pd.Series(
+            [1, 2, 3],
+            index=pd.MultiIndex.from_tuples([("a", "x"), ("a", "y"), ("b", "z")]),
+            name="a",
         )
-        pser = kser.to_pandas()
+        kser = ks.from_pandas(pser)
         self.assert_eq(
-            repr(getattr(kser.groupby(kser).expanding(2), f)().sort_index()),
-            repr(getattr(pser.groupby(pser).expanding(2), f)().sort_index()),
+            getattr(kser.groupby(kser).expanding(2), f)().sort_index(),
+            getattr(pser.groupby(pser).expanding(2), f)().sort_index(),
+            almost=True,
         )
 
-        kdf = ks.DataFrame({"a": [1, 2, 3, 2], "b": [4.0, 2.0, 3.0, 1.0]})
-        pdf = kdf.to_pandas()
+        pdf = pd.DataFrame({"a": [1, 2, 3, 2], "b": [4.0, 2.0, 3.0, 1.0]})
+        kdf = ks.from_pandas(pdf)
         self.assert_eq(
-            repr(getattr(kdf.groupby(kdf.a).expanding(2), f)().sort_index()),
-            repr(getattr(pdf.groupby(pdf.a).expanding(2), f)().sort_index()),
+            getattr(kdf.groupby(kdf.a).expanding(2), f)().sort_index(),
+            getattr(pdf.groupby(pdf.a).expanding(2), f)().sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            getattr(kdf.groupby(kdf.a + 1).expanding(2), f)().sort_index(),
+            getattr(pdf.groupby(pdf.a + 1).expanding(2), f)().sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            getattr(kdf.groupby(kdf.a)["b"].expanding(2), f)().sort_index(),
+            getattr(pdf.groupby(pdf.a)["b"].expanding(2), f)().sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            getattr(kdf.groupby(kdf.a)[["b"]].expanding(2), f)().sort_index(),
+            getattr(pdf.groupby(pdf.a)[["b"]].expanding(2), f)().sort_index(),
+            almost=True,
         )
 
         # Multiindex column
-        kdf = ks.DataFrame({"a": [1, 2, 3, 2], "b": [4.0, 2.0, 3.0, 1.0]})
-        kdf.columns = pd.MultiIndex.from_tuples([("a", "x"), ("a", "y")])
-        pdf = kdf.to_pandas()
+        columns = pd.MultiIndex.from_tuples([("a", "x"), ("a", "y")])
+        pdf.columns = columns
+        kdf.columns = columns
         self.assert_eq(
-            repr(getattr(kdf.groupby(("a", "x")).expanding(2), f)().sort_index()),
-            repr(getattr(pdf.groupby(("a", "x")).expanding(2), f)().sort_index()),
+            getattr(kdf.groupby(("a", "x")).expanding(2), f)().sort_index(),
+            getattr(pdf.groupby(("a", "x")).expanding(2), f)().sort_index(),
+            almost=True,
         )
 
         self.assert_eq(
-            repr(getattr(kdf.groupby([("a", "x"), ("a", "y")]).expanding(2), f)().sort_index()),
-            repr(getattr(pdf.groupby([("a", "x"), ("a", "y")]).expanding(2), f)().sort_index()),
+            getattr(kdf.groupby([("a", "x"), ("a", "y")]).expanding(2), f)().sort_index(),
+            getattr(pdf.groupby([("a", "x"), ("a", "y")]).expanding(2), f)().sort_index(),
+            almost=True,
         )
 
     def test_groupby_expanding_count(self):
@@ -169,27 +192,29 @@ class ExpandingTest(ReusedSQLTestCase, TestUtils):
             midx = pd.MultiIndex.from_tuples(
                 list(zip(kser.to_pandas().values, kser.index.to_pandas().values))
             )
-            expected_result = ks.Series([np.nan, np.nan, np.nan], index=midx)
+            expected_result = pd.Series([np.nan, np.nan, np.nan], index=midx)
             self.assert_eq(
                 kser.groupby(kser).expanding(2).count().sort_index(),
                 expected_result.sort_index(),
                 almost=True,
             )
+
             # MultiIndex
             kser = ks.Series(
                 [1, 2, 3], index=pd.MultiIndex.from_tuples([("a", "x"), ("a", "y"), ("b", "z")])
             )
             midx = pd.MultiIndex.from_tuples([(1, "a", "x"), (2, "a", "y"), (3, "b", "z")])
-            expected_result = ks.Series([np.nan, np.nan, np.nan], index=midx)
+            expected_result = pd.Series([np.nan, np.nan, np.nan], index=midx)
             self.assert_eq(
                 kser.groupby(kser).expanding(2).count().sort_index(),
                 expected_result.sort_index(),
                 almost=True,
             )
+
             # DataFrame
             kdf = ks.DataFrame({"a": [1, 2, 3, 2], "b": [4.0, 2.0, 3.0, 1.0]})
             midx = pd.MultiIndex.from_tuples([(1, 0), (2, 1), (2, 3), (3, 2)])
-            expected_result = ks.DataFrame(
+            expected_result = pd.DataFrame(
                 {"a": [None, None, 2.0, None], "b": [None, None, 2.0, None]}, index=midx
             )
             self.assert_eq(
@@ -197,11 +222,33 @@ class ExpandingTest(ReusedSQLTestCase, TestUtils):
                 expected_result.sort_index(),
                 almost=True,
             )
+            expected_result = pd.DataFrame(
+                {"a": [None, None, 2.0, None], "b": [None, None, 2.0, None]},
+                index=pd.MultiIndex.from_tuples([(2, 0), (3, 1), (3, 3), (4, 2)]),
+            )
+            self.assert_eq(
+                kdf.groupby(kdf.a + 1).expanding(2).count().sort_index(),
+                expected_result.sort_index(),
+                almost=True,
+            )
+            expected_result = pd.Series([None, None, 2.0, None], index=midx, name="b")
+            self.assert_eq(
+                kdf.groupby(kdf.a)["b"].expanding(2).count().sort_index(),
+                expected_result.sort_index(),
+                almost=True,
+            )
+            expected_result = pd.DataFrame({"b": [None, None, 2.0, None]}, index=midx)
+            self.assert_eq(
+                kdf.groupby(kdf.a)[["b"]].expanding(2).count().sort_index(),
+                expected_result.sort_index(),
+                almost=True,
+            )
+
             # MultiIndex column
             kdf = ks.DataFrame({"a": [1, 2, 3, 2], "b": [4.0, 2.0, 3.0, 1.0]})
             kdf.columns = pd.MultiIndex.from_tuples([("a", "x"), ("a", "y")])
             midx = pd.MultiIndex.from_tuples([(1, 0), (2, 1), (2, 3), (3, 2)])
-            expected_result = ks.DataFrame(
+            expected_result = pd.DataFrame(
                 {"a": [None, None, 2.0, None], "b": [None, None, 2.0, None]}, index=midx
             )
             expected_result.columns = pd.MultiIndex.from_tuples([("a", "x"), ("a", "y")])
@@ -211,11 +258,13 @@ class ExpandingTest(ReusedSQLTestCase, TestUtils):
                 almost=True,
             )
             midx = pd.MultiIndex.from_tuples([(1, 4.0, 0), (2, 1.0, 3), (2, 2.0, 1), (3, 3.0, 2)])
-            expected_result = ks.DataFrame(
-                {"a": [np.nan, np.nan, np.nan, np.nan], "b": [np.nan, np.nan, np.nan, np.nan]},
+            expected_result = pd.DataFrame(
+                {
+                    ("a", "x"): [np.nan, np.nan, np.nan, np.nan],
+                    ("a", "y"): [np.nan, np.nan, np.nan, np.nan],
+                },
                 index=midx,
             )
-            expected_result.columns = pd.MultiIndex.from_tuples([("a", "x"), ("a", "y")])
             self.assert_eq(
                 kdf.groupby([("a", "x"), ("a", "y")]).expanding(2).count().sort_index(),
                 expected_result.sort_index(),

--- a/databricks/koalas/tests/test_ops_on_diff_frames_groupby_expanding.py
+++ b/databricks/koalas/tests/test_ops_on_diff_frames_groupby_expanding.py
@@ -1,0 +1,131 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from distutils.version import LooseVersion
+
+import numpy as np
+import pandas as pd
+
+import databricks.koalas as ks
+from databricks.koalas.config import set_option, reset_option
+from databricks.koalas.testing.utils import ReusedSQLTestCase, TestUtils
+
+
+class OpsOnDiffFramesGroupByExpandingTest(ReusedSQLTestCase, TestUtils):
+    @classmethod
+    def setUpClass(cls):
+        super(OpsOnDiffFramesGroupByExpandingTest, cls).setUpClass()
+        set_option("compute.ops_on_diff_frames", True)
+
+    @classmethod
+    def tearDownClass(cls):
+        reset_option("compute.ops_on_diff_frames")
+        super(OpsOnDiffFramesGroupByExpandingTest, cls).tearDownClass()
+
+    def _test_groupby_expanding_func(self, f):
+        pser = pd.Series([1, 2, 3], name="a")
+        pkey = pd.Series([1, 2, 3], name="a")
+        kser = ks.from_pandas(pser)
+        kkey = ks.from_pandas(pkey)
+
+        self.assert_eq(
+            getattr(kser.groupby(kkey).expanding(2), f)().sort_index(),
+            getattr(pser.groupby(pkey).expanding(2), f)().sort_index(),
+            almost=True,
+        )
+
+        pdf = pd.DataFrame({"a": [1, 2, 3, 2], "b": [4.0, 2.0, 3.0, 1.0]})
+        pkey = pd.Series([1, 2, 3, 2], name="a")
+        kdf = ks.from_pandas(pdf)
+        kkey = ks.from_pandas(pkey)
+
+        self.assert_eq(
+            getattr(kdf.groupby(kkey).expanding(2), f)().sort_index(),
+            getattr(pdf.groupby(pkey).expanding(2), f)().sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            getattr(kdf.groupby(kkey)["b"].expanding(2), f)().sort_index(),
+            getattr(pdf.groupby(pkey)["b"].expanding(2), f)().sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            getattr(kdf.groupby(kkey)[["b"]].expanding(2), f)().sort_index(),
+            getattr(pdf.groupby(pkey)[["b"]].expanding(2), f)().sort_index(),
+            almost=True,
+        )
+
+    def test_groupby_expanding_count(self):
+        # The behaviour of ExpandingGroupby.count are different between pandas>=1.0.0 and lower,
+        # and we're following the behaviour of latest version of pandas.
+        if LooseVersion(pd.__version__) >= LooseVersion("1.0.0"):
+            self._test_groupby_expanding_func("count")
+        else:
+            # Series
+            kser = ks.Series([1, 2, 3])
+            kkey = ks.Series([1, 2, 3])
+            midx = pd.MultiIndex.from_tuples(
+                list(zip(kkey.to_pandas().values, kser.index.to_pandas().values))
+            )
+            expected_result = pd.Series([np.nan, np.nan, np.nan], index=midx)
+            self.assert_eq(
+                kser.groupby(kkey).expanding(2).count().sort_index(),
+                expected_result.sort_index(),
+                almost=True,
+            )
+
+            # DataFrame
+            kdf = ks.DataFrame({"a": [1, 2, 3, 2], "b": [4.0, 2.0, 3.0, 1.0]})
+            kkey = ks.Series([1, 2, 3, 2], name="a")
+            midx = pd.MultiIndex.from_tuples([(1, 0), (2, 1), (2, 3), (3, 2)])
+            expected_result = pd.DataFrame(
+                {"a": [None, None, 2.0, None], "b": [None, None, 2.0, None]}, index=midx
+            )
+            self.assert_eq(
+                kdf.groupby(kkey).expanding(2).count().sort_index(),
+                expected_result.sort_index(),
+                almost=True,
+            )
+            expected_result = pd.Series([None, None, 2.0, None], index=midx, name="b")
+            self.assert_eq(
+                kdf.groupby(kkey)["b"].expanding(2).count().sort_index(),
+                expected_result.sort_index(),
+                almost=True,
+            )
+            expected_result = pd.DataFrame({"b": [None, None, 2.0, None]}, index=midx)
+            self.assert_eq(
+                kdf.groupby(kkey)[["b"]].expanding(2).count().sort_index(),
+                expected_result.sort_index(),
+                almost=True,
+            )
+
+    def test_groupby_expanding_min(self):
+        self._test_groupby_expanding_func("min")
+
+    def test_groupby_expanding_max(self):
+        self._test_groupby_expanding_func("max")
+
+    def test_groupby_expanding_mean(self):
+        self._test_groupby_expanding_func("mean")
+
+    def test_groupby_expanding_sum(self):
+        self._test_groupby_expanding_func("sum")
+
+    def test_groupby_expanding_std(self):
+        self._test_groupby_expanding_func("std")
+
+    def test_groupby_expanding_var(self):
+        self._test_groupby_expanding_func("var")

--- a/databricks/koalas/tests/test_ops_on_diff_frames_groupby_rolling.py
+++ b/databricks/koalas/tests/test_ops_on_diff_frames_groupby_rolling.py
@@ -1,0 +1,88 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import pandas as pd
+
+import databricks.koalas as ks
+from databricks.koalas.config import set_option, reset_option
+from databricks.koalas.testing.utils import ReusedSQLTestCase, TestUtils
+
+
+class OpsOnDiffFramesGroupByRollingTest(ReusedSQLTestCase, TestUtils):
+    @classmethod
+    def setUpClass(cls):
+        super(OpsOnDiffFramesGroupByRollingTest, cls).setUpClass()
+        set_option("compute.ops_on_diff_frames", True)
+
+    @classmethod
+    def tearDownClass(cls):
+        reset_option("compute.ops_on_diff_frames")
+        super(OpsOnDiffFramesGroupByRollingTest, cls).tearDownClass()
+
+    def _test_groupby_rolling_func(self, f):
+        pser = pd.Series([1, 2, 3], name="a")
+        pkey = pd.Series([1, 2, 3], name="a")
+        kser = ks.from_pandas(pser)
+        kkey = ks.from_pandas(pkey)
+
+        self.assert_eq(
+            getattr(kser.groupby(kkey).rolling(2), f)().sort_index(),
+            getattr(pser.groupby(pkey).rolling(2), f)().sort_index(),
+            almost=True,
+        )
+
+        pdf = pd.DataFrame({"a": [1, 2, 3, 2], "b": [4.0, 2.0, 3.0, 1.0]})
+        pkey = pd.Series([1, 2, 3, 2], name="a")
+        kdf = ks.from_pandas(pdf)
+        kkey = ks.from_pandas(pkey)
+
+        self.assert_eq(
+            getattr(kdf.groupby(kkey).rolling(2), f)().sort_index(),
+            getattr(pdf.groupby(pkey).rolling(2), f)().sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            getattr(kdf.groupby(kkey)["b"].rolling(2), f)().sort_index(),
+            getattr(pdf.groupby(pkey)["b"].rolling(2), f)().sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            getattr(kdf.groupby(kkey)[["b"]].rolling(2), f)().sort_index(),
+            getattr(pdf.groupby(pkey)[["b"]].rolling(2), f)().sort_index(),
+            almost=True,
+        )
+
+    def test_groupby_rolling_count(self):
+        self._test_groupby_rolling_func("count")
+
+    def test_groupby_rolling_min(self):
+        self._test_groupby_rolling_func("min")
+
+    def test_groupby_rolling_max(self):
+        self._test_groupby_rolling_func("max")
+
+    def test_groupby_rolling_mean(self):
+        self._test_groupby_rolling_func("mean")
+
+    def test_groupby_rolling_sum(self):
+        self._test_groupby_rolling_func("sum")
+
+    def test_groupby_rolling_std(self):
+        # TODO: `std` now raise error in pandas 1.0.0
+        self._test_groupby_rolling_func("std")
+
+    def test_groupby_rolling_var(self):
+        self._test_groupby_rolling_func("var")

--- a/databricks/koalas/tests/test_rolling.py
+++ b/databricks/koalas/tests/test_rolling.py
@@ -118,6 +118,11 @@ class RollingTest(ReusedSQLTestCase, TestUtils):
             almost=True,
         )
         self.assert_eq(
+            getattr(kdf.b.groupby(kdf.a).rolling(2), f)().sort_index(),
+            getattr(pdf.b.groupby(pdf.a).rolling(2), f)().sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
             getattr(kdf.groupby(kdf.a)["b"].rolling(2), f)().sort_index(),
             getattr(pdf.groupby(pdf.a)["b"].rolling(2), f)().sort_index(),
             almost=True,

--- a/databricks/koalas/tests/test_rolling.py
+++ b/databricks/koalas/tests/test_rolling.py
@@ -35,30 +35,32 @@ class RollingTest(ReusedSQLTestCase, TestUtils):
             Rolling(1, 2)
 
     def _test_rolling_func(self, f):
-        kser = ks.Series([1, 2, 3], index=np.random.rand(3))
-        pser = kser.to_pandas()
-        self.assert_eq(repr(getattr(kser.rolling(2), f)()), repr(getattr(pser.rolling(2), f)()))
+        pser = pd.Series([1, 2, 3], index=np.random.rand(3), name="a")
+        kser = ks.from_pandas(pser)
+        self.assert_eq(getattr(kser.rolling(2), f)(), getattr(pser.rolling(2), f)(), almost=True)
 
-        kdf = ks.DataFrame({"a": [1, 2, 3, 2], "b": [4.0, 2.0, 3.0, 1.0]}, index=np.random.rand(4))
-        pdf = kdf.to_pandas()
-        self.assert_eq(repr(getattr(kdf.rolling(2), f)()), repr(getattr(pdf.rolling(2), f)()))
+        pdf = pd.DataFrame({"a": [1, 2, 3, 2], "b": [4.0, 2.0, 3.0, 1.0]}, index=np.random.rand(4))
+        kdf = ks.from_pandas(pdf)
+        self.assert_eq(getattr(kdf.rolling(2), f)(), getattr(pdf.rolling(2), f)(), almost=True)
 
         # Multiindex
-        kser = ks.Series(
-            [1, 2, 3], index=pd.MultiIndex.from_tuples([("a", "x"), ("a", "y"), ("b", "z")])
+        pser = pd.Series(
+            [1, 2, 3],
+            index=pd.MultiIndex.from_tuples([("a", "x"), ("a", "y"), ("b", "z")]),
+            name="a",
         )
-        pser = kser.to_pandas()
-        self.assert_eq(repr(getattr(kser.rolling(2), f)()), repr(getattr(pser.rolling(2), f)()))
+        kser = ks.from_pandas(pser)
+        self.assert_eq(getattr(kser.rolling(2), f)(), getattr(pser.rolling(2), f)(), almost=True)
 
-        kdf = ks.DataFrame({"a": [1, 2, 3, 2], "b": [4.0, 2.0, 3.0, 1.0]}, index=np.random.rand(4))
-        pdf = kdf.to_pandas()
-        self.assert_eq(repr(getattr(kdf.rolling(2), f)()), repr(getattr(pdf.rolling(2), f)()))
+        pdf = pd.DataFrame({"a": [1, 2, 3, 2], "b": [4.0, 2.0, 3.0, 1.0]}, index=np.random.rand(4))
+        kdf = ks.from_pandas(pdf)
+        self.assert_eq(getattr(kdf.rolling(2), f)(), getattr(pdf.rolling(2), f)(), almost=True)
 
         # Multiindex column
-        kdf = ks.DataFrame({"a": [1, 2, 3, 2], "b": [4.0, 2.0, 3.0, 1.0]}, index=np.random.rand(4))
-        kdf.columns = pd.MultiIndex.from_tuples([("a", "x"), ("a", "y")])
-        pdf = kdf.to_pandas()
-        self.assert_eq(repr(getattr(kdf.rolling(2), f)()), repr(getattr(pdf.rolling(2), f)()))
+        columns = pd.MultiIndex.from_tuples([("a", "x"), ("a", "y")])
+        pdf.columns = columns
+        kdf.columns = columns
+        self.assert_eq(getattr(kdf.rolling(2), f)(), getattr(pdf.rolling(2), f)(), almost=True)
 
     def test_rolling_min(self):
         self._test_rolling_func("min")
@@ -82,42 +84,64 @@ class RollingTest(ReusedSQLTestCase, TestUtils):
         self._test_rolling_func("var")
 
     def _test_groupby_rolling_func(self, f):
-        kser = ks.Series([1, 2, 3], index=np.random.rand(3))
-        pser = kser.to_pandas()
+        pser = pd.Series([1, 2, 3], index=np.random.rand(3), name="a")
+        kser = ks.from_pandas(pser)
         self.assert_eq(
-            repr(getattr(kser.groupby(kser).rolling(2), f)().sort_index()),
-            repr(getattr(pser.groupby(pser).rolling(2), f)().sort_index()),
+            getattr(kser.groupby(kser).rolling(2), f)().sort_index(),
+            getattr(pser.groupby(pser).rolling(2), f)().sort_index(),
+            almost=True,
         )
 
         # Multiindex
-        kser = ks.Series(
-            [1, 2, 3], index=pd.MultiIndex.from_tuples([("a", "x"), ("a", "y"), ("b", "z")])
+        pser = pd.Series(
+            [1, 2, 3],
+            index=pd.MultiIndex.from_tuples([("a", "x"), ("a", "y"), ("b", "z")]),
+            name="a",
         )
-        pser = kser.to_pandas()
+        kser = ks.from_pandas(pser)
         self.assert_eq(
-            repr(getattr(kser.groupby(kser).rolling(2), f)().sort_index()),
-            repr(getattr(pser.groupby(pser).rolling(2), f)()),
+            getattr(kser.groupby(kser).rolling(2), f)().sort_index(),
+            getattr(pser.groupby(pser).rolling(2), f)().sort_index(),
+            almost=True,
         )
 
-        kdf = ks.DataFrame({"a": [1, 2, 3, 2], "b": [4.0, 2.0, 3.0, 1.0]})
-        pdf = kdf.to_pandas()
+        pdf = pd.DataFrame({"a": [1, 2, 3, 2], "b": [4.0, 2.0, 3.0, 1.0]})
+        kdf = ks.from_pandas(pdf)
         self.assert_eq(
-            repr(getattr(kdf.groupby(kdf.a).rolling(2), f)().sort_index()),
-            repr(getattr(pdf.groupby(pdf.a).rolling(2), f)().sort_index()),
+            getattr(kdf.groupby(kdf.a).rolling(2), f)().sort_index(),
+            getattr(pdf.groupby(pdf.a).rolling(2), f)().sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            getattr(kdf.groupby(kdf.a + 1).rolling(2), f)().sort_index(),
+            getattr(pdf.groupby(pdf.a + 1).rolling(2), f)().sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            getattr(kdf.groupby(kdf.a)["b"].rolling(2), f)().sort_index(),
+            getattr(pdf.groupby(pdf.a)["b"].rolling(2), f)().sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            getattr(kdf.groupby(kdf.a)[["b"]].rolling(2), f)().sort_index(),
+            getattr(pdf.groupby(pdf.a)[["b"]].rolling(2), f)().sort_index(),
+            almost=True,
         )
 
         # Multiindex column
-        kdf = ks.DataFrame({"a": [1, 2, 3, 2], "b": [4.0, 2.0, 3.0, 1.0]})
-        kdf.columns = pd.MultiIndex.from_tuples([("a", "x"), ("a", "y")])
-        pdf = kdf.to_pandas()
+        columns = pd.MultiIndex.from_tuples([("a", "x"), ("a", "y")])
+        pdf.columns = columns
+        kdf.columns = columns
         self.assert_eq(
-            repr(getattr(kdf.groupby(("a", "x")).rolling(2), f)().sort_index()),
-            repr(getattr(pdf.groupby(("a", "x")).rolling(2), f)().sort_index()),
+            getattr(kdf.groupby(("a", "x")).rolling(2), f)().sort_index(),
+            getattr(pdf.groupby(("a", "x")).rolling(2), f)().sort_index(),
+            almost=True,
         )
 
         self.assert_eq(
-            repr(getattr(kdf.groupby([("a", "x"), ("a", "y")]).rolling(2), f)().sort_index()),
-            repr(getattr(pdf.groupby([("a", "x"), ("a", "y")]).rolling(2), f)().sort_index()),
+            getattr(kdf.groupby([("a", "x"), ("a", "y")]).rolling(2), f)().sort_index(),
+            getattr(pdf.groupby([("a", "x"), ("a", "y")]).rolling(2), f)().sort_index(),
+            almost=True,
         )
 
     def test_groupby_rolling_count(self):


### PR DESCRIPTION
Fix `Rolling` and `Expanding` to handle `agg_columns`.

E.g.,

```py
>>> kdf
   a    b
0  1  4.0
1  2  2.0
2  3  3.0
3  2  1.0
>>> kdf.groupby(kdf.a)[['b']].rolling(2).sum()
       a    b
a
1 0  NaN  NaN
3 2  NaN  NaN
2 1  NaN  NaN
  3  4.0  3.0
```

This should be:

```py
>>> pdf.groupby(pdf.a)[['b']].rolling(2).sum()
       b
a
1 0  NaN
2 1  NaN
  3  3.0
3 2  NaN
```

Also, it raises errors for other cases:

```py
>>> kdf.b.groupby(kdf.a).rolling(2).sum()
Traceback (most recent call last):
...
pyspark.sql.utils.AnalysisException: "cannot resolve '`a`' given input columns: ...

>>> kdf.groupby(kdf.a)['b'].rolling(2).sum()
Traceback (most recent call last):
...
pyspark.sql.utils.AnalysisException: "cannot resolve '`a`' given input columns: ...
```