### PR TITLE
Make Read the Docs build to use PySpark 3.0, and remove hacks due to JDK

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -32,7 +32,6 @@ python:
   version: 3.6
   install:
     - requirements: requirements-dev.txt
-    - requirements: docs/requirements-readthedocs.txt
     - method: pip
       path: .
       extra_requirements:

--- a/docs/requirements-readthedocs.txt
+++ b/docs/requirements-readthedocs.txt
@@ -1,3 +1,0 @@
-# For Read the docs. Only support Python 3.6+ and PIP.
-install-jdk
-sphinx>=3.0.0

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -29,18 +29,6 @@ except OSError as e:
         raise
 
 
-if "READTHEDOCS" in os.environ:
-    # For Read the Docs, it has JDK 11 by default. Spark 2.x only supports JDK 8 at most.
-    # Once Spark 3.0 is released, we can remove this as Spark 3.0 supports JDK 11.
-    # For now, we should manually install JDK 8.
-    import jdk
-    if not os.path.isdir(jdk._JRE_DIR):
-        jdk.install("8", jre=True)
-    java_home = "%s/%s" % (jdk._JRE_DIR, os.listdir(jdk._JRE_DIR)[0])
-    os.environ["JAVA_HOME"] = java_home
-    os.environ["PATH"] = "%s/bin:%s" % (java_home, os.environ["PATH"])
-
-
 # Lower the number of partitions to speed up documentation build
 utils.default_session({"spark.sql.shuffle.partitions": "4"})
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,8 +7,8 @@ numpy>=1.14
 # Optional dependencies in Koalas.
 mlflow>=1.0
 
-# Documentation build
-sphinx<3.1.0
+# Documentation build.
+sphinx>=2.0.0,<3.1.0
 nbsphinx
 numpydoc==0.8
 pypandoc


### PR DESCRIPTION
This PR proposes to use PySpark 3.0 and remove unnecessary dependency to install JDK 8.