### PR TITLE
Remove to set ARROW_PRE_0_15_IPC_FORMAT in binder and use PySpark 3.0

### DIFF
--- a/postBuild
+++ b/postBuild
@@ -10,4 +10,3 @@ cd jdk1.8.0_131
 echo "export JAVA_HOME="`pwd` >> ~/.profile
 cd bin
 echo "export PATH="`pwd`":$PATH" >> ~/.profile
-echo "export ARROW_PRE_0_15_IPC_FORMAT=1" >> ~/.profile


### PR DESCRIPTION
![Screen Shot 2020-06-18 at 11 50 03 AM](https://user-images.githubusercontent.com/6477701/84972515-f80c9000-b159-11ea-9fc7-6b3f391cb5a5.png)
