### PR TITLE
Remove the prefix 'u' for strings.

### DIFF
--- a/databricks/koalas/sql.py
+++ b/databricks/koalas/sql.py
@@ -178,13 +178,13 @@ def _get_ipython_scope():
 
 # Originally from pymysql package
 _escape_table = [chr(x) for x in range(128)]
-_escape_table[0] = u"\\0"
-_escape_table[ord("\\")] = u"\\\\"
-_escape_table[ord("\n")] = u"\\n"
-_escape_table[ord("\r")] = u"\\r"
-_escape_table[ord("\032")] = u"\\Z"
-_escape_table[ord('"')] = u'\\"'
-_escape_table[ord("'")] = u"\\'"
+_escape_table[0] = "\\0"
+_escape_table[ord("\\")] = "\\\\"
+_escape_table[ord("\n")] = "\\n"
+_escape_table[ord("\r")] = "\\r"
+_escape_table[ord("\032")] = "\\Z"
+_escape_table[ord('"')] = '\\"'
+_escape_table[ord("'")] = "\\'"
 
 
 def escape_sql_string(value: str) -> str:


### PR DESCRIPTION
Since Koalas is only in Python 3, we don't need the prefix 'u' for strings.