### PR TITLE
Manage data_spark_columns to avoid creating very many Spark DataFrames.

### DIFF
--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -351,7 +351,7 @@ class IndexOpsMixin(object):
         >>> ks.DataFrame({}, index=list('abc')).index.empty
         False
         """
-        return self._internal._sdf.rdd.isEmpty()
+        return self._internal.applied.spark_frame.rdd.isEmpty()
 
     @property
     def hasnans(self):
@@ -860,7 +860,7 @@ class IndexOpsMixin(object):
         if axis != 0:
             raise NotImplementedError('axis should be either 0 or "index" currently.')
 
-        sdf = self._internal._sdf.select(self.spark.column)
+        sdf = self._internal.spark_frame.select(self.spark.column)
         col = scol_for(sdf, sdf.columns[0])
 
         # Note that we're ignoring `None`s here for now.
@@ -923,7 +923,7 @@ class IndexOpsMixin(object):
         if axis != 0:
             raise NotImplementedError('axis should be either 0 or "index" currently.')
 
-        sdf = self._internal._sdf.select(self.spark.column)
+        sdf = self._internal.spark_frame.select(self.spark.column)
         col = scol_for(sdf, sdf.columns[0])
 
         # Note that we're ignoring `None`s here for now.
@@ -1156,9 +1156,9 @@ class IndexOpsMixin(object):
             raise NotImplementedError("value_counts currently does not support bins")
 
         if dropna:
-            sdf_dropna = self._internal._sdf.select(self.spark.column).dropna()
+            sdf_dropna = self._internal.spark_frame.select(self.spark.column).dropna()
         else:
-            sdf_dropna = self._internal._sdf.select(self.spark.column)
+            sdf_dropna = self._internal.spark_frame.select(self.spark.column)
         index_name = SPARK_DEFAULT_INDEX_NAME
         column_name = self._internal.data_spark_column_names[0]
         sdf = sdf_dropna.groupby(scol_for(sdf_dropna, column_name).alias(index_name)).count()
@@ -1241,7 +1241,7 @@ class IndexOpsMixin(object):
         >>> idx.nunique(dropna=False)
         3
         """
-        res = self._internal._sdf.select([self._nunique(dropna, approx, rsd)])
+        res = self._internal.spark_frame.select([self._nunique(dropna, approx, rsd)])
         return res.collect()[0][0]
 
     def _nunique(self, dropna=True, approx=False, rsd=0.05):

--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -351,7 +351,7 @@ class IndexOpsMixin(object):
         >>> ks.DataFrame({}, index=list('abc')).index.empty
         False
         """
-        return self._internal.applied.spark_frame.rdd.isEmpty()
+        return self._internal.resolved_copy.spark_frame.rdd.isEmpty()
 
     @property
     def hasnans(self):

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -143,6 +143,12 @@ circle          0      720
 triangle        6      360
 rectangle       8      720
 
+>>> df + df + df
+           angles  degrees
+circle          0     1080
+triangle        9      540
+rectangle      12     1080
+
 >>> df.radd(1)
            angles  degrees
 circle          1      361
@@ -409,10 +415,6 @@ class DataFrame(Frame, Generic[T]):
             super(DataFrame, self).__init__(InternalFrame.from_pandas(pdf))
 
     @property
-    def _sdf(self) -> spark.DataFrame:
-        return self._internal.spark_frame
-
-    @property
     def ndim(self):
         """
         Return an int representing the number of array dimensions.
@@ -505,7 +507,7 @@ class DataFrame(Frame, Generic[T]):
                     exprs.append(col_sdf.alias(name_like_string(label)))
                     new_column_labels.append(label)
 
-            sdf = self._sdf.select(*exprs)
+            sdf = self._internal.spark_frame.select(*exprs)
 
             # The data is expected to be small so it's fine to transpose/use default index.
             with ks.option_context(
@@ -534,7 +536,7 @@ class DataFrame(Frame, Generic[T]):
             def calculate_columns_axis(*cols):
                 return getattr(pd.concat(cols, axis=1), name)(axis=axis, numeric_only=numeric_only)
 
-            df = self._sdf.select(
+            df = self._internal.spark_frame.select(
                 calculate_columns_axis(*self._internal.data_spark_columns).alias("0")
             )
             return DataFrame(df)["0"]
@@ -1253,7 +1255,9 @@ class DataFrame(Frame, Generic[T]):
             v = [row[c] for c in internal_data_columns]
             return k, v
 
-        for k, v in map(extract_kv_from_spark_row, self._sdf.toLocalIterator()):
+        for k, v in map(
+            extract_kv_from_spark_row, self._internal.applied.spark_frame.toLocalIterator()
+        ):
             s = pd.Series(v, index=columns, name=k)
             yield k, s
 
@@ -1945,7 +1949,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             )
         )
 
-        exploded_df = self._sdf.withColumn("pairs", pairs).select(
+        exploded_df = self._internal.spark_frame.withColumn("pairs", pairs).select(
             [
                 F.to_json(
                     F.struct(
@@ -2106,11 +2110,13 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         original_func = func
         func = lambda o: original_func(o, *args, **kwds)
 
+        self_applied = DataFrame(self._internal.applied)
+
         if should_infer_schema:
             # Here we execute with the first 1000 to get the return type.
             # If the records were less than 1000, it uses pandas API directly for a shortcut.
             limit = get_option("compute.shortcut_limit")
-            pdf = self.head(limit + 1)._to_internal_pandas()
+            pdf = self_applied.head(limit + 1)._to_internal_pandas()
             applied = func(pdf)
             if not isinstance(applied, pd.DataFrame):
                 raise ValueError(
@@ -2124,14 +2130,14 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             return_schema = kdf._internal.to_internal_spark_frame.schema
             if should_use_map_in_pandas:
                 output_func = GroupBy._make_pandas_df_builder_func(
-                    self, func, return_schema, retain_index=True
+                    self_applied, func, return_schema, retain_index=True
                 )
-                sdf = self._internal.to_internal_spark_frame.mapInPandas(
+                sdf = self_applied._internal.to_internal_spark_frame.mapInPandas(
                     lambda iterator: map(output_func, iterator), schema=return_schema
                 )
             else:
                 sdf = GroupBy._spark_group_map_apply(
-                    self, func, (F.spark_partition_id(),), return_schema, retain_index=True
+                    self_applied, func, (F.spark_partition_id(),), return_schema, retain_index=True
                 )
 
             # If schema is inferred, we can restore indexes too.
@@ -2147,14 +2153,14 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
             if should_use_map_in_pandas:
                 output_func = GroupBy._make_pandas_df_builder_func(
-                    self, func, return_schema, retain_index=False
+                    self_applied, func, return_schema, retain_index=False
                 )
-                sdf = self._internal.to_internal_spark_frame.mapInPandas(
+                sdf = self_applied._internal.to_internal_spark_frame.mapInPandas(
                     lambda iterator: map(output_func, iterator), schema=return_schema
                 )
             else:
                 sdf = GroupBy._spark_group_map_apply(
-                    self, func, (F.spark_partition_id(),), return_schema, retain_index=False
+                    self_applied, func, (F.spark_partition_id(),), return_schema, retain_index=False
                 )
 
             # Otherwise, it loses index.
@@ -2361,11 +2367,13 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             else:
                 return pdf_or_pser
 
+        self_applied = DataFrame(self._internal.applied)
+
         if should_infer_schema:
             # Here we execute with the first 1000 to get the return type.
             # If the records were less than 1000, it uses pandas API directly for a shortcut.
             limit = get_option("compute.shortcut_limit")
-            pdf = self.head(limit + 1)._to_internal_pandas()
+            pdf = self_applied.head(limit + 1)._to_internal_pandas()
             applied = pdf.apply(func, axis=axis, args=args, **kwds)
             kser_or_kdf = ks.from_pandas(applied)
             if len(pdf) <= limit:
@@ -2380,14 +2388,18 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
             if should_use_map_in_pandas:
                 output_func = GroupBy._make_pandas_df_builder_func(
-                    self, apply_func, return_schema, retain_index=True
+                    self_applied, apply_func, return_schema, retain_index=True
                 )
-                sdf = self._internal.to_internal_spark_frame.mapInPandas(
+                sdf = self_applied._internal.to_internal_spark_frame.mapInPandas(
                     lambda iterator: map(output_func, iterator), schema=return_schema
                 )
             else:
                 sdf = GroupBy._spark_group_map_apply(
-                    self, apply_func, (F.spark_partition_id(),), return_schema, retain_index=True
+                    self_applied,
+                    apply_func,
+                    (F.spark_partition_id(),),
+                    return_schema,
+                    retain_index=True,
                 )
 
             # If schema is inferred, we can restore indexes too.
@@ -2403,7 +2415,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                         "hints when axis is 0 or 'index'; however, the return type "
                         "was %s" % return_sig
                     )
-                fields_types = zip(self.columns, [return_schema] * len(self.columns))
+                fields_types = zip(
+                    self_applied.columns, [return_schema] * len(self_applied.columns)
+                )
                 return_schema = StructType([StructField(c, t) for c, t in fields_types])
             elif require_column_axis:
                 if axis != 1:
@@ -2419,14 +2433,18 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
             if should_use_map_in_pandas:
                 output_func = GroupBy._make_pandas_df_builder_func(
-                    self, apply_func, return_schema, retain_index=False
+                    self_applied, apply_func, return_schema, retain_index=False
                 )
-                sdf = self._internal.to_internal_spark_frame.mapInPandas(
+                sdf = self_applied._internal.to_internal_spark_frame.mapInPandas(
                     lambda iterator: map(output_func, iterator), schema=return_schema
                 )
             else:
                 sdf = GroupBy._spark_group_map_apply(
-                    self, apply_func, (F.spark_partition_id(),), return_schema, retain_index=False
+                    self_applied,
+                    apply_func,
+                    (F.spark_partition_id(),),
+                    return_schema,
+                    retain_index=False,
                 )
 
             # Otherwise, it loses index.
@@ -2767,19 +2785,22 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 return_schema = StructType(
                     [StructField(field.name, field.dataType) for field in return_schema.fields]
                 )
+
+                self_applied = DataFrame(self._internal.applied)
+
                 output_func = GroupBy._make_pandas_df_builder_func(
-                    self, func, return_schema, retain_index=True
+                    self_applied, func, return_schema, retain_index=True
                 )
-                columns = self._internal.spark_columns
+                columns = self_applied._internal.spark_columns
                 if should_by_pass:
                     pudf = pandas_udf(
                         output_func, returnType=return_schema, functionType=PandasUDFType.SCALAR
                     )
                     temp_struct_column = verify_temp_column_name(
-                        self._internal.spark_frame, "__temp_struct__"
+                        self_applied._internal.spark_frame, "__temp_struct__"
                     )
                     applied = pudf(F.struct(*columns)).alias(temp_struct_column)
-                    sdf = self._internal.spark_frame.select(applied)
+                    sdf = self_applied._internal.spark_frame.select(applied)
                     sdf = sdf.selectExpr("%s.*" % temp_struct_column)
                 else:
                     applied = []
@@ -2791,7 +2812,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                                 functionType=PandasUDFType.SCALAR,
                             )(*columns).alias(field.name)
                         )
-                    sdf = self._internal.spark_frame.select(*applied)
+                    sdf = self_applied._internal.spark_frame.select(*applied)
                 return DataFrame(kdf._internal.with_new_sdf(sdf))
         else:
             return_schema = infer_return_type(original_func).tpe
@@ -2816,20 +2837,22 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 )
                 return Series(internal, anchor=self)
             else:
+                self_applied = DataFrame(self._internal.applied)
+
                 output_func = GroupBy._make_pandas_df_builder_func(
-                    self, func, return_schema, retain_index=False
+                    self_applied, func, return_schema, retain_index=False
                 )
-                columns = self._internal.spark_columns
+                columns = self_applied._internal.spark_columns
 
                 if should_by_pass:
                     pudf = pandas_udf(
                         output_func, returnType=return_schema, functionType=PandasUDFType.SCALAR
                     )
                     temp_struct_column = verify_temp_column_name(
-                        self._internal.spark_frame, "__temp_struct__"
+                        self_applied._internal.spark_frame, "__temp_struct__"
                     )
                     applied = pudf(F.struct(*columns)).alias(temp_struct_column)
-                    sdf = self._internal.spark_frame.select(applied)
+                    sdf = self_applied._internal.spark_frame.select(applied)
                     sdf = sdf.selectExpr("%s.*" % temp_struct_column)
                 else:
                     applied = []
@@ -2841,7 +2864,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                                 functionType=PandasUDFType.SCALAR,
                             )(*columns).alias(field.name)
                         )
-                    sdf = self._internal.spark_frame.select(*applied)
+                    sdf = self_applied._internal.spark_frame.select(*applied)
                 return DataFrame(sdf)
 
     def pop(self, item):
@@ -3025,7 +3048,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         rows = [self._internal.spark_columns[lvl] == index for lvl, index in enumerate(key, level)]
 
         sdf = (
-            self._sdf.select(scols + list(HIDDEN_COLUMNS))
+            self._internal.spark_frame.select(scols + list(HIDDEN_COLUMNS))
             .drop(NATURAL_ORDER_COLUMN_NAME)
             .filter(reduce(lambda x, y: x & y, rows))
         )
@@ -3347,7 +3370,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         >>> ks.DataFrame({}, index=list('abc')).empty
         True
         """
-        return len(self._internal.column_labels) == 0 or self._sdf.rdd.isEmpty()
+        return (
+            len(self._internal.column_labels) == 0
+            or self._internal.applied.spark_frame.rdd.isEmpty()
+        )
 
     @property
     def style(self):
@@ -3457,10 +3483,11 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 (self._internal.spark_column_name_for(label), label) for label in keys
             )
 
-        internal = self._internal.copy(
+        internal = self._internal.applied
+        internal = internal.copy(
             index_map=index_map,
             column_labels=column_labels,
-            data_spark_columns=[self._internal.spark_column_for(label) for label in column_labels],
+            data_spark_columns=[internal.spark_column_for(label) for label in column_labels],
         )
 
         if inplace:
@@ -3682,21 +3709,21 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             if name in self._internal.column_labels:
                 raise ValueError("cannot insert {}, already exists".format(name_like_string(name)))
 
+        sdf = self._internal.spark_frame
         new_data_scols = [
-            scol_for(self._sdf, column).alias(name_like_string(name))
-            for column, name in new_index_map
+            scol_for(sdf, column).alias(name_like_string(name)) for column, name in new_index_map
         ]
 
         if len(index_map) > 0:
-            index_scols = [scol_for(self._sdf, column) for column in index_map]
-            sdf = self._sdf.select(
+            index_scols = [scol_for(sdf, column) for column in index_map]
+            sdf = sdf.select(
                 index_scols
                 + new_data_scols
                 + self._internal.data_spark_columns
                 + list(HIDDEN_COLUMNS)
             )
         else:
-            sdf = self._sdf.select(
+            sdf = sdf.select(
                 new_data_scols + self._internal.data_spark_columns + list(HIDDEN_COLUMNS)
             )
 
@@ -3984,7 +4011,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         axis = validate_axis(axis)
         if axis != 0:
             raise NotImplementedError('axis should be either 0 or "index" currently.')
-        sdf = self._sdf.select(
+        sdf = self._internal.spark_frame.select(
             [
                 self._kser_for(label)._nunique(dropna, approx, rsd)
                 for label in self._internal.column_labels
@@ -4102,7 +4129,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 raise KeyError(", ".join([str(d) if len(d) > 1 else d[0] for d in diff]))
         group_cols = [self._internal.spark_column_name_for(label) for label in subset]
 
-        sdf = self._sdf
+        sdf = self._internal.applied.spark_frame
 
         column = verify_temp_column_name(sdf, "__duplicated__")
 
@@ -5278,7 +5305,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             subset = [sub if isinstance(sub, tuple) else (sub,) for sub in subset]
         subset = [self._internal.spark_column_name_for(label) for label in subset]
 
-        sdf = self._sdf
+        sdf = self._internal.applied.spark_frame
         if (
             isinstance(to_replace, dict)
             and value is None
@@ -5408,10 +5435,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         if n <= 0:
             return DataFrame(self._internal.with_filter(F.lit(False)))
         else:
+            sdf = self._internal.applied.spark_frame
             if get_option("compute.ordered_head"):
-                sdf = self._sdf.orderBy(NATURAL_ORDER_COLUMN_NAME)
-            else:
-                sdf = self._sdf
+                sdf = sdf.orderBy(NATURAL_ORDER_COLUMN_NAME)
             return DataFrame(self._internal.with_new_sdf(sdf.limit(n)))
 
     def pivot_table(self, values=None, index=None, columns=None, aggfunc="mean", fill_value=None):
@@ -5588,9 +5614,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             if set(agg_columns) != set(values):
                 raise ValueError("Columns in aggfunc must be the same as values.")
 
+        sdf = self._internal.applied.spark_frame
         if index is None:
             sdf = (
-                self._sdf.groupBy()
+                sdf.groupBy()
                 .pivot(pivot_col=self._internal.spark_column_name_for(columns))
                 .agg(*agg_cols)
             )
@@ -5598,7 +5625,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         elif isinstance(index, list):
             index = [label if isinstance(label, tuple) else (label,) for label in index]
             sdf = (
-                self._sdf.groupBy([self._internal.spark_column_for(label) for label in index])
+                sdf.groupBy([self._internal.spark_column_name_for(label) for label in index])
                 .pivot(pivot_col=self._internal.spark_column_name_for(columns))
                 .agg(*agg_cols)
             )
@@ -6287,7 +6314,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             (False, "last"): lambda x: Column(getattr(x._jc, "desc_nulls_last")()),
         }
         by = [mapper[(asc, na_position)](scol) for scol, asc in zip(by, ascending)]
-        sdf = self._sdf.sort(*(by + [NATURAL_ORDER_COLUMN_NAME]))
+        sdf = self._internal.applied.spark_frame.sort(*(by + [NATURAL_ORDER_COLUMN_NAME]))
         kdf = DataFrame(self._internal.with_new_sdf(sdf))  # type: ks.DataFrame
         if inplace:
             self._internal = kdf._internal
@@ -6927,8 +6954,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 "['inner', 'left', 'right', 'outer']",
             )
 
-        left_table = self._sdf.alias("left_table")
-        right_table = right._sdf.alias("right_table")
+        left_table = self._internal.applied.spark_frame.alias("left_table")
+        right_table = right._internal.applied.spark_frame.alias("right_table")
 
         left_key_columns = [  # type: ignore
             scol_for(left_table, label) for label in left_key_names
@@ -7222,8 +7249,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
             if verify_integrity and len(index_scols) > 0:
                 if (
-                    self._sdf.select(index_scols)
-                    .intersect(other._sdf.select(other._internal.index_spark_columns))
+                    self._internal.spark_frame.select(index_scols)
+                    .intersect(
+                        other._internal.spark_frame.select(other._internal.index_spark_columns)
+                    )
                     .count()
                 ) > 0:
                     raise ValueError("Indices have overlapping values")
@@ -7315,7 +7344,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         update_columns = list(
             set(self._internal.column_labels).intersection(set(other._internal.column_labels))
         )
-        update_sdf = self.join(other[update_columns], rsuffix="_new")._sdf
+        update_sdf = self.join(other[update_columns], rsuffix="_new")._internal.applied.spark_frame
 
         for column_labels in update_columns:
             column_name = self._internal.spark_column_name_for(column_labels)
@@ -7422,7 +7451,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         if frac is None:
             raise ValueError("frac must be specified.")
 
-        sdf = self._sdf.sample(withReplacement=replace, fraction=frac, seed=random_state)
+        sdf = self._internal.applied.spark_frame.sample(
+            withReplacement=replace, fraction=frac, seed=random_state
+        )
         return DataFrame(self._internal.with_new_sdf(sdf))
 
     def astype(self, dtype) -> "DataFrame":
@@ -7757,7 +7788,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         formatted_perc = ["{:.0%}".format(p) for p in sorted(percentiles)]
         stats = ["count", "mean", "stddev", "min", *formatted_perc, "max"]
 
-        sdf = self._sdf.select(*exprs).summary(stats)
+        sdf = self._internal.spark_frame.select(*exprs).summary(stats)
         sdf = sdf.replace("stddev", "std", subset="summary")
 
         internal = InternalFrame(
@@ -8050,9 +8081,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         index_column = self._internal.index_spark_column_names[0]
 
         kser = ks.Series(list(index))
-        labels = kser._internal._sdf.select(kser.spark.column.alias(index_column))
+        labels = kser._internal.spark_frame.select(kser.spark.column.alias(index_column))
 
-        joined_df = self._sdf.drop(NATURAL_ORDER_COLUMN_NAME).join(
+        joined_df = self._internal.applied.spark_frame.drop(NATURAL_ORDER_COLUMN_NAME).join(
             labels, on=index_column, how="right"
         )
         internal = self._internal.with_new_sdf(joined_df)
@@ -8244,7 +8275,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         column_labels = [label for label in column_labels if label not in id_vars]
 
-        sdf = self._sdf
+        sdf = self._internal.spark_frame
 
         if var_name is None:
             if self._internal.column_label_names is not None:
@@ -8444,7 +8475,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         pairs = F.explode(F.array(structs))
 
-        sdf = self._sdf.withColumn("pairs", pairs)
+        sdf = self._internal.spark_frame.withColumn("pairs", pairs)
         sdf = sdf.select(
             self._internal.index_spark_columns
             + [sdf["pairs"][index_column].alias(index_column)]
@@ -8576,7 +8607,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         # TODO: Codes here are similar with melt. Should we deduplicate?
         column_labels = self._internal.column_labels
         ser_name = "0"
-        sdf = self._sdf
+        sdf = self._internal.spark_frame
         new_index_columns = [
             SPARK_INDEX_NAME_FORMAT(i) for i in range(self._internal.column_labels_level)
         ]
@@ -8689,7 +8720,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 )
             )
 
-        sdf = self._sdf.select(F.array(*cols).alias("arrays")).select(F.explode(F.col("arrays")))
+        sdf = self._internal.spark_frame.select(F.array(*cols).alias("arrays")).select(
+            F.explode(F.col("arrays"))
+        )
         sdf = sdf.selectExpr("col.*")
 
         index_column_name = lambda i: (
@@ -8777,7 +8810,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 )
             )
 
-        sdf = self._sdf.select(F.array(*cols).alias("arrays")).select(F.explode(F.col("arrays")))
+        sdf = self._internal.spark_frame.select(F.array(*cols).alias("arrays")).select(
+            F.explode(F.col("arrays"))
+        )
         sdf = sdf.selectExpr("col.*")
 
         index_column_name = lambda i: (
@@ -9208,7 +9243,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 )
                 return index_mapper_udf(scol_for(internal.spark_frame, index_col_name))
 
-            sdf = internal.spark_frame
+            sdf = internal.applied.spark_frame
             if level is None:
                 for i in range(num_indices):
                     sdf = sdf.withColumn(index_columns[i], gen_new_index_column(i))
@@ -9399,7 +9434,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         Name: 0, dtype: int64
         """
         max_cols = map(lambda scol: F.max(scol), self._internal.data_spark_columns)
-        sdf_max = self._sdf.select(*max_cols).head()
+        sdf_max = self._internal.spark_frame.select(*max_cols).head()
         # `sdf_max` looks like below
         # +------+------+------+
         # |(a, x)|(b, y)|(c, z)|
@@ -9478,7 +9513,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         Name: 0, dtype: int64
         """
         min_cols = map(lambda scol: F.min(scol), self._internal.data_spark_columns)
-        sdf_min = self._sdf.select(*min_cols).head()
+        sdf_min = self._internal.spark_frame.select(*min_cols).head()
 
         conds = (
             scol == min_val for scol, min_val in zip(self._internal.data_spark_columns, sdf_min)
@@ -9814,7 +9849,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         inplace = validate_bool_kwarg(inplace, "inplace")
 
         data_columns = [label[0] for label in self._internal.column_labels]
-        sdf = self._sdf.select(
+        sdf = self._internal.spark_frame.select(
             self._internal.index_spark_columns
             + [
                 scol.alias(col)
@@ -10077,20 +10112,21 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         if not isinstance(column, (tuple, str)):
             raise ValueError("column must be a scalar")
 
-        kser = self[column]
+        kdf = DataFrame(self._internal.applied)
+        kser = kdf[column]
         if not isinstance(kser, Series):
             raise ValueError(
                 "The column %s is not unique. For a multi-index, the label must be a tuple "
                 "with elements corresponding to each level." % name_like_string(column)
             )
         if not isinstance(kser.spark.data_type, ArrayType):
-            return self
+            return self.copy()
 
-        sdf = self._sdf.withColumn(
+        sdf = kdf._internal.spark_frame.withColumn(
             kser._internal.data_spark_column_names[0], F.explode_outer(kser.spark.column)
         )
 
-        internal = self._internal.with_new_sdf(sdf)
+        internal = kdf._internal.with_new_sdf(sdf)
         return DataFrame(internal)
 
     def _to_internal_pandas(self):
@@ -10260,10 +10296,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             )
 
     def __len__(self):
-        return self._sdf.count()
+        return self._internal.applied.spark_frame.count()
 
     def __dir__(self):
-        fields = [f for f in self._sdf.schema.fieldNames() if " " not in f]
+        fields = [f for f in self._internal.applied.spark_frame.schema.fieldNames() if " " not in f]
         return super(DataFrame, self).__dir__() + fields
 
     def __iter__(self):
@@ -10344,9 +10380,9 @@ class CachedDataFrame(DataFrame):
 
     def __init__(self, internal, storage_level=None):
         if storage_level is None:
-            self._cached = internal._sdf.cache()
+            self._cached = internal.spark_frame.cache()
         elif isinstance(storage_level, StorageLevel):
-            self._cached = internal._sdf.persist(storage_level)
+            self._cached = internal.spark_frame.persist(storage_level)
         else:
             raise TypeError(
                 "Only a valid pyspark.StorageLevel type is acceptable for the `storage_level`"

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -1139,7 +1139,9 @@ class GroupBy(object):
                 if label not in self._column_labels_to_exlcude
             ]
 
-        data_schema = kdf[agg_columns]._internal.applied.spark_frame.drop(*HIDDEN_COLUMNS).schema
+        data_schema = (
+            kdf[agg_columns]._internal.resolved_copy.spark_frame.drop(*HIDDEN_COLUMNS).schema
+        )
 
         kdf, groupkey_labels, groupkey_names = GroupBy._prepare_group_map_apply(
             kdf, self._groupkeys, agg_columns
@@ -1181,7 +1183,7 @@ class GroupBy(object):
         ]
         kdf = kdf[[s.rename(label) for s, label in zip(groupkeys, groupkey_labels)] + agg_columns]
         groupkey_names = [label if len(label) > 1 else label[0] for label in groupkey_labels]
-        return DataFrame(kdf._internal.applied), groupkey_labels, groupkey_names
+        return DataFrame(kdf._internal.resolved_copy), groupkey_labels, groupkey_names
 
     @staticmethod
     def _spark_group_map_apply(kdf, func, groupkeys_scols, return_schema, retain_index):

--- a/databricks/koalas/indexing.py
+++ b/databricks/koalas/indexing.py
@@ -374,7 +374,7 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
 
     def __getitem__(self, key):
         from databricks.koalas.frame import DataFrame
-        from databricks.koalas.series import Series
+        from databricks.koalas.series import Series, first_series
 
         if self._is_series:
             if isinstance(key, Series) and not same_anchor(key, self._kdf_or_kser):
@@ -444,21 +444,19 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
             column_label_names = None
 
         try:
-            sdf = self._internal._sdf
+            sdf = self._internal.spark_frame
+
             if cond is not None:
-                sdf = sdf.drop(NATURAL_ORDER_COLUMN_NAME).filter(cond)
+                data_columns = sdf.select(data_spark_columns).columns
+                sdf = sdf.select(index_scols + data_spark_columns).filter(cond)
+                data_spark_columns = [scol_for(sdf, col) for col in data_columns]
+
             if limit is not None:
                 if limit >= 0:
                     sdf = sdf.limit(limit)
                 else:
                     sdf = sdf.limit(sdf.count() + limit)
-
-            data_columns = sdf.select(data_spark_columns).columns
-
-            if cond is None:
-                sdf = sdf.select(index_scols + data_spark_columns + [NATURAL_ORDER_COLUMN_NAME])
-            else:
-                sdf = sdf.select(index_scols + data_spark_columns)
+                sdf = sdf.drop(NATURAL_ORDER_COLUMN_NAME)
         except AnalysisException:
             raise KeyError(
                 "[{}] don't exist in columns".format(
@@ -470,15 +468,13 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
             spark_frame=sdf,
             index_map=index_map,
             column_labels=column_labels,
-            data_spark_columns=[scol_for(sdf, col) for col in data_columns],
+            data_spark_columns=data_spark_columns,
             column_label_names=column_label_names,
         )
         kdf = DataFrame(internal)
 
         if returns_series:
-            kdf_or_kser = Series(
-                kdf._internal.copy(spark_column=kdf._internal.data_spark_columns[0]), anchor=kdf
-            )
+            kdf_or_kser = first_series(kdf)
         else:
             kdf_or_kser = kdf
 
@@ -1512,6 +1508,10 @@ class iLocIndexer(LocIndexerLike):
             self._kdf_or_kser._kdf = kser._kdf
         else:
             assert self._is_df
+            internal = self._kdf_or_kser._internal
+            self._kdf_or_kser._internal = internal.with_new_sdf(
+                internal.spark_frame.select(internal.spark_columns)
+            )
 
         # Clean up implicitly cached properties to be able to reuse the indexer.
         del self._internal

--- a/databricks/koalas/internal.py
+++ b/databricks/koalas/internal.py
@@ -698,7 +698,7 @@ class InternalFrame(object):
         index_spark_columns = self.index_spark_columns
         return index_spark_columns + [
             spark_column
-            for label, spark_column in zip(self.column_labels, self.data_spark_columns)
+            for spark_column in self.data_spark_columns
             if all(not spark_column._jc.equals(scol._jc) for scol in index_spark_columns)
         ]
 
@@ -793,12 +793,26 @@ class InternalFrame(object):
             ]
         return pdf
 
+    @lazy_property
+    def applied(self):
+        """ Copy the immutable InternalFrame with the updates applied. """
+        sdf = self.spark_frame.select(self.spark_columns + list(HIDDEN_COLUMNS))
+        if self.spark_column is None:
+            return self.copy(
+                spark_frame=sdf,
+                data_spark_columns=[scol_for(sdf, col) for col in self.data_spark_column_names],
+            )
+        else:
+            return self.copy(
+                spark_frame=sdf, spark_column=scol_for(sdf, self.data_spark_column_names[0])
+            )
+
     def with_new_sdf(
-        self, sdf: spark.DataFrame, data_columns: Optional[List[str]] = None
+        self, spark_frame: spark.DataFrame, data_columns: Optional[List[str]] = None
     ) -> "InternalFrame":
         """ Copy the immutable _InternalFrame with the updates by the specified Spark DataFrame.
 
-        :param sdf: the new Spark DataFrame
+        :param spark_frame: the new Spark DataFrame
         :param data_columns: the new column names.
             If None, the original one is used.
         :return: the copied _InternalFrame.
@@ -812,7 +826,7 @@ class InternalFrame(object):
                 len(data_columns),
                 len(self.column_labels),
             )
-        sdf = sdf.drop(NATURAL_ORDER_COLUMN_NAME)
+        sdf = spark_frame.drop(NATURAL_ORDER_COLUMN_NAME)
         return self.copy(
             spark_frame=sdf, data_spark_columns=[scol_for(sdf, col) for col in data_columns]
         )
@@ -856,20 +870,19 @@ class InternalFrame(object):
             )
 
         data_spark_columns = []
-        for scol_or_kser, label in zip(scols_or_ksers, column_labels):
+        for scol_or_kser in scols_or_ksers:
             if isinstance(scol_or_kser, Series):
                 scol = scol_or_kser._internal.spark_column
             else:
                 scol = scol_or_kser
             data_spark_columns.append(scol)
 
-        hidden_columns = []
-        if keep_order:
-            hidden_columns.append(NATURAL_ORDER_COLUMN_NAME)
-
-        sdf = self.spark_frame.select(
-            self.index_spark_columns + data_spark_columns + hidden_columns
-        )
+        sdf = self.spark_frame
+        if not keep_order:
+            sdf = self.spark_frame.select(self.index_spark_columns + data_spark_columns)
+            data_spark_columns = [
+                scol_for(sdf, col) for col in self.spark_frame.select(data_spark_columns).columns
+            ]
 
         if column_label_names is _NoValue:
             column_label_names = self._column_label_names
@@ -877,9 +890,7 @@ class InternalFrame(object):
         return self.copy(
             spark_frame=sdf,
             column_labels=column_labels,
-            data_spark_columns=[
-                scol_for(sdf, col) for col in self.spark_frame.select(data_spark_columns).columns
-            ],
+            data_spark_columns=data_spark_columns,
             column_label_names=column_label_names,
             spark_column=None,
         )
@@ -899,7 +910,13 @@ class InternalFrame(object):
             spark_type = self.spark_frame.select(pred).schema[0].dataType
             assert isinstance(spark_type, BooleanType), spark_type
 
-        return self.copy(spark_frame=self.spark_frame.drop(NATURAL_ORDER_COLUMN_NAME).filter(pred))
+        sdf = self.spark_frame.select(self.spark_columns).filter(pred)
+        if self.spark_column is None:
+            return self.with_new_sdf(sdf)
+        else:
+            return self.copy(
+                spark_frame=sdf, spark_column=scol_for(sdf, self.data_spark_column_names[0])
+            )
 
     def copy(
         self,

--- a/databricks/koalas/internal.py
+++ b/databricks/koalas/internal.py
@@ -794,8 +794,8 @@ class InternalFrame(object):
         return pdf
 
     @lazy_property
-    def applied(self):
-        """ Copy the immutable InternalFrame with the updates applied. """
+    def resolved_copy(self):
+        """ Copy the immutable InternalFrame with the updates resolved. """
         sdf = self.spark_frame.select(self.spark_columns + list(HIDDEN_COLUMNS))
         if self.spark_column is None:
             return self.copy(

--- a/databricks/koalas/ml.py
+++ b/databricks/koalas/ml.py
@@ -82,7 +82,7 @@ def to_numeric_df(kdf: "ks.DataFrame") -> Tuple[pyspark.sql.DataFrame, List[Tupl
     numeric_column_labels = [
         label for label in kdf._internal.column_labels if kdf[label].dtype in accepted_types
     ]
-    numeric_df = kdf._sdf.select(
+    numeric_df = kdf._internal.spark_frame.select(
         *[kdf._internal.spark_column_for(idx) for idx in numeric_column_labels]
     )
     va = VectorAssembler(inputCols=numeric_df.columns, outputCol=CORRELATION_OUTPUT_COLUMN)

--- a/databricks/koalas/mlflow.py
+++ b/databricks/koalas/mlflow.py
@@ -90,7 +90,9 @@ class PythonModelWrapper(object):
             # However, this is only possible with spark >= 3.0
             # s = F.struct(*data.columns)
             # return_col = self._model_udf(s)
-            column_labels = [(col,) for col in data._sdf.select(return_col).columns]
+            column_labels = [
+                (col,) for col in data._internal.spark_frame.select(return_col).columns
+            ]
             return Series(
                 data._internal.copy(spark_column=return_col, column_labels=column_labels),
                 anchor=data,

--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -1580,7 +1580,8 @@ def get_dummies(
         prefix = [prefix[column_label[0]] for column_label in column_labels]
 
     all_values = _reduce_spark_multi(
-        kdf._sdf, [F.collect_set(kdf._internal.spark_column_for(label)) for label in column_labels]
+        kdf._internal.spark_frame,
+        [F.collect_set(kdf._internal.spark_column_for(label)) for label in column_labels],
     )
     for i, label in enumerate(column_labels):
         values = sorted(all_values[i])
@@ -1860,7 +1861,6 @@ def concat(objs, axis=0, join="outer", ignore_index=False):
     ):
         # If all columns are in the same order and values, use it.
         kdfs = objs
-        merged_columns = column_labelses_of_kdfs[0]
     else:
         if join == "inner":
             interested_columns = set.intersection(*map(set, column_labelses_of_kdfs))
@@ -1886,7 +1886,7 @@ def concat(objs, axis=0, join="outer", ignore_index=False):
                 columns_to_add = list(set(merged_columns) - set(kdf._internal.column_labels))
 
                 # TODO: NaN and None difference for missing values. pandas seems filling NaN.
-                sdf = kdf._sdf
+                sdf = kdf._internal.applied.spark_frame
                 for label in columns_to_add:
                     sdf = sdf.withColumn(name_like_string(label), F.lit(None))
 
@@ -1906,10 +1906,12 @@ def concat(objs, axis=0, join="outer", ignore_index=False):
             raise ValueError("Only can inner (intersect) or outer (union) join the other axis.")
 
     if ignore_index:
-        sdfs = [kdf._sdf.select(kdf._internal.data_spark_columns) for kdf in kdfs]
+        sdfs = [kdf._internal.spark_frame.select(kdf._internal.data_spark_columns) for kdf in kdfs]
     else:
         sdfs = [
-            kdf._sdf.select(kdf._internal.index_spark_columns + kdf._internal.data_spark_columns)
+            kdf._internal.spark_frame.select(
+                kdf._internal.index_spark_columns + kdf._internal.data_spark_columns
+            )
             for kdf in kdfs
         ]
     concatenated = reduce(lambda x, y: x.union(y), sdfs)
@@ -2332,7 +2334,7 @@ def broadcast(obj):
     """
     if not isinstance(obj, DataFrame):
         raise ValueError("Invalid type : expected DataFrame got {}".format(type(obj)))
-    return DataFrame(obj._internal.with_new_sdf(F.broadcast(obj._sdf)))
+    return DataFrame(obj._internal.with_new_sdf(F.broadcast(obj._internal.applied.spark_frame)))
 
 
 def _get_index_map(sdf: spark.DataFrame, index_col: Optional[Union[str, List[str]]] = None):

--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -1886,7 +1886,7 @@ def concat(objs, axis=0, join="outer", ignore_index=False):
                 columns_to_add = list(set(merged_columns) - set(kdf._internal.column_labels))
 
                 # TODO: NaN and None difference for missing values. pandas seems filling NaN.
-                sdf = kdf._internal.applied.spark_frame
+                sdf = kdf._internal.resolved_copy.spark_frame
                 for label in columns_to_add:
                     sdf = sdf.withColumn(name_like_string(label), F.lit(None))
 
@@ -2334,7 +2334,9 @@ def broadcast(obj):
     """
     if not isinstance(obj, DataFrame):
         raise ValueError("Invalid type : expected DataFrame got {}".format(type(obj)))
-    return DataFrame(obj._internal.with_new_sdf(F.broadcast(obj._internal.applied.spark_frame)))
+    return DataFrame(
+        obj._internal.with_new_sdf(F.broadcast(obj._internal.resolved_copy.spark_frame))
+    )
 
 
 def _get_index_map(sdf: spark.DataFrame, index_col: Optional[Union[str, List[str]]] = None):

--- a/databricks/koalas/plot.py
+++ b/databricks/koalas/plot.py
@@ -110,7 +110,7 @@ class SampledPlot:
         if isinstance(data, (DataFrame, Series)):
             if isinstance(data, Series):
                 data = data.to_frame()
-            sampled = data._internal.applied.spark_frame.sample(fraction=self.fraction)
+            sampled = data._internal.resolved_copy.spark_frame.sample(fraction=self.fraction)
             return DataFrame(data._internal.with_new_sdf(sampled)).to_pandas()
         else:
             raise ValueError("Only DataFrame and Series are supported for plotting.")
@@ -423,7 +423,7 @@ class KoalasBoxPlot(BoxPlot):
     @staticmethod
     def _compute_stats(data, colname, whis, precision):
         # Computes mean, median, Q1 and Q3 with approx_percentile and precision
-        pdf = data._kdf._internal.applied.spark_frame.agg(
+        pdf = data._kdf._internal.resolved_copy.spark_frame.agg(
             *[
                 F.expr(
                     "approx_percentile({}, {}, {})".format(colname, q, int(1.0 / precision))
@@ -460,7 +460,7 @@ class KoalasBoxPlot(BoxPlot):
         # Builds expression to identify outliers
         expression = F.col(colname).between(lfence, ufence)
         # Creates a column to flag rows as outliers or not
-        return data._kdf._internal.applied.spark_frame.withColumn(
+        return data._kdf._internal.resolved_copy.spark_frame.withColumn(
             "__{}_outlier".format(colname), ~expression
         )
 

--- a/databricks/koalas/plot.py
+++ b/databricks/koalas/plot.py
@@ -110,7 +110,7 @@ class SampledPlot:
         if isinstance(data, (DataFrame, Series)):
             if isinstance(data, Series):
                 data = data.to_frame()
-            sampled = data._sdf.sample(fraction=self.fraction)
+            sampled = data._internal.applied.spark_frame.sample(fraction=self.fraction)
             return DataFrame(data._internal.with_new_sdf(sampled)).to_pandas()
         else:
             raise ValueError("Only DataFrame and Series are supported for plotting.")
@@ -423,7 +423,7 @@ class KoalasBoxPlot(BoxPlot):
     @staticmethod
     def _compute_stats(data, colname, whis, precision):
         # Computes mean, median, Q1 and Q3 with approx_percentile and precision
-        pdf = data._kdf._sdf.agg(
+        pdf = data._kdf._internal.applied.spark_frame.agg(
             *[
                 F.expr(
                     "approx_percentile({}, {}, {})".format(colname, q, int(1.0 / precision))
@@ -460,7 +460,9 @@ class KoalasBoxPlot(BoxPlot):
         # Builds expression to identify outliers
         expression = F.col(colname).between(lfence, ufence)
         # Creates a column to flag rows as outliers or not
-        return data._kdf._sdf.withColumn("__{}_outlier".format(colname), ~expression)
+        return data._kdf._internal.applied.spark_frame.withColumn(
+            "__{}_outlier".format(colname), ~expression
+        )
 
     @staticmethod
     def _calc_whiskers(colname, outliers):
@@ -525,7 +527,7 @@ class KoalasHistPlot(HistPlot):
         colors = self._get_colors(num_colors=1)
         stacking_id = self._get_stacking_id()
 
-        sdf = self.data._sdf
+        sdf = self.data._internal.spark_frame
 
         for i, label in enumerate(self.data._internal.column_labels):
             # 'y' is a Spark DataFrame that selects one column.
@@ -685,7 +687,7 @@ class KoalasKdePlot(KdePlot):
         colors = self._get_colors(num_colors=1)
         stacking_id = self._get_stacking_id()
 
-        sdf = self.data._sdf
+        sdf = self.data._internal.spark_frame
 
         for i, label in enumerate(self.data._internal.column_labels):
             # 'y' is a Spark DataFrame that selects one column.

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -4187,7 +4187,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         index_scol_names = [index_map[0] for index_map in self._internal.index_map.items()]
         combined = combine_frames(self.to_frame(), other.to_frame(), how="leftouter")
-        combined_sdf = combined._internal.applied.spark_frame
+        combined_sdf = combined._internal.resolved_copy.spark_frame
         this_col = "__this_%s" % str(
             self._internal.spark_column_name_for(self._internal.column_labels[0])
         )

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -1100,7 +1100,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         #
         # This workaround is in order to calculate the distinct count including nulls in
         # single pass. Note that COUNT(DISTINCT expr) in Spark is designed to ignore nulls.
-        return self._internal._sdf.select(
+        return self._internal.spark_frame.select(
             (F.count(scol) == F.countDistinct(scol))
             & (F.count(F.when(scol.isNull(), 1).otherwise(None)) <= 1)
         ).collect()[0][0]
@@ -2251,8 +2251,10 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         sdf = internal.spark_frame
         sdf = sdf.select(
             [
-                F.concat(F.lit(prefix), scol_for(sdf, index_column)).alias(index_column)
-                for index_column in internal.index_spark_column_names
+                F.concat(F.lit(prefix), index_spark_column).alias(index_spark_column_name)
+                for index_spark_column, index_spark_column_name in zip(
+                    internal.index_spark_columns, internal.index_spark_column_names
+                )
             ]
             + internal.data_spark_columns
         )
@@ -2305,8 +2307,10 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         sdf = internal.spark_frame
         sdf = sdf.select(
             [
-                F.concat(scol_for(sdf, index_column), F.lit(suffix)).alias(index_column)
-                for index_column in internal.index_spark_column_names
+                F.concat(index_spark_column, F.lit(suffix)).alias(index_spark_column_name)
+                for index_spark_column, index_spark_column_name in zip(
+                    internal.index_spark_columns, internal.index_spark_column_names
+                )
             ]
             + internal.data_spark_columns
         )
@@ -3588,7 +3592,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         >>> s.idxmin()
         10
         """
-        sdf = self._internal._sdf
+        sdf = self._internal.spark_frame
         scol = self.spark.column
         index_scols = self._internal.index_spark_columns
         # asc_nulls_(last|first)is used via Py4J directly because
@@ -4183,7 +4187,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         index_scol_names = [index_map[0] for index_map in self._internal.index_map.items()]
         combined = combine_frames(self.to_frame(), other.to_frame(), how="leftouter")
-        combined_sdf = combined._sdf
+        combined_sdf = combined._internal.applied.spark_frame
         this_col = "__this_%s" % str(
             self._internal.spark_column_name_for(self._internal.column_labels[0])
         )
@@ -4779,10 +4783,9 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         if not is_list_like(where):
             should_return_series = False
             where = [where]
-        sdf = self._internal._sdf
         index_scol = self._internal.index_spark_columns[0]
         cond = [F.max(F.when(index_scol <= index, self.spark.column)) for index in where]
-        sdf = sdf.select(cond)
+        sdf = self._internal.spark_frame.select(cond)
         if not should_return_series:
             result = sdf.head()[0]
             return result if result is not None else np.nan

--- a/databricks/koalas/spark/accessors.py
+++ b/databricks/koalas/spark/accessors.py
@@ -443,6 +443,7 @@ class SparkFrameMethods(object):
         """
         from databricks.koalas.frame import CachedDataFrame
 
+        self._kdf._internal = self._kdf._internal.applied
         return CachedDataFrame(self._kdf._internal)
 
     def persist(self, storage_level=StorageLevel.MEMORY_AND_DISK):
@@ -552,7 +553,11 @@ class SparkFrameMethods(object):
         """
         from databricks.koalas.frame import DataFrame
 
-        return DataFrame(self._kdf._internal.with_new_sdf(self._kdf._sdf.hint(name, *parameters)))
+        return DataFrame(
+            self._kdf._internal.with_new_sdf(
+                self._kdf._internal.spark_frame.hint(name, *parameters)
+            )
+        )
 
     def to_table(
         self,

--- a/databricks/koalas/spark/accessors.py
+++ b/databricks/koalas/spark/accessors.py
@@ -443,7 +443,7 @@ class SparkFrameMethods(object):
         """
         from databricks.koalas.frame import CachedDataFrame
 
-        self._kdf._internal = self._kdf._internal.applied
+        self._kdf._internal = self._kdf._internal.resolved_copy
         return CachedDataFrame(self._kdf._internal)
 
     def persist(self, storage_level=StorageLevel.MEMORY_AND_DISK):

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -541,7 +541,8 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
     def test_dot_in_column_name(self):
         self.assert_eq(
-            ks.DataFrame(ks.range(1)._sdf.selectExpr("1 as `a.b`"))["a.b"], ks.Series([1])
+            ks.DataFrame(ks.range(1)._internal.spark_frame.selectExpr("1 as `a.b`"))["a.b"],
+            ks.Series([1]),
         )
 
     def test_drop(self):

--- a/databricks/koalas/utils.py
+++ b/databricks/koalas/utils.py
@@ -103,8 +103,8 @@ def combine_frames(this, *args, how="full", preserve_order_column=False):
         # level.
         this_and_that_index_map = zip(this_index_map.items(), that_index_map.items())
 
-        this_sdf = this._internal.applied.spark_frame.alias("this")
-        that_sdf = that._internal.applied.spark_frame.alias("that")
+        this_sdf = this._internal.resolved_copy.spark_frame.alias("this")
+        that_sdf = that._internal.resolved_copy.spark_frame.alias("that")
 
         # If the same named index is found, that's used.
         for (this_column, this_name), (that_column, that_name) in this_and_that_index_map:
@@ -563,7 +563,7 @@ def verify_temp_column_name(
     ...
     AssertionError: ... should be empty or start and end with `__`: ('', 'dummy')
 
-    >>> internal = kdf._internal.applied
+    >>> internal = kdf._internal.resolved_copy
     >>> sdf = internal.spark_frame
     >>> sdf.select(internal.data_spark_columns).show()  # doctest: +NORMALIZE_WHITESPACE
     +------+---------+-------------+
@@ -611,7 +611,7 @@ def verify_temp_column_name(
         ), "The given column name `{}` already exists in the Koalas DataFrame: {}".format(
             name_like_string(column_name_or_label), df.columns
         )
-        df = df._internal.applied.spark_frame
+        df = df._internal.resolved_copy.spark_frame
     else:
         assert isinstance(column_name_or_label, str), type(column_name_or_label)
         assert column_name_or_label.startswith("__") and column_name_or_label.endswith(

--- a/databricks/koalas/utils.py
+++ b/databricks/koalas/utils.py
@@ -103,13 +103,16 @@ def combine_frames(this, *args, how="full", preserve_order_column=False):
         # level.
         this_and_that_index_map = zip(this_index_map.items(), that_index_map.items())
 
+        this_sdf = this._internal.applied.spark_frame.alias("this")
+        that_sdf = that._internal.applied.spark_frame.alias("that")
+
         # If the same named index is found, that's used.
         for (this_column, this_name), (that_column, that_name) in this_and_that_index_map:
             if this_name == that_name:
                 # We should merge the Spark columns into one
                 # to mimic pandas' behavior.
-                this_scol = scol_for(this._sdf, this_column)
-                that_scol = scol_for(that._sdf, that_column)
+                this_scol = scol_for(this_sdf, this_column)
+                that_scol = scol_for(that_sdf, that_column)
                 join_scol = this_scol == that_scol
                 join_scols.append(join_scol)
                 merged_index_scols.append(
@@ -120,23 +123,23 @@ def combine_frames(this, *args, how="full", preserve_order_column=False):
 
         assert len(join_scols) > 0, "cannot join with no overlapping index names"
 
-        joined_df = this._sdf.alias("this").join(that._sdf.alias("that"), on=join_scols, how=how)
+        joined_df = this_sdf.join(that_sdf, on=join_scols, how=how)
 
         if preserve_order_column:
-            order_column = [scol_for(this._sdf, NATURAL_ORDER_COLUMN_NAME)]
+            order_column = [scol_for(this_sdf, NATURAL_ORDER_COLUMN_NAME)]
         else:
             order_column = []
 
         joined_df = joined_df.select(
             merged_index_scols
             + [
-                this[label].spark.column.alias(
+                scol_for(this_sdf, this._internal.spark_column_name_for(label)).alias(
                     "__this_%s" % this._internal.spark_column_name_for(label)
                 )
                 for label in this._internal.column_labels
             ]
             + [
-                that[label].spark.column.alias(
+                scol_for(that_sdf, that._internal.spark_column_name_for(label)).alias(
                     "__that_%s" % that._internal.spark_column_name_for(label)
                 )
                 for label in that._internal.column_labels
@@ -560,8 +563,9 @@ def verify_temp_column_name(
     ...
     AssertionError: ... should be empty or start and end with `__`: ('', 'dummy')
 
-    >>> sdf = kdf._internal.spark_frame
-    >>> sdf.select(kdf._internal.data_spark_columns).show()  # doctest: +NORMALIZE_WHITESPACE
+    >>> internal = kdf._internal.applied
+    >>> sdf = internal.spark_frame
+    >>> sdf.select(internal.data_spark_columns).show()  # doctest: +NORMALIZE_WHITESPACE
     +------+---------+-------------+
     |(x, a)|__dummy__|(, __dummy__)|
     +------+---------+-------------+
@@ -607,7 +611,7 @@ def verify_temp_column_name(
         ), "The given column name `{}` already exists in the Koalas DataFrame: {}".format(
             name_like_string(column_name_or_label), df.columns
         )
-        df = df._internal.spark_frame
+        df = df._internal.applied.spark_frame
     else:
         assert isinstance(column_name_or_label, str), type(column_name_or_label)
         assert column_name_or_label.startswith("__") and column_name_or_label.endswith(


### PR DESCRIPTION
This PR makes huge changes on the way of `InternalFrame` management to avoid creating very many Spark DataFrames.
It will make a lot of DataFrame operations without enabling "compute.ops_on_diff_frames" option possible.

```py
df + df + df
df['foo'] = df['bar']['baz']
df[['x', 'y']] = df[['x', 'y']].fillna(0)
```

The new way in functions to manage `InternalFrame` is:

- If the function only needs to handle Spark columns, e.g., functions using `InternalFrame. with_new_columns`, use the new columns without creating new Spark DataFrame. Basically we can just use the `with_new_columns` to create a new `InternalFrame`.
- If the function needs to create a new Spark DataFrame, e.g., functions need filter, order, groupby, use `_internal.spark_frame` with columns from `_internal.spark_column_for`. Working with a Spark DataFrame from `_internal.spark_frame` and column names from `_internal.spark_column_name_for` will usually NOT work.
- If the function can only access by the column name, e.g., `pivot_table` or functions with udfs, use `_internal.applied.spark_frame` instead. The `_internal.applied.spark_frame` will be applied all the changes. Note that the `_internal.applied.spark_frame` won't work with Spark columns from `_internal.spark_column_for`.
- `DataFrame._sdf` was removed to explicitly specify which `spark_frame` should be used, `_internal.spark_frame` or `_internal.applied.spark_frame`.
