### PR TITLE
Fixing DataFrame.iteritems to return generator

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -1312,10 +1312,10 @@ class DataFrame(Frame, Generic[T]):
         polar    22000
         koala    80000
         """
-        return [
+        return (
             (label if len(label) > 1 else label[0], self._kser_for(label))
             for label in self._internal.column_labels
-        ]
+        )
 
     def iterrows(self):
         """

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -3694,3 +3694,14 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         self.assert_eq(abs(kdf), abs(pdf))
         self.assert_eq(np.abs(kdf), np.abs(pdf))
+
+    def test_iteritems(self):
+        pdf = pd.DataFrame(
+            {"species": ["bear", "bear", "marsupial"], "population": [1864, 22000, 80000]},
+            index=["panda", "polar", "koala"],
+            columns=["species", "population"],
+        )
+        kdf = ks.from_pandas(pdf)
+
+        for p_items, k_items in zip(pdf.iteritems(), kdf.iteritems()):
+            self.assert_eq(repr(p_items), repr(k_items))


### PR DESCRIPTION
`ks.DataFrame.iteritems` returns a list whereas `pd.DataFrame.iteritems` returns a generator.

```python
>>> pdf
         species  population
panda       bear        1864
polar       bear       22000
koala  marsupial       80000

>>> kdf
         species  population
panda       bear        1864
polar       bear       22000
koala  marsupial       80000

>>> pdf.iteritems()
<generator object DataFrame.iteritems at 0x11eeb4318>

>>> kdf.iteritems()
[('species', panda         bear
polar         bear
koala    marsupial
Name: species, dtype: object), ('population', panda     1864
polar    22000
koala    80000
Name: population, dtype: int64)]
```

This PR synced them and added test.

```python
>>> pdf.iteritems()
<generator object DataFrame.iteritems at 0x121c8e840>
>>> kdf.iteritems()
<generator object DataFrame.iteritems.<locals>.<genexpr> at 0x121c8ea20>
```