### PR TITLE
Set the upper bound for numpy.

### DIFF
--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -752,17 +752,10 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
 
         self.assert_eq(pidx.delete(5).sort_values(), kidx.delete(5).sort_values())
         self.assert_eq(pidx.delete(-5).sort_values(), kidx.delete(-5).sort_values())
-
-        if LooseVersion(np.__version__) < LooseVersion("1.19"):
-            self.assert_eq(
-                pidx.delete([0, 10000]).sort_values(), kidx.delete([0, 10000]).sort_values()
-            )
-            self.assert_eq(
-                pidx.delete([10000, 20000]).sort_values(), kidx.delete([10000, 20000]).sort_values()
-            )
-        else:
-            self.assert_eq(pidx.delete([0]).sort_values(), kidx.delete([0, 10000]).sort_values())
-            self.assert_eq(pidx.delete([]).sort_values(), kidx.delete([10000, 20000]).sort_values())
+        self.assert_eq(pidx.delete([0, 10000]).sort_values(), kidx.delete([0, 10000]).sort_values())
+        self.assert_eq(
+            pidx.delete([10000, 20000]).sort_values(), kidx.delete([10000, 20000]).sort_values()
+        )
 
         with self.assertRaisesRegex(IndexError, "index 10 is out of bounds for axis 0 with size 9"):
             kidx.delete(10)
@@ -772,17 +765,10 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
 
         self.assert_eq(pidx.delete(1).sort_values(), kidx.delete(1).sort_values())
         self.assert_eq(pidx.delete(-1).sort_values(), kidx.delete(-1).sort_values())
-
-        if LooseVersion(np.__version__) < LooseVersion("1.19"):
-            self.assert_eq(
-                pidx.delete([0, 10000]).sort_values(), kidx.delete([0, 10000]).sort_values()
-            )
-            self.assert_eq(
-                pidx.delete([10000, 20000]).sort_values(), kidx.delete([10000, 20000]).sort_values()
-            )
-        else:
-            self.assert_eq(pidx.delete([0]).sort_values(), kidx.delete([0, 10000]).sort_values())
-            self.assert_eq(pidx.delete([]).sort_values(), kidx.delete([10000, 20000]).sort_values())
+        self.assert_eq(pidx.delete([0, 10000]).sort_values(), kidx.delete([0, 10000]).sort_values())
+        self.assert_eq(
+            pidx.delete([10000, 20000]).sort_values(), kidx.delete([10000, 20000]).sort_values()
+        )
 
     def test_append(self):
         # Index

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@
 pandas>=0.23.2
 pyarrow>=0.10
 matplotlib>=3.0.0,<3.3.0
-numpy>=1.14
+numpy>=1.14,<1.19.0
 
 # Optional dependencies in Koalas.
 mlflow>=1.0


### PR DESCRIPTION
So far pandas sets the upper bound for numpy: https://github.com/pandas-dev/pandas/blob/master/requirements-dev.txt#L4
I'd revert the previous change to fix build and set the upper bound here as well.
Tracking to remove the upper bounds for `numpy` and `matplotlib` at #1670.