### PR TITLE
Temporary group keys should preserve the names.

### DIFF
--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -2198,13 +2198,13 @@ class GroupBy(object):
     @staticmethod
     def _resolve_grouping(kdf: DataFrame, by: List[Union[Series, Tuple[str, ...]]]) -> List[Series]:
         new_by_series = []
-        for i, col_or_s in enumerate(by):
+        for col_or_s in by:
             if isinstance(col_or_s, Series):
                 if col_or_s._kdf is kdf:
                     new_by_series.append(col_or_s)
                 else:
                     # Rename to distinguish the key from a different DataFrame.
-                    new_by_series.append(col_or_s.rename("__tmp_groupkey_{}__".format(i)))
+                    new_by_series.append(col_or_s.rename(col_or_s.name))
             elif isinstance(col_or_s, tuple):
                 kser = kdf[col_or_s]
                 if not isinstance(kser, Series):


### PR DESCRIPTION
Temporary group keys should preserve the names.

```py
>>> kdf = ks.DataFrame({"a": [1, 2, 6, 4, 4, 6, 4, 3, 7], "b": [4, 2, 7, 3, 3, 1, 1, 1, 2], "c": [4, 2, 7, 3, None, 1, 1, 1, 2], "d": list("abcdefght")}, index=[0, 1, 3, 5, 6, 8, 9, 9, 9])
>>> kdf.groupby(kdf.b + 1).sum().sort_index()
                     a  b    c
__tmp_groupkey_0__
2                   13  3  3.0
3                    9  4  4.0
4                    8  6  3.0
5                    1  4  4.0
8                    6  7  7.0
```

This should be:

```py
>>> pdf.groupby(pdf.b + 1).sum().sort_index()
    a  b    c
b
2  13  3  3.0
3   9  4  4.0
4   8  6  3.0
5   1  4  4.0
8   6  7  7.0
```
