### PR TITLE
Fix Series.fillna to avoid Spark jobs.

### DIFF
--- a/databricks/koalas/internal.py
+++ b/databricks/koalas/internal.py
@@ -637,21 +637,25 @@ class InternalFrame(object):
             (sdf[offset_column] + sdf[row_number_column] - 1).alias(column_name), *scols
         )
 
-    def spark_column_name_for(self, labels: Tuple[str, ...]) -> str:
-        """ Return the actual Spark column name for the given column name. """
-        return self.spark_frame.select(self.spark_column_for(labels)).columns[0]
+    def spark_column_name_for(self, label: Tuple[str, ...]) -> str:
+        """ Return the actual Spark column name for the given column label. """
+        return self.spark_frame.select(self.spark_column_for(label)).columns[0]
 
-    def spark_column_for(self, labels: Tuple[str, ...]):
-        """ Return Spark Column for the given column name. """
+    def spark_column_for(self, label: Tuple[str, ...]):
+        """ Return Spark Column for the given column label. """
         column_labels_to_scol = dict(zip(self.column_labels, self.data_spark_columns))
-        if labels in column_labels_to_scol:
-            return column_labels_to_scol[labels]  # type: ignore
+        if label in column_labels_to_scol:
+            return column_labels_to_scol[label]  # type: ignore
         else:
-            raise KeyError(name_like_string(labels))
+            raise KeyError(name_like_string(label))
 
-    def spark_type_for(self, labels: Tuple[str, ...]) -> DataType:
-        """ Return DataType for the given column name. """
-        return self.spark_frame.select(self.spark_column_for(labels)).schema[0].dataType
+    def spark_type_for(self, label: Tuple[str, ...]) -> DataType:
+        """ Return DataType for the given column label. """
+        return self.spark_frame.select(self.spark_column_for(label)).schema[0].dataType
+
+    def spark_column_nullable_for(self, label: Tuple[str, ...]) -> bool:
+        """ Return nullability for the given column label. """
+        return self.spark_frame.select(self.spark_column_for(label)).schema[0].nullable
 
     @property
     def spark_frame(self) -> spark.DataFrame:

--- a/databricks/koalas/spark/accessors.py
+++ b/databricks/koalas/spark/accessors.py
@@ -45,6 +45,11 @@ class SparkIndexOpsMethods(object):
         return self._data._internal.spark_type_for(self._data._internal.column_labels[0])
 
     @property
+    def nullable(self):
+        """ Returns the nullability as defined by Spark. """
+        return self._data._internal.spark_column_nullable_for(self._data._internal.column_labels[0])
+
+    @property
     def column(self):
         """
         Spark Column object representing the Series/Index.

--- a/docs/source/reference/series.rst
+++ b/docs/source/reference/series.rst
@@ -224,6 +224,7 @@ in Spark. These can be accessed by ``Series.spark.<function/property>``.
    :toctree: api/
 
    Series.spark.data_type
+   Series.spark.nullable
    Series.spark.column
    Series.spark.transform
    Series.spark.apply


### PR DESCRIPTION
`DataFrame.fillna` reuses `Series.fillna` which always runs a Spark job to check if there are null values, then it ends up with running many jobs if the DataFrame has a lot of columns.
We should avoid it, and we can check its nullability defined by Spark instead.