### PR TITLE
Support Series as repeats in Series.repeat.

### DIFF
--- a/databricks/koalas/spark/functions.py
+++ b/databricks/koalas/spark/functions.py
@@ -63,6 +63,20 @@ def percentile_approx(col, percentage, accuracy=10000):
     return _call_udf(sc, "percentile_approx", _to_java_column(col), percentage, accuracy)
 
 
+def array_repeat(col, count):
+    """
+    Collection function: creates an array containing a column repeated count times.
+
+    Ported from Spark 3.0.
+    """
+    sc = SparkContext._active_spark_context
+    return Column(
+        sc._jvm.functions.array_repeat(
+            _to_java_column(col), _to_java_column(count) if isinstance(count, Column) else count
+        )
+    )
+
+
 def _call_udf(sc, name, *cols):
     return Column(sc._jvm.functions.callUDF(name, _make_arguments(sc, *cols)))
 

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -1382,6 +1382,14 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         self.assertRaises(ValueError, lambda: kser.repeat(-1))
         self.assertRaises(ValueError, lambda: kser.repeat("abc"))
 
+        pdf = pd.DataFrame({"a": ["a", "b", "c"], "rep": [10, 20, 30]}, index=np.random.rand(3))
+        kdf = ks.from_pandas(pdf)
+
+        if LooseVersion(pyspark.__version__) < LooseVersion("2.4"):
+            self.assertRaises(ValueError, lambda: kdf.a.repeat(kdf.rep))
+        else:
+            self.assert_eq(kdf.a.repeat(kdf.rep).sort_index(), pdf.a.repeat(pdf.rep).sort_index())
+
     def test_take(self):
         pser = pd.Series([100, 200, 300, 400, 500], name="Koalas")
         kser = ks.from_pandas(pser)


### PR DESCRIPTION
It's good to support `Series` as `repeats` in `Series.repeat()`.

```py
>>> kdf = ks.DataFrame({"a": ["a", "b", "c"], "rep": [1, 2, 3]})
>>> kdf
   a  rep
0  a    1
1  b    2
2  c    3
>>> kdf.a.repeat(kdf.rep)
0    a
1    b
1    b
2    c
2    c
2    c
Name: a, dtype: object
```

As this PR is using a function added since Spark 2.4, it doesn't support Spark 2.3.