### PR TITLE
Make DataFrame and Series/Index manage the connection with each other.

### DIFF
--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -17,6 +17,7 @@
 """
 Base and utility classes for Koalas objects.
 """
+from abc import ABCMeta, abstractmethod
 from collections import OrderedDict
 from functools import wraps, partial
 from typing import Union, Callable, Any
@@ -118,22 +119,27 @@ def numpy_column_op(f):
     return wrapper
 
 
-class IndexOpsMixin(object):
+class IndexOpsMixin(object, metaclass=ABCMeta):
     """common ops mixin to support a unified interface / docs for Series / Index
 
     Assuming there are following attributes or properties and function.
 
-    :ivar _kdf: Parent's Koalas DataFrame
-    :type _kdf: ks.DataFrame
-    :ivar spark: Spark-related features
-    :type spark: SparkIndexOpsMethods
+    :ivar _anchor: Parent's Koalas DataFrame
+    :type _anchor: ks.DataFrame
     """
 
-    def __init__(self, internal: InternalFrame, kdf):
-        assert internal is not None
-        assert kdf is not None and isinstance(kdf, DataFrame)
-        self._internal = internal  # type: InternalFrame
-        self._kdf = kdf
+    def __init__(self, anchor: DataFrame):
+        assert anchor is not None
+        self._anchor = anchor
+
+    @property
+    @abstractmethod
+    def _internal(self) -> InternalFrame:
+        pass
+
+    @property
+    def _kdf(self) -> DataFrame:
+        return self._anchor
 
     spark = CachedAccessor("spark", SparkIndexOpsMethods)
 

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -478,6 +478,9 @@ class DataFrame(Frame, Generic[T]):
         self._internal_frame = internal
         self._kseries = kseries
 
+        if hasattr(self, "_repr_pandas_cache"):
+            del self._repr_pandas_cache
+
     @property
     def ndim(self):
         """
@@ -10128,14 +10131,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         return self._internal.to_pandas_frame
 
     def _get_or_create_repr_pandas_cache(self, n):
-        if (
-            not hasattr(self, "_repr_pandas_cache")
-            or (id(self._internal), n) not in self._repr_pandas_cache
-        ):
-            self._repr_pandas_cache = {
-                (id(self._internal), n): self.head(n + 1)._to_internal_pandas()
-            }
-        return self._repr_pandas_cache[(id(self._internal), n)]
+        if not hasattr(self, "_repr_pandas_cache") or n not in self._repr_pandas_cache:
+            self._repr_pandas_cache = {n: self.head(n + 1)._to_internal_pandas()}
+        return self._repr_pandas_cache[n]
 
     def __repr__(self):
         max_display_count = get_option("display.max_rows")

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -464,7 +464,7 @@ class DataFrame(Frame, Generic[T]):
                             column_labels=[old_label],
                             data_spark_columns=[self._internal.spark_column_for(old_label)],
                         )
-                    )
+                    )  # type: DataFrame
                     kser._anchor = kdf
                     kdf._kseries = {old_label: kser}
                     kser = None

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -17,12 +17,13 @@
 """
 A base class to be monkey-patched to DataFrame/Column to behave similar to pandas DataFrame/Series.
 """
-import warnings
+from abc import ABCMeta, abstractmethod
 from collections import Counter
 from collections.abc import Iterable
 from distutils.version import LooseVersion
 from functools import reduce
 from typing import Optional, Union, List
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -45,13 +46,15 @@ from databricks.koalas.utils import (
 from databricks.koalas.window import Rolling, Expanding
 
 
-class Frame(object):
+class Frame(object, metaclass=ABCMeta):
     """
     The base class for both DataFrame and Series.
     """
 
-    def __init__(self, internal: InternalFrame):
-        self._internal = internal  # type: InternalFrame
+    @property
+    @abstractmethod
+    def _internal(self) -> InternalFrame:
+        pass
 
     # TODO: add 'axis' parameter
     def cummin(self, skipna: bool = True):

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -1240,7 +1240,7 @@ class GroupBy(object):
                 # if we should restore the index or not. For instance, see the example in
                 # https://github.com/databricks/koalas/issues/628.
 
-                # TODO: deduplicate this logic with _InternalFrame.from_pandas
+                # TODO: deduplicate this logic with InternalFrame.from_pandas
                 new_index_columns = [
                     SPARK_INDEX_NAME_FORMAT(i) for i in range(len(pdf.index.names))
                 ]

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -1933,22 +1933,12 @@ class Index(IndexOpsMixin):
                 return partial(property_or_func, self)
         raise AttributeError("'Index' object has no attribute '{}'".format(item))
 
-    def _get_or_create_repr_pandas_cache(self, n):
-        if (
-            not hasattr(self, "_repr_pandas_cache")
-            or (id(self._kdf._internal), n) not in self._repr_pandas_cache
-        ):
-            self._repr_pandas_cache = {
-                (id(self._kdf._internal), n): self._kdf.head(n + 1).index.to_pandas()
-            }
-        return self._repr_pandas_cache[(id(self._kdf._internal), n)]
-
     def __repr__(self):
         max_display_count = get_option("display.max_rows")
         if max_display_count is None:
             return repr(self.to_pandas())
 
-        pindex = self._get_or_create_repr_pandas_cache(max_display_count)
+        pindex = self._kdf._get_or_create_repr_pandas_cache(max_display_count).index
 
         pindex_length = len(pindex)
         repr_string = repr(pindex[:max_display_count])

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -110,15 +110,19 @@ class Index(IndexOpsMixin):
         if isinstance(data, DataFrame):
             assert dtype is None
             assert name is None
-            kdf = data
         else:
-            kdf = DataFrame(index=pd.Index(data=data, dtype=dtype, name=name))
-        internal = kdf._internal.copy(
-            spark_column=kdf._internal.index_spark_columns[0],
-            column_labels=kdf._internal.index_names,
+            data = DataFrame(index=pd.Index(data=data, dtype=dtype, name=name))
+
+        super(Index, self).__init__(data)
+
+    @property
+    def _internal(self) -> InternalFrame:
+        internal = self._kdf._internal
+        return internal.copy(
+            spark_column=internal.index_spark_columns[0],
+            column_labels=internal.index_names,
             column_label_names=None,
         )
-        IndexOpsMixin.__init__(self, internal, kdf)
 
     def _with_new_scol(self, scol: spark.Column) -> "Index":
         """
@@ -556,21 +560,14 @@ class Index(IndexOpsMixin):
         """
         names = self._verify_for_rename(name)
 
-        if inplace:
-            kdf = self._kdf
-        else:
-            kdf = self._kdf.copy()
-
-        kdf._internal = kdf._internal.copy(
-            index_map=OrderedDict(zip(kdf._internal.index_spark_column_names, names))
+        internal = self._kdf._internal.copy(
+            index_map=OrderedDict(zip(self._kdf._internal.index_spark_column_names, names))
         )
 
-        idx = kdf.index
-        idx._internal = idx._internal.copy(spark_column=self.spark.column)
         if inplace:
-            self._internal = idx._internal
+            self._kdf._update_internal_frame(internal)
         else:
-            return idx
+            return DataFrame(internal).index
 
     def _verify_for_rename(self, name):
         if name is None or isinstance(name, tuple):
@@ -678,13 +675,18 @@ class Index(IndexOpsMixin):
         scol = self.spark.column
         if name is not None:
             scol = scol.alias(name_like_string(name))
-        column_labels = [None] if len(kdf._internal.index_map) > 1 else kdf._internal.index_names
-        return Series(
-            kdf._internal.copy(
-                spark_column=scol, column_labels=column_labels, column_label_names=None
-            ),
-            anchor=kdf,
+        column_labels = (
+            [(SPARK_DEFAULT_SERIES_NAME,)]
+            if len(kdf._internal.index_map) > 1
+            else [
+                (SPARK_DEFAULT_SERIES_NAME,) if name is None else name
+                for name in kdf._internal.index_names
+            ]
         )
+        internal = kdf._internal.copy(
+            column_labels=column_labels, data_spark_columns=[scol], column_label_names=None
+        )
+        return first_series(DataFrame(internal))
 
     def to_frame(self, index=True, name=None) -> DataFrame:
         """
@@ -1033,7 +1035,7 @@ class Index(IndexOpsMixin):
         >>> df.index.copy(name='snake')
         Index(['cobra', 'viper', 'sidewinder'], dtype='object', name='snake')
         """
-        result = Index(self._kdf.copy())
+        result = self._kdf.copy().index
         if name:
             result.name = name
         return result
@@ -1934,12 +1936,12 @@ class Index(IndexOpsMixin):
     def _get_or_create_repr_pandas_cache(self, n):
         if (
             not hasattr(self, "_repr_pandas_cache")
-            or (id(self._internal), n) not in self._repr_pandas_cache
+            or (id(self._kdf._internal), n) not in self._repr_pandas_cache
         ):
             self._repr_pandas_cache = {
-                (id(self._internal), n): self._kdf.head(n + 1).index.to_pandas()
+                (id(self._kdf._internal), n): self._kdf.head(n + 1).index.to_pandas()
             }
-        return self._repr_pandas_cache[(id(self._internal), n)]
+        return self._repr_pandas_cache[(id(self._kdf._internal), n)]
 
     def __repr__(self):
         max_display_count = get_option("display.max_rows")
@@ -2003,14 +2005,19 @@ class MultiIndex(Index):
 
     def __init__(self, kdf: DataFrame):
         assert len(kdf._internal._index_map) > 1
-        scol = F.struct(kdf._internal.index_spark_columns)
-        data_columns = kdf._internal.spark_frame.select(scol).columns
-        internal = kdf._internal.copy(
+
+        super(MultiIndex, self).__init__(kdf)
+
+    @property
+    def _internal(self):
+        internal = self._kdf._internal
+        scol = F.struct(internal.index_spark_columns)
+        data_columns = internal.spark_frame.select(scol).columns
+        return internal.copy(
             spark_column=scol,
             column_labels=[(col, None) for col in data_columns],
             column_label_names=None,
         )
-        IndexOpsMixin.__init__(self, internal, kdf)
 
     def __abs__(self):
         raise TypeError("TypeError: cannot perform __abs__ with this index type: MultiIndex")
@@ -2460,7 +2467,7 @@ class MultiIndex(Index):
                     ('d', 'h')],
                    )
         """
-        return MultiIndex(self._kdf.copy())
+        return super(MultiIndex, self).copy(deep=deep)
 
     def symmetric_difference(self, other, result_name=None, sort=None):
         """

--- a/databricks/koalas/indexing.py
+++ b/databricks/koalas/indexing.py
@@ -71,8 +71,16 @@ class IndexerLike(object):
         return isinstance(self._kdf_or_kser, Series)
 
     @property
+    def _kdf(self):
+        if self._is_df:
+            return self._kdf_or_kser
+        else:
+            assert self._is_series
+            return self._kdf_or_kser._kdf
+
+    @property
     def _internal(self):
-        return self._kdf_or_kser._internal
+        return self._kdf._internal
 
 
 class AtIndexer(IndexerLike):
@@ -123,7 +131,7 @@ class AtIndexer(IndexerLike):
             if isinstance(key, tuple) and len(key) != 1:
                 raise TypeError("Use Series.at like .at[row_index]")
             row_sel = key
-            col_sel = self._internal.column_labels[0]
+            col_sel = self._kdf_or_kser._column_label
 
         if len(self._internal.index_map) == 1:
             if is_list_like(row_sel):
@@ -392,8 +400,9 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
             if cond is None and limit is None:
                 return self._kdf_or_kser
 
-            column_labels = self._internal.column_labels
-            data_spark_columns = self._internal.data_spark_columns
+            column_label = self._kdf_or_kser._column_label
+            column_labels = [column_label]
+            data_spark_columns = [self._internal.spark_column_for(column_label)]
             returns_series = True
         else:
             assert self._is_df
@@ -502,7 +511,7 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
             if (isinstance(key, Series) and not same_anchor(key, self._kdf_or_kser)) or (
                 isinstance(value, Series) and not same_anchor(value, self._kdf_or_kser)
             ):
-                kdf = self._kdf_or_kser.to_frame()
+                kdf = self._kdf_or_kser._kdf.copy()
                 temp_natural_order = verify_temp_column_name(kdf, "__temp_natural_order__")
                 temp_key_col = verify_temp_column_name(kdf, "__temp_key_col__")
                 temp_value_col = verify_temp_column_name(kdf, "__temp_value_col__")
@@ -514,7 +523,7 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
                     kdf[temp_value_col] = value
                 kdf = kdf.sort_values(temp_natural_order).drop(temp_natural_order)
 
-                kser = kdf[self._kdf_or_kser.name]
+                kser = kdf._kser_for(self._kdf_or_kser._column_label)
                 if isinstance(key, Series):
                     key = kdf[temp_key_col]
                 if isinstance(value, Series):
@@ -522,8 +531,10 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
 
                 type(self)(kser)[key] = value
 
-                self._kdf_or_kser._internal = kser._internal
-                self._kdf_or_kser._kdf = kser._kdf
+                self._kdf_or_kser._kdf._update_internal_frame(
+                    kdf[list(self._kdf_or_kser._kdf.columns)]._internal.resolved_copy,
+                    requires_same_anchor=False,
+                )
                 return
 
             if isinstance(value, DataFrame):
@@ -543,11 +554,12 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
                 value = F.lit(value)
             scol = (
                 F.when(cond, value)
-                .otherwise(self._internal.spark_column)
+                .otherwise(self._internal.spark_column_for(self._kdf_or_kser._column_label))
                 .alias(name_like_string(self._kdf_or_kser.name or SPARK_DEFAULT_SERIES_NAME))
             )
-            internal = self._internal.copy(spark_column=scol)
-            self._kdf_or_kser._internal = internal
+
+            internal = self._internal.with_new_spark_column(self._kdf_or_kser._column_label, scol)
+            self._kdf_or_kser._kdf._update_internal_frame(internal, requires_same_anchor=False)
         else:
             assert self._is_df
 
@@ -587,7 +599,10 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
 
                 type(self)(kdf)[rows_sel, cols_sel] = value
 
-                self._kdf_or_kser._internal = kdf[list(self._kdf_or_kser.columns)]._internal
+                self._kdf_or_kser._update_internal_frame(
+                    kdf[list(self._kdf_or_kser.columns)]._internal.resolved_copy,
+                    requires_same_anchor=False,
+                )
                 return
 
             cond, limit, remaining_index = self._select_rows(rows_sel)
@@ -636,7 +651,7 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
                 new_data_spark_columns.append(F.when(cond, value).alias(name_like_string(label)))
 
             internal = self._internal.with_new_columns(new_data_spark_columns, column_labels)
-            self._kdf_or_kser._internal = internal
+            self._kdf_or_kser._update_internal_frame(internal, requires_same_anchor=False)
 
 
 class LocIndexer(LocIndexerLike):
@@ -1490,32 +1505,10 @@ class iLocIndexer(LocIndexerLike):
             )
 
     def __setitem__(self, key, value):
-        from databricks.koalas.frame import DataFrame
-        from databricks.koalas.series import first_series
-
         super(iLocIndexer, self).__setitem__(key, value)
-
-        if self._is_series:
-            internal = self._kdf_or_kser._internal
-            sdf = internal.spark_frame.select(
-                internal.index_spark_columns + [internal.spark_column]
-            )
-            internal = internal.copy(
-                spark_frame=sdf,
-                column_labels=[internal.column_labels[0] or (SPARK_DEFAULT_SERIES_NAME,)],
-                data_spark_columns=[scol_for(sdf, internal.data_spark_column_names[0])],
-                spark_column=None,
-            )
-            kser = first_series(DataFrame(internal))
-
-            self._kdf_or_kser._internal = kser._internal
-            self._kdf_or_kser._kdf = kser._kdf
-        else:
-            assert self._is_df
-            internal = self._kdf_or_kser._internal
-            self._kdf_or_kser._internal = internal.with_new_sdf(
-                internal.spark_frame.select(internal.spark_columns)
-            )
+        self._kdf._update_internal_frame(
+            self._kdf._internal.resolved_copy, requires_same_anchor=False
+        )
 
         # Clean up implicitly cached properties to be able to reuse the indexer.
         del self._internal

--- a/databricks/koalas/indexing.py
+++ b/databricks/koalas/indexing.py
@@ -1299,7 +1299,7 @@ class iLocIndexer(LocIndexerLike):
 
     @lazy_property
     def _sequence_col(self):
-        internal = super(iLocIndexer, self)._internal
+        internal = super(iLocIndexer, self)._internal.resolved_copy
         return verify_temp_column_name(internal.spark_frame, "__distributed_sequence_column__")
 
     def _select_rows_by_series(

--- a/databricks/koalas/indexing.py
+++ b/databricks/koalas/indexing.py
@@ -1291,7 +1291,7 @@ class iLocIndexer(LocIndexerLike):
 
     @lazy_property
     def _internal(self):
-        internal = super(iLocIndexer, self)._internal
+        internal = super(iLocIndexer, self)._internal.resolved_copy
         sdf = InternalFrame.attach_distributed_sequence_column(
             internal.spark_frame, column_name=self._sequence_col
         )

--- a/databricks/koalas/indexing.py
+++ b/databricks/koalas/indexing.py
@@ -1291,6 +1291,7 @@ class iLocIndexer(LocIndexerLike):
 
     @lazy_property
     def _internal(self):
+        # Use resolved_copy to fix the natural order.
         internal = super(iLocIndexer, self)._internal.resolved_copy
         sdf = InternalFrame.attach_distributed_sequence_column(
             internal.spark_frame, column_name=self._sequence_col
@@ -1299,6 +1300,7 @@ class iLocIndexer(LocIndexerLike):
 
     @lazy_property
     def _sequence_col(self):
+        # Use resolved_copy to fix the natural order.
         internal = super(iLocIndexer, self)._internal.resolved_copy
         return verify_temp_column_name(internal.spark_frame, "__distributed_sequence_column__")
 
@@ -1506,6 +1508,7 @@ class iLocIndexer(LocIndexerLike):
 
     def __setitem__(self, key, value):
         super(iLocIndexer, self).__setitem__(key, value)
+        # Update again with resolved_copy to drop extra columns.
         self._kdf._update_internal_frame(
             self._kdf._internal.resolved_copy, requires_same_anchor=False
         )

--- a/databricks/koalas/internal.py
+++ b/databricks/koalas/internal.py
@@ -812,12 +812,12 @@ class InternalFrame(object):
     def with_new_sdf(
         self, spark_frame: spark.DataFrame, data_columns: Optional[List[str]] = None
     ) -> "InternalFrame":
-        """ Copy the immutable _InternalFrame with the updates by the specified Spark DataFrame.
+        """ Copy the immutable InternalFrame with the updates by the specified Spark DataFrame.
 
         :param spark_frame: the new Spark DataFrame
         :param data_columns: the new column names.
             If None, the original one is used.
-        :return: the copied _InternalFrame.
+        :return: the copied InternalFrame.
         """
         assert self.spark_column is None
 
@@ -841,13 +841,13 @@ class InternalFrame(object):
         keep_order: bool = True,
     ) -> "InternalFrame":
         """
-        Copy the immutable _InternalFrame with the updates by the specified Spark Columns or Series.
+        Copy the immutable InternalFrame with the updates by the specified Spark Columns or Series.
 
         :param scols_or_ksers: the new Spark Columns or Series.
         :param column_labels: the new column index.
             If None, the its column_labels is used when the corresponding `scols_or_ksers` is
             Series, otherwise the original one is used.
-        :return: the copied _InternalFrame.
+        :return: the copied InternalFrame.
         """
         from databricks.koalas.series import Series
 
@@ -898,10 +898,10 @@ class InternalFrame(object):
         )
 
     def with_filter(self, pred: Union[spark.Column, "Series"]):
-        """ Copy the immutable _InternalFrame with the updates by the predicate.
+        """ Copy the immutable InternalFrame with the updates by the predicate.
 
         :param pred: the predicate to filter.
-        :return: the copied _InternalFrame.
+        :return: the copied InternalFrame.
         """
         from databricks.koalas.series import Series
 
@@ -920,6 +920,22 @@ class InternalFrame(object):
                 spark_frame=sdf, spark_column=scol_for(sdf, self.data_spark_column_names[0])
             )
 
+    def with_new_spark_column(
+        self, column_label: Tuple[str, ...], scol: spark.Column, keep_order: bool = True
+    ):
+        """
+        Copy the immutable InternalFrame with the updates by the specified Spark Column.
+
+        :param column_label: the column label to be updated.
+        :param scol: the new Spark Column
+        """
+        assert column_label in self.column_labels, column_label
+
+        idx = self.column_labels.index(column_label)
+        data_spark_columns = self.data_spark_columns.copy()
+        data_spark_columns[idx] = scol
+        return self.with_new_columns(data_spark_columns, keep_order=keep_order)
+
     def copy(
         self,
         spark_frame: Union[spark.DataFrame, _NoValueType] = _NoValue,
@@ -929,7 +945,7 @@ class InternalFrame(object):
         column_label_names: Optional[Union[List[str], _NoValueType]] = _NoValue,
         spark_column: Optional[Union[spark.Column, _NoValueType]] = _NoValue,
     ) -> "InternalFrame":
-        """ Copy the immutable DataFrame.
+        """ Copy the immutable InternalFrame.
 
         :param spark_frame: the new Spark DataFrame. If None, then the original one is used.
         :param index_map: the new index information. If None, then the original one is used.
@@ -937,7 +953,7 @@ class InternalFrame(object):
         :param data_spark_columns: the new Spark Columns. If None, then the original ones are used.
         :param column_label_names: the new names of the index levels.
         :param spark_column: the new Spark Column. If None, then the original one is used.
-        :return: the copied immutable DataFrame.
+        :return: the copied immutable InternalFrame.
         """
         if spark_frame is _NoValue:
             spark_frame = self.spark_frame

--- a/databricks/koalas/mlflow.py
+++ b/databricks/koalas/mlflow.py
@@ -24,7 +24,8 @@ import numpy as np
 from typing import Any
 
 from databricks.koalas.utils import lazy_property, default_session
-from databricks.koalas import Series, DataFrame
+from databricks.koalas.frame import DataFrame
+from databricks.koalas.series import first_series
 from databricks.koalas.typedef import as_spark_type
 
 __all__ = ["PythonModelWrapper", "load_model"]
@@ -93,10 +94,10 @@ class PythonModelWrapper(object):
             column_labels = [
                 (col,) for col in data._internal.spark_frame.select(return_col).columns
             ]
-            return Series(
-                data._internal.copy(spark_column=return_col, column_labels=column_labels),
-                anchor=data,
+            internal = data._internal.copy(
+                column_labels=column_labels, data_spark_columns=[return_col]
             )
+            return first_series(DataFrame(internal))
 
 
 def load_model(model_uri, predict_type="infer") -> PythonModelWrapper:

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -374,10 +374,6 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             column_labels=[self._column_label],
         )
 
-    @property
-    def _kdf(self):
-        return self._anchor
-
     def _with_new_scol(self, scol: spark.Column) -> "Series":
         """
         Copy Koalas Series with the new Spark Column.

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -338,17 +338,16 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         Copy input data
     """
 
-    def __init__(
-        self, data=None, index=None, dtype=None, name=None, copy=False, fastpath=False, anchor=None
-    ):
-        if isinstance(data, InternalFrame):
+    def __init__(self, data=None, index=None, dtype=None, name=None, copy=False, fastpath=False):
+        if isinstance(data, DataFrame):
+            assert index is not None
             assert dtype is None
             assert name is None
             assert not copy
             assert not fastpath
-            IndexOpsMixin.__init__(self, data, anchor)
+            anchor = data
+            column_label = index
         else:
-            assert anchor is None
             if isinstance(data, pd.Series):
                 assert index is None
                 assert dtype is None
@@ -360,10 +359,24 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
                 s = pd.Series(
                     data=data, index=index, dtype=dtype, name=name, copy=copy, fastpath=fastpath
                 )
-            kdf = DataFrame(s)
-            IndexOpsMixin.__init__(
-                self, kdf._internal.copy(spark_column=kdf._internal.data_spark_columns[0]), kdf
-            )
+            anchor = DataFrame(s)
+            column_label = anchor._internal.column_labels[0]
+            anchor._kseries = {column_label: self}
+
+        super(Series, self).__init__(anchor)
+        self._column_label = column_label
+
+    @property
+    def _internal(self) -> InternalFrame:
+        internal = self._kdf._internal
+        return internal.copy(
+            spark_column=internal.spark_column_for(self._column_label),
+            column_labels=[self._column_label],
+        )
+
+    @property
+    def _kdf(self):
+        return self._anchor
 
     def _with_new_scol(self, scol: spark.Column) -> "Series":
         """
@@ -372,7 +385,10 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         :param scol: the new Spark Column
         :return: the copied Series
         """
-        return Series(self._internal.copy(spark_column=scol), anchor=self._kdf)  # type: ignore
+        internal = self._kdf._internal.copy(
+            column_labels=[self._column_label], data_spark_columns=[scol]
+        )
+        return first_series(DataFrame(internal))
 
     @property
     def dtypes(self):
@@ -1010,7 +1026,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
     @property
     def name(self) -> Union[str, Tuple[str, ...]]:
         """Return name of the Series."""
-        name = self._internal.column_labels[0]  # type: ignore
+        name = self._column_label
         if name is not None and len(name) == 1:
             return name[0]
         else:
@@ -1057,18 +1073,21 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         Name: my_name, dtype: int64
         """
         if index is None:
-            scol = self.spark.column
-        else:
-            scol = self.spark.column.alias(name_like_string(index))
-        internal = self._internal.copy(  # type: ignore
-            spark_column=scol,
-            column_labels=[index if index is None or isinstance(index, tuple) else (index,)],
-        )
+            index = self._column_label
+        elif not isinstance(index, tuple):
+            index = (index,)
+        scol = self.spark.column.alias(name_like_string(index))
+
+        internal = self._kdf._internal.copy(column_labels=[index], data_spark_columns=[scol])
+        kdf = DataFrame(internal)  # type: DataFrame
+
         if kwargs.get("inplace", False):
-            self._internal = internal
+            self._anchor = kdf
+            self._column_label = index
+            kdf._kseries = {index: self}
             return self
         else:
-            return Series(internal, anchor=self._kdf)
+            return first_series(kdf)
 
     @property
     def index(self):
@@ -1187,17 +1206,16 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             raise TypeError("Cannot reset_index inplace on a Series to create a DataFrame")
 
         if name is not None:
-            kdf = self.rename(name).to_dataframe()
+            kdf = self.rename(name).to_frame()
         else:
-            kdf = self.to_dataframe()
+            kdf = self.to_frame()
         kdf = kdf.reset_index(level=level, drop=drop)
         if drop:
-            kseries = first_series(kdf)
             if inplace:
-                self._internal = kseries._internal
-                self._kdf = kseries._kdf
+                self._anchor = kdf
+                kdf._kseries = {self._column_label: self}
             else:
-                return kseries
+                return first_series(kdf)
         else:
             return kdf
 
@@ -1514,13 +1532,13 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         Name: animal, dtype: object
         """
         inplace = validate_bool_kwarg(inplace, "inplace")
-        kseries = first_series(self.to_frame().drop_duplicates(keep=keep))
+        kdf = self.to_frame().drop_duplicates(keep=keep)
 
         if inplace:
-            self._internal = kseries._internal
-            self._kdf = kseries._kdf
+            self._anchor = kdf
+            kdf._kseries = {self._column_label: self}
         else:
-            return kseries
+            return first_series(kdf)
 
     def fillna(self, value=None, method=None, axis=None, inplace=False, limit=None):
         """Fill NA/NaN values.
@@ -1651,12 +1669,13 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
                 .rowsBetween(begin, end)
             )
             scol = F.when(cond, func(scol, True).over(window)).otherwise(scol)
-        kseries = self._with_new_scol(scol).rename(self.name)
+
         if inplace:
-            self._internal = kseries._internal
-            self._kdf = kseries._kdf
+            self._kdf._update_internal_frame(
+                self._kdf._internal.with_new_spark_column(self._column_label, scol)
+            )
         else:
-            return kseries
+            return self._with_new_scol(scol).rename(self.name)
 
     def dropna(self, axis=0, inplace=False, **kwargs):
         """
@@ -1702,12 +1721,12 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         """
         inplace = validate_bool_kwarg(inplace, "inplace")
         # TODO: last two examples from pandas produce different results.
-        kseries = first_series(self.to_dataframe().dropna(axis=axis, inplace=False))
+        kdf = self.to_frame().dropna(axis=axis, inplace=False)
         if inplace:
-            self._internal = kseries._internal
-            self._kdf = kseries._kdf
+            self._anchor = kdf
+            kdf._kseries = {self._column_label: self}
         else:
-            return kseries
+            return first_series(kdf)
 
     def clip(self, lower: Union[float, int] = None, upper: Union[float, int] = None) -> "Series":
         """
@@ -1873,11 +1892,19 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
                 length      0.3
         Name: 0, dtype: float64
         """
+        return first_series(self._drop(labels=labels, index=index, level=level))
+
+    def _drop(
+        self,
+        labels=None,
+        index: Union[str, Tuple[str, ...], List[str], List[Tuple[str, ...]]] = None,
+        level=None,
+    ):
         level_param = level
         if labels is not None:
             if index is not None:
                 raise ValueError("Cannot specify both 'labels' and 'index'")
-            return self.drop(index=labels, level=level)
+            return self._drop(index=labels, level=level)
         if index is not None:
             if not isinstance(index, (str, tuple, list)):
                 raise ValueError("'index' type should be one of str, list, tuple")
@@ -1924,11 +1951,11 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
                             )
                         )
                     else:
-                        return self
+                        return self.to_frame()
                 drop_index_scols.append(reduce(lambda x, y: x & y, index_scols))
 
             cond = ~reduce(lambda x, y: x | y, drop_index_scols)
-            return first_series(DataFrame(self._internal.with_filter(cond)))
+            return DataFrame(self._internal.with_filter(cond))
         else:
             raise ValueError("Need to specify at least one of 'labels' or 'index'")
 
@@ -2105,17 +2132,15 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         Name: 0, dtype: object
         """
         inplace = validate_bool_kwarg(inplace, "inplace")
-        kseries = first_series(
-            self.to_dataframe().sort_values(
-                by=self.name, ascending=ascending, na_position=na_position
-            )
+        kdf = self.to_frame().sort_values(
+            by=self.name, ascending=ascending, na_position=na_position
         )
+
         if inplace:
-            self._internal = kseries._internal
-            self._kdf = kseries._kdf
-            return None
+            self._anchor = kdf
+            kdf._kseries = {self._column_label: self}
         else:
-            return kseries
+            return first_series(kdf)
 
     def sort_index(
         self,
@@ -2201,17 +2226,15 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         Name: 0, dtype: int64
         """
         inplace = validate_bool_kwarg(inplace, "inplace")
-        kseries = first_series(
-            self.to_dataframe().sort_index(
-                axis=axis, level=level, ascending=ascending, kind=kind, na_position=na_position
-            )
+        kdf = self.to_frame().sort_index(
+            axis=axis, level=level, ascending=ascending, kind=kind, na_position=na_position
         )
+
         if inplace:
-            self._internal = kseries._internal
-            self._kdf = kseries._kdf
-            return None
+            self._anchor = kdf
+            kdf._kseries = {self._column_label: self}
         else:
-            return kseries
+            return first_series(kdf)
 
     def add_prefix(self, prefix):
         """
@@ -2254,10 +2277,8 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         Name: 0, dtype: int64
         """
         assert isinstance(prefix, str)
-        kdf = self.to_dataframe()
-        internal = kdf._internal
-        sdf = internal.spark_frame
-        sdf = sdf.select(
+        internal = self.to_frame()._internal
+        sdf = internal.spark_frame.select(
             [
                 F.concat(F.lit(prefix), index_spark_column).alias(index_spark_column_name)
                 for index_spark_column, index_spark_column_name in zip(
@@ -2266,8 +2287,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             ]
             + internal.data_spark_columns
         )
-        kdf._internal = internal.with_new_sdf(sdf)
-        return first_series(kdf)
+        return first_series(DataFrame(internal.with_new_sdf(sdf)))
 
     def add_suffix(self, suffix):
         """
@@ -2310,10 +2330,8 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         Name: 0, dtype: int64
         """
         assert isinstance(suffix, str)
-        kdf = self.to_dataframe()
-        internal = kdf._internal
-        sdf = internal.spark_frame
-        sdf = sdf.select(
+        internal = self.to_frame()._internal
+        sdf = internal.spark_frame.select(
             [
                 F.concat(index_spark_column, F.lit(suffix)).alias(index_spark_column_name)
                 for index_spark_column, index_spark_column_name in zip(
@@ -2322,8 +2340,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             ]
             + internal.data_spark_columns
         )
-        kdf._internal = internal.with_new_sdf(sdf)
-        return first_series(kdf)
+        return first_series(DataFrame(internal.with_new_sdf(sdf)))
 
     def corr(self, other, method="pearson"):
         """
@@ -2803,7 +2820,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         2    3
         Name: 0, dtype: int64
         """
-        return Series(self._internal.copy(), anchor=self._kdf)
+        return first_series(DataFrame(self._internal.copy(spark_column=None)))
 
     T = property(transpose)
 
@@ -3768,15 +3785,18 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         rows = [self._internal.spark_columns[level] == index for level, index in enumerate(item)]
         sdf = self._internal.spark_frame.select(cols).filter(reduce(lambda x, y: x & y, rows))
 
+        kdf = self._drop(item)
+        self._anchor = kdf
+        kdf._kseries = {self._column_label: self}
+
         if len(self._internal._index_map) == len(item):
+
             # if spark_frame has one column and one data, return data only without frame
             pdf = sdf.limit(2).toPandas()
             length = len(pdf)
             if length == 1:
-                self._internal = self.drop(item)._internal
                 return pdf[self.name].iloc[0]
 
-            self._internal = self.drop(item)._internal
             item_string = name_like_string(item)
             sdf = sdf.withColumn(SPARK_DEFAULT_INDEX_NAME, F.lit(str(item_string)))
             internal = InternalFrame(
@@ -3784,14 +3804,13 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             )
             return first_series(DataFrame(internal))
 
-        internal = self._internal.copy(
-            spark_frame=sdf,
-            index_map=OrderedDict(list(self._internal._index_map.items())[len(item) :]),
-        )
+        else:
+            internal = self._internal.copy(
+                spark_frame=sdf,
+                index_map=OrderedDict(list(self._internal._index_map.items())[len(item) :]),
+            )
 
-        self._internal = self.drop(item)._internal
-
-        return first_series(DataFrame(internal))
+            return first_series(DataFrame(internal))
 
     def copy(self, deep=None) -> "Series":
         """
@@ -3819,7 +3838,11 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         b    2
         Name: 0, dtype: int64
         """
-        return first_series(DataFrame(self._internal.copy()))
+        internal = self._kdf._internal.copy(
+            column_labels=[self._column_label],
+            data_spark_columns=[self._kdf._internal.spark_column_for(self._column_label)],
+        )
+        return first_series(DataFrame(internal))
 
     def mode(self, dropna=True) -> "Series":
         """
@@ -3902,10 +3925,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         )
         internal = InternalFrame(spark_frame=sdf, index_map=None)
 
-        result = first_series(DataFrame(internal))
-        result.name = self.name
-
-        return result
+        return first_series(DataFrame(internal)).rename(self.name)
 
     def keys(self):
         """
@@ -4195,28 +4215,20 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         if not isinstance(other, Series):
             raise ValueError("'other' must be a Series")
 
-        index_scol_names = [index_map[0] for index_map in self._internal.index_map.items()]
-        combined = combine_frames(self.to_frame(), other.to_frame(), how="leftouter")
-        combined_sdf = combined._internal.resolved_copy.spark_frame
-        this_col = "__this_%s" % str(
-            self._internal.spark_column_name_for(self._internal.column_labels[0])
+        combined = combine_frames(self._kdf, other.to_frame(), how="leftouter")
+
+        this_scol = combined["this"]._internal.spark_column_for(self._column_label)
+        that_scol = combined["that"]._internal.spark_column_for(other._column_label)
+
+        scol = (
+            F.when(that_scol.isNotNull(), that_scol)
+            .otherwise(this_scol)
+            .alias(self._kdf._internal.spark_column_name_for(self._column_label))
         )
-        that_col = "__that_%s" % str(
-            self._internal.spark_column_name_for(other._internal.column_labels[0])
-        )
-        cond = (
-            F.when(scol_for(combined_sdf, that_col).isNotNull(), scol_for(combined_sdf, that_col))
-            .otherwise(combined_sdf[this_col])
-            .alias(str(self._internal.spark_column_name_for(self._internal.column_labels[0])))
-        )
-        internal = InternalFrame(
-            spark_frame=combined_sdf.select(index_scol_names + [cond]),
-            index_map=self._internal.index_map,
-            column_labels=self._internal.column_labels,
-        )
-        self_updated = first_series(ks.DataFrame(internal))
-        self._internal = self_updated._internal
-        self._kdf = self_updated._kdf
+
+        internal = combined["this"]._internal.with_new_spark_column(self._column_label, scol)
+
+        self._kdf._update_internal_frame(internal.resolved_copy, requires_same_anchor=False)
 
     def where(self, cond, other=np.nan):
         """
@@ -4278,8 +4290,8 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         assert isinstance(cond, Series)
 
         # We should check the DataFrame from both `cond` and `other`.
-        should_try_ops_on_diff_frame = cond._kdf is not self._kdf or (
-            isinstance(other, Series) and other._kdf is not self._kdf
+        should_try_ops_on_diff_frame = not same_anchor(cond, self) or (
+            isinstance(other, Series) and not same_anchor(other, self)
         )
 
         if should_try_ops_on_diff_frame:
@@ -4833,10 +4845,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         ):
             kdf = ks.DataFrame(sdf)
             kdf.columns = pd.Index(where)
-            result_series = first_series(kdf.transpose())
-
-        result_series.name = self.name
-        return result_series
+            return first_series(kdf.transpose()).rename(self.name)
 
     def mad(self):
         """
@@ -5143,12 +5152,12 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
     def _get_or_create_repr_pandas_cache(self, n):
         if (
             not hasattr(self, "_repr_pandas_cache")
-            or (id(self._internal), n) not in self._repr_pandas_cache
+            or (id(self._kdf._internal), n) not in self._repr_pandas_cache
         ):
             self._repr_pandas_cache = {
-                (id(self._internal), n): self.head(n + 1)._to_internal_pandas()
+                (id(self._kdf._internal), n): self.head(n + 1)._to_internal_pandas()
             }
-        return self._repr_pandas_cache[(id(self._internal), n)]
+        return self._repr_pandas_cache[(id(self._kdf._internal), n)]
 
     def __repr__(self):
         max_display_count = get_option("display.max_rows")

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -2139,6 +2139,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         if inplace:
             self._anchor = kdf
             kdf._kseries = {self._column_label: self}
+            return None
         else:
             return first_series(kdf)
 
@@ -2233,6 +2234,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         if inplace:
             self._anchor = kdf
             kdf._kseries = {self._column_label: self}
+            return None
         else:
             return first_series(kdf)
 

--- a/databricks/koalas/spark/accessors.py
+++ b/databricks/koalas/spark/accessors.py
@@ -443,7 +443,9 @@ class SparkFrameMethods(object):
         """
         from databricks.koalas.frame import CachedDataFrame
 
-        self._kdf._internal = self._kdf._internal.resolved_copy
+        self._kdf._update_internal_frame(
+            self._kdf._internal.resolved_copy, requires_same_anchor=False
+        )
         return CachedDataFrame(self._kdf._internal)
 
     def persist(self, storage_level=StorageLevel.MEMORY_AND_DISK):
@@ -517,6 +519,9 @@ class SparkFrameMethods(object):
         """
         from databricks.koalas.frame import CachedDataFrame
 
+        self._kdf._update_internal_frame(
+            self._kdf._internal.resolved_copy, requires_same_anchor=False
+        )
         return CachedDataFrame(self._kdf._internal, storage_level=storage_level)
 
     def hint(self, name: str, *parameters) -> "ks.DataFrame":

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -128,8 +128,11 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         self.assertIsNone(kdf.index.name)
 
         idx = pd.Index([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], name="x")
-        pdf = pd.DataFrame(np.random.randn(10, 5), idx)
+        pdf = pd.DataFrame(np.random.randn(10, 5), index=idx, columns=list("abcde"))
         kdf = ks.from_pandas(pdf)
+
+        pser = pdf.a
+        kser = kdf.a
 
         self.assertEqual(kdf.index.name, pdf.index.name)
         self.assertEqual(kdf.index.names, pdf.index.names)
@@ -141,12 +144,18 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         self.assertEqual(kidx.name, pidx.name)
         self.assertEqual(kidx.names, pidx.names)
         self.assert_eq(kidx, pidx)
+        self.assertEqual(kdf.index.name, pdf.index.name)
+        self.assertEqual(kdf.index.names, pdf.index.names)
+        self.assertEqual(kser.index.names, pser.index.names)
 
         pidx.name = None
         kidx.name = None
         self.assertEqual(kidx.name, pidx.name)
         self.assertEqual(kidx.names, pidx.names)
         self.assert_eq(kidx, pidx)
+        self.assertEqual(kdf.index.name, pdf.index.name)
+        self.assertEqual(kdf.index.names, pdf.index.names)
+        self.assertEqual(kser.index.names, pser.index.names)
 
         with self.assertRaisesRegex(ValueError, "Names must be a list-like"):
             kidx.names = "hi"

--- a/databricks/koalas/tests/test_ops_on_diff_frames.py
+++ b/databricks/koalas/tests/test_ops_on_diff_frames.py
@@ -422,17 +422,23 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
     def test_assignment_series(self):
         kdf = ks.from_pandas(self.pdf1)
         pdf = self.pdf1
+        kser = kdf.a
+        pser = pdf.a
         kdf["a"] = self.kdf2.a
         pdf["a"] = self.pdf2.a
 
         self.assert_eq(kdf.sort_index(), pdf.sort_index())
+        self.assert_eq(kser, pser)
 
         kdf = ks.from_pandas(self.pdf1)
         pdf = self.pdf1
+        kser = kdf.a
+        pser = pdf.a
         kdf["a"] = self.kdf2.b
         pdf["a"] = self.pdf2.b
 
         self.assert_eq(kdf.sort_index(), pdf.sort_index())
+        self.assert_eq(kser, pser)
 
         kdf = ks.from_pandas(self.pdf1)
         pdf = self.pdf1
@@ -455,18 +461,24 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
     def test_assignment_frame(self):
         kdf = ks.from_pandas(self.pdf1)
         pdf = self.pdf1
+        kser = kdf.a
+        pser = pdf.a
         kdf[["a", "b"]] = self.kdf1
         pdf[["a", "b"]] = self.pdf1
 
         self.assert_eq(kdf.sort_index(), pdf.sort_index())
+        self.assert_eq(kser, pser)
 
         # 'c' does not exist in `kdf`.
         kdf = ks.from_pandas(self.pdf1)
         pdf = self.pdf1
+        kser = kdf.a
+        pser = pdf.a
         kdf[["b", "c"]] = self.kdf1
         pdf[["b", "c"]] = self.pdf1
 
         self.assert_eq(kdf.sort_index(), pdf.sort_index())
+        self.assert_eq(kser, pser)
 
         # 'c' and 'd' do not exist in `kdf`.
         kdf = ks.from_pandas(self.pdf1)
@@ -600,23 +612,42 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
 
         pdf = pdf_orig.copy()
         kdf = kdf_orig.copy()
+        pser1 = pdf.max_speed
+        pser2 = pdf.shield
+        kser1 = kdf.max_speed
+        kser2 = kdf.shield
+
         another_kdf = ks.DataFrame(pdf_orig)
 
         kdf.loc[["viper", "sidewinder"], ["shield"]] = -another_kdf.max_speed
         pdf.loc[["viper", "sidewinder"], ["shield"]] = -pdf.max_speed
         self.assert_eq(kdf, pdf)
+        self.assert_eq(kser1, pser1)
+        self.assert_eq(kser2, pser2)
 
         pdf = pdf_orig.copy()
         kdf = kdf_orig.copy()
+        pser1 = pdf.max_speed
+        pser2 = pdf.shield
+        kser1 = kdf.max_speed
+        kser2 = kdf.shield
         kdf.loc[another_kdf.max_speed < 5, ["shield"]] = -kdf.max_speed
         pdf.loc[pdf.max_speed < 5, ["shield"]] = -pdf.max_speed
         self.assert_eq(kdf, pdf)
+        self.assert_eq(kser1, pser1)
+        self.assert_eq(kser2, pser2)
 
         pdf = pdf_orig.copy()
         kdf = kdf_orig.copy()
+        pser1 = pdf.max_speed
+        pser2 = pdf.shield
+        kser1 = kdf.max_speed
+        kser2 = kdf.shield
         kdf.loc[another_kdf.max_speed < 5, ["shield"]] = -another_kdf.max_speed
         pdf.loc[pdf.max_speed < 5, ["shield"]] = -pdf.max_speed
         self.assert_eq(kdf, pdf)
+        self.assert_eq(kser1, pser1)
+        self.assert_eq(kser2, pser2)
 
     def test_frame_iloc_setitem(self):
         pdf = pd.DataFrame(
@@ -636,8 +667,12 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(kdf, pdf)
 
     def test_series_loc_setitem(self):
-        pser = pd.Series([1, 2, 3], index=["cobra", "viper", "sidewinder"])
-        kser = ks.from_pandas(pser)
+        pdf = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]}, index=["cobra", "viper", "sidewinder"])
+        kdf = ks.from_pandas(pdf)
+        pser = pdf.x
+        psery = pdf.y
+        kser = kdf.x
+        ksery = kdf.y
 
         pser_another = pd.Series([1, 2, 3], index=["cobra", "viper", "sidewinder"])
         kser_another = ks.from_pandas(pser_another)
@@ -645,40 +680,77 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
         kser.loc[kser % 2 == 1] = -kser_another
         pser.loc[pser % 2 == 1] = -pser_another
         self.assert_eq(kser, pser)
+        self.assert_eq(kdf, pdf)
+        self.assert_eq(ksery, psery)
 
-        pser = pd.Series([1, 2, 3], index=["cobra", "viper", "sidewinder"])
-        kser = ks.from_pandas(pser)
+        pdf = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]}, index=["cobra", "viper", "sidewinder"])
+        kdf = ks.from_pandas(pdf)
+        pser = pdf.x
+        psery = pdf.y
+        kser = kdf.x
+        ksery = kdf.y
         kser.loc[kser_another % 2 == 1] = -kser
         pser.loc[pser_another % 2 == 1] = -pser
         self.assert_eq(kser, pser)
+        self.assert_eq(kdf, pdf)
+        self.assert_eq(ksery, psery)
 
-        pser = pd.Series([1, 2, 3], index=["cobra", "viper", "sidewinder"])
-        kser = ks.from_pandas(pser)
+        pdf = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]}, index=["cobra", "viper", "sidewinder"])
+        kdf = ks.from_pandas(pdf)
+        pser = pdf.x
+        psery = pdf.y
+        kser = kdf.x
+        ksery = kdf.y
         kser.loc[kser_another % 2 == 1] = -kser
         pser.loc[pser_another % 2 == 1] = -pser
         self.assert_eq(kser, pser)
+        self.assert_eq(kdf, pdf)
+        self.assert_eq(ksery, psery)
 
-        pser = pd.Series([1, 2, 3], index=["cobra", "viper", "sidewinder"])
-        kser = ks.from_pandas(pser)
+        pdf = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]}, index=["cobra", "viper", "sidewinder"])
+        kdf = ks.from_pandas(pdf)
+        pser = pdf.x
+        psery = pdf.y
+        kser = kdf.x
+        ksery = kdf.y
         kser.loc[kser_another % 2 == 1] = -kser_another
         pser.loc[pser_another % 2 == 1] = -pser_another
         self.assert_eq(kser, pser)
+        self.assert_eq(kdf, pdf)
+        self.assert_eq(ksery, psery)
 
-        pser = pd.Series([1, 2, 3], index=["cobra", "viper", "sidewinder"])
-        kser = ks.from_pandas(pser)
+        pdf = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]}, index=["cobra", "viper", "sidewinder"])
+        kdf = ks.from_pandas(pdf)
+        pser = pdf.x
+        psery = pdf.y
+        kser = kdf.x
+        ksery = kdf.y
         kser.loc[["viper", "sidewinder"]] = -kser_another
         pser.loc[["viper", "sidewinder"]] = -pser_another
         self.assert_eq(kser, pser)
+        self.assert_eq(kdf, pdf)
+        self.assert_eq(ksery, psery)
 
-        pser = pd.Series([1, 2, 3], index=["cobra", "viper", "sidewinder"])
-        kser = ks.from_pandas(pser)
+        pdf = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]}, index=["cobra", "viper", "sidewinder"])
+        kdf = ks.from_pandas(pdf)
+        pser = pdf.x
+        psery = pdf.y
+        kser = kdf.x
+        ksery = kdf.y
         kser.loc[kser_another % 2 == 1] = 10
         pser.loc[pser_another % 2 == 1] = 10
         self.assert_eq(kser, pser)
+        self.assert_eq(kdf, pdf)
+        self.assert_eq(ksery, psery)
 
     def test_series_iloc_setitem(self):
-        pser = pd.Series([1, 2, 3], index=["cobra", "viper", "sidewinder"])
-        kser = ks.from_pandas(pser)
+        pdf = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]}, index=["cobra", "viper", "sidewinder"])
+        kdf = ks.from_pandas(pdf)
+
+        pser = pdf.x
+        psery = pdf.y
+        kser = kdf.x
+        ksery = kdf.y
 
         pser1 = pser + 1
         kser1 = kser + 1
@@ -689,17 +761,28 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
         kser.iloc[[1, 2]] = -kser_another
         pser.iloc[[1, 2]] = -pser_another
         self.assert_eq(kser, pser)
+        self.assert_eq(kdf, pdf)
+        self.assert_eq(ksery, psery)
 
         kser.iloc[[0]] = 10 * kser_another
         pser.iloc[[0]] = 10 * pser_another
         self.assert_eq(kser, pser)
+        self.assert_eq(kdf, pdf)
+        self.assert_eq(ksery, psery)
 
         kser1.iloc[[1, 2]] = -kser_another
         pser1.iloc[[1, 2]] = -pser_another
         self.assert_eq(kser1, pser1)
+        self.assert_eq(kdf, pdf)
+        self.assert_eq(ksery, psery)
 
-        pser = pd.Series([1, 2, 3], index=["cobra", "viper", "sidewinder"])
-        kser = ks.from_pandas(pser)
+        pdf = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]}, index=["cobra", "viper", "sidewinder"])
+        kdf = ks.from_pandas(pdf)
+
+        pser = pdf.x
+        psery = pdf.y
+        kser = kdf.x
+        ksery = kdf.y
 
         piloc = pser.iloc
         kiloc = kser.iloc
@@ -707,10 +790,25 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
         kiloc[[1, 2]] = -kser_another
         piloc[[1, 2]] = -pser_another
         self.assert_eq(kser, pser)
+        self.assert_eq(kdf, pdf)
+        self.assert_eq(ksery, psery)
 
         kiloc[[0]] = 10 * kser_another
         piloc[[0]] = 10 * pser_another
         self.assert_eq(kser, pser)
+        self.assert_eq(kdf, pdf)
+        self.assert_eq(ksery, psery)
+
+    def test_update(self):
+        pdf = pd.DataFrame({"x": [1, 2, 3], "y": [10, 20, 30]})
+        kdf = ks.from_pandas(pdf)
+
+        pser = pdf.x
+        kser = kdf.x
+        pser.update(pd.Series([4, 5, 6]))
+        kser.update(ks.Series([4, 5, 6]))
+        self.assert_eq(kser.sort_index(), pser.sort_index())
+        self.assert_eq(kdf.sort_index(), pdf.sort_index())
 
     def test_where(self):
         pdf1 = pd.DataFrame({"A": [0, 1, 2, 3, 4], "B": [100, 200, 300, 400, 500]})


### PR DESCRIPTION
Making `DataFrame` and `Series`/`Index` manage the connection with each other to support inplace updates.

`Series` and `Index` don't manage its own `InternalFrame` anymore, basically they refer the anchor `DataFrame` and create the `InternalFrame` only when needed.

E.g.,

```py
>>> pdf = pd.DataFrame({"x": [np.nan, 2, 3, 4, np.nan, 6], "y": [np.nan, 2, 3, 4, np.nan, 6]})
>>> pser = pdf.x
>>> pser.fillna(0, inplace=True)
>>> pser
0    0.0
1    2.0
2    3.0
3    4.0
4    0.0
5    6.0
Name: x, dtype: float64
>>> pdf
     x    y
0  0.0  NaN
1  2.0  2.0
2  3.0  3.0
3  4.0  4.0
4  0.0  NaN
5  6.0  6.0
```

Here, `pser.fillna(0, inplace=True)` should also update `pdf`, whereas:

```py
>>> kdf = ks.DataFrame({"x": [np.nan, 2, 3, 4, np.nan, 6], "y": [np.nan, 2, 3, 4, np.nan, 6]})
>>> kser = kdf.x
>>> kser.fillna(0, inplace=True)
>>> kser
0    0.0
1    2.0
2    3.0
3    4.0
4    0.0
5    6.0
Name: x, dtype: float64
>>> kdf
     x    y
0  NaN  NaN
1  2.0  2.0
2  3.0  3.0
3  4.0  4.0
4  NaN  NaN
5  6.0  6.0
```

Other examples:

- The update of `pser` should be refected to `pdf`.

  ```py
  >>> pdf = pd.DataFrame({"x": [np.nan, 2, 3, 4, np.nan, 6], "y": [np.nan, 2, 3, 4, np.nan, 6]})
  >>> pser = pdf.x
  >>> pser.loc[2] = 30
  >>> pser
  0     NaN
  1     2.0
  2    30.0
  3     4.0
  4     NaN
  5     6.0
  Name: x, dtype: float64
  >>> pdf
        x    y
  0   NaN  NaN
  1   2.0  2.0
  2  30.0  3.0
  3   4.0  4.0
  4   NaN  NaN
  5   6.0  6.0
  ```

- The update of `pdf` should be reflected to `pser`.

  ```py
  >>> pdf = pd.DataFrame({"x": [np.nan, 2, 3, 4, np.nan, 6], "y": [np.nan, 2, 3, 4, np.nan, 6]})
  >>> pser = pdf.x
  >>> pdf.loc[2, 'x'] = 30
  >>> pser
  0     NaN
  1     2.0
  2    30.0
  3     4.0
  4     NaN
  5     6.0
  Name: x, dtype: float64
  >>> pdf
        x    y
  0   NaN  NaN
  1   2.0  2.0
  2  30.0  3.0
  3   4.0  4.0
  4   NaN  NaN
  5   6.0  6.0
  ```
