### PR TITLE
Adding Series.bfill and Series.ffill

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -5055,61 +5055,6 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         else:
             return kdf
 
-    # TODO: add 'downcast' when value parameter exists
-    def ffill(self, axis=None, inplace=False, limit=None):
-        """
-        Synonym for `DataFrame.fillna()` with ``method=`ffill```.
-
-        .. note:: the current implementation of 'ffiff' uses Spark's Window
-            without specifying partition specification. This leads to move all data into
-            single partition in single machine and could cause serious
-            performance degradation. Avoid this method against very large dataset.
-
-        Parameters
-        ----------
-        axis : {0 or `index`}
-            1 and `columns` are not supported.
-        inplace : boolean, default False
-            Fill in place (do not create a new object)
-        limit : int, default None
-            If method is specified, this is the maximum number of consecutive NaN values to
-            forward/backward fill. In other words, if there is a gap with more than this number of
-            consecutive NaNs, it will only be partially filled. If method is not specified,
-            this is the maximum number of entries along the entire axis where NaNs will be filled.
-            Must be greater than 0 if not None
-
-        Returns
-        -------
-        DataFrame
-            DataFrame with NA entries filled.
-
-        Examples
-        --------
-        >>> df = ks.DataFrame({
-        ...     'A': [None, 3, None, None],
-        ...     'B': [2, 4, None, 3],
-        ...     'C': [None, None, None, 1],
-        ...     'D': [0, 1, 5, 4]
-        ...     },
-        ...     columns=['A', 'B', 'C', 'D'])
-        >>> df
-             A    B    C  D
-        0  NaN  2.0  NaN  0
-        1  3.0  4.0  NaN  1
-        2  NaN  NaN  NaN  5
-        3  NaN  3.0  1.0  4
-
-        Propagate non-null values forward.
-
-        >>> df.ffill()
-             A    B    C  D
-        0  NaN  2.0  NaN  0
-        1  3.0  4.0  NaN  1
-        2  3.0  4.0  NaN  5
-        3  3.0  3.0  1.0  4
-        """
-        return self.fillna(method="ffill", axis=axis, inplace=inplace, limit=limit)
-
     def replace(
         self, to_replace=None, value=None, inplace=False, limit=None, regex=False, method="pad",
     ):

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -5056,61 +5056,6 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             return kdf
 
     # TODO: add 'downcast' when value parameter exists
-    def bfill(self, axis=None, inplace=False, limit=None):
-        """
-        Synonym for `DataFrame.fillna()` with ``method=`bfill```.
-
-        .. note:: the current implementation of 'bfiff' uses Spark's Window
-            without specifying partition specification. This leads to move all data into
-            single partition in single machine and could cause serious
-            performance degradation. Avoid this method against very large dataset.
-
-        Parameters
-        ----------
-        axis : {0 or `index`}
-            1 and `columns` are not supported.
-        inplace : boolean, default False
-            Fill in place (do not create a new object)
-        limit : int, default None
-            If method is specified, this is the maximum number of consecutive NaN values to
-            forward/backward fill. In other words, if there is a gap with more than this number of
-            consecutive NaNs, it will only be partially filled. If method is not specified,
-            this is the maximum number of entries along the entire axis where NaNs will be filled.
-            Must be greater than 0 if not None
-
-        Returns
-        -------
-        DataFrame
-            DataFrame with NA entries filled.
-
-        Examples
-        --------
-        >>> df = ks.DataFrame({
-        ...     'A': [None, 3, None, None],
-        ...     'B': [2, 4, None, 3],
-        ...     'C': [None, None, None, 1],
-        ...     'D': [0, 1, 5, 4]
-        ...     },
-        ...     columns=['A', 'B', 'C', 'D'])
-        >>> df
-             A    B    C  D
-        0  NaN  2.0  NaN  0
-        1  3.0  4.0  NaN  1
-        2  NaN  NaN  NaN  5
-        3  NaN  3.0  1.0  4
-
-        Propagate non-null values backward.
-
-        >>> df.bfill()
-             A    B    C  D
-        0  3.0  2.0  1.0  0
-        1  3.0  4.0  1.0  1
-        2  NaN  3.0  1.0  5
-        3  NaN  3.0  1.0  4
-        """
-        return self.fillna(method="bfill", axis=axis, inplace=inplace, limit=limit)
-
-    # TODO: add 'downcast' when value parameter exists
     def ffill(self, axis=None, inplace=False, limit=None):
         """
         Synonym for `DataFrame.fillna()` with ``method=`ffill```.

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -2149,6 +2149,78 @@ class Frame(object):
             internal_pandas, self.to_markdown, type(internal_pandas).to_markdown, args
         )
 
+    # TODO: add 'downcast' when value parameter exists
+    def bfill(self, axis=None, inplace=False, limit=None):
+        """
+        Synonym for `DataFrame.fillna()` or `Series.fillna()` with ``method=`bfill```.
+
+        .. note:: the current implementation of 'bfill' uses Spark's Window
+            without specifying partition specification. This leads to move all data into
+            single partition in single machine and could cause serious
+            performance degradation. Avoid this method against very large dataset.
+
+        Parameters
+        ----------
+        axis : {0 or `index`}
+            1 and `columns` are not supported.
+        inplace : boolean, default False
+            Fill in place (do not create a new object)
+        limit : int, default None
+            If method is specified, this is the maximum number of consecutive NaN values to
+            forward/backward fill. In other words, if there is a gap with more than this number of
+            consecutive NaNs, it will only be partially filled. If method is not specified,
+            this is the maximum number of entries along the entire axis where NaNs will be filled.
+            Must be greater than 0 if not None
+
+        Returns
+        -------
+        DataFrame or Series
+            DataFrame or Series with NA entries filled.
+
+        Examples
+        --------
+        >>> kdf = ks.DataFrame({
+        ...     'A': [None, 3, None, None],
+        ...     'B': [2, 4, None, 3],
+        ...     'C': [None, None, None, 1],
+        ...     'D': [0, 1, 5, 4]
+        ...     },
+        ...     columns=['A', 'B', 'C', 'D'])
+        >>> kdf
+             A    B    C  D
+        0  NaN  2.0  NaN  0
+        1  3.0  4.0  NaN  1
+        2  NaN  NaN  NaN  5
+        3  NaN  3.0  1.0  4
+
+        Propagate non-null values backward.
+
+        >>> kdf.bfill()
+             A    B    C  D
+        0  3.0  2.0  1.0  0
+        1  3.0  4.0  1.0  1
+        2  NaN  3.0  1.0  5
+        3  NaN  3.0  1.0  4
+
+        For Series
+
+        >>> kser = kdf.C
+        >>> kser
+        0    NaN
+        1    NaN
+        2    NaN
+        3    1.0
+        Name: C, dtype: float64
+
+        >>> kser.bfill()
+        0    1.0
+        1    1.0
+        2    1.0
+        3    1.0
+        Name: C, dtype: float64
+        """
+        return self.fillna(method="bfill", axis=axis, inplace=inplace, limit=limit)
+
     @property
     def at(self):
         return AtIndexer(self)

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -2221,6 +2221,78 @@ class Frame(object):
         """
         return self.fillna(method="bfill", axis=axis, inplace=inplace, limit=limit)
 
+    # TODO: add 'downcast' when value parameter exists
+    def ffill(self, axis=None, inplace=False, limit=None):
+        """
+        Synonym for `DataFrame.fillna()` or `Series.fillna()` with ``method=`ffill```.
+
+        .. note:: the current implementation of 'ffill' uses Spark's Window
+            without specifying partition specification. This leads to move all data into
+            single partition in single machine and could cause serious
+            performance degradation. Avoid this method against very large dataset.
+
+        Parameters
+        ----------
+        axis : {0 or `index`}
+            1 and `columns` are not supported.
+        inplace : boolean, default False
+            Fill in place (do not create a new object)
+        limit : int, default None
+            If method is specified, this is the maximum number of consecutive NaN values to
+            forward/backward fill. In other words, if there is a gap with more than this number of
+            consecutive NaNs, it will only be partially filled. If method is not specified,
+            this is the maximum number of entries along the entire axis where NaNs will be filled.
+            Must be greater than 0 if not None
+
+        Returns
+        -------
+        DataFrame or Series
+            DataFrame or Series with NA entries filled.
+
+        Examples
+        --------
+        >>> kdf = ks.DataFrame({
+        ...     'A': [None, 3, None, None],
+        ...     'B': [2, 4, None, 3],
+        ...     'C': [None, None, None, 1],
+        ...     'D': [0, 1, 5, 4]
+        ...     },
+        ...     columns=['A', 'B', 'C', 'D'])
+        >>> kdf
+             A    B    C  D
+        0  NaN  2.0  NaN  0
+        1  3.0  4.0  NaN  1
+        2  NaN  NaN  NaN  5
+        3  NaN  3.0  1.0  4
+
+        Propagate non-null values forward.
+
+        >>> kdf.ffill()
+             A    B    C  D
+        0  NaN  2.0  NaN  0
+        1  3.0  4.0  NaN  1
+        2  3.0  4.0  NaN  5
+        3  3.0  3.0  1.0  4
+
+        For Series
+
+        >>> kser = kdf.B
+        >>> kser
+        0    2.0
+        1    4.0
+        2    NaN
+        3    3.0
+        Name: B, dtype: float64
+
+        >>> kser.ffill()
+        0    2.0
+        1    4.0
+        2    4.0
+        3    3.0
+        Name: B, dtype: float64
+        """
+        return self.fillna(method="ffill", axis=axis, inplace=inplace, limit=limit)
+
     @property
     def at(self):
         return AtIndexer(self)

--- a/databricks/koalas/missing/series.py
+++ b/databricks/koalas/missing/series.py
@@ -41,7 +41,6 @@ class MissingPandasLikeSeries(object):
     at_time = _unsupported_function("at_time")
     autocorr = _unsupported_function("autocorr")
     between_time = _unsupported_function("between_time")
-    bfill = _unsupported_function("bfill")
     combine = _unsupported_function("combine")
     cov = _unsupported_function("cov")
     droplevel = _unsupported_function("droplevel")

--- a/databricks/koalas/missing/series.py
+++ b/databricks/koalas/missing/series.py
@@ -46,7 +46,6 @@ class MissingPandasLikeSeries(object):
     droplevel = _unsupported_function("droplevel")
     ewm = _unsupported_function("ewm")
     factorize = _unsupported_function("factorize")
-    ffill = _unsupported_function("ffill")
     first = _unsupported_function("first")
     infer_objects = _unsupported_function("infer_objects")
     interpolate = _unsupported_function("interpolate")

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -1694,3 +1694,13 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         kser.bfill(inplace=True)
         pser.bfill(inplace=True)
         self.assert_eq(kser, pser)
+
+    def test_ffill(self):
+        pser = pd.Series([np.nan, 2, 3, 4, np.nan, 6], name="x")
+        kser = ks.from_pandas(pser)
+
+        self.assert_eq(repr(kser.ffill()), repr(pser.ffill()))
+
+        kser.ffill(inplace=True)
+        pser.ffill(inplace=True)
+        self.assert_eq(repr(kser), repr(pser))

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -1684,3 +1684,13 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
 
         self.assert_eq(abs(kser), abs(pser))
         self.assert_eq(np.abs(kser), np.abs(pser))
+
+    def test_bfill(self):
+        pser = pd.Series([np.nan, 2, 3, 4, np.nan, 6], name="x")
+        kser = ks.from_pandas(pser)
+
+        self.assert_eq(kser.bfill(), pser.bfill())
+
+        kser.bfill(inplace=True)
+        pser.bfill(inplace=True)
+        self.assert_eq(kser, pser)


### PR DESCRIPTION
This PR propses `Series.bfill` and `Series.ffill` integrating with `DataFrame.bfill` and `DataFrame.ffill` to the `generic.py`

```python
>>> kser = ks.Series([np.nan, 2, 3, 4, np.nan, 6], name="x")
>>> kser
0    NaN
1    2.0
2    3.0
3    4.0
4    NaN
5    6.0
Name: x, dtype: float64

>>> kser.bfill()
0    2.0
1    2.0
2    3.0
3    4.0
4    6.0
5    6.0
Name: x, dtype: float64

>>> kser.ffill()
0    NaN
1    2.0
2    3.0
3    4.0
4    4.0
5    6.0
Name: x, dtype: float64
```