### PR TITLE
Matching an error message same as pandas for Index.to_series

### DIFF
--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -17,7 +17,7 @@
 """
 Wrappers for Indexes to behave similar to pandas Index, MultiIndex.
 """
-from collections import OrderedDict
+from collections import OrderedDict, abc
 from distutils.version import LooseVersion
 from functools import partial
 from typing import Any, List, Tuple, Union
@@ -675,6 +675,8 @@ class Index(IndexOpsMixin):
         d    d
         Name: 0, dtype: object
         """
+        if not isinstance(name, abc.Hashable):
+            raise TypeError("Series.name must be a hashable type")
         kdf = self._kdf
         scol = self.spark.column
         if name is not None:

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -17,7 +17,7 @@
 """
 Wrappers for Indexes to behave similar to pandas Index, MultiIndex.
 """
-from collections import OrderedDict, abc
+from collections import OrderedDict
 from distutils.version import LooseVersion
 from functools import partial
 from typing import Any, List, Tuple, Union
@@ -36,6 +36,7 @@ from pandas.api.types import (
     is_object_dtype,
 )
 from pandas.io.formats.printing import pprint_thing
+from pandas.api.types import is_hashable
 
 import pyspark
 from pyspark import sql as spark
@@ -675,7 +676,7 @@ class Index(IndexOpsMixin):
         d    d
         Name: 0, dtype: object
         """
-        if not isinstance(name, abc.Hashable):
+        if not is_hashable(name):
             raise TypeError("Series.name must be a hashable type")
         kdf = self._kdf
         scol = self.spark.column

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -98,6 +98,10 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
             self.assert_eq(kidx.to_series(), pidx.to_series())
             self.assert_eq(kidx.to_series(name="a"), pidx.to_series(name="a"))
 
+        expected_error_message = "Series.name must be a hashable type"
+        with self.assertRaisesRegex(TypeError, expected_error_message):
+            kidx.to_series(name=["x", "a"])
+
     def test_to_frame(self):
         pidx = self.pdf.index
         kidx = self.kdf.index


### PR DESCRIPTION
To match an error message same as pandas.

```python
>>> pdf
   dogs  cats
a   0.2   0.3
b   0.0   0.6
c   0.6   0.0
d   0.2   0.1
>>> kdf
   dogs  cats
a   0.2   0.3
b   0.0   0.6
c   0.6   0.0
d   0.2   0.1

>>> pdf['dogs'].index.to_series(name=["x", "a"])
Traceback (most recent call last):
...
TypeError: Series.name must be a hashable type

>>> kdf['dogs'].index.to_series(name=["x", "a"])
Traceback (most recent call last):
...
TypeError: Series.name must be a hashable type
```