### PR TITLE
Support pandas typehints names

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -2072,7 +2072,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             `c0, c1, c2 ... cn`. These names are positionally mapped to the returned
             DataFrame in ``func``.
 
-            To specify the names, you can assign them in a pandas friendly style as below:
+            To specify the column names, you can assign them in a pandas friendly style as below:
 
             >>> def plus_one(x) -> ks.DataFrame["a": float, "b": float]:
             ...     return x + 1
@@ -2291,7 +2291,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             `c0, c1, c2 ... cn`. These names are positionally mapped to the returned
             DataFrame in ``func``.
 
-            To specify the names, you can assign them in a pandas friendly style as below:
+            To specify the column names, you can assign them in a pandas friendly style as below:
 
             >>> def plus_one(x) -> ks.DataFrame["a": float, "b": float]:
             ...     return x + 1
@@ -2711,7 +2711,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             `c0, c1, c2 ... cn`. These names are positionally mapped to the returned
             DataFrame in ``func``.
 
-            To specify the names, you can assign them in a pandas friendly style as below:
+            To specify the column names, you can assign them in a pandas friendly style as below:
 
             >>> def plus_one(x) -> ks.DataFrame['a': float, 'b': float]:
             ...     return x + 1

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -292,6 +292,43 @@ rectangle    16.0  2.348543e+108
 T = TypeVar("T")
 
 
+def _create_tuple_for_frame_type(params):
+    from databricks.koalas.typedef import NameTypeHolder
+
+    if isinstance(params, zip):
+        params = [slice(name, tpe) for name, tpe in params]
+
+    if isinstance(params, slice):
+        params = (params,)
+
+    if (
+        hasattr(params, "__len__")
+        and isinstance(params, Iterable)
+        and all(isinstance(param, slice) for param in params)
+    ):
+        for param in params:
+            if isinstance(param.start, str) and param.step is not None:
+                raise TypeError(
+                    "Type hints should be specified as "
+                    "DataFrame['name': type]; however, got %s" % param
+                )
+
+        name_classes = []
+        for param in params:
+            new_class = type("NameType", (NameTypeHolder,), {})
+            new_class.name = param.start
+            # When the given argument is a numpy's dtype instance.
+            new_class.tpe = param.stop.type if isinstance(param.stop, np.dtype) else param.stop
+            name_classes.append(new_class)
+
+        return Tuple[tuple(name_classes)]
+
+    if not isinstance(params, Iterable):
+        params = [params]
+    params = [param.type if isinstance(param, np.dtype) else param for param in params]
+    return Tuple[tuple(params)]
+
+
 if (3, 5) <= sys.version_info < (3, 7):
     from typing import GenericMeta  # type: ignore
 
@@ -302,7 +339,7 @@ if (3, 5) <= sys.version_info < (3, 7):
 
     def new_getitem(self, params):
         if hasattr(self, "is_dataframe"):
-            return old_getitem(self, Tuple[params])
+            return old_getitem(self, _create_tuple_for_frame_type(params))
         else:
             return old_getitem(self, params)
 
@@ -2033,7 +2070,16 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
             If the return type is specified, the output column names become
             `c0, c1, c2 ... cn`. These names are positionally mapped to the returned
-            DataFrame in ``func``. See examples below.
+            DataFrame in ``func``.
+
+            To specify the names, you can assign them in a pandas friendly style as below:
+
+            >>> def plus_one(x) -> ks.DataFrame["a": float, "b": float]:
+            ...     return x + 1
+
+            >>> pdf = pd.DataFrame({'a': [1, 2, 3], 'b': [3, 4, 5]})
+            >>> def plus_one(x) -> ks.DataFrame[zip(pdf.dtypes, pdf.columns)]:
+            ...     return x + 1
 
 
         Parameters
@@ -2073,6 +2119,12 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         >>> df.apply_batch(query_func)
            c0  c1
         0   1   2
+
+        >>> def query_func(pdf) -> ks.DataFrame["A": int, "B": int]:
+        ...     return pdf.query('A == 1')
+        >>> df.apply_batch(query_func)
+           A  B
+        0  1  2
 
         You can also omit the type hints so Koalas infers the return schema as below:
 
@@ -2237,7 +2289,16 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
             If the return type is specified as `DataFrame`, the output column names become
             `c0, c1, c2 ... cn`. These names are positionally mapped to the returned
-            DataFrame in ``func``. See examples below.
+            DataFrame in ``func``.
+
+            To specify the names, you can assign them in a pandas friendly style as below:
+
+            >>> def plus_one(x) -> ks.DataFrame["a": float, "b": float]:
+            ...     return x + 1
+
+            >>> pdf = pd.DataFrame({'a': [1, 2, 3], 'b': [3, 4, 5]})
+            >>> def plus_one(x) -> ks.DataFrame[zip(pdf.dtypes, pdf.columns)]:
+            ...     return x + 1
 
             However, this way switches the index type to default index type in the output
             because the type hint cannot express the index type at this moment. Use
@@ -2331,14 +2392,14 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         In order to specify the types when `axis` is '1', it should use DataFrame[...]
         annotation. In this case, the column names are automatically generated.
 
-        >>> def identify(x) -> ks.DataFrame[np.int64, np.int64]:
+        >>> def identify(x) -> ks.DataFrame['A': np.int64, 'B': np.int64]:
         ...     return x
         ...
         >>> df.apply(identify, axis=1)
-           c0  c1
-        0   4   9
-        1   4   9
-        2   4   9
+           A  B
+        0  4  9
+        1  4  9
+        2  4  9
 
         You can also specify extra arguments.
 
@@ -2648,7 +2709,16 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
             If the return type is specified, the output column names become
             `c0, c1, c2 ... cn`. These names are positionally mapped to the returned
-            DataFrame in ``func``. See examples below.
+            DataFrame in ``func``.
+
+            To specify the names, you can assign them in a pandas friendly style as below:
+
+            >>> def plus_one(x) -> ks.DataFrame['a': float, 'b': float]:
+            ...     return x + 1
+
+            >>> pdf = pd.DataFrame({'a': [1, 2, 3], 'b': [3, 4, 5]})
+            >>> def plus_one(x) -> ks.DataFrame[zip(pdf.dtypes, pdf.columns)]:
+            ...     return x + 1
 
 
         Parameters
@@ -2685,6 +2755,14 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         0   2   3
         1   4   5
         2   6   7
+
+        >>> def plus_one_func(pdf) -> ks.DataFrame['A': int, 'B': int]:
+        ...     return pdf + 1
+        >>> df.transform_batch(plus_one_func)
+           A  B
+        0  2  3
+        1  4  5
+        2  6  7
 
         >>> def plus_one_func(pdf) -> ks.Series[int]:
         ...     return pdf.B + 1
@@ -10282,7 +10360,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             # This is a workaround to support variadic generic in DataFrame in Python 3.7.
             # See https://github.com/python/typing/issues/193
             # we always wraps the given type hints by a tuple to mimic the variadic generic.
-            return Tuple[params]
+            return _create_tuple_for_frame_type(params)
 
     elif (3, 5) <= sys.version_info < (3, 7):
         # This is a workaround to support variadic generic in DataFrame in Python 3.5+

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -848,17 +848,26 @@ class GroupBy(object):
         use them before reaching for `apply`.
 
         .. note:: this API executes the function once to infer the type which is
-             potentially expensive, for instance, when the dataset is created after
-             aggregations or sorting.
+            potentially expensive, for instance, when the dataset is created after
+            aggregations or sorting.
 
-             To avoid this, specify return type in ``func``, for instance, as below:
+            To avoid this, specify return type in ``func``, for instance, as below:
 
-             >>> def pandas_div(x) -> ks.DataFrame[float, float]:
-             ...     return x[['B', 'C']] / x[['B', 'C']]
+            >>> def pandas_div(x) -> ks.DataFrame[float, float]:
+            ...     return x[['B', 'C']] / x[['B', 'C']]
 
-             If the return type is specified, the output column names become
-             `c0, c1, c2 ... cn`. These names are positionally mapped to the returned
-             DataFrame in ``func``. See examples below.
+            If the return type is specified, the output column names become
+            `c0, c1, c2 ... cn`. These names are positionally mapped to the returned
+            DataFrame in ``func``.
+
+            To specify the names, you can assign them in a pandas friendly style as below:
+
+            >>> def pandas_div(x) -> ks.DataFrame["a": float, "b": float]:
+            ...     return x[['B', 'C']] / x[['B', 'C']]
+
+            >>> pdf = pd.DataFrame({'B': [1.], 'C': [3.]})
+            >>> def plus_one(x) -> ks.DataFrame[zip(pdf.columns, pdf.dtypes)]:
+            ...     return x[['B', 'C']] / x[['B', 'C']]
 
         .. note:: the dataframe within ``func`` is actually a pandas dataframe. Therefore,
             any pandas APIs within this function is allowed.

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -860,7 +860,7 @@ class GroupBy(object):
             `c0, c1, c2 ... cn`. These names are positionally mapped to the returned
             DataFrame in ``func``.
 
-            To specify the names, you can assign them in a pandas friendly style as below:
+            To specify the column names, you can assign them in a pandas friendly style as below:
 
             >>> def pandas_div(x) -> ks.DataFrame["a": float, "b": float]:
             ...     return x[['B', 'C']] / x[['B', 'C']]

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -1050,7 +1050,7 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
 
         self.assert_eq(kser.astype(bool), pser.astype(bool))
 
-        with self.assertRaisesRegex(ValueError, "Type int63 not understood"):
+        with self.assertRaisesRegex(TypeError, "not understood"):
             kser.astype("int63")
 
     def test_aggregate(self):

--- a/databricks/koalas/typedef/typehints.py
+++ b/databricks/koalas/typedef/typehints.py
@@ -50,8 +50,7 @@ class SeriesType(typing.Generic[T]):
 class DataFrameType(object):
     def __init__(self, tpe, names=None):
         if names is None:
-            # Seems we cannot specify field names. I currently gave some default names
-            # `c0, c1, ... cn`.
+            # Default names `c0, c1, ... cn`.
             self.tpe = types.StructType(
                 [types.StructField("c%s" % i, tpe[i]) for i in range(len(tpe))]
             )  # type: types.StructType


### PR DESCRIPTION
This PR proposes a way to specify names in the type hint in DataFrame. See the examples below:

```python
import pandas as pd
import databricks.koalas as ks
pdf = pd.DataFrame({'a': [1, 2, 3], 'b': [3, 4, 5]})
kdf = ks.from_pandas(pdf)

def transform(pdf) -> pd.DataFrame[zip(pdf.columns, pdf.dtypes)]:
    return pdf + 1

kdf.apply_batch(transform)
```

```
   a  b
0  2  4
1  3  5
2  4  6
```

```python
import pandas as pd
import databricks.koalas as ks

def transform(pdf) -> pd.DataFrame["id": int, "A": int]:
    pdf['A'] = pdf.id + 1
    return pdf

ks.range(10).apply_batch(transform)
```

```
   id   A
0   0   1
1   1   2
2   2   3
3   3   4
4   4   5
5   5   6
6   6   7
7   7   8
8   8   9
9   9  10
```

I think we should take this as an experimental feature which could change between minor releases.

This PR also implements an easy way to specify the types without names too:

```python
import pandas as pd
import databricks.koalas as ks
pdf = pd.DataFrame({'a': [1, 2, 3], 'b': [3, 4, 5]})
kdf = ks.from_pandas(pdf)

def transform(pdf) -> pd.DataFrame[pdf.dtypes]:
    return pdf + 1

kdf.apply_batch(transform)
```

```
   c0  c1
0   2   4
1   3   5
2   4   6
```

Closes #1307
Closes #1143
