### PR TITLE
Fix DataFrame.rename to use updated Spark columns.

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -9269,15 +9269,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
             new_column_labels = list(map(gen_new_column_labels_entry, internal.column_labels))
 
-            if internal.column_labels_level == 1:
-                new_data_columns = [col[0] for col in new_column_labels]
-            else:
-                new_data_columns = [str(col) for col in new_column_labels]
             new_data_scols = [
-                scol_for(internal.spark_frame, old_col_name).alias(new_col_name)
-                for old_col_name, new_col_name in zip(
-                    internal.data_spark_column_names, new_data_columns
-                )
+                scol.alias(name_like_string(new_label))
+                for scol, new_label in zip(internal.data_spark_columns, new_column_labels)
             ]
             internal = internal.with_new_columns(new_data_scols, column_labels=new_column_labels)
         if inplace:

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -539,6 +539,14 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(kdf3.rename(index=str_lower, level=0), pdf3.rename(index=str_lower, level=0))
         self.assert_eq(kdf3.rename(index=str_lower, level=1), pdf3.rename(index=str_lower, level=1))
 
+        pdf4 = pdf2 + 1
+        kdf4 = kdf2 + 1
+        self.assert_eq(kdf4.rename(columns=str_lower), pdf4.rename(columns=str_lower))
+
+        pdf5 = pdf3 + 1
+        kdf5 = kdf3 + 1
+        self.assert_eq(kdf5.rename(index=str_lower), pdf5.rename(index=str_lower))
+
     def test_dot_in_column_name(self):
         self.assert_eq(
             ks.DataFrame(ks.range(1)._internal.spark_frame.selectExpr("1 as `a.b`"))["a.b"],


### PR DESCRIPTION
Fixing `DataFrame.rename` with `columns` parameter to use updated Spark columns; otherwise it rolls back the updates for columns.

```py
>>> kdf = ks.DataFrame([[1, 2, 3, 4], [5, 6, 7, 8]], columns=pd.MultiIndex.from_tuples([("X", "A"), ("X", "B"), ("Y", "C"), ("Y", "D")]))
>>> kdf
   X     Y
   A  B  C  D
0  1  2  3  4
1  5  6  7  8
>>> kdf1 = kdf + 1
>>> def str_lower(s) -> str:
...   return str.lower(s)
...
>>> kdf1.rename(columns=str_lower)
   x     y
   a  b  c  d
0  1  2  3  4
1  5  6  7  8
```

This should be:

```py
>>> pdf1.rename(columns=str_lower)
   x     y
   a  b  c  d
0  2  3  4  5
1  6  7  8  9
```

Resolves #1608 