### PR TITLE
Support pd.DataFrame and pd.Series in return type hints

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -80,7 +80,7 @@ from databricks.koalas.internal import (
 )
 from databricks.koalas.missing.frame import _MissingPandasLikeDataFrame
 from databricks.koalas.ml import corr
-from databricks.koalas.typedef import infer_return_type, as_spark_type
+from databricks.koalas.typedef import infer_return_type, as_spark_type, DataFrameType, SeriesType
 from databricks.koalas.plot import KoalasFramePlotMethods
 
 # These regular expression patterns are complied and defined here to avoid to compile the same
@@ -2146,8 +2146,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             # If schema is inferred, we can restore indexes too.
             internal = kdf._internal.with_new_sdf(sdf)
         else:
-            return_schema = infer_return_type(original_func).tpe
-            is_return_dataframe = getattr(return_sig, "__origin__", None) == ks.DataFrame
+            return_type = infer_return_type(original_func)
+            return_schema = return_type.tpe
+            is_return_dataframe = isinstance(return_type, DataFrameType)
             if not is_return_dataframe:
                 raise TypeError(
                     "The given function should specify a frame as its type "
@@ -2408,9 +2409,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             # If schema is inferred, we can restore indexes too.
             internal = kdf._internal.with_new_sdf(sdf)
         else:
-            return_schema = infer_return_type(func).tpe
-            require_index_axis = getattr(return_sig, "__origin__", None) == ks.Series
-            require_column_axis = getattr(return_sig, "__origin__", None) == ks.DataFrame
+            return_type = infer_return_type(func)
+            return_schema = return_type.tpe
+            require_index_axis = isinstance(return_type, SeriesType)
+            require_column_axis = isinstance(return_type, DataFrameType)
             if require_index_axis:
                 if axis != 0:
                     raise TypeError(
@@ -2818,9 +2820,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                     sdf = self_applied._internal.spark_frame.select(*applied)
                 return DataFrame(kdf._internal.with_new_sdf(sdf))
         else:
-            return_schema = infer_return_type(original_func).tpe
-            is_return_dataframe = getattr(return_sig, "__origin__", None) == ks.DataFrame
-            is_return_series = getattr(return_sig, "__origin__", None) == ks.Series
+            return_type = infer_return_type(original_func)
+            return_schema = return_type.tpe
+            is_return_series = isinstance(return_type, SeriesType)
+            is_return_dataframe = isinstance(return_type, DataFrameType)
             if not is_return_dataframe and not is_return_series:
                 raise TypeError(
                     "The given function should specify a frame or series as its type "
@@ -10389,7 +10392,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             # This is a workaround to support variadic generic in DataFrame in Python 3.7.
             # See https://github.com/python/typing/issues/193
             # we always wraps the given type hints by a tuple to mimic the variadic generic.
-            return super(cls, DataFrame).__class_getitem__(Tuple[params])
+            return Tuple[params]
 
     elif (3, 5) <= sys.version_info < (3, 7):
         # This is a workaround to support variadic generic in DataFrame in Python 3.5+

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -44,7 +44,7 @@ from pyspark.sql.types import (
 from pyspark.sql.functions import PandasUDFType, pandas_udf, Column
 
 from databricks import koalas as ks  # For running doctests and reference resolution in PyCharm.
-from databricks.koalas.typedef import infer_return_type
+from databricks.koalas.typedef import infer_return_type, SeriesType
 from databricks.koalas.frame import DataFrame
 from databricks.koalas.internal import (
     InternalFrame,
@@ -1014,13 +1014,14 @@ class GroupBy(object):
 
             return_schema = kdf_from_pandas._internal.spark_frame.drop(*HIDDEN_COLUMNS).schema
         else:
-            if not is_series_groupby and getattr(return_sig, "__origin__", None) == ks.Series:
+            return_type = infer_return_type(func)
+            if not is_series_groupby and isinstance(return_type, SeriesType):
                 raise TypeError(
                     "Series as a return type hint at frame groupby is not supported "
                     "currently; however got [%s]. Use DataFrame type hint instead." % return_sig
                 )
 
-            return_schema = infer_return_type(func).tpe
+            return_schema = return_type.tpe
             if not isinstance(return_schema, StructType):
                 should_return_series = True
                 if is_series_groupby:

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -19,6 +19,7 @@ A wrapper class for Spark Column to behave similar to pandas Series.
 """
 import re
 import inspect
+import sys
 import warnings
 from collections import OrderedDict
 from collections.abc import Iterable
@@ -5179,6 +5180,11 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
     def _equals(self, other: "Series") -> bool:
         return self.spark.column._jc.equals(other.spark.column._jc)
+
+    if sys.version_info >= (3, 7):
+        # In order to support the type hints such as Series[...]. See DataFrame.__class_getitem__.
+        def __class_getitem__(cls, tpe):
+            return SeriesType[tpe]
 
 
 def unpack_scalar(sdf):

--- a/databricks/koalas/tests/test_typedef.py
+++ b/databricks/koalas/tests/test_typedef.py
@@ -1,0 +1,78 @@
+#
+# Copyright (C) 2019 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import sys
+import unittest
+
+import pandas
+import pandas as pd
+import numpy as np
+from pyspark.sql.types import *
+
+from databricks.koalas.typedef import infer_return_type
+from databricks import koalas as ks
+
+
+class TypeHintTests(unittest.TestCase):
+    @unittest.skipIf(
+        sys.version_info < (3, 7),
+        "Type inference from pandas instances is supported with Python 3.7+",
+    )
+    def test_infer_schema_from_pandas_instances(self):
+        def func() -> pd.Series[int]:
+            pass
+
+        self.assertEqual(infer_return_type(func).tpe, IntegerType())
+
+        def func() -> pd.Series[np.float]:
+            pass
+
+        self.assertEqual(infer_return_type(func).tpe, FloatType())
+
+        def func() -> "pd.DataFrame[np.float, str]":
+            pass
+
+        expected = StructType([StructField("c0", FloatType()), StructField("c1", StringType())])
+        self.assertEqual(infer_return_type(func).tpe, expected)
+
+        def func() -> "pandas.DataFrame[np.float]":
+            pass
+
+        expected = StructType([StructField("c0", FloatType())])
+        self.assertEqual(infer_return_type(func).tpe, expected)
+
+        def func() -> "pd.Series[int]":
+            pass
+
+        self.assertEqual(infer_return_type(func).tpe, IntegerType())
+
+        def func() -> pd.DataFrame[np.float, str]:
+            pass
+
+        expected = StructType([StructField("c0", FloatType()), StructField("c1", StringType())])
+        self.assertEqual(infer_return_type(func).tpe, expected)
+
+        def func() -> pd.DataFrame[np.float]:
+            pass
+
+        expected = StructType([StructField("c0", FloatType())])
+        self.assertEqual(infer_return_type(func).tpe, expected)
+
+    def test_if_pandas_implements_class_getitem(self):
+        # the current type hint implementation of pandas DataFrame assumes pandas doesn't
+        # implement '__class_getitem__'. This test case is to make sure pandas
+        # doesn't implement them.
+        assert not ks._frame_has_class_getitem
+        assert not ks._series_has_class_getitem

--- a/databricks/koalas/typedef/string_typehints.py
+++ b/databricks/koalas/typedef/string_typehints.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 import numpy as np
+import pandas
 import pandas as pd
 from numpy import *
 from pandas import *
@@ -24,7 +25,12 @@ def resolve_string_type_hint(tpe):
     import databricks.koalas as ks
     from databricks.koalas import DataFrame, Series
 
-    locs = {"ks": ks, "DataFrame": DataFrame, "Series": Series}
+    locs = {
+        "ks": ks,
+        "koalas": ks,
+        "DataFrame": DataFrame,
+        "Series": Series,
+    }
     # This is a hack to resolve the forward reference string.
     exec("def func() -> %s: pass\narg_spec = getfullargspec(func)" % tpe, globals(), locs)
     return locs["arg_spec"].annotations.get("return", None)


### PR DESCRIPTION
This PR proposes to support the type hints with pandas Series and pandas DataFrame directly.

```python
import pandas as pd
import databricks.koalas as ks
def transform(pdf) -> pd.DataFrame[int]:
    # pdf is actually a pandas DataFrame.
    return pdf + 1

ks.range(10).apply_batch(transform)
```

```
     c0
0     1
1     2
2     3
3     4
4     5
5     6
6     7
7     8
8     9
9    10
```

Note that:

- The type hints with Pandas only works with Python 3.7+.

- The previous way with Koalas DataFrame type hint will still work but will be deprecated once we deprecate Python 3.5 and 3.6.

    ```python
    import databricks.koalas as ks
    def transform(pdf) -> ks.DataFrame[int]:
        return pdf + 1

    ks.range(10).apply_batch(transform)
    ```