### PR TITLE
Cache an internal pandas object to avoid run twice in Jupyter.

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -10220,12 +10220,22 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         """
         return self._internal.to_pandas_frame
 
+    def _get_or_create_repr_pandas_cache(self, n):
+        if (
+            not hasattr(self, "_repr_pandas_cache")
+            or (id(self._internal), n) not in self._repr_pandas_cache
+        ):
+            self._repr_pandas_cache = {
+                (id(self._internal), n): self.head(n + 1)._to_internal_pandas()
+            }
+        return self._repr_pandas_cache[(id(self._internal), n)]
+
     def __repr__(self):
         max_display_count = get_option("display.max_rows")
         if max_display_count is None:
             return self._to_internal_pandas().to_string()
 
-        pdf = self.head(max_display_count + 1)._to_internal_pandas()
+        pdf = self._get_or_create_repr_pandas_cache(max_display_count)
         pdf_length = len(pdf)
         pdf = pdf.iloc[:max_display_count]
         if pdf_length > max_display_count:
@@ -10248,7 +10258,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         if max_display_count is None:
             return self._to_internal_pandas().to_html(notebook=True, bold_rows=bold_rows)
 
-        pdf = self.head(max_display_count + 1)._to_internal_pandas()
+        pdf = self._get_or_create_repr_pandas_cache(max_display_count)
         pdf_length = len(pdf)
         pdf = pdf.iloc[:max_display_count]
         if pdf_length > max_display_count:

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -2695,12 +2695,22 @@ class MultiIndex(Index):
         )
         return ks.DataFrame(internal).index
 
+    def _get_or_create_repr_pandas_cache(self, n):
+        if (
+                not hasattr(self, "_repr_pandas_cache")
+                or (id(self._internal), n) not in self._repr_pandas_cache
+        ):
+            self._repr_pandas_cache = {
+                (id(self._internal), n): self._kdf.head(n + 1).index.to_pandas()
+            }
+        return self._repr_pandas_cache[(id(self._internal), n)]
+
     def __repr__(self):
         max_display_count = get_option("display.max_rows")
         if max_display_count is None:
             return repr(self.to_pandas())
 
-        pindex = self._kdf.head(max_display_count + 1).index.to_pandas()
+        pindex = self._get_or_create_repr_pandas_cache(max_display_count)
 
         pindex_length = len(pindex)
         repr_string = repr(pindex[:max_display_count])

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -2697,8 +2697,8 @@ class MultiIndex(Index):
 
     def _get_or_create_repr_pandas_cache(self, n):
         if (
-                not hasattr(self, "_repr_pandas_cache")
-                or (id(self._internal), n) not in self._repr_pandas_cache
+            not hasattr(self, "_repr_pandas_cache")
+            or (id(self._internal), n) not in self._repr_pandas_cache
         ):
             self._repr_pandas_cache = {
                 (id(self._internal), n): self._kdf.head(n + 1).index.to_pandas()

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -5103,12 +5103,22 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         """
         return first_series(self._internal.to_pandas_frame)
 
+    def _get_or_create_repr_pandas_cache(self, n):
+        if (
+                not hasattr(self, "_repr_pandas_cache")
+                or (id(self._internal), n) not in self._repr_pandas_cache
+        ):
+            self._repr_pandas_cache = {
+                (id(self._internal), n): self.head(n + 1)._to_internal_pandas()
+            }
+        return self._repr_pandas_cache[(id(self._internal), n)]
+
     def __repr__(self):
         max_display_count = get_option("display.max_rows")
         if max_display_count is None:
             return self._to_internal_pandas().to_string(name=self.name, dtype=self.dtype)
 
-        pser = self.head(max_display_count + 1)._to_internal_pandas()
+        pser = self._get_or_create_repr_pandas_cache(max_display_count)
         pser_length = len(pser)
         pser = pser.iloc[:max_display_count]
         if pser_length > max_display_count:

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -5105,8 +5105,8 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
     def _get_or_create_repr_pandas_cache(self, n):
         if (
-                not hasattr(self, "_repr_pandas_cache")
-                or (id(self._internal), n) not in self._repr_pandas_cache
+            not hasattr(self, "_repr_pandas_cache")
+            or (id(self._internal), n) not in self._repr_pandas_cache
         ):
             self._repr_pandas_cache = {
                 (id(self._internal), n): self.head(n + 1)._to_internal_pandas()


### PR DESCRIPTION
IPython calls Spark jobs twice due to Notebook calls both `__repr__` and `_repr_html_`.
See https://github.com/ipython/ipython/issues/9771