### PR TITLE
__iter__() for Index & MultiIndex

### DIFF
--- a/databricks/koalas/missing/indexes.py
+++ b/databricks/koalas/missing/indexes.py
@@ -82,7 +82,6 @@ class MissingPandasLikeIndex(object):
     memory_usage = common.memory_usage(_unsupported_function)
     to_list = common.to_list(_unsupported_function)
     tolist = common.tolist(_unsupported_function)
-    __iter__ = common.__iter__(_unsupported_function)
 
     if LooseVersion(pd.__version__) < LooseVersion("1.0"):
         # Deprecated properties
@@ -167,7 +166,6 @@ class MissingPandasLikeMultiIndex(object):
         "design principle of Koalas. Alternatively, you could call 'to_pandas()' and"
         " use 'levels' property in pandas.",
     )
-    __iter__ = common.__iter__(_unsupported_function)
 
     # Properties we won't support.
     memory_usage = common.memory_usage(_unsupported_function)

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -1352,3 +1352,17 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         kidx = ks.MultiIndex.from_tuples([(1, 2)], names=["level1", "level2"])
         with self.assertRaisesRegex(TypeError, "perform __abs__ with this index"):
             abs(kidx)
+
+    def test_iter(self):
+        pidx = pd.Index([1, 2, 3])
+        kidx = ks.from_pandas(pidx)
+
+        for pandas_value, koalas_value in zip(pidx, kidx):
+            self.assert_eq(pandas_value, koalas_value)
+
+        # MultiIndex
+        pmidx = pd.MultiIndex.from_tuples([("x", "a"), ("x", "b"), ("y", "c")])
+        kmidx = ks.from_pandas(pmidx)
+
+        for pandas_value, koalas_value in zip(pmidx, kmidx):
+            self.assert_eq(pandas_value, koalas_value)


### PR DESCRIPTION
This PR proposes `__iter__()` for Index & MultiIndex by using `toLocalIterator` like we did at `DataFrame.iterrows` and `Series.iteritems`.

```python
>>> kidx = ks.Index([1, 2, 3])
>>> for value in kidx:
...     value
...
1
2
3
```