### PR TITLE
Fix test failures caused by numpy upgrade.

### DIFF
--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -752,10 +752,17 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
 
         self.assert_eq(pidx.delete(5).sort_values(), kidx.delete(5).sort_values())
         self.assert_eq(pidx.delete(-5).sort_values(), kidx.delete(-5).sort_values())
-        self.assert_eq(pidx.delete([0, 10000]).sort_values(), kidx.delete([0, 10000]).sort_values())
-        self.assert_eq(
-            pidx.delete([10000, 20000]).sort_values(), kidx.delete([10000, 20000]).sort_values()
-        )
+
+        if LooseVersion(np.__version__) < LooseVersion("1.19"):
+            self.assert_eq(
+                pidx.delete([0, 10000]).sort_values(), kidx.delete([0, 10000]).sort_values()
+            )
+            self.assert_eq(
+                pidx.delete([10000, 20000]).sort_values(), kidx.delete([10000, 20000]).sort_values()
+            )
+        else:
+            self.assert_eq(pidx.delete([0]).sort_values(), kidx.delete([0, 10000]).sort_values())
+            self.assert_eq(pidx.delete([]).sort_values(), kidx.delete([10000, 20000]).sort_values())
 
         with self.assertRaisesRegex(IndexError, "index 10 is out of bounds for axis 0 with size 9"):
             kidx.delete(10)
@@ -765,10 +772,17 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
 
         self.assert_eq(pidx.delete(1).sort_values(), kidx.delete(1).sort_values())
         self.assert_eq(pidx.delete(-1).sort_values(), kidx.delete(-1).sort_values())
-        self.assert_eq(pidx.delete([0, 10000]).sort_values(), kidx.delete([0, 10000]).sort_values())
-        self.assert_eq(
-            pidx.delete([10000, 20000]).sort_values(), kidx.delete([10000, 20000]).sort_values()
-        )
+
+        if LooseVersion(np.__version__) < LooseVersion("1.19"):
+            self.assert_eq(
+                pidx.delete([0, 10000]).sort_values(), kidx.delete([0, 10000]).sort_values()
+            )
+            self.assert_eq(
+                pidx.delete([10000, 20000]).sort_values(), kidx.delete([10000, 20000]).sort_values()
+            )
+        else:
+            self.assert_eq(pidx.delete([0]).sort_values(), kidx.delete([0, 10000]).sort_values())
+            self.assert_eq(pidx.delete([]).sort_values(), kidx.delete([10000, 20000]).sort_values())
 
     def test_append(self):
         # Index


### PR DESCRIPTION
Since numpy 1.19, `np.delete` came to fail on out-of-bounds indices (https://github.com/numpy/numpy/pull/15804) and pandas will as well since it depends on numpy.