### PR TITLE
Implementing Series.tail() & DataFrame.tail()

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -10289,8 +10289,6 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         if n < 0:
             n = len(self) + n
         sdf = self._internal.spark_frame
-        data_spark_column_name = self._internal.data_spark_column_names[0]
-        index_spark_column_names = self._internal.index_spark_column_names
         rows = sdf.tail(n)
         new_sdf = default_session().createDataFrame(rows, sdf.schema)
 

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -10253,7 +10253,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Viewing the last 5 lines
 
-        >>> df.tail()
+        >>> df.tail()  # doctest: +SKIP
            animal
         4  monkey
         5  parrot
@@ -10263,7 +10263,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Viewing the last `n` lines (three in this case)
 
-        >>> df.tail(3)
+        >>> df.tail(3)  # doctest: +SKIP
           animal
         6  shark
         7  whale
@@ -10271,7 +10271,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         For negative values of `n`
 
-        >>> df.tail(-3)
+        >>> df.tail(-3)  # doctest: +SKIP
            animal
         3    lion
         4  monkey

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -10284,10 +10284,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             raise RuntimeError("tail can be used in PySpark >= 3.0")
         if not isinstance(n, int):
             raise TypeError("bad operand type for unary -: '{}'".format(type(n).__name__))
-        if n == 0:
-            return ks.DataFrame(self._internal.with_filter(F.lit(False)))
         if n < 0:
             n = len(self) + n
+        if n <= 0:
+            return ks.DataFrame(self._internal.with_filter(F.lit(False)))
         sdf = self._internal.spark_frame
         rows = sdf.tail(n)
         new_sdf = default_session().createDataFrame(rows, sdf.schema)

--- a/databricks/koalas/missing/frame.py
+++ b/databricks/koalas/missing/frame.py
@@ -68,7 +68,6 @@ class _MissingPandasLikeDataFrame(object):
     slice_shift = _unsupported_function("slice_shift")
     swapaxes = _unsupported_function("swapaxes")
     swaplevel = _unsupported_function("swaplevel")
-    tail = _unsupported_function("tail")
     to_feather = _unsupported_function("to_feather")
     to_gbq = _unsupported_function("to_gbq")
     to_hdf = _unsupported_function("to_hdf")

--- a/databricks/koalas/missing/series.py
+++ b/databricks/koalas/missing/series.py
@@ -64,7 +64,6 @@ class MissingPandasLikeSeries(object):
     slice_shift = _unsupported_function("slice_shift")
     swapaxes = _unsupported_function("swapaxes")
     swaplevel = _unsupported_function("swaplevel")
-    tail = _unsupported_function("tail")
     to_hdf = _unsupported_function("to_hdf")
     to_period = _unsupported_function("to_period")
     to_sql = _unsupported_function("to_sql")

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -5040,7 +5040,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         if not isinstance(n, int):
             raise TypeError("bad operand type for unary -: '{}'".format(type(n).__name__))
         if n == 0:
-            return ks.Series([])
+            return first_series(ks.DataFrame(self._internal.with_filter(F.lit(False))))
         if n < 0:
             n = len(self) + n
         sdf = self._internal.spark_frame

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -5035,19 +5035,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         4    5
         Name: 0, dtype: int64
         """
-        if LooseVersion(pyspark.__version__) < LooseVersion("3.0"):
-            raise RuntimeError("tail can be used in PySpark >= 3.0")
-        if not isinstance(n, int):
-            raise TypeError("bad operand type for unary -: '{}'".format(type(n).__name__))
-        if n == 0:
-            return first_series(ks.DataFrame(self._internal.with_filter(F.lit(False))))
-        if n < 0:
-            n = len(self) + n
-        sdf = self._internal.spark_frame
-        rows = sdf.tail(n)
-        new_sdf = default_session().createDataFrame(rows, sdf.schema)
-
-        return first_series(DataFrame(self._internal.with_new_sdf(new_sdf)))
+        return first_series(self.to_frame().tail(n=n))
 
     def _cum(self, func, skipna, part_cols=()):
         # This is used to cummin, cummax, cumsum, etc.

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -5029,7 +5029,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         4    5
         Name: 0, dtype: int64
 
-        >>> kser.tail(3)
+        >>> kser.tail(3)  # doctest: +SKIP
         2    3
         3    4
         4    5

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -5044,8 +5044,6 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         if n < 0:
             n = len(self) + n
         sdf = self._internal.spark_frame
-        data_spark_column_name = self._internal.data_spark_column_names[0]
-        index_spark_column_names = self._internal.index_spark_column_names
         rows = sdf.tail(n)
         new_sdf = default_session().createDataFrame(rows, sdf.schema)
 

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -3723,9 +3723,11 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             pdf = pd.DataFrame(range(1000))
             kdf = ks.from_pandas(pdf)
 
-            self.assert_eq(repr(pdf.tail()), repr(kdf.tail()))
-            self.assert_eq(repr(pdf.tail(10)), repr(kdf.tail(10)))
-            self.assert_eq(repr(pdf.tail(-990)), repr(kdf.tail(-990)))
-            self.assert_eq(repr(pdf.tail(0)), repr(kdf.tail(0)))
+            self.assert_eq(pdf.tail(), kdf.tail(), almost=True)
+            self.assert_eq(pdf.tail(10), kdf.tail(10), almost=True)
+            self.assert_eq(pdf.tail(-990), kdf.tail(-990), almost=True)
+            self.assert_eq(pdf.tail(0), kdf.tail(0), almost=True)
+            self.assert_eq(pdf.tail(-1001), kdf.tail(-1001), almost=True)
+            self.assert_eq(pdf.tail(1001), kdf.tail(1001), almost=True)
             with self.assertRaisesRegex(TypeError, "bad operand type for unary -: 'str'"):
                 kdf.tail("10")

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -3717,3 +3717,15 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         for p_items, k_items in zip(pdf.iteritems(), kdf.iteritems()):
             self.assert_eq(repr(p_items), repr(k_items))
+
+    def test_tail(self):
+        if LooseVersion(pyspark.__version__) >= LooseVersion("3.0"):
+            pdf = pd.DataFrame(range(1000))
+            kdf = ks.from_pandas(pdf)
+
+            self.assert_eq(repr(pdf.tail()), repr(kdf.tail()))
+            self.assert_eq(repr(pdf.tail(10)), repr(kdf.tail(10)))
+            self.assert_eq(repr(pdf.tail(-990)), repr(kdf.tail(-990)))
+            self.assert_eq(repr(pdf.tail(0)), repr(kdf.tail(0)))
+            with self.assertRaisesRegex(TypeError, "bad operand type for unary -: 'str'"):
+                kdf.tail("10")

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -1808,5 +1808,7 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
             self.assert_eq(pser.tail(10), kser.tail(10))
             self.assert_eq(pser.tail(-990), kser.tail(-990))
             self.assert_eq(pser.tail(0), kser.tail(0))
+            self.assert_eq(pser.tail(1001), kser.tail(1001))
+            self.assert_eq(pser.tail(-1001), kser.tail(-1001))
             with self.assertRaisesRegex(TypeError, "bad operand type for unary -: 'str'"):
                 kser.tail("10")

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -1801,7 +1801,7 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
 
     def test_tail(self):
         if LooseVersion(pyspark.__version__) >= LooseVersion("3.0"):
-            pser = pd.Series(range(1000))
+            pser = pd.Series(range(1000), name="Koalas")
             kser = ks.from_pandas(pser)
 
             self.assert_eq(pser.tail(), kser.tail())

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -1798,3 +1798,14 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
 
         for p_items, k_items in zip(pser.iteritems(), kser.iteritems()):
             self.assert_eq(repr(p_items), repr(k_items))
+
+    def test_tail(self):
+        pser = pd.Series(range(1000))
+        kser = ks.from_pandas(pser)
+
+        self.assert_eq(pser.tail(), kser.tail())
+        self.assert_eq(pser.tail(10), kser.tail(10))
+        self.assert_eq(pser.tail(-10), kser.tail(-10))
+        self.assert_eq(pser.tail(0), kser.tail(0))
+        with self.assertRaisesRegex(TypeError, "bad operand type for unary -: 'str'"):
+            kser.tail("10")

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -1800,12 +1800,13 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
             self.assert_eq(repr(p_items), repr(k_items))
 
     def test_tail(self):
-        pser = pd.Series(range(1000))
-        kser = ks.from_pandas(pser)
+        if LooseVersion(pyspark.__version__) >= LooseVersion("3.0"):
+            pser = pd.Series(range(1000))
+            kser = ks.from_pandas(pser)
 
-        self.assert_eq(pser.tail(), kser.tail())
-        self.assert_eq(pser.tail(10), kser.tail(10))
-        self.assert_eq(pser.tail(-10), kser.tail(-10))
-        self.assert_eq(pser.tail(0), kser.tail(0))
-        with self.assertRaisesRegex(TypeError, "bad operand type for unary -: 'str'"):
-            kser.tail("10")
+            self.assert_eq(pser.tail(), kser.tail())
+            self.assert_eq(pser.tail(10), kser.tail(10))
+            self.assert_eq(pser.tail(-990), kser.tail(-990))
+            self.assert_eq(pser.tail(0), kser.tail(0))
+            with self.assertRaisesRegex(TypeError, "bad operand type for unary -: 'str'"):
+                kser.tail("10")

--- a/docs/source/reference/frame.rst
+++ b/docs/source/reference/frame.rst
@@ -63,6 +63,7 @@ Indexing, iteration
    DataFrame.iterrows
    DataFrame.keys
    DataFrame.pop
+   DataFrame.tail
    DataFrame.xs
    DataFrame.get
    DataFrame.where

--- a/docs/source/reference/series.rst
+++ b/docs/source/reference/series.rst
@@ -171,6 +171,7 @@ Reindexing / Selection / Label manipulation
    Series.reset_index
    Series.sample
    Series.take
+   Series.tail
    Series.where
    Series.mask
    Series.truncate


### PR DESCRIPTION
As since Spark 3.0 supports a `tail()`, this PR proposes a `Series.tail()` and `DataFrame.tail()` for Koalas based on it.


- Series
```python
>>> kser = ks.Series([1, 2, 3, 4, 5])
>>> kser
0    1
1    2
2    3
3    4
4    5
Name: 0, dtype: int64

>>> kser.tail(3)
2    3
3    4
4    5
Name: 0, dtype: int64
```

- DataFrame
```python
>>> df = ks.DataFrame({'animal': ['alligator', 'bee', 'falcon', 'lion',
...                    'monkey', 'parrot', 'shark', 'whale', 'zebra']})
>>> df
      animal
0  alligator
1        bee
2     falcon
3       lion
4     monkey
5     parrot
6      shark
7      whale
8      zebra

>>> df.tail()
   animal
4  monkey
5  parrot
6   shark
7   whale
8   zebra

>>> df.tail(3)
  animal
6  shark
7  whale
8  zebra

>>> df.tail(-3)
   animal
3    lion
4  monkey
5  parrot
6   shark
7   whale
8   zebra
```

Resolves #343