### PR TITLE
Reflect renaming of configuration spark.sql.analyzer.failAmbiguousSelfJoin

### DIFF
--- a/databricks/koalas/utils.py
+++ b/databricks/koalas/utils.py
@@ -354,7 +354,7 @@ def default_session(conf=None):
         builder = builder.config(key, value)
     # Currently, Koalas is dependent on such join due to 'compute.ops_on_diff_frames'
     # configuration. This is needed with Spark 3.0+.
-    builder.config("spark.sql.analyzer.failAmbiguousSelfJoin.enabled", False)
+    builder.config("spark.sql.analyzer.failAmbiguousSelfJoin", False)
     session = builder.getOrCreate()
 
     if not should_use_legacy_ipc:


### PR DESCRIPTION
It was renamed at https://github.com/apache/spark/commit/68d7edf9497bea2f73707d32ab55dd8e53088e7c