### PR TITLE
Set upper bound for Sphinx.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,7 @@ numpy>=1.14
 mlflow>=1.0
 
 # Documentation build
-sphinx
+sphinx<3.1.0
 nbsphinx
 numpydoc==0.8
 pypandoc


### PR DESCRIPTION
Setting the upper bound for Sphinx for now to unblock PRs since Sphinx 3.1.0 which was published 5 hours ago causes `lint-python` failure.