### PR TITLE
Implementing Series.droplevel

### DIFF
--- a/databricks/koalas/missing/series.py
+++ b/databricks/koalas/missing/series.py
@@ -43,7 +43,6 @@ class MissingPandasLikeSeries(object):
     between_time = _unsupported_function("between_time")
     combine = _unsupported_function("combine")
     cov = _unsupported_function("cov")
-    droplevel = _unsupported_function("droplevel")
     ewm = _unsupported_function("ewm")
     factorize = _unsupported_function("factorize")
     first = _unsupported_function("first")

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -4914,37 +4914,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         y    3
         Name: 0, dtype: int64
         """
-        if not isinstance(level, (tuple, list)):
-            if not isinstance(level, (str, int)):
-                raise KeyError("Level {} not found".format(level))
-            level = [level]
-
-        spark_frame = self._internal.spark_frame
-        index_map = self._internal.index_map.copy()
-        index_names = self.index.names
-        nlevels = self.index.nlevels
-        for n in level:
-            if isinstance(n, str):
-                if n not in index_names:
-                    raise KeyError("Level {} not found".format(n))
-                n = index_names.index(n)
-            elif isinstance(n, int):
-                if n >= nlevels:
-                    raise IndexError(
-                        "Too many levels: Index has only {} levels, not {}".format(nlevels, n + 1)
-                    )
-            index_spark_column = self._internal.index_spark_column_names[n]
-            spark_frame = spark_frame.drop(index_spark_column)
-            index_map.pop(index_spark_column)
-
-        if len(level) == nlevels:
-            raise ValueError(
-                "Cannot remove {0} levels from an index with {0} levels: "
-                "at least one level must be left.".format(nlevels)
-            )
-        internal = self._internal.copy(spark_frame=spark_frame, index_map=index_map)
-
-        return first_series(DataFrame(internal))
+        return first_series(self.to_frame().droplevel(level=level, axis=0))
 
     def tail(self, n=5):
         """

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -581,10 +581,21 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
                 [("c", "e"), ("d", "f")], names=["level_1", "level_2"]
             )
             kdf = ks.from_pandas(pdf)
+
             self.assert_eq(pdf.droplevel("a"), kdf.droplevel("a"))
+            self.assert_eq(pdf.droplevel(0), kdf.droplevel(0))
+            self.assert_eq(pdf.droplevel(-1), kdf.droplevel(-1))
             self.assert_eq(pdf.droplevel("level_1", axis=1), kdf.droplevel("level_1", axis=1))
+            self.assert_eq(pdf.droplevel(0, axis=1), kdf.droplevel(0, axis=1))
             self.assertRaises(ValueError, lambda: kdf.droplevel(["a", "b"]))
             self.assertRaises(ValueError, lambda: kdf.droplevel(["level_1", "level_2"], axis=1))
+            self.assertRaises(ValueError, lambda: kdf.droplevel([1, 1, 1, 1, 1]))
+            self.assertRaises(IndexError, lambda: kdf.droplevel(-3))
+
+            # Tupled names
+            pdf.index.names = [("a", "b"), ("x", "y")]
+            kdf = ks.from_pandas(pdf)
+            self.assert_eq(pdf.droplevel([("a", "b")]), kdf.droplevel([("a", "b")]))
 
     def test_drop(self):
         pdf = pd.DataFrame({"x": [1, 2], "y": [3, 4], "z": [5, 6]}, index=np.random.rand(2))

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -1798,3 +1798,31 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
 
         for p_items, k_items in zip(pser.iteritems(), kser.iteritems()):
             self.assert_eq(repr(p_items), repr(k_items))
+
+    def test_droplevel(self):
+        pser = pd.Series(
+            [1, 2, 3],
+            index=pd.MultiIndex.from_tuples(
+                [("x", "a", "q"), ("x", "b", "w"), ("y", "c", "e")],
+                names=["level_1", "level_2", "level_3"],
+            ),
+        )
+        kser = ks.from_pandas(pser)
+
+        self.assert_eq(pser.droplevel(0), kser.droplevel(0))
+        self.assert_eq(pser.droplevel([0]), kser.droplevel([0]))
+        self.assert_eq(pser.droplevel((0,)), kser.droplevel((0,)))
+        self.assert_eq(pser.droplevel([0, 2]), kser.droplevel([0, 2]))
+        self.assert_eq(pser.droplevel((1, 2)), kser.droplevel((1, 2)))
+
+        with self.assertRaisesRegex(KeyError, "Level {0, 1, 2} not found"):
+            kser.droplevel({0, 1, 2})
+        with self.assertRaisesRegex(KeyError, "Level level_100 not found"):
+            kser.droplevel(["level_1", "level_100"])
+        with self.assertRaisesRegex(IndexError, "Too many levels: Index has only 3 levels, not 11"):
+            kser.droplevel(10)
+        with self.assertRaisesRegex(
+            ValueError,
+            "Cannot remove 3 levels from an index with 3 levels: at least one level must be left.",
+        ):
+            kser.droplevel([0, 1, 2])

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -1800,29 +1800,34 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
             self.assert_eq(repr(p_items), repr(k_items))
 
     def test_droplevel(self):
-        pser = pd.Series(
-            [1, 2, 3],
-            index=pd.MultiIndex.from_tuples(
-                [("x", "a", "q"), ("x", "b", "w"), ("y", "c", "e")],
-                names=["level_1", "level_2", "level_3"],
-            ),
-        )
-        kser = ks.from_pandas(pser)
+        # droplevel is new in pandas 0.24.0
+        if LooseVersion(pd.__version__) >= LooseVersion("0.24.0"):
+            pser = pd.Series(
+                [1, 2, 3],
+                index=pd.MultiIndex.from_tuples(
+                    [("x", "a", "q"), ("x", "b", "w"), ("y", "c", "e")],
+                    names=["level_1", "level_2", "level_3"],
+                ),
+            )
+            kser = ks.from_pandas(pser)
 
-        self.assert_eq(pser.droplevel(0), kser.droplevel(0))
-        self.assert_eq(pser.droplevel([0]), kser.droplevel([0]))
-        self.assert_eq(pser.droplevel((0,)), kser.droplevel((0,)))
-        self.assert_eq(pser.droplevel([0, 2]), kser.droplevel([0, 2]))
-        self.assert_eq(pser.droplevel((1, 2)), kser.droplevel((1, 2)))
+            self.assert_eq(pser.droplevel(0), kser.droplevel(0))
+            self.assert_eq(pser.droplevel([0]), kser.droplevel([0]))
+            self.assert_eq(pser.droplevel((0,)), kser.droplevel((0,)))
+            self.assert_eq(pser.droplevel([0, 2]), kser.droplevel([0, 2]))
+            self.assert_eq(pser.droplevel((1, 2)), kser.droplevel((1, 2)))
 
-        with self.assertRaisesRegex(KeyError, "Level {0, 1, 2} not found"):
-            kser.droplevel({0, 1, 2})
-        with self.assertRaisesRegex(KeyError, "Level level_100 not found"):
-            kser.droplevel(["level_1", "level_100"])
-        with self.assertRaisesRegex(IndexError, "Too many levels: Index has only 3 levels, not 11"):
-            kser.droplevel(10)
-        with self.assertRaisesRegex(
-            ValueError,
-            "Cannot remove 3 levels from an index with 3 levels: at least one level must be left.",
-        ):
-            kser.droplevel([0, 1, 2])
+            with self.assertRaisesRegex(KeyError, "Level {0, 1, 2} not found"):
+                kser.droplevel({0, 1, 2})
+            with self.assertRaisesRegex(KeyError, "Level level_100 not found"):
+                kser.droplevel(["level_1", "level_100"])
+            with self.assertRaisesRegex(
+                IndexError, "Too many levels: Index has only 3 levels, not 11"
+            ):
+                kser.droplevel(10)
+            with self.assertRaisesRegex(
+                ValueError,
+                "Cannot remove 3 levels from an index with 3 levels: "
+                "at least one level must be left.",
+            ):
+                kser.droplevel([0, 1, 2])

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -1820,11 +1820,20 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
             kser = ks.from_pandas(pser)
 
             self.assert_eq(pser.droplevel(0), kser.droplevel(0))
+            self.assert_eq(pser.droplevel("level_1"), kser.droplevel("level_1"))
             self.assert_eq(pser.droplevel(-1), kser.droplevel(-1))
             self.assert_eq(pser.droplevel([0]), kser.droplevel([0]))
+            self.assert_eq(pser.droplevel(["level_1"]), kser.droplevel(["level_1"]))
             self.assert_eq(pser.droplevel((0,)), kser.droplevel((0,)))
+            self.assert_eq(pser.droplevel(("level_1",)), kser.droplevel(("level_1",)))
             self.assert_eq(pser.droplevel([0, 2]), kser.droplevel([0, 2]))
+            self.assert_eq(
+                pser.droplevel(["level_1", "level_3"]), kser.droplevel(["level_1", "level_3"])
+            )
             self.assert_eq(pser.droplevel((1, 2)), kser.droplevel((1, 2)))
+            self.assert_eq(
+                pser.droplevel(("level_2", "level_3")), kser.droplevel(("level_2", "level_3"))
+            )
 
             with self.assertRaisesRegex(KeyError, "Level {0, 1, 2} not found"):
                 kser.droplevel({0, 1, 2})

--- a/docs/source/reference/series.rst
+++ b/docs/source/reference/series.rst
@@ -159,6 +159,7 @@ Reindexing / Selection / Label manipulation
    :toctree: api/
 
    Series.drop
+   Series.drop_level
    Series.drop_duplicates
    Series.equals
    Series.add_prefix

--- a/docs/source/reference/series.rst
+++ b/docs/source/reference/series.rst
@@ -159,7 +159,7 @@ Reindexing / Selection / Label manipulation
    :toctree: api/
 
    Series.drop
-   Series.drop_level
+   Series.droplevel
    Series.drop_duplicates
    Series.equals
    Series.add_prefix


### PR DESCRIPTION
This should close #1615 

```python
>>> kser = ks.Series(
...     [1, 2, 3],
...     index=pd.MultiIndex.from_tuples(
...         [("x", "a"), ("x", "b"), ("y", "c")], names=["level_1", "level_2"]
...     ),
... )
>>> kser
level_1  level_2
x        a          1
         b          2
y        c          3
Name: 0, dtype: int64
```

Removing specific index level by level

```python
>>> kser.droplevel(0)
level_2
a    1
b    2
c    3
Name: 0, dtype: int64
```

Removing specific index level by name

```python
>>> kser.droplevel("level_2")
level_1
x    1
x    2
y    3
Name: 0, dtype: int64
```