### PR TITLE
Fix MultiIndex.to_frame() work properly internally

### DIFF
--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -2385,19 +2385,21 @@ class MultiIndex(Index):
         else:
             raise TypeError("'name' must be a list / sequence of column names.")
 
-        sdf = self._internal.spark_frame.select(
-            [
-                scol.alias(name_like_string(label))
-                for scol, label in zip(self._internal.index_spark_columns, name)
-            ]
-            + [NATURAL_ORDER_COLUMN_NAME]
-        )
-
         if index:
+            sdf = self._internal.spark_frame
+            for label, index_spark_column in zip(name, self._internal.index_spark_columns):
+                sdf = sdf.withColumn(label[0], index_spark_column)
             index_map = OrderedDict(
                 (name_like_string(label), n) for label, n in zip(name, self._internal.index_names)
             )
         else:
+            sdf = self._internal.spark_frame.select(
+                [
+                    scol.alias(name_like_string(label))
+                    for scol, label in zip(self._internal.index_spark_columns, name)
+                ]
+                + [NATURAL_ORDER_COLUMN_NAME]
+            )
             index_map = None  # type: ignore
 
         internal = InternalFrame(


### PR DESCRIPTION
This should resolve #1647 

```python
>>> idx
MultiIndex([(1,  'red'),
            (1, 'blue'),
            (2,  'red'),
            (2, 'blue')],
           names=['number', 'color'])

>>> kdf = idx.to_frame()
>>> kdf
              number color
number color
1      red         1   red
       blue        1  blue
2      red         2   red
       blue        2  blue

>>> kdf._internal.spark_frame.show()
+-----------------+-----------------+-----------------+------+-----+
|__index_level_0__|__index_level_1__|__natural_order__|number|color|
+-----------------+-----------------+-----------------+------+-----+
|                1|              red|      17179869184|     1|  red|
|                1|             blue|      42949672960|     1| blue|
|                2|              red|      68719476736|     2|  red|
|                2|             blue|      94489280512|     2| blue|
+-----------------+-----------------+-----------------+------+-----+
```