### PR TITLE
Enables Delta tests for Spark 3.0 CI.

### DIFF
--- a/databricks/conftest.py
+++ b/databricks/conftest.py
@@ -37,7 +37,7 @@ shared_conf = {"spark.sql.shuffle.partitions": "4"}
 # Delta requires Spark 2.4.2+. See
 # https://github.com/delta-io/delta#compatibility-with-apache-spark-versions.
 if LooseVersion(__version__) >= LooseVersion("3.0.0"):
-    shared_conf["spark.jars.packages"] = "io.delta:delta-core_2.12:0.6.1"
+    shared_conf["spark.jars.packages"] = "io.delta:delta-core_2.12:0.7.0"
     session = utils.default_session(shared_conf)
 elif LooseVersion(__version__) >= LooseVersion("2.4.2"):
     shared_conf["spark.jars.packages"] = "io.delta:delta-core_2.11:0.6.1"

--- a/dev/pytest
+++ b/dev/pytest
@@ -41,8 +41,8 @@ fi
 
 # Runs both doctests and unit tests by default, otherwise hands arguments over to pytest.
 if [ "$#" = 0 ]; then
-    if [[ "$SPARK_VERSION" == 2.3* ]] || [[ "$SPARK_VERSION" == 2.4.1* ]] || [[ "$SPARK_VERSION" == 2.4.2* ]] || [[ "$SPARK_VERSION" == 3.0* ]]; then
-        # Delta requires Spark 2.4.2+, and doesn't support Spark 3.0+ yet. We skip the related doctests.
+    if [[ "$SPARK_VERSION" == 2.3* ]] || [[ "$SPARK_VERSION" == 2.4.1* ]] || [[ "$SPARK_VERSION" == 2.4.2* ]]; then
+        # Delta requires Spark 2.4.2+. We skip the related doctests.
         if [[ "$SPARK_VERSION" == 2.3* ]]; then
             $PYTHON_EXECUTABLE -m pytest --cov=databricks --cov-report xml:"$FWDIR/coverage.xml" -k " -melt -to_delta -read_delta" --verbose --showlocals --color=yes --doctest-modules databricks "${logopts[@]}"
         else


### PR DESCRIPTION
Since Delta Lake 0.7.0 on Apache Spark 3.0 has been released, we can enable the tests now.
https://github.com/delta-io/delta/releases/tag/v0.7.0