### PR TITLE
Fix some legitimate doc errors from the latest Sphinx

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -9103,8 +9103,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         -------
         DataFrame with the renamed axis labels.
 
-        Raises:
-        -------
+        Raises
+        ------
         `KeyError`
             If any of the labels is not found in the selected axis and "errors='raise'".
 

--- a/databricks/koalas/sql.py
+++ b/databricks/koalas/sql.py
@@ -47,13 +47,13 @@ def sql(query: str, globals=None, locals=None, **kwargs) -> DataFrame:
 
     The following variable types are supported:
 
-    - string
-    - int
-    - float
-    - list, tuple, range of above types
-    - Koalas DataFrame
-    - Koalas Series
-    - pandas DataFrame
+        * string
+        * int
+        * float
+        * list, tuple, range of above types
+        * Koalas DataFrame
+        * Koalas Series
+        * pandas DataFrame
 
     Parameters
     ----------


### PR DESCRIPTION
```
/home/runner/miniconda/envs/test-environment/lib/python3.8/site-packages/numpydoc/docscrape.py:377: UserWarning: Unknown section Raises: in the docstring of <function DataFrame.rename at 0x7f381f361e50> in /home/runner/work/koalas/koalas/databricks/koalas/frame.py.
  warn(msg)
/home/runner/miniconda/envs/test-environment/lib/python3.8/site-packages/numpydoc/docscrape.py:377: UserWarning: Unknown section Raises: in the docstring of <function DataFrame.rename at 0x7f381f361e50> in /home/runner/work/koalas/koalas/databricks/koalas/frame.py.
  warn(msg)
/home/runner/miniconda/envs/test-environment/lib/python3.8/site-packages/numpydoc/docscrape.py:377: UserWarning: Unknown section Raises: in the docstring of <function DataFrame.rename at 0x7f381f361e50> in /home/runner/work/koalas/koalas/databricks/koalas/frame.py.
  warn(msg)
```

```
don't know which module to import for autodocumenting 'DataFrame.plot' (try placing a "module" or "currentmodule" directive in the document, or giving an explicit module name)
```

seems a bug in Sphinx so we should still keep the bounds. See also #1570