### PR TITLE
Clean up groupby to use the anchor.

### DIFF
--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -2142,7 +2142,7 @@ class GroupBy(object):
                     column_labels.append(col_or_s._internal.column_labels[0])
                 elif same_anchor(col_or_s, kdf):
                     temp_label = verify_temp_column_name(kdf, "__tmp_groupkey_{}__".format(i))
-                    column_labels.append(temp_label)
+                    column_labels.append(temp_label)  # type: ignore
                     additional_spark_columns.append(col_or_s.rename(temp_label).spark.column)
                     additional_column_labels.append(temp_label)
                 else:
@@ -2165,7 +2165,9 @@ class GroupBy(object):
         kdf = DataFrame(
             kdf._internal.with_new_columns(
                 kdf._internal.data_spark_columns + additional_spark_columns,
-                column_labels=kdf._internal.column_labels + additional_column_labels,
+                column_labels=(
+                    kdf._internal.column_labels + additional_column_labels  # type: ignore
+                ),
             )
         )
 

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -5166,9 +5166,6 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
     def __iter__(self):
         return MissingPandasLikeSeries.__iter__(self)
 
-    def _equals(self, other: "Series") -> bool:
-        return self.spark.column._jc.equals(other.spark.column._jc)
-
     if sys.version_info >= (3, 7):
         # In order to support the type hints such as Series[...]. See DataFrame.__class_getitem__.
         def __class_getitem__(cls, tpe):

--- a/databricks/koalas/tests/test_ops_on_diff_frames_groupby.py
+++ b/databricks/koalas/tests/test_ops_on_diff_frames_groupby.py
@@ -119,6 +119,14 @@ class OpsOnDiffFramesGroupByTest(ReusedSQLTestCase, SQLTestUtils):
                     sort(kdf1.groupby(kdf2.A, as_index=as_index).B.sum()),
                     sort(pdf1.groupby(pdf2.A, as_index=as_index).B.sum()),
                 )
+                self.assert_eq(
+                    sort(kdf1.groupby([kdf1.C, kdf2.A], as_index=as_index).sum()),
+                    sort(pdf1.groupby([pdf1.C, pdf2.A], as_index=as_index).sum()),
+                )
+                self.assert_eq(
+                    sort(kdf1.groupby([kdf1.C + 1, kdf2.A], as_index=as_index).sum()),
+                    sort(pdf1.groupby([pdf1.C + 1, pdf2.A], as_index=as_index).sum()),
+                )
 
         self.assert_eq(
             kdf1.B.groupby(kdf2.A).sum().sort_index(), pdf1.B.groupby(pdf2.A).sum().sort_index(),
@@ -160,6 +168,14 @@ class OpsOnDiffFramesGroupByTest(ReusedSQLTestCase, SQLTestUtils):
                             {"B": ["min", "max"], "C": "sum"}
                         )
                     ),
+                )
+                self.assert_eq(
+                    sort(kdf1.groupby([kdf1.C, kdf2.A], as_index=as_index).agg("sum")),
+                    sort(pdf1.groupby([pdf1.C, pdf2.A], as_index=as_index).agg("sum")),
+                )
+                self.assert_eq(
+                    sort(kdf1.groupby([kdf1.C + 1, kdf2.A], as_index=as_index).agg("sum")),
+                    sort(pdf1.groupby([pdf1.C + 1, pdf2.A], as_index=as_index).agg("sum")),
                 )
 
         # multi-index columns


### PR DESCRIPTION
Now that Series has a different anchor from the one it is originally derived from if it is modified, we don't need to check Spark column's equality in groupby.

Also fixing a bug when it needs `compute.ops_on_diff_frames` but the first group key is from the same DataFrame but modified.

E.g.,

```py
>>> ks.options.compute.ops_on_diff_frames = True
>>> kdf1 = ks.DataFrame({"C": [0.362, 0.227, 1.267, -0.562], "B": [1, 2, 3, 4]})
>>> kdf2 = ks.DataFrame({"A": [1, 1, 2, 2]})
>>> kdf1.groupby([kdf1.C + 1, kdf2.A]).sum()
Traceback (most recent call last):
...
AttributeError: 'NoneType' object has no attribute '_internal'
```