### PR TITLE
Make Window functions create a new DataFrame.

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -688,11 +688,13 @@ class DataFrame(Frame, Generic[T]):
         """
         return self._ksers[label]
 
-    def _apply_series_op(self, op):
+    def _apply_series_op(self, op, should_resolve: bool = False):
         applied = []
         for label in self._internal.column_labels:
             applied.append(op(self._kser_for(label)))
         internal = self._internal.with_new_columns(applied)
+        if should_resolve:
+            internal = internal.resolved_copy
         return DataFrame(internal)
 
     # Arithmetic Operators

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -56,6 +56,14 @@ class Frame(object, metaclass=ABCMeta):
     def _internal(self) -> InternalFrame:
         pass
 
+    @abstractmethod
+    def _apply_series_op(self, op, should_resolve: bool = False):
+        pass
+
+    @abstractmethod
+    def _reduce_for_stat_function(self, sfun, name, axis=None, numeric_only=True):
+        pass
+
     # TODO: add 'axis' parameter
     def cummin(self, skipna: bool = True):
         """
@@ -114,7 +122,9 @@ class Frame(object, metaclass=ABCMeta):
         2    1.0
         Name: A, dtype: float64
         """
-        return self._apply_series_op(lambda kser: kser._cum(F.min, skipna))  # type: ignore
+        return self._apply_series_op(
+            lambda kser: kser._cum(F.min, skipna), should_resolve=True
+        )  # type: ignore
 
     # TODO: add 'axis' parameter
     def cummax(self, skipna: bool = True):
@@ -175,7 +185,9 @@ class Frame(object, metaclass=ABCMeta):
         2    1.0
         Name: B, dtype: float64
         """
-        return self._apply_series_op(lambda kser: kser._cum(F.max, skipna))  # type: ignore
+        return self._apply_series_op(
+            lambda kser: kser._cum(F.max, skipna), should_resolve=True
+        )  # type: ignore
 
     # TODO: add 'axis' parameter
     def cumsum(self, skipna: bool = True):
@@ -236,7 +248,9 @@ class Frame(object, metaclass=ABCMeta):
         2    6.0
         Name: A, dtype: float64
         """
-        return self._apply_series_op(lambda kser: kser._cum(F.sum, skipna))  # type: ignore
+        return self._apply_series_op(
+            lambda kser: kser._cum(F.sum, skipna), should_resolve=True
+        )  # type: ignore
 
     # TODO: add 'axis' parameter
     # TODO: use pandas_udf to support negative values and other options later
@@ -305,7 +319,9 @@ class Frame(object, metaclass=ABCMeta):
         Name: A, dtype: float64
 
         """
-        return self._apply_series_op(lambda kser: kser._cumprod(skipna))  # type: ignore
+        return self._apply_series_op(
+            lambda kser: kser._cumprod(skipna), should_resolve=True
+        )  # type: ignore
 
     # TODO: Although this has removed pandas >= 1.0.0, but we're keeping this as deprecated
     # since we're using this for `DataFrame.info` internally.

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -18,6 +18,7 @@
 A wrapper for GroupedData to behave similar to pandas GroupBy.
 """
 
+from abc import ABCMeta, abstractmethod
 import sys
 import inspect
 from collections import OrderedDict, namedtuple
@@ -72,7 +73,7 @@ from databricks.koalas.window import RollingGroupby, ExpandingGroupby
 NamedAgg = namedtuple("NamedAgg", ["column", "aggfunc"])
 
 
-class GroupBy(object):
+class GroupBy(object, metaclass=ABCMeta):
     """
     :ivar _kdf: The parent dataframe that is used to perform the groupby
     :type _kdf: DataFrame
@@ -87,6 +88,10 @@ class GroupBy(object):
     @property
     def _agg_columns_scols(self):
         return [s.spark.column for s in self._agg_columns]
+
+    @abstractmethod
+    def _apply_series_op(self, op, should_resolve: bool = False):
+        pass
 
     # TODO: Series support is not implemented yet.
     # TODO: not all arguments are implemented comparing to pandas' for now.
@@ -680,7 +685,8 @@ class GroupBy(object):
 
         """
         return self._apply_series_op(
-            lambda sg: sg._kser._cum(F.max, True, part_cols=sg._groupkeys_scols)
+            lambda sg: sg._kser._cum(F.max, True, part_cols=sg._groupkeys_scols),
+            should_resolve=True,
         )
 
     def cummin(self):
@@ -727,7 +733,8 @@ class GroupBy(object):
         Name: B, dtype: float64
         """
         return self._apply_series_op(
-            lambda sg: sg._kser._cum(F.min, True, part_cols=sg._groupkeys_scols)
+            lambda sg: sg._kser._cum(F.min, True, part_cols=sg._groupkeys_scols),
+            should_resolve=True,
         )
 
     def cumprod(self):
@@ -775,7 +782,7 @@ class GroupBy(object):
 
         """
         return self._apply_series_op(
-            lambda sg: sg._kser._cumprod(True, part_cols=sg._groupkeys_scols)
+            lambda sg: sg._kser._cumprod(True, part_cols=sg._groupkeys_scols), should_resolve=True
         )
 
     def cumsum(self):
@@ -823,7 +830,8 @@ class GroupBy(object):
 
         """
         return self._apply_series_op(
-            lambda sg: sg._kser._cum(F.sum, True, part_cols=sg._groupkeys_scols)
+            lambda sg: sg._kser._cum(F.sum, True, part_cols=sg._groupkeys_scols),
+            should_resolve=True,
         )
 
     def apply(self, func, *args, **kwargs):
@@ -2295,11 +2303,13 @@ class DataFrameGroupBy(GroupBy):
                 agg_columns=item,
             )
 
-    def _apply_series_op(self, op):
+    def _apply_series_op(self, op, should_resolve: bool = False):
         applied = []
         for column in self._agg_columns:
             applied.append(op(column.groupby(self._groupkeys)))
         internal = self._kdf._internal.with_new_columns(applied, keep_order=False)
+        if should_resolve:
+            internal = internal.resolved_copy
         return DataFrame(internal)
 
     # TODO: Implement 'percentiles', 'include', and 'exclude' arguments.
@@ -2424,8 +2434,13 @@ class SeriesGroupBy(GroupBy):
                 return partial(property_or_func, self)
         raise AttributeError(item)
 
-    def _apply_series_op(self, op):
-        return op(self)
+    def _apply_series_op(self, op, should_resolve: bool = False):
+        kser = op(self)
+        if should_resolve:
+            internal = kser._internal.resolved_copy
+            return first_series(DataFrame(internal))
+        else:
+            return kser
 
     @property
     def _kdf(self) -> DataFrame:

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -5110,8 +5110,13 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
     # ----------------------------------------------------------------------
 
-    def _apply_series_op(self, op):
-        return op(self)
+    def _apply_series_op(self, op, should_resolve: bool = False):
+        kser = op(self)
+        if should_resolve:
+            internal = kser._internal.resolved_copy
+            return first_series(DataFrame(internal))
+        else:
+            return kser
 
     def _reduce_for_stat_function(self, sfun, name, axis=None, numeric_only=None):
         """

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -2111,6 +2111,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
     def _test_cummin(self, pdf, kdf):
         self.assert_eq(pdf.cummin(), kdf.cummin())
         self.assert_eq(pdf.cummin(skipna=False), kdf.cummin(skipna=False))
+        self.assert_eq(pdf.cummin().sum(), kdf.cummin().sum())
 
     def test_cummin(self):
         pdf = pd.DataFrame(
@@ -2131,6 +2132,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
     def _test_cummax(self, pdf, kdf):
         self.assert_eq(pdf.cummax(), kdf.cummax())
         self.assert_eq(pdf.cummax(skipna=False), kdf.cummax(skipna=False))
+        self.assert_eq(pdf.cummax().sum(), kdf.cummax().sum())
 
     def test_cummax(self):
         pdf = pd.DataFrame(
@@ -2151,6 +2153,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
     def _test_cumsum(self, pdf, kdf):
         self.assert_eq(pdf.cumsum(), kdf.cumsum())
         self.assert_eq(pdf.cumsum(skipna=False), kdf.cumsum(skipna=False))
+        self.assert_eq(pdf.cumsum().sum(), kdf.cumsum().sum())
 
     def test_cumsum(self):
         pdf = pd.DataFrame(
@@ -2169,8 +2172,9 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self._test_cumsum(pdf, kdf)
 
     def _test_cumprod(self, pdf, kdf):
-        self.assertEqual(repr(pdf.cumprod()), repr(kdf.cumprod()))
-        self.assertEqual(repr(pdf.cumprod(skipna=False)), repr(kdf.cumprod(skipna=False)))
+        self.assert_eq(pdf.cumprod(), kdf.cumprod(), almost=True)
+        self.assert_eq(pdf.cumprod(skipna=False), kdf.cumprod(skipna=False), almost=True)
+        self.assert_eq(pdf.cumprod().sum(), kdf.cumprod().sum(), almost=True)
 
     def test_cumprod(self):
         pdf = pd.DataFrame(

--- a/databricks/koalas/tests/test_expanding.py
+++ b/databricks/koalas/tests/test_expanding.py
@@ -46,7 +46,9 @@ class ExpandingTest(ReusedSQLTestCase, TestUtils):
             getattr(kser.expanding(2), f)(), getattr(pser.expanding(2), f)(), almost=True
         )
 
-        pdf = pd.DataFrame({"a": [1, 2, 3, 2], "b": [4.0, 2.0, 3.0, 1.0]}, index=np.random.rand(4))
+        pdf = pd.DataFrame(
+            {"a": [1.0, 2.0, 3.0, 2.0], "b": [4.0, 2.0, 3.0, 1.0]}, index=np.random.rand(4)
+        )
         kdf = ks.from_pandas(pdf)
         self.assert_eq(getattr(kdf.expanding(2), f)(), getattr(pdf.expanding(2), f)(), almost=True)
         self.assert_eq(
@@ -158,7 +160,7 @@ class ExpandingTest(ReusedSQLTestCase, TestUtils):
             almost=True,
         )
 
-        pdf = pd.DataFrame({"a": [1, 2, 3, 2], "b": [4.0, 2.0, 3.0, 1.0]})
+        pdf = pd.DataFrame({"a": [1.0, 2.0, 3.0, 2.0], "b": [4.0, 2.0, 3.0, 1.0]})
         kdf = ks.from_pandas(pdf)
         self.assert_eq(
             getattr(kdf.groupby(kdf.a).expanding(2), f)().sort_index(),

--- a/databricks/koalas/tests/test_expanding.py
+++ b/databricks/koalas/tests/test_expanding.py
@@ -31,6 +31,11 @@ class ExpandingTest(ReusedSQLTestCase, TestUtils):
         self.assert_eq(
             getattr(kser.expanding(2), f)(), getattr(pser.expanding(2), f)(), almost=True
         )
+        self.assert_eq(
+            getattr(kser.expanding(2), f)().sum(),
+            getattr(pser.expanding(2), f)().sum(),
+            almost=True,
+        )
 
         # Multiindex
         pser = pd.Series(
@@ -44,6 +49,9 @@ class ExpandingTest(ReusedSQLTestCase, TestUtils):
         pdf = pd.DataFrame({"a": [1, 2, 3, 2], "b": [4.0, 2.0, 3.0, 1.0]}, index=np.random.rand(4))
         kdf = ks.from_pandas(pdf)
         self.assert_eq(getattr(kdf.expanding(2), f)(), getattr(pdf.expanding(2), f)(), almost=True)
+        self.assert_eq(
+            getattr(kdf.expanding(2), f)().sum(), getattr(pdf.expanding(2), f)().sum(), almost=True
+        )
 
         # Multiindex column
         columns = pd.MultiIndex.from_tuples([("a", "x"), ("a", "y")])
@@ -76,6 +84,8 @@ class ExpandingTest(ReusedSQLTestCase, TestUtils):
             self.assert_eq(
                 kser.expanding(2).count().sort_index(), expected_result.sort_index(), almost=True
             )
+            self.assert_eq(kser.expanding(2).count().sum(), expected_result.sum(), almost=True)
+
             # MultiIndex
             midx = pd.MultiIndex.from_tuples([("a", "x"), ("a", "y"), ("b", "z")])
             kser = ks.Series([1, 2, 3], index=midx, name="a")
@@ -90,6 +100,7 @@ class ExpandingTest(ReusedSQLTestCase, TestUtils):
             self.assert_eq(
                 kdf.expanding(2).count().sort_index(), expected_result.sort_index(), almost=True
             )
+            self.assert_eq(kdf.expanding(2).count().sum(), expected_result.sum(), almost=True)
 
             # MultiIndex columns
             idx = np.random.rand(4)
@@ -121,18 +132,23 @@ class ExpandingTest(ReusedSQLTestCase, TestUtils):
         self._test_expanding_func("var")
 
     def _test_groupby_expanding_func(self, f):
-        pser = pd.Series([1, 2, 3], index=np.random.rand(3), name="a")
+        pser = pd.Series([1, 2, 3, 2], index=np.random.rand(4), name="a")
         kser = ks.from_pandas(pser)
         self.assert_eq(
             getattr(kser.groupby(kser).expanding(2), f)().sort_index(),
             getattr(pser.groupby(pser).expanding(2), f)().sort_index(),
             almost=True,
         )
+        self.assert_eq(
+            getattr(kser.groupby(kser).expanding(2), f)().sum(),
+            getattr(pser.groupby(pser).expanding(2), f)().sum(),
+            almost=True,
+        )
 
         # Multiindex
         pser = pd.Series(
-            [1, 2, 3],
-            index=pd.MultiIndex.from_tuples([("a", "x"), ("a", "y"), ("b", "z")]),
+            [1, 2, 3, 2],
+            index=pd.MultiIndex.from_tuples([("a", "x"), ("a", "y"), ("b", "z"), ("c", "z")]),
             name="a",
         )
         kser = ks.from_pandas(pser)
@@ -147,6 +163,11 @@ class ExpandingTest(ReusedSQLTestCase, TestUtils):
         self.assert_eq(
             getattr(kdf.groupby(kdf.a).expanding(2), f)().sort_index(),
             getattr(pdf.groupby(pdf.a).expanding(2), f)().sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            getattr(kdf.groupby(kdf.a).expanding(2), f)().sum(),
+            getattr(pdf.groupby(pdf.a).expanding(2), f)().sum(),
             almost=True,
         )
         self.assert_eq(
@@ -193,23 +214,29 @@ class ExpandingTest(ReusedSQLTestCase, TestUtils):
             self._test_groupby_expanding_func("count")
         else:
             # Series
-            kser = ks.Series([1, 2, 3], index=np.random.rand(3))
+            kser = ks.Series([1, 2, 3, 2], index=np.random.rand(4))
             midx = pd.MultiIndex.from_tuples(
                 list(zip(kser.to_pandas().values, kser.index.to_pandas().values))
             )
-            expected_result = pd.Series([np.nan, np.nan, np.nan], index=midx)
+            expected_result = pd.Series([np.nan, np.nan, np.nan, 2], index=midx)
             self.assert_eq(
                 kser.groupby(kser).expanding(2).count().sort_index(),
                 expected_result.sort_index(),
                 almost=True,
             )
+            self.assert_eq(
+                kser.groupby(kser).expanding(2).count().sum(), expected_result.sum(), almost=True
+            )
 
             # MultiIndex
             kser = ks.Series(
-                [1, 2, 3], index=pd.MultiIndex.from_tuples([("a", "x"), ("a", "y"), ("b", "z")])
+                [1, 2, 3, 2],
+                index=pd.MultiIndex.from_tuples([("a", "x"), ("a", "y"), ("b", "z"), ("a", "y")]),
             )
-            midx = pd.MultiIndex.from_tuples([(1, "a", "x"), (2, "a", "y"), (3, "b", "z")])
-            expected_result = pd.Series([np.nan, np.nan, np.nan], index=midx)
+            midx = pd.MultiIndex.from_tuples(
+                [(1, "a", "x"), (2, "a", "y"), (3, "b", "z"), (2, "a", "y")]
+            )
+            expected_result = pd.Series([np.nan, np.nan, np.nan, 2], index=midx)
             self.assert_eq(
                 kser.groupby(kser).expanding(2).count().sort_index(),
                 expected_result.sort_index(),
@@ -226,6 +253,9 @@ class ExpandingTest(ReusedSQLTestCase, TestUtils):
                 kdf.groupby(kdf.a).expanding(2).count().sort_index(),
                 expected_result.sort_index(),
                 almost=True,
+            )
+            self.assert_eq(
+                kdf.groupby(kdf.a).expanding(2).count().sum(), expected_result.sum(), almost=True
             )
             expected_result = pd.DataFrame(
                 {"a": [None, None, 2.0, None], "b": [None, None, 2.0, None]},

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -890,6 +890,10 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             pdf.groupby(pdf.b // 5)["a"].cummin().sort_index(),
             almost=True,
         )
+        self.assert_eq(
+            kdf.groupby("b").cummin().sum().sort_index(),
+            pdf.groupby("b").cummin().sum().sort_index(),
+        )
 
         # multi-index columns
         columns = pd.MultiIndex.from_tuples([("x", "a"), ("x", "b"), ("y", "c")])
@@ -943,6 +947,10 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             pdf.groupby(pdf.b // 5)["a"].cummax().sort_index(),
             almost=True,
         )
+        self.assert_eq(
+            kdf.groupby("b").cummax().sum().sort_index(),
+            pdf.groupby("b").cummax().sum().sort_index(),
+        )
 
         # multi-index columns
         columns = pd.MultiIndex.from_tuples([("x", "a"), ("x", "b"), ("y", "c")])
@@ -995,6 +1003,10 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             kdf.groupby(kdf.b // 5)["a"].cumsum().sort_index(),
             pdf.groupby(pdf.b // 5)["a"].cumsum().sort_index(),
             almost=True,
+        )
+        self.assert_eq(
+            kdf.groupby("b").cumsum().sum().sort_index(),
+            pdf.groupby("b").cumsum().sum().sort_index(),
         )
 
         # multi-index columns
@@ -1050,6 +1062,11 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         self.assert_eq(
             kdf.groupby(kdf.b // 3)["a"].cumprod().sort_index(),
             pdf.groupby(pdf.b // 3)["a"].cumprod().sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            kdf.groupby("b").cumprod().sum().sort_index(),
+            pdf.groupby("b").cumprod().sum().sort_index(),
             almost=True,
         )
 

--- a/databricks/koalas/tests/test_rolling.py
+++ b/databricks/koalas/tests/test_rolling.py
@@ -38,10 +38,16 @@ class RollingTest(ReusedSQLTestCase, TestUtils):
         pser = pd.Series([1, 2, 3], index=np.random.rand(3), name="a")
         kser = ks.from_pandas(pser)
         self.assert_eq(getattr(kser.rolling(2), f)(), getattr(pser.rolling(2), f)(), almost=True)
+        self.assert_eq(
+            getattr(kser.rolling(2), f)().sum(), getattr(pser.rolling(2), f)().sum(), almost=True
+        )
 
         pdf = pd.DataFrame({"a": [1, 2, 3, 2], "b": [4.0, 2.0, 3.0, 1.0]}, index=np.random.rand(4))
         kdf = ks.from_pandas(pdf)
         self.assert_eq(getattr(kdf.rolling(2), f)(), getattr(pdf.rolling(2), f)(), almost=True)
+        self.assert_eq(
+            getattr(kdf.rolling(2), f)().sum(), getattr(pdf.rolling(2), f)().sum(), almost=True
+        )
 
         # Multiindex
         pser = pd.Series(
@@ -55,6 +61,9 @@ class RollingTest(ReusedSQLTestCase, TestUtils):
         pdf = pd.DataFrame({"a": [1, 2, 3, 2], "b": [4.0, 2.0, 3.0, 1.0]}, index=np.random.rand(4))
         kdf = ks.from_pandas(pdf)
         self.assert_eq(getattr(kdf.rolling(2), f)(), getattr(pdf.rolling(2), f)(), almost=True)
+        self.assert_eq(
+            getattr(kdf.rolling(2), f)().sum(), getattr(pdf.rolling(2), f)().sum(), almost=True
+        )
 
         # Multiindex column
         columns = pd.MultiIndex.from_tuples([("a", "x"), ("a", "y")])
@@ -84,18 +93,23 @@ class RollingTest(ReusedSQLTestCase, TestUtils):
         self._test_rolling_func("var")
 
     def _test_groupby_rolling_func(self, f):
-        pser = pd.Series([1, 2, 3], index=np.random.rand(3), name="a")
+        pser = pd.Series([1, 2, 3, 2], index=np.random.rand(4), name="a")
         kser = ks.from_pandas(pser)
         self.assert_eq(
             getattr(kser.groupby(kser).rolling(2), f)().sort_index(),
             getattr(pser.groupby(pser).rolling(2), f)().sort_index(),
             almost=True,
         )
+        self.assert_eq(
+            getattr(kser.groupby(kser).rolling(2), f)().sum(),
+            getattr(pser.groupby(pser).rolling(2), f)().sum(),
+            almost=True,
+        )
 
         # Multiindex
         pser = pd.Series(
-            [1, 2, 3],
-            index=pd.MultiIndex.from_tuples([("a", "x"), ("a", "y"), ("b", "z")]),
+            [1, 2, 3, 2],
+            index=pd.MultiIndex.from_tuples([("a", "x"), ("a", "y"), ("b", "z"), ("c", "z")]),
             name="a",
         )
         kser = ks.from_pandas(pser)
@@ -110,6 +124,11 @@ class RollingTest(ReusedSQLTestCase, TestUtils):
         self.assert_eq(
             getattr(kdf.groupby(kdf.a).rolling(2), f)().sort_index(),
             getattr(pdf.groupby(pdf.a).rolling(2), f)().sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            getattr(kdf.groupby(kdf.a).rolling(2), f)().sum(),
+            getattr(pdf.groupby(pdf.a).rolling(2), f)().sum(),
             almost=True,
         )
         self.assert_eq(

--- a/databricks/koalas/tests/test_rolling.py
+++ b/databricks/koalas/tests/test_rolling.py
@@ -42,13 +42,6 @@ class RollingTest(ReusedSQLTestCase, TestUtils):
             getattr(kser.rolling(2), f)().sum(), getattr(pser.rolling(2), f)().sum(), almost=True
         )
 
-        pdf = pd.DataFrame({"a": [1, 2, 3, 2], "b": [4.0, 2.0, 3.0, 1.0]}, index=np.random.rand(4))
-        kdf = ks.from_pandas(pdf)
-        self.assert_eq(getattr(kdf.rolling(2), f)(), getattr(pdf.rolling(2), f)(), almost=True)
-        self.assert_eq(
-            getattr(kdf.rolling(2), f)().sum(), getattr(pdf.rolling(2), f)().sum(), almost=True
-        )
-
         # Multiindex
         pser = pd.Series(
             [1, 2, 3],
@@ -58,7 +51,9 @@ class RollingTest(ReusedSQLTestCase, TestUtils):
         kser = ks.from_pandas(pser)
         self.assert_eq(getattr(kser.rolling(2), f)(), getattr(pser.rolling(2), f)(), almost=True)
 
-        pdf = pd.DataFrame({"a": [1, 2, 3, 2], "b": [4.0, 2.0, 3.0, 1.0]}, index=np.random.rand(4))
+        pdf = pd.DataFrame(
+            {"a": [1.0, 2.0, 3.0, 2.0], "b": [4.0, 2.0, 3.0, 1.0]}, index=np.random.rand(4)
+        )
         kdf = ks.from_pandas(pdf)
         self.assert_eq(getattr(kdf.rolling(2), f)(), getattr(pdf.rolling(2), f)(), almost=True)
         self.assert_eq(
@@ -119,7 +114,7 @@ class RollingTest(ReusedSQLTestCase, TestUtils):
             almost=True,
         )
 
-        pdf = pd.DataFrame({"a": [1, 2, 3, 2], "b": [4.0, 2.0, 3.0, 1.0]})
+        pdf = pd.DataFrame({"a": [1.0, 2.0, 3.0, 2.0], "b": [4.0, 2.0, 3.0, 1.0]})
         kdf = ks.from_pandas(pdf)
         self.assert_eq(
             getattr(kdf.groupby(kdf.a).rolling(2), f)().sort_index(),

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -952,50 +952,54 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
     def test_cummin(self):
         pser = pd.Series([1.0, None, 0.0, 4.0, 9.0]).rename("a")
         kser = ks.from_pandas(pser)
-        self.assertEqual(repr(pser.cummin()), repr(kser.cummin()))
-        self.assertEqual(repr(pser.cummin(skipna=False)), repr(kser.cummin(skipna=False)))
+        self.assert_eq(pser.cummin(), kser.cummin(), almost=True)
+        self.assert_eq(pser.cummin(skipna=False), kser.cummin(skipna=False), almost=True)
+        self.assert_eq(pser.cummin().sum(), kser.cummin().sum(), almost=True)
 
         # with reversed index
         pser.index = [4, 3, 2, 1, 0]
         kser = ks.from_pandas(pser)
-        self.assertEqual(repr(pser.cummin()), repr(kser.cummin()))
-        self.assertEqual(repr(pser.cummin(skipna=False)), repr(kser.cummin(skipna=False)))
+        self.assert_eq(pser.cummin(), kser.cummin(), almost=True)
+        self.assert_eq(pser.cummin(skipna=False), kser.cummin(skipna=False), almost=True)
 
     def test_cummax(self):
         pser = pd.Series([1.0, None, 0.0, 4.0, 9.0]).rename("a")
         kser = ks.from_pandas(pser)
-        self.assertEqual(repr(pser.cummax()), repr(kser.cummax()))
-        self.assertEqual(repr(pser.cummax(skipna=False)), repr(kser.cummax(skipna=False)))
+        self.assert_eq(pser.cummax(), kser.cummax(), almost=True)
+        self.assert_eq(pser.cummax(skipna=False), kser.cummax(skipna=False), almost=True)
+        self.assert_eq(pser.cummax().sum(), kser.cummax().sum(), almost=True)
 
         # with reversed index
         pser.index = [4, 3, 2, 1, 0]
         kser = ks.from_pandas(pser)
-        self.assertEqual(repr(pser.cummax()), repr(kser.cummax()))
-        self.assertEqual(repr(pser.cummax(skipna=False)), repr(kser.cummax(skipna=False)))
+        self.assert_eq(pser.cummax(), kser.cummax(), almost=True)
+        self.assert_eq(pser.cummax(skipna=False), kser.cummax(skipna=False), almost=True)
 
     def test_cumsum(self):
         pser = pd.Series([1.0, None, 0.0, 4.0, 9.0]).rename("a")
         kser = ks.from_pandas(pser)
-        self.assertEqual(repr(pser.cumsum()), repr(kser.cumsum()))
-        self.assertEqual(repr(pser.cumsum(skipna=False)), repr(kser.cumsum(skipna=False)))
+        self.assert_eq(pser.cumsum(), kser.cumsum(), almost=True)
+        self.assert_eq(pser.cumsum(skipna=False), kser.cumsum(skipna=False), almost=True)
+        self.assert_eq(pser.cumsum().sum(), kser.cumsum().sum(), almost=True)
 
         # with reversed index
         pser.index = [4, 3, 2, 1, 0]
         kser = ks.from_pandas(pser)
-        self.assertEqual(repr(pser.cumsum()), repr(kser.cumsum()))
-        self.assertEqual(repr(pser.cumsum(skipna=False)), repr(kser.cumsum(skipna=False)))
+        self.assert_eq(pser.cumsum(), kser.cumsum(), almost=True)
+        self.assert_eq(pser.cumsum(skipna=False), kser.cumsum(skipna=False), almost=True)
 
     def test_cumprod(self):
         pser = pd.Series([1.0, None, 1.0, 4.0, 9.0]).rename("a")
         kser = ks.from_pandas(pser)
-        self.assertEqual(repr(pser.cumprod()), repr(kser.cumprod()))
-        self.assertEqual(repr(pser.cumprod(skipna=False)), repr(kser.cumprod(skipna=False)))
+        self.assert_eq(pser.cumprod(), kser.cumprod(), almost=True)
+        self.assert_eq(pser.cumprod(skipna=False), kser.cumprod(skipna=False), almost=True)
+        self.assert_eq(pser.cumprod().sum(), kser.cumprod().sum(), almost=True)
 
         # with reversed index
         pser.index = [4, 3, 2, 1, 0]
         kser = ks.from_pandas(pser)
-        self.assertEqual(repr(pser.cumprod()), repr(kser.cumprod()))
-        self.assertEqual(repr(pser.cumprod(skipna=False)), repr(kser.cumprod(skipna=False)))
+        self.assert_eq(pser.cumprod(), kser.cumprod(), almost=True)
+        self.assert_eq(pser.cumprod(skipna=False), kser.cumprod(skipna=False), almost=True)
 
         with self.assertRaisesRegex(Exception, "values should be bigger than 0"):
             repr(ks.Series([0, 1]).cumprod())

--- a/databricks/koalas/window.py
+++ b/databricks/koalas/window.py
@@ -150,7 +150,8 @@ class Rolling(RollingAndExpanding):
 
     def _apply_as_series_or_frame(self, func):
         return self._kdf_or_kser._apply_series_op(
-            lambda kser: kser._with_new_scol(func(kser.spark.column)).rename(kser.name)
+            lambda kser: kser._with_new_scol(func(kser.spark.column)).rename(kser.name),
+            should_resolve=True,
         )
 
     def count(self):


### PR DESCRIPTION
Make Window functions create a new Spark DataFrame; otherwise, `AnalysisException` will be raised when aggregate function is applied after the window function.

```py
>>> kdf = ks.DataFrame([[1, 2, 3, 4], [5, 6, 7, 8]], columns=["A", "B", "C", "D"])
>>> kdf.cumsum().sum()
Traceback (most recent call last):
...
pyspark.sql.utils.AnalysisException: It is not allowed to use a window function inside an aggregate function. Please use the inner window function in a sub-query.;
```