### PR TITLE
Added droplevel function to dataframe

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -6193,7 +6193,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = pd.DataFrame([
+        >>> df = ks.DataFrame([
         ...    [1, 2, 3, 4],
         ...    [5, 6, 7, 8],
         ...    [9, 10, 11, 12]
@@ -6226,8 +6226,6 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         9 10    11  12
         """
         axis = validate_axis(axis)
-        # idx = self.index
-        # cols = self.columns
         internal = self.copy()
         if axis == 0:
             names = self.index.names

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -6175,6 +6175,104 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             Frame._count_expr, name="count", axis=axis, numeric_only=False
         )
 
+    def droplevel(self, level, axis=0) -> "DataFrame":
+        """
+        Return DataFrame with requested index / column level(s) removed.
+
+        Parameters
+        ----------
+        level: int, str, or list-like
+            If a string is given, must be the name of a level If list-like, elements must
+            be names or positional indexes of levels.
+
+        axis: {0 or ‘index’, 1 or ‘columns’}, default 0
+
+        Returns
+        -------
+        DataFrame with requested index / column level(s) removed.
+
+        Examples
+        --------
+        >>> df = pd.DataFrame([
+        ...    [1, 2, 3, 4],
+        ...    [5, 6, 7, 8],
+        ...    [9, 10, 11, 12]
+        ... ]).set_index([0, 1]).rename_axis(['a', 'b'])
+
+        >>> df.columns = pd.MultiIndex.from_tuples([
+        ...   ('c', 'e'), ('d', 'f')
+        ... ], names=['level_1', 'level_2'])
+
+        >>> df
+        level_1   c   d
+        level_2   e   f
+        a b
+        1 2      3   4
+        5 6      7   8
+        9 10    11  12
+        >>> df.droplevel('a')
+        level_1   c   d
+        level_2   e   f
+        b
+        2        3   4
+        6        7   8
+        10      11  12
+
+        >>> df.droplevel('level2', axis=1)
+        level_1   c   d
+        a b
+        1 2      3   4
+        5 6      7   8
+        9 10    11  12
+        """
+        axis = validate_axis(axis)
+        # idx = self.index
+        # cols = self.columns
+        internal = self.copy()
+        if axis == 0:
+            names = self.index.names
+            nlevels = self.index.nlevels
+            if not isinstance(level, (tuple, list)):
+                level = [level]
+
+            for n in level:
+                if isinstance(n, int) and (n > nlevels - 1):
+                    raise IndexError(
+                        "Too many levels: Index has only {} levels, not {}".format(nlevels, n + 1)
+                    )
+                if isinstance(n, (str, tuple)) and (n not in names):
+                    raise KeyError("Level {} not found".format(n))
+
+            if len(level) >= nlevels:
+                raise ValueError(
+                    "Cannot remove {} levels from an index with {} "
+                    "levels: at least one level must be "
+                    "left.".format(len(level), nlevels)
+                )
+            internal = internal.reset_index(level).drop(level)
+        elif axis == 1:
+            names = self.columns.names
+            nlevels = self.columns.nlevels
+            if not isinstance(level, (tuple, list)):
+                level = [level]
+
+            for n in level:
+                if isinstance(n, int) and (n > nlevels - 1):
+                    raise IndexError(
+                        "Too many levels: Column has only {} levels, not {}".format(nlevels, n + 1)
+                    )
+                if isinstance(n, (str, tuple)) and (n not in names):
+                    raise KeyError("Level {} not found".format(n))
+
+            if len(level) >= nlevels:
+                raise ValueError(
+                    "Cannot remove {} levels from an index with {} "
+                    "levels: at least one level must be "
+                    "left.".format(len(level), nlevels)
+                )
+            internal.columns = internal.columns.droplevel(level)
+        return internal
+
     def drop(
         self,
         labels=None,

--- a/databricks/koalas/missing/frame.py
+++ b/databricks/koalas/missing/frame.py
@@ -46,7 +46,6 @@ class _MissingPandasLikeDataFrame(object):
     corrwith = _unsupported_function("corrwith")
     cov = _unsupported_function("cov")
     dot = _unsupported_function("dot")
-    droplevel = _unsupported_function("droplevel")
     ewm = _unsupported_function("ewm")
     first = _unsupported_function("first")
     infer_objects = _unsupported_function("infer_objects")

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -560,7 +560,8 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             [9, 10, 11, 12]
         ]).set_index([0, 1]).rename_axis(['a', 'b'])
 
-        pdf.columns = pd.MultiIndex.from_tuples([('c', 'e'), ('d', 'f')], names=['level_1', 'level_2'])
+        pdf.columns = pd.MultiIndex.from_tuples([('c', 'e'), ('d', 'f')],
+                                                names=['level_1', 'level_2'])
         kdf = ks.from_pandas(pdf)
         self.assert_eq(pdf.droplevel('a'), kdf.droplevel('a'))
         self.assert_eq(pdf.droplevel('level_1', axis=1), kdf.droplevel('level_1', axis=1))

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -554,19 +554,20 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         )
 
     def test_droplevel(self):
-        pdf = pd.DataFrame([
-            [1, 2, 3, 4],
-            [5, 6, 7, 8],
-            [9, 10, 11, 12]
-        ]).set_index([0, 1]).rename_axis(['a', 'b'])
+        pdf = (
+            pd.DataFrame([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]])
+            .set_index([0, 1])
+            .rename_axis(["a", "b"])
+        )
 
-        pdf.columns = pd.MultiIndex.from_tuples([('c', 'e'), ('d', 'f')],
-                                                names=['level_1', 'level_2'])
+        pdf.columns = pd.MultiIndex.from_tuples(
+            [("c", "e"), ("d", "f")], names=["level_1", "level_2"]
+        )
         kdf = ks.from_pandas(pdf)
-        self.assert_eq(pdf.droplevel('a'), kdf.droplevel('a'))
-        self.assert_eq(pdf.droplevel('level_1', axis=1), kdf.droplevel('level_1', axis=1))
-        self.assertRaises(ValueError, lambda: kdf.droplevel(['a', 'b']))
-        self.assertRaises(ValueError, lambda: kdf.droplevel(['level_1', 'level_2'], axis=1))
+        self.assert_eq(pdf.droplevel("a"), kdf.droplevel("a"))
+        self.assert_eq(pdf.droplevel("level_1", axis=1), kdf.droplevel("level_1", axis=1))
+        self.assertRaises(ValueError, lambda: kdf.droplevel(["a", "b"]))
+        self.assertRaises(ValueError, lambda: kdf.droplevel(["level_1", "level_2"], axis=1))
 
     def test_drop(self):
         pdf = pd.DataFrame({"x": [1, 2], "y": [3, 4], "z": [5, 6]}, index=np.random.rand(2))

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -553,6 +553,20 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             ks.Series([1]),
         )
 
+    def test_droplevel(self):
+        pdf = pd.DataFrame([
+            [1, 2, 3, 4],
+            [5, 6, 7, 8],
+            [9, 10, 11, 12]
+        ]).set_index([0, 1]).rename_axis(['a', 'b'])
+
+        pdf.columns = pd.MultiIndex.from_tuples([('c', 'e'), ('d', 'f')], names=['level_1', 'level_2'])
+        kdf = ks.from_pandas(pdf)
+        self.assert_eq(pdf.droplevel('a'), kdf.droplevel('a'))
+        self.assert_eq(pdf.droplevel('level_1', axis=1), kdf.droplevel('level_1', axis=1))
+        self.assertRaises(ValueError, lambda: kdf.droplevel(['a', 'b']))
+        self.assertRaises(ValueError, lambda: kdf.droplevel(['level_1', 'level_2'], axis=1))
+
     def test_drop(self):
         pdf = pd.DataFrame({"x": [1, 2], "y": [3, 4], "z": [5, 6]}, index=np.random.rand(2))
         kdf = ks.from_pandas(pdf)

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -554,20 +554,22 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         )
 
     def test_droplevel(self):
-        pdf = (
-            pd.DataFrame([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]])
-            .set_index([0, 1])
-            .rename_axis(["a", "b"])
-        )
+        # droplevel is new in pandas 0.24.0
+        if LooseVersion(pd.__version__) >= LooseVersion("0.24.0"):
+            pdf = (
+                pd.DataFrame([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]])
+                .set_index([0, 1])
+                .rename_axis(["a", "b"])
+            )
 
-        pdf.columns = pd.MultiIndex.from_tuples(
-            [("c", "e"), ("d", "f")], names=["level_1", "level_2"]
-        )
-        kdf = ks.from_pandas(pdf)
-        self.assert_eq(pdf.droplevel("a"), kdf.droplevel("a"))
-        self.assert_eq(pdf.droplevel("level_1", axis=1), kdf.droplevel("level_1", axis=1))
-        self.assertRaises(ValueError, lambda: kdf.droplevel(["a", "b"]))
-        self.assertRaises(ValueError, lambda: kdf.droplevel(["level_1", "level_2"], axis=1))
+            pdf.columns = pd.MultiIndex.from_tuples(
+                [("c", "e"), ("d", "f")], names=["level_1", "level_2"]
+            )
+            kdf = ks.from_pandas(pdf)
+            self.assert_eq(pdf.droplevel("a"), kdf.droplevel("a"))
+            self.assert_eq(pdf.droplevel("level_1", axis=1), kdf.droplevel("level_1", axis=1))
+            self.assertRaises(ValueError, lambda: kdf.droplevel(["a", "b"]))
+            self.assertRaises(ValueError, lambda: kdf.droplevel(["level_1", "level_2"], axis=1))
 
     def test_drop(self):
         pdf = pd.DataFrame({"x": [1, 2], "y": [3, 4], "z": [5, 6]}, index=np.random.rand(2))

--- a/docs/source/reference/frame.rst
+++ b/docs/source/reference/frame.rst
@@ -159,6 +159,7 @@ Reindexing / Selection / Label manipulation
    DataFrame.add_prefix
    DataFrame.add_suffix
    DataFrame.drop
+   DataFrame.droplevel
    DataFrame.drop_duplicates
    DataFrame.duplicated
    DataFrame.equals


### PR DESCRIPTION
Resolves #1614 

This pull request implements droplevel functionality for koalas dataframe.

```
>>> df
level_1   c   d
level_2   e   f
a b
1 2      3   4
5 6      7   8
9 10    11  12

>>> df.droplevel('a')
level_1   c   d
level_2   e   f
b
2        3   4
6        7   8
10      11  12

>>> df.droplevel('level_2', axis=1)
level_1   c   d
a b
1 2      3   4
5 6      7   8
9 10    11  12
```
