### PR TITLE
Avoid using _exception_message.

### DIFF
--- a/databricks/koalas/__init__.py
+++ b/databricks/koalas/__init__.py
@@ -115,12 +115,10 @@ def _auto_patch_spark():
 
             usage_logging.attach(logger_module)
         except Exception as e:
-            from pyspark.util import _exception_message
-
             logger = logging.getLogger("databricks.koalas.usage_logger")
             logger.warning(
                 "Tried to attach usage logger `{}`, but an exception was raised: {}".format(
-                    logger_module, _exception_message(e)
+                    logger_module, str(e)
                 )
             )
 

--- a/databricks/koalas/usage_logging/usage_logger.py
+++ b/databricks/koalas/usage_logging/usage_logger.py
@@ -22,8 +22,6 @@ from inspect import Signature
 import logging
 from typing import Any, Optional
 
-from pyspark.util import _exception_message
-
 
 def get_logger() -> Any:
     """ An entry point of the plug-in and return the usage logger. """
@@ -101,7 +99,7 @@ class KoalasUsageLogger(object):
                 class_name=class_name,
                 name=name,
                 signature=_format_signature(signature),
-                msg=_exception_message(ex),
+                msg=str(ex),
                 duration=duration * 1000,
                 function="function" if signature is not None else "property",
             )


### PR DESCRIPTION
Since Koalas works only in Python 3, we don't need to use `pyspark.util._exception_message`.