### PR TITLE
read_csv: Implement reading of number of rows

### DIFF
--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -183,6 +183,7 @@ def read_csv(
     squeeze=False,
     mangle_dupe_cols=True,
     dtype=None,
+    nrows=None,
     parse_dates=False,
     quotechar=None,
     escapechar=None,
@@ -228,6 +229,8 @@ def read_csv(
     dtype : Type name or dict of column -> type, default None
         Data type for data or columns. E.g. {‘a’: np.float64, ‘b’: np.int32} Use str or object
         together with suitable na_values settings to preserve and not interpret dtype.
+    nrows : int, default None
+        Number of rows to read from the CSV file.
     parse_dates : boolean or list of ints or names or list of lists or dict, default `False`.
         Currently only `False` is allowed.
     quotechar : str (length 1), optional
@@ -340,6 +343,9 @@ def read_csv(
                 sdf = default_session().createDataFrame([], schema=StructType())
     else:
         sdf = default_session().createDataFrame([], schema=StructType())
+
+    if nrows is not None:
+        sdf = sdf.limit(nrows)
 
     index_map = _get_index_map(sdf, index_col)
     kdf = DataFrame(InternalFrame(spark_frame=sdf, index_map=index_map))

--- a/databricks/koalas/tests/test_csv.py
+++ b/databricks/koalas/tests/test_csv.py
@@ -220,6 +220,12 @@ class CsvTest(ReusedSQLTestCase, TestUtils):
                 lambda: ks.read_csv(fn, comment=[1]),
             )
 
+    def test_read_csv_with_limit(self):
+        with self.csv_file(self.csv_text_with_comments) as fn:
+            expected = pd.read_csv(fn, comment="#", nrows=2)
+            actual = ks.read_csv(fn, comment="#", nrows=2)
+            self.assertPandasAlmostEqual(expected, actual.toPandas())
+
     def test_read_csv_with_sep(self):
         with self.csv_file(self.tab_delimited_csv_text) as fn:
             expected = pd.read_csv(fn, sep="\t")


### PR DESCRIPTION
Implement reading of number of rows (nrows) in read_csv by using spark's limit.

On the first read, this does not seem to help much with regards to reading speed, because `inferSchema` is True and spark seems to scan over the full data anyway (see e.g. [here](https://stackoverflow.com/questions/44277019/how-to-read-only-n-rows-of-large-csv-file-on-hdfs-using-spark-csv-package)). It would help to use it as a similar parameter to `read_csv` than in pandas to make the API more compatible.