### PR TITLE
Implement __abs__ in Series, Index and DataFrame

### DIFF
--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -278,6 +278,7 @@ class IndexOpsMixin(object):
 
     __pow__ = column_op(Column.__pow__)
     __rpow__ = column_op(Column.__rpow__)
+    __abs__ = column_op(F.abs)
 
     # comparison operators
     __eq__ = column_op(Column.__eq__)

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -292,7 +292,7 @@ T = TypeVar("T")
 
 
 if (3, 5) <= sys.version_info < (3, 7):
-    from typing import GenericMeta
+    from typing import GenericMeta  # type: ignore
 
     # This is a workaround to support variadic generic in DataFrame in Python 3.5+.
     # See https://github.com/python/typing/issues/193

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -687,6 +687,9 @@ class DataFrame(Frame, Generic[T]):
     def __rfloordiv__(self, other):
         return self._map_series_op("rfloordiv", other)
 
+    def __abs__(self):
+        return self._apply_series_op(lambda kser: abs(kser))
+
     def add(self, other):
         return self + other
 

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -1972,6 +1972,9 @@ class MultiIndex(Index):
         )
         IndexOpsMixin.__init__(self, internal, kdf)
 
+    def __abs__(self):
+        raise TypeError("TypeError: cannot perform __abs__ with this index type: MultiIndex")
+
     def _with_new_scol(self, scol: spark.Column):
         raise NotImplementedError("Not supported for type MultiIndex")
 

--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -90,7 +90,7 @@ __all__ = [
 def from_pandas(
     pobj: Union["pd.DataFrame", "pd.Series", "pd.Index"]
 ) -> Union["Series", "DataFrame", "Index"]:
-    """Create a Koalas DataFrame or Series from a pandas DataFrame or Series.
+    """Create a Koalas DataFrame, Series or Index from a pandas DataFrame, Series or Index.
 
     This is similar to Spark's `SparkSession.createDataFrame()` with pandas DataFrame,
     but this also works with pandas Series and picks the index.

--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -55,6 +55,7 @@ from databricks.koalas.utils import (
 from databricks.koalas.frame import DataFrame, _reduce_spark_multi
 from databricks.koalas.internal import InternalFrame
 from databricks.koalas.series import Series, first_series
+from databricks.koalas.indexes import Index
 
 
 __all__ = [
@@ -86,7 +87,9 @@ __all__ = [
 ]
 
 
-def from_pandas(pobj: Union["pd.DataFrame", "pd.Series"]) -> Union["Series", "DataFrame"]:
+def from_pandas(
+    pobj: Union["pd.DataFrame", "pd.Series", "pd.Index"]
+) -> Union["Series", "DataFrame", "Index"]:
     """Create a Koalas DataFrame or Series from a pandas DataFrame or Series.
 
     This is similar to Spark's `SparkSession.createDataFrame()` with pandas DataFrame,

--- a/databricks/koalas/numpy_compat.py
+++ b/databricks/koalas/numpy_compat.py
@@ -138,7 +138,7 @@ def maybe_dispatch_ufunc_to_dunder_op(
         "matmul",
     }
     aliases = {
-        "absolute": "abs",  # TODO: Koalas Series and Index should implement __abs__.
+        "absolute": "abs",
         "multiply": "mul",
         "floor_divide": "floordiv",
         "true_divide": "truediv",

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -3645,3 +3645,10 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         self.assert_eq(kdf.mad(), pdf.mad())
         self.assert_eq(kdf.mad(axis=1), pdf.mad(axis=1))
+
+    def test_abs(self):
+        pdf = pd.DataFrame({"a": [-2, -1, 0, 1]})
+        kdf = ks.from_pandas(pdf)
+
+        self.assert_eq(abs(kdf), abs(pdf))
+        self.assert_eq(np.abs(kdf), np.abs(pdf))

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -1312,9 +1312,8 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
             self.assertEqual(output, kdf.index._get_level_number(lv))
 
     def test_abs(self):
-        pdf = pd.DataFrame({"a": [-2, -1, 0, 1]}, index=[-2, -1, 0, 1])
-        pidx = pdf.index
-        kidx = ks.from_pandas(pdf).index
+        pidx = pd.Index([-2, -1, 0, 1])
+        kidx = ks.from_pandas(pidx)
 
         self.assert_eq(abs(pidx), abs(kidx))
         self.assert_eq(np.abs(pidx), np.abs(kidx))

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -1318,6 +1318,6 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         self.assert_eq(abs(pidx), abs(kidx))
         self.assert_eq(np.abs(pidx), np.abs(kidx))
 
-        kidx = ks.from_pandas(pd.MultiIndex.from_tuples([(1, 2)], names=["level1", "level2"]))
+        kidx = ks.MultiIndex.from_tuples([(1, 2)], names=["level1", "level2"])
         with self.assertRaisesRegexp(TypeError, "perform __abs__ with this index"):
             abs(kidx)

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -1310,3 +1310,15 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
 
         for lv, output in zip(level_names, outputs):
             self.assertEqual(output, kdf.index._get_level_number(lv))
+
+    def test_abs(self):
+        pdf = pd.DataFrame({"a": [-2, -1, 0, 1]}, index=[-2, -1, 0, 1])
+        pidx = pdf.index
+        kidx = ks.from_pandas(pdf).index
+
+        self.assert_eq(abs(pidx), abs(kidx))
+        self.assert_eq(np.abs(pidx), np.abs(kidx))
+
+        kidx = ks.from_pandas(pd.MultiIndex.from_tuples([(1, 2)], names=["level1", "level2"]))
+        with self.assertRaisesRegexp(TypeError, "perform __abs__ with this index"):
+            abs(kidx)

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -1658,3 +1658,10 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
 
         with self.assertRaisesRegex(ValueError, "The item should not be empty."):
             kser.filter(items=[(), ("three", "z")])
+
+    def test_abs(self):
+        pser = pd.Series([-2, -1, 0, 1])
+        kser = ks.from_pandas(pser)
+
+        self.assert_eq(abs(kser), abs(pser))
+        self.assert_eq(np.abs(kser), np.abs(pser))


### PR DESCRIPTION
This PR implements `__abs__` in Koalas Series, Index and DataFrame.

Pandas:

```python
>>> import pandas as pd
>>> abs(pd.Series([-1, -2, -3]))
0    1
1    2
2    3
dtype: int64
>>> import numpy as np
>>> np.abs(pd.Series([-1, -2, -3]))
0    1
1    2
2    3
dtype: int64
```

Koalas:

```python
>>> from databricks import koalas as ks
>>> abs(ks.Series([-1, -2, -3]))
0    1
1    2
2    3
Name: 0, dtype: int64
>>> import numpy as np
>>> np.abs(ks.Series([-1, -2, -3]))
0    1
1    2
2    3
Name: 0, dtype: int64
```