### PR TITLE
Set the lower bound for Plotly.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -28,4 +28,4 @@ pytest-cov
 scikit-learn
 openpyxl
 xlrd
-plotly
+plotly>=4.8


### PR DESCRIPTION
Sets the lower bound for Plotly, just in case, since Plotly works as a plotting background since `4.8`.

> Since version 0.25, Pandas has provided a mechanism to use different backends, and as of version 4.8 of plotly, you can now use a Plotly Express-powered backend for Pandas plotting.

https://plotly.com/python/pandas-backend/