### PR TITLE
Add dataframe property to spark accessors

### DIFF
--- a/databricks/koalas/spark/accessors.py
+++ b/databricks/koalas/spark/accessors.py
@@ -54,6 +54,11 @@ class SparkIndexOpsMethods(object):
         """
         return self._data._internal.spark_column
 
+    @property
+    def dataframe(self):
+        """ Returns the Spark DataFrame representing the Series/Index of Koalas."""
+        return self._data._internal.spark_frame
+
     def transform(self, func):
         """
         Applies a function that takes and returns a Spark column. It allows to natively


### PR DESCRIPTION
Since we have `spark` namespace now, proposes adding `dataframe` to the spark accessors for accessing to the spark dataframe more intuitively.

I think `self.spark.dataframe` is a bit more intuitive than `self._internal.spark_frame`.