### PR TITLE
Fix fillna to handle NaN properly.

### DIFF
--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -224,10 +224,12 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         pser = pd.Series([1, 2, 3, 4, 5, 6], name="x")
         kser = ks.from_pandas(pser)
 
-        pser.loc[0] = np.nan
-        kser.loc[0] = np.nan
+        pser.loc[3] = np.nan
+        kser.loc[3] = np.nan
 
         self.assert_eq(kser.fillna(0), pser.fillna(0))
+        self.assert_eq(kser.fillna(method="ffill"), pser.fillna(method="ffill"))
+        self.assert_eq(kser.fillna(method="bfill"), pser.fillna(method="bfill"))
 
     def test_dropna(self):
         pser = pd.Series([np.nan, 2, 3, 4, np.nan, 6], name="x")

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -210,6 +210,7 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         kser = ks.from_pandas(pser)
 
         self.assert_eq(kser.fillna(0), pser.fillna(0))
+        self.assert_eq(kser.fillna(np.nan).fillna(0), pser.fillna(np.nan).fillna(0))
 
         kser.fillna(0, inplace=True)
         pser.fillna(0, inplace=True)
@@ -219,6 +220,14 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         kser.fillna(0, inplace=True)
         pser.fillna(0, inplace=True)
         self.assert_eq(kser, pser)
+
+        pser = pd.Series([1, 2, 3, 4, 5, 6], name="x")
+        kser = ks.from_pandas(pser)
+
+        pser.loc[0] = np.nan
+        kser.loc[0] = np.nan
+
+        self.assert_eq(kser.fillna(0), pser.fillna(0))
 
     def test_dropna(self):
         pser = pd.Series([np.nan, 2, 3, 4, np.nan, 6], name="x")


### PR DESCRIPTION
`Series.fillna` should handle NaN properly.

```py
>>> kser = ks.Series([1, 2, 3, 4, 5, 6], name="x")
>>> kser.loc[0] = np.nan
>>> kser
0    NaN
1    2.0
2    3.0
3    4.0
4    5.0
5    6.0
Name: x, dtype: float64
>>> kser.fillna(0)
0    NaN
1    2.0
2    3.0
3    4.0
4    5.0
5    6.0
Name: x, dtype: float64
```

This should be:

```py
>>> kser.fillna(0)
0    0.0
1    2.0
2    3.0
3    4.0
4    5.0
5    6.0
Name: x, dtype: float64
```