### PR TITLE
Fixed ks.Index.to_series() to work properly with name paramter

### DIFF
--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -683,9 +683,9 @@ class Index(IndexOpsMixin):
             name = self.name
         column_labels = (
             [(SPARK_DEFAULT_SERIES_NAME,)]
-            if len(kdf._internal.index_map) > 1
-            else [(SPARK_DEFAULT_SERIES_NAME,) if name is None else (name,)]
-        )
+            if len(kdf._internal.index_map) > 1 or name is None
+            else [name if isinstance(name, tuple) else (name,)]
+        )  # type: List[Tuple[str, ...]]
         internal = kdf._internal.copy(
             column_labels=column_labels, data_spark_columns=[scol], column_label_names=None
         )

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -679,6 +679,8 @@ class Index(IndexOpsMixin):
         scol = self.spark.column
         if name is not None:
             scol = scol.alias(name_like_string(name))
+        elif len(kdf._internal.index_map) == 1:
+            name = self.name
         column_labels = (
             [(SPARK_DEFAULT_SERIES_NAME,)]
             if len(kdf._internal.index_map) > 1

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -682,10 +682,7 @@ class Index(IndexOpsMixin):
         column_labels = (
             [(SPARK_DEFAULT_SERIES_NAME,)]
             if len(kdf._internal.index_map) > 1
-            else [
-                (SPARK_DEFAULT_SERIES_NAME,) if name is None else name
-                for name in kdf._internal.index_names
-            ]
+            else [(SPARK_DEFAULT_SERIES_NAME,) if name is None else (name,)]
         )
         internal = kdf._internal.copy(
             column_labels=column_labels, data_spark_columns=[scol], column_label_names=None

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -75,7 +75,7 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         kidx = self.kdf.index
 
         self.assert_eq(kidx.to_series(), pidx.to_series())
-        self.assert_eq(kidx.to_series(name="a"), pidx.to_series(name="a"))
+        self.assert_eq(repr(kidx.to_series(name="a")), repr(pidx.to_series(name="a")))
 
         self.assert_eq((kidx + 1).to_series(), (pidx + 1).to_series())
 

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -81,7 +81,7 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         pidx.name = "Koalas"
         kidx.name = "Koalas"
         self.assert_eq(repr(kidx.to_series()), repr(pidx.to_series()))
-        self.assert_eq(repr(kidx.to_series(name="a")), repr(pidx.to_series(name="a")))
+        self.assert_eq(repr(kidx.to_series(name=("x", "a"))), repr(pidx.to_series(name=("x", "a"))))
 
         # With tupled name
         pidx.name = ("x", "a")

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -77,8 +77,15 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         self.assert_eq(kidx.to_series(), pidx.to_series())
         self.assert_eq(repr(kidx.to_series(name="a")), repr(pidx.to_series(name="a")))
 
+        # With name
         pidx.name = "Koalas"
         kidx.name = "Koalas"
+        self.assert_eq(repr(kidx.to_series()), repr(pidx.to_series()))
+        self.assert_eq(repr(kidx.to_series(name="a")), repr(pidx.to_series(name="a")))
+
+        # With tupled name
+        pidx.name = ("x", "a")
+        kidx.name = ("x", "a")
         self.assert_eq(repr(kidx.to_series()), repr(pidx.to_series()))
         self.assert_eq(repr(kidx.to_series(name="a")), repr(pidx.to_series(name="a")))
 

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -77,6 +77,11 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         self.assert_eq(kidx.to_series(), pidx.to_series())
         self.assert_eq(repr(kidx.to_series(name="a")), repr(pidx.to_series(name="a")))
 
+        pidx.name = "Koalas"
+        kidx.name = "Koalas"
+        self.assert_eq(repr(kidx.to_series()), repr(pidx.to_series()))
+        self.assert_eq(repr(kidx.to_series(name="a")), repr(pidx.to_series(name="a")))
+
         self.assert_eq((kidx + 1).to_series(), (pidx + 1).to_series())
 
         pidx = self.pdf.set_index("b", append=True).index


### PR DESCRIPTION
The existing `ks.Index.to_series()` work not properly with `name` parameter
(**Although Its test was passed !**)

```python
>>> kidx = ks.Index([1, 2, 3])
>>> kidx.to_series(name="Koalas")
1    1
2    2
3    3
Name: 0, dtype: int64  # It should have renamed to 'Koalas'
```

This PR addressed it.