### PR TITLE
Fix fillna to handle "ffill" and "bfill" properly.

### DIFF
--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -1564,8 +1564,9 @@ class GroupBy(object, metaclass=ABCMeta):
         """
         return self._apply_series_op(
             lambda sg: sg._kser._fillna(
-                value, method, axis, inplace, limit, part_cols=sg._groupkeys_scols,
-            )
+                value=value, method=method, axis=axis, limit=limit, part_cols=sg._groupkeys_scols
+            ),
+            should_resolve=(method is not None),
         )
 
     def bfill(self, limit=None):

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -2710,30 +2710,54 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         )
 
     def test_ffill(self):
+        idx = np.random.rand(6)
         pdf = pd.DataFrame(
             {
                 "x": [np.nan, 2, 3, 4, np.nan, 6],
                 "y": [1, 2, np.nan, 4, np.nan, np.nan],
                 "z": [1, 2, 3, 4, np.nan, np.nan],
             },
-            index=np.random.rand(6),
+            index=idx,
         )
         kdf = ks.from_pandas(pdf)
+
         self.assert_eq(kdf.ffill(), pdf.ffill())
         self.assert_eq(kdf.ffill(limit=1), pdf.ffill(limit=1))
 
+        pser = pdf.y
+        kser = kdf.y
+
+        kdf.ffill(inplace=True)
+        pdf.ffill(inplace=True)
+
+        self.assert_eq(kdf, pdf)
+        self.assert_eq(kser, pser)
+        self.assert_eq(kser[idx[2]], pser[idx[2]])
+
     def test_bfill(self):
+        idx = np.random.rand(6)
         pdf = pd.DataFrame(
             {
                 "x": [np.nan, 2, 3, 4, np.nan, 6],
                 "y": [1, 2, np.nan, 4, np.nan, np.nan],
                 "z": [1, 2, 3, 4, np.nan, np.nan],
             },
-            index=np.random.rand(6),
+            index=idx,
         )
         kdf = ks.from_pandas(pdf)
+
         self.assert_eq(kdf.bfill(), pdf.bfill())
         self.assert_eq(kdf.bfill(limit=1), pdf.bfill(limit=1))
+
+        pser = pdf.x
+        kser = kdf.x
+
+        kdf.bfill(inplace=True)
+        pdf.bfill(inplace=True)
+
+        self.assert_eq(kdf, pdf)
+        self.assert_eq(kser, pser)
+        self.assert_eq(kser[idx[0]], pser[idx[0]])
 
     def test_filter(self):
         pdf = pd.DataFrame(

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -1232,6 +1232,7 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         )
 
     def test_ffill(self):
+        idx = np.random.rand(4 * 3)
         pdf = pd.DataFrame(
             {
                 "A": [1, 1, 2, 2] * 3,
@@ -1239,7 +1240,7 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
                 "C": [None, None, None, 1] * 3,
                 "D": [0, 1, 5, 4] * 3,
             },
-            index=np.random.rand(4 * 3),
+            index=idx,
         )
         kdf = ks.from_pandas(pdf)
 
@@ -1265,6 +1266,7 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             pdf.groupby("A")["B"].ffill().sort_index(),
             almost=True,
         )
+        self.assert_eq(kdf.groupby("A")["B"].ffill()[idx[6]], pdf.groupby("A")["B"].ffill()[idx[6]])
 
         # multi-index columns
         columns = pd.MultiIndex.from_tuples([("X", "A"), ("X", "B"), ("Y", "C"), ("Z", "D")])
@@ -1283,6 +1285,7 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             )
 
     def test_bfill(self):
+        idx = np.random.rand(4 * 3)
         pdf = pd.DataFrame(
             {
                 "A": [1, 1, 2, 2] * 3,
@@ -1290,7 +1293,7 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
                 "C": [None, None, None, 1] * 3,
                 "D": [0, 1, 5, 4] * 3,
             },
-            index=np.random.rand(4 * 3),
+            index=idx,
         )
         kdf = ks.from_pandas(pdf)
 
@@ -1314,6 +1317,7 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         self.assert_eq(
             kdf.groupby("A")["B"].bfill().sort_index(), pdf.groupby("A")["B"].bfill().sort_index(),
         )
+        self.assert_eq(kdf.groupby("A")["B"].bfill()[idx[6]], pdf.groupby("A")["B"].bfill()[idx[6]])
 
         # multi-index columns
         columns = pd.MultiIndex.from_tuples([("X", "A"), ("X", "B"), ("Y", "C"), ("Z", "D")])

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -227,7 +227,7 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(kdf, pdf)
 
     def test_fillna(self):
-        pdf = pd.DataFrame({"x": [np.nan, 2, 3, 4, np.nan, 6]})
+        pdf = pd.DataFrame({"x": [np.nan, 2, 3, 4, np.nan, 6], "y": [np.nan, 2, 3, 4, np.nan, 6]})
         kdf = ks.from_pandas(pdf)
 
         pser = pdf.x
@@ -1781,24 +1781,36 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(np.abs(kser), np.abs(pser))
 
     def test_bfill(self):
-        pser = pd.Series([np.nan, 2, 3, 4, np.nan, 6], name="x")
-        kser = ks.from_pandas(pser)
+        pdf = pd.DataFrame({"x": [np.nan, 2, 3, 4, np.nan, 6], "y": [np.nan, 2, 3, 4, np.nan, 6]})
+        kdf = ks.from_pandas(pdf)
+
+        pser = pdf.x
+        kser = kdf.x
 
         self.assert_eq(kser.bfill(), pser.bfill())
+        self.assert_eq(kser.bfill()[0], pser.bfill()[0])
 
         kser.bfill(inplace=True)
         pser.bfill(inplace=True)
         self.assert_eq(kser, pser)
+        self.assert_eq(kser[0], pser[0])
+        self.assert_eq(kdf, pdf)
 
     def test_ffill(self):
-        pser = pd.Series([np.nan, 2, 3, 4, np.nan, 6], name="x")
-        kser = ks.from_pandas(pser)
+        pdf = pd.DataFrame({"x": [np.nan, 2, 3, 4, np.nan, 6], "y": [np.nan, 2, 3, 4, np.nan, 6]})
+        kdf = ks.from_pandas(pdf)
 
-        self.assert_eq(repr(kser.ffill()), repr(pser.ffill()))
+        pser = pdf.x
+        kser = kdf.x
+
+        self.assert_eq(kser.ffill(), pser.ffill(), almost=True)
+        self.assert_eq(kser.ffill()[4], pser.ffill()[4])
 
         kser.ffill(inplace=True)
         pser.ffill(inplace=True)
-        self.assert_eq(repr(kser), repr(pser))
+        self.assert_eq(kser, pser, almost=True)
+        self.assert_eq(kser[4], pser[4])
+        self.assert_eq(kdf, pdf)
 
     def test_iteritems(self):
         pser = pd.Series(["A", "B", "C"])


### PR DESCRIPTION
`fillna` with `method="ffill"` or `method="bfill"` uses Spark's Window functions internally, so we should create a new Spark DataFrame to apply the function properly.

Fixes #1651:

```py
>>> from databricks.koalas import Series
>>> import numpy as np
>>> a = ["Bob", "John", None]
>>> b = ["Bob", "John", np.nan]
>>> s1 = Series(a)
>>> s2 = Series(b)
>>> r1 = s1.fillna(method="ffill")
>>> r1
0     Bob
1    John
2    John
Name: 0, dtype: object
>>> r1[2]
'John'
>>> r2 = s2.fillna(method="ffill")
>>> r2
0     Bob
1    John
2    John
Name: 0, dtype: object
>>> r2[2]
'John'
```
