### PR TITLE
pandas 1.0.3 -> 1.0.4 for CI

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -102,7 +102,7 @@ jobs:
             pyarrow-version: 0.14.1
           - python-version: 3.7
             spark-version: 2.4.5
-            pandas-version: 1.0.3
+            pandas-version: 1.0.4
             pyarrow-version: 0.15.1
     env:
       PYTHON_VERSION: ${{ matrix.python-version }}


### PR DESCRIPTION
Because new version of pandas (1.0.4) was released on May 28, also bumped up our test version of pandas to the latest one.