### PR TITLE
Rewrite requirements-dev.txt before installing in conda CI.

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -136,11 +136,10 @@ jobs:
         conda activate test-environment
         conda install -c conda-forge --yes codecov
         conda config --env --add pinned_packages python=$PYTHON_VERSION
-        conda config --env --add pinned_packages pandas==$PANDAS_VERSION
-        conda config --env --add pinned_packages pyarrow==$PYARROW_VERSION
         conda config --env --add pinned_packages pyspark==$SPARK_VERSION
-        conda install -c conda-forge --yes pandas==$PANDAS_VERSION pyarrow==$PYARROW_VERSION pyspark==$SPARK_VERSION
-        conda install -c conda-forge --yes --freeze-installed --file requirements-dev.txt
+        conda install -c conda-forge --yes pyspark==$SPARK_VERSION
+        sed -i -e "s/pandas.*/pandas==$PANDAS_VERSION/" -e "s/pyarrow.*/pyarrow==$PYARROW_VERSION/" requirements-dev.txt
+        conda install -c conda-forge --yes --file requirements-dev.txt
         conda list
     - name: Run tests
       run: |
@@ -204,10 +203,8 @@ jobs:
           conda activate test-environment
           conda install -c conda-forge --yes codecov
           conda config --env --add pinned_packages python=$PYTHON_VERSION
-          conda config --env --add pinned_packages pandas==$PANDAS_VERSION
-          conda config --env --add pinned_packages pyarrow==$PYARROW_VERSION
-          conda install -c conda-forge --yes pandas==$PANDAS_VERSION pyarrow==$PYARROW_VERSION
-          conda install -c conda-forge --yes --freeze-installed --file requirements-dev.txt
+          sed -i -e "s/pandas.*/pandas==$PANDAS_VERSION/" -e "s/pyarrow.*/pyarrow==$PYARROW_VERSION/" requirements-dev.txt
+          conda install -c conda-forge --yes --file requirements-dev.txt
           conda list
       - name: Run tests
         run: |

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -136,9 +136,11 @@ jobs:
         conda activate test-environment
         conda install -c conda-forge --yes codecov
         conda config --env --add pinned_packages python=$PYTHON_VERSION
+        conda config --env --add pinned_packages pandas==$PANDAS_VERSION
+        conda config --env --add pinned_packages pyarrow==$PYARROW_VERSION
         conda config --env --add pinned_packages pyspark==$SPARK_VERSION
-        conda install -c conda-forge --yes pyspark==$SPARK_VERSION
-        sed -i -e "s/pandas.*/pandas==$PANDAS_VERSION/" -e "s/pyarrow.*/pyarrow==$PYARROW_VERSION/" requirements-dev.txt
+        conda install -c conda-forge --yes pandas==$PANDAS_VERSION pyarrow==$PYARROW_VERSION pyspark==$SPARK_VERSION
+        sed -i -e "/pandas/d" -e "/pyarrow/d" requirements-dev.txt
         conda install -c conda-forge --yes --file requirements-dev.txt
         conda list
     - name: Run tests
@@ -203,7 +205,10 @@ jobs:
           conda activate test-environment
           conda install -c conda-forge --yes codecov
           conda config --env --add pinned_packages python=$PYTHON_VERSION
-          sed -i -e "s/pandas.*/pandas==$PANDAS_VERSION/" -e "s/pyarrow.*/pyarrow==$PYARROW_VERSION/" requirements-dev.txt
+          conda config --env --add pinned_packages pandas==$PANDAS_VERSION
+          conda config --env --add pinned_packages pyarrow==$PYARROW_VERSION
+          conda install -c conda-forge --yes pandas==$PANDAS_VERSION pyarrow==$PYARROW_VERSION
+          sed -i -e "/pandas/d" -e "/pyarrow/d" requirements-dev.txt
           conda install -c conda-forge --yes --file requirements-dev.txt
           conda list
       - name: Run tests


### PR DESCRIPTION
Even if packages are listed as pinned_packages, conda still tries to upgrade/downgrade them if the packages are in `requirements-dev.txt` without the version or with a version range.

```
pinned spec pyarrow==0.15.1 conflicts with explicit specs.  Overriding pinned spec.
```

The installed version satisfies the version range, though.