### PR TITLE
Fix Series._with_new_scol to use alias.

### DIFF
--- a/databricks/koalas/accessors.py
+++ b/databricks/koalas/accessors.py
@@ -817,4 +817,4 @@ class KoalasSeriesMethods(object):
             spark_return_type = return_schema
 
         pudf = pandas_udf(func, returnType=spark_return_type, functionType=PandasUDFType.SCALAR)
-        return self._kser._with_new_scol(scol=pudf(self._kser.spark.column)).rename(self._kser.name)
+        return self._kser._with_new_scol(scol=pudf(self._kser.spark.column))

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -2550,9 +2550,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                     functionType=PandasUDFType.SCALAR,
                 )
                 kser = self._kser_for(input_label)
-                applied.append(
-                    kser._with_new_scol(scol=pudf(kser.spark.column)).rename(input_label)
-                )
+                applied.append(kser._with_new_scol(scol=pudf(kser.spark.column)))
 
             internal = self._internal.with_new_columns(applied)
             return DataFrame(internal)

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -1419,9 +1419,7 @@ class Frame(object, metaclass=ABCMeta):
         3  7  40   50
         """
         # TODO: The first example above should not have "Name: 0".
-        return self._apply_series_op(
-            lambda kser: kser._with_new_scol(F.abs(kser.spark.column)).rename(kser.name)
-        )
+        return self._apply_series_op(lambda kser: kser._with_new_scol(F.abs(kser.spark.column)))
 
     # TODO: by argument only support the grouping name and as_index only for now. Documentation
     # should be updated when it's supported.

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -135,7 +135,7 @@ class Index(IndexOpsMixin):
         :param scol: the new Spark Column
         :return: the copied Index
         """
-        sdf = self._internal.spark_frame.select(scol)  # type: ignore
+        sdf = self._internal.spark_frame.select(scol.alias(SPARK_DEFAULT_INDEX_NAME))
         internal = InternalFrame(
             spark_frame=sdf,
             index_map=OrderedDict(zip(sdf.columns, self._internal.index_names)),  # type: ignore

--- a/databricks/koalas/spark/accessors.py
+++ b/databricks/koalas/spark/accessors.py
@@ -116,7 +116,7 @@ class SparkIndexOpsMethods(object):
                 "The output of the function [%s] should be of a "
                 "pyspark.sql.Column; however, got [%s]." % (func, type(output))
             )
-        new_ser = self._data._with_new_scol(scol=output).rename(self._data.name)
+        new_ser = self._data._with_new_scol(scol=output)
         # Trigger the resolution so it throws an exception if anything does wrong
         # within the function, for example,
         # `df1.a.spark.transform(lambda _: F.col("non-existent"))`.

--- a/databricks/koalas/strings.py
+++ b/databricks/koalas/strings.py
@@ -38,7 +38,6 @@ class StringMethods(object):
         if not isinstance(series.spark.data_type, (StringType, BinaryType, ArrayType)):
             raise ValueError("Cannot call StringMethods on type {}".format(series.spark.data_type))
         self._data = series
-        self.name = self._data.name
 
     # Methods
     def capitalize(self) -> "ks.Series":
@@ -1148,7 +1147,7 @@ class StringMethods(object):
             returnType=ArrayType(StringType(), containsNull=True),
             functionType=PandasUDFType.SCALAR,
         )
-        return self._data._with_new_scol(scol=pudf(self._data.spark.column)).rename(self.name)
+        return self._data._with_new_scol(scol=pudf(self._data.spark.column))
 
     def index(self, sub, start=0, end=None) -> "ks.Series":
         """
@@ -2001,7 +2000,7 @@ class StringMethods(object):
             returnType=ArrayType(StringType(), containsNull=True),
             functionType=PandasUDFType.SCALAR,
         )
-        kser = self._data._with_new_scol(scol=pudf(self._data.spark.column)).rename(self.name)
+        kser = self._data._with_new_scol(scol=pudf(self._data.spark.column))
 
         if expand:
             kdf = kser.to_frame()
@@ -2135,7 +2134,7 @@ class StringMethods(object):
             returnType=ArrayType(StringType(), containsNull=True),
             functionType=PandasUDFType.SCALAR,
         )
-        kser = self._data._with_new_scol(scol=pudf(self._data.spark.column)).rename(self.name)
+        kser = self._data._with_new_scol(scol=pudf(self._data.spark.column))
 
         if expand:
             kdf = kser.to_frame()

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -141,6 +141,8 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         self.assertEqual(kser.name, "x")  # no mutation
         self.assert_eq(kser.rename(), pser.rename())
 
+        self.assert_eq((kser.rename("y") + 1).head(), (pser.rename("y") + 1).head())
+
         kser.rename("z", inplace=True)
         pser.rename("z", inplace=True)
         self.assertEqual(kser.name, "z")
@@ -243,6 +245,12 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         kser.fillna(0, inplace=True)
         pser.fillna(0, inplace=True)
         self.assert_eq(kser, pser)
+
+        kser = kdf.x.rename("y")
+        pser = pdf.x.rename("y")
+        kser.fillna(0, inplace=True)
+        pser.fillna(0, inplace=True)
+        self.assert_eq(kser.head(), pser.head())
 
         pser = pd.Series([1, 2, 3, 4, 5, 6], name="x")
         kser = ks.from_pandas(pser)

--- a/databricks/koalas/utils.py
+++ b/databricks/koalas/utils.py
@@ -342,7 +342,8 @@ def align_diff_series(func, this_series, *args, how="full"):
     )
 
     internal = combined._internal.copy(
-        column_labels=this_series._internal.column_labels, data_spark_columns=[scol]
+        column_labels=this_series._internal.column_labels,
+        data_spark_columns=[scol.alias(name_like_string(this_series.name))],
     )
     return first_series(DataFrame(internal))
 

--- a/databricks/koalas/window.py
+++ b/databricks/koalas/window.py
@@ -150,8 +150,7 @@ class Rolling(RollingAndExpanding):
 
     def _apply_as_series_or_frame(self, func):
         return self._kdf_or_kser._apply_series_op(
-            lambda kser: kser._with_new_scol(func(kser.spark.column)).rename(kser.name),
-            should_resolve=True,
+            lambda kser: kser._with_new_scol(func(kser.spark.column)), should_resolve=True
         )
 
     def count(self):
@@ -687,9 +686,7 @@ class RollingGroupby(Rolling):
 
         applied = []
         for agg_column in agg_columns:
-            applied.append(
-                agg_column._with_new_scol(func(agg_column.spark.column)).rename(agg_column.name)
-            )
+            applied.append(agg_column._with_new_scol(func(agg_column.spark.column)))
 
         # Seems like pandas filters out when grouped key is NA.
         cond = groupby._groupkeys[0].spark.column.isNotNull()


### PR DESCRIPTION
We should always use alias when `IndexOpsMixin._with_new_scol` to make sure the column name is valid.

```py
>>> kser = ks.Series([1, 2, 3, 4, 5, 6, 7], name="x")
>>> (kser.rename("y") + 1).head()
Traceback (most recent call last):
...
pyspark.sql.utils.AnalysisException: syntax error in attribute name: `(x AS `y` + 1)`;
```

Resolves #1633.