### PR TITLE
Add Series.product

### DIFF
--- a/databricks/koalas/missing/series.py
+++ b/databricks/koalas/missing/series.py
@@ -50,8 +50,6 @@ class MissingPandasLikeSeries(object):
     interpolate = _unsupported_function("interpolate")
     last = _unsupported_function("last")
     last_valid_index = _unsupported_function("last_valid_index")
-    prod = _unsupported_function("prod")
-    product = _unsupported_function("product")
     reindex = _unsupported_function("reindex")
     reindex_like = _unsupported_function("reindex_like")
     rename_axis = _unsupported_function("rename_axis")

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -4993,7 +4993,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         data_type = self.spark.data_type
         if isinstance(data_type, StringType):
             raise TypeError("can't multiply sequence by non-int of type 'str'")
-        # When number of valid values less than `min_count`, pandas returns np.nan
+        # When number of valid values is fewer than `min_count`, pandas returns np.nan
         if (min_count > 0) and (len(self.dropna()) < min_count):
             return np.nan
         # When Series is empty, pandas returns 1.0

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -44,7 +44,6 @@ from pyspark.sql.types import (
     NumericType,
     StringType,
     StructType,
-    TimestampType,
     IntegralType,
     FractionalType,
 )

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -4972,21 +4972,6 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         .. note:: unlike pandas', Koalas' emulates product by ``exp(sum(log(...)))``
             trick. Therefore, it only works for positive numbers.
 
-        .. note:: the result can be slightly difference from pandas since the rounding error.
-            In this case, use `math.isclose` to check whether the result is close to pandas' or not.
-
-             >>> result_pandas = pd.Series([10, np.nan, 30, np.nan, 50]).prod()
-             >>> result_pandas
-             15000.0
-
-             >>> result_koalas = ks.Series([10, np.nan, 30, np.nan, 50]).prod()
-             >>> result_koalas
-             15000.000000000004
-
-             >>> from math import isclose
-             >>> isclose(result_pandas, result_koalas)
-             True
-
         Parameters
         ----------
         min_count : int, default 0
@@ -5014,7 +4999,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         data_type = self.spark.data_type
         if isinstance(data_type, BooleanType):
-            return self.sum() == len(self)
+            return self.all()
         elif isinstance(data_type, (IntegralType, FractionalType)):
             spark_frame = self._internal.spark_frame
             spark_column = self.spark.column

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -4990,6 +4990,9 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         >>> ks.Series([]).prod(min_count=1)
         nan
         """
+        data_type = self.spark.data_type
+        if isinstance(data_type, StringType):
+            raise TypeError("can't multiply sequence by non-int of type 'str'")
         # When number of valid values less than `min_count`, pandas returns np.nan
         if (min_count > 0) and (len(self.dropna()) < min_count):
             return np.nan
@@ -5003,7 +5006,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         spark_frame = spark_frame.select(F.exp(F.sum(F.log(cond))))
 
         result = round(spark_frame.head(1)[0][0], 6)
-        if isinstance(self.spark.data_type, LongType):
+        if isinstance(data_type, LongType):
             return int(result)
         else:
             return result

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -45,7 +45,6 @@ from pyspark.sql.types import (
     StringType,
     StructType,
     IntegralType,
-    FractionalType,
 )
 from pyspark.sql.window import Window
 
@@ -4999,7 +4998,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         data_type = self.spark.data_type
         if isinstance(data_type, BooleanType):
             return self.all()
-        elif isinstance(data_type, (IntegralType, FractionalType)):
+        elif isinstance(data_type, NumericType):
             spark_frame = self._internal.spark_frame
             spark_column = self.spark.column
 
@@ -5010,7 +5009,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             if result is None:
                 # When Series is empty, pandas returns 1.0
                 return 1.0
-            elif isinstance(data_type, (LongType, BooleanType)):
+            elif isinstance(data_type, IntegralType):
                 return int(round(result))
             else:
                 return result

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -1904,7 +1904,7 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         # Containing NA values
         pser = pd.Series([10, np.nan, 30, np.nan, 50])
         kser = ks.from_pandas(pser)
-        self.assert_eq(isclose(pser.prod(), kser.prod()), True)
+        self.assert_eq(pser.prod(), kser.prod(), almost=True)
 
         # All-NA values
         pser = pd.Series([np.nan, np.nan, np.nan])
@@ -1925,7 +1925,7 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
 
         pser = pd.Series([10, np.nan, 30, np.nan, 50])
         kser = ks.from_pandas(pser)
-        self.assert_eq(isclose(pser.prod(min_count=3), kser.prod(min_count=3)), True)
+        self.assert_eq(pser.prod(min_count=3), kser.prod(min_count=3), almost=True)
         # ditto.
         self.assert_eq(repr(pser.prod(min_count=4)), repr(kser.prod(min_count=4)))
 

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -1915,6 +1915,19 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         kser = ks.from_pandas(pser)
         self.assert_eq(pser.prod(), kser.prod())
 
+        # Boolean Series
+        pser = pd.Series([True, True, True])
+        kser = ks.from_pandas(pser)
+        self.assert_eq(pser.prod(), kser.prod())
+
+        pser = pd.Series([False, False, False])
+        kser = ks.from_pandas(pser)
+        self.assert_eq(pser.prod(), kser.prod())
+
+        pser = pd.Series([True, False, True])
+        kser = ks.from_pandas(pser)
+        self.assert_eq(pser.prod(), kser.prod())
+
         # With `min_count` parameter
         pser = pd.Series([10, 20, 30, 40, 50])
         kser = ks.from_pandas(pser)
@@ -1938,5 +1951,7 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         # ditto.
         self.assert_eq(repr(pser.prod(min_count=1)), repr(kser.prod(min_count=1)))
 
-        with self.assertRaisesRegex(TypeError, "can't multiply sequence by non-int of type 'str'"):
+        with self.assertRaisesRegex(TypeError, "cannot perform prod with type object"):
             ks.Series(["a", "b", "c"]).prod()
+        with self.assertRaisesRegex(TypeError, "cannot perform prod with type datetime64"):
+            ks.Series([pd.Timestamp("2016-01-01") for _ in range(3)]).prod()

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -1894,3 +1894,46 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
             self.assert_eq(pser.tail(-1001), kser.tail(-1001))
             with self.assertRaisesRegex(TypeError, "bad operand type for unary -: 'str'"):
                 kser.tail("10")
+
+    def test_product(self):
+        pser = pd.Series([10, 20, 30, 40, 50])
+        kser = ks.from_pandas(pser)
+        self.assert_eq(pser.prod(), kser.prod())
+
+        # Containing NA values
+        pser = pd.Series([10, np.nan, 30, np.nan, 50])
+        kser = ks.from_pandas(pser)
+        self.assert_eq(pser.prod(), kser.prod())
+
+        # All-NA values
+        pser = pd.Series([np.nan, np.nan, np.nan])
+        kser = ks.from_pandas(pser)
+        self.assert_eq(pser.prod(), kser.prod())
+
+        # Empty Series
+        pser = pd.Series([])
+        kser = ks.from_pandas(pser)
+        self.assert_eq(pser.prod(), kser.prod())
+
+        # With `min_count` parameter
+        pser = pd.Series([10, 20, 30, 40, 50])
+        kser = ks.from_pandas(pser)
+        self.assert_eq(pser.prod(min_count=5), kser.prod(min_count=5))
+        # Using `repr` since the result of below will be `np.nan`.
+        self.assert_eq(repr(pser.prod(min_count=6)), repr(kser.prod(min_count=6)))
+
+        pser = pd.Series([10, np.nan, 30, np.nan, 50])
+        kser = ks.from_pandas(pser)
+        self.assert_eq(pser.prod(min_count=3), kser.prod(min_count=3))
+        # ditto.
+        self.assert_eq(repr(pser.prod(min_count=4)), repr(kser.prod(min_count=4)))
+
+        pser = pd.Series([np.nan, np.nan, np.nan])
+        kser = ks.from_pandas(pser)
+        # ditto.
+        self.assert_eq(repr(pser.prod(min_count=1)), repr(kser.prod(min_count=1)))
+
+        pser = pd.Series([])
+        kser = ks.from_pandas(pser)
+        # ditto.
+        self.assert_eq(repr(pser.prod(min_count=1)), repr(kser.prod(min_count=1)))

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -1937,3 +1937,6 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         kser = ks.from_pandas(pser)
         # ditto.
         self.assert_eq(repr(pser.prod(min_count=1)), repr(kser.prod(min_count=1)))
+
+        with self.assertRaisesRegex(TypeError, "can't multiply sequence by non-int of type 'str'"):
+            ks.Series(["a", "b", "c"]).prod()

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -1974,4 +1974,3 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         pser = pd.Series([pd.Timestamp("2020-07-30"), np.nan, pd.Timestamp("2020-07-30")])
         kser = ks.from_pandas(pser)
         self.assert_eq(pser.hasnans, kser.hasnans)
->>>>>>> fb2eedcfad66635039c05009586f310cc79fe17a

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -15,6 +15,7 @@
 #
 
 import base64
+from math import isclose
 from collections import defaultdict
 from distutils.version import LooseVersion
 import inspect
@@ -1903,7 +1904,7 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         # Containing NA values
         pser = pd.Series([10, np.nan, 30, np.nan, 50])
         kser = ks.from_pandas(pser)
-        self.assert_eq(pser.prod(), kser.prod())
+        self.assert_eq(isclose(pser.prod(), kser.prod()), True)
 
         # All-NA values
         pser = pd.Series([np.nan, np.nan, np.nan])
@@ -1924,7 +1925,7 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
 
         pser = pd.Series([10, np.nan, 30, np.nan, 50])
         kser = ks.from_pandas(pser)
-        self.assert_eq(pser.prod(min_count=3), kser.prod(min_count=3))
+        self.assert_eq(isclose(pser.prod(min_count=3), kser.prod(min_count=3)), True)
         # ditto.
         self.assert_eq(repr(pser.prod(min_count=4)), repr(kser.prod(min_count=4)))
 

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -15,7 +15,6 @@
 #
 
 import base64
-from math import isclose
 from collections import defaultdict
 from distutils.version import LooseVersion
 import inspect

--- a/docs/source/reference/series.rst
+++ b/docs/source/reference/series.rst
@@ -88,6 +88,7 @@ Binary operator functions
    Series.ge
    Series.ne
    Series.eq
+   Series.product
    Series.dot
 
 Function application, GroupBy & Window
@@ -134,6 +135,7 @@ Computations / Descriptive Stats
    Series.nlargest
    Series.nsmallest
    Series.pct_change
+   Series.prod
    Series.nunique
    Series.is_unique
    Series.quantile


### PR DESCRIPTION
Implemented `Series.product` (`Series.prod` as an alias).

*Note that since It is implemented by using `exp(sum(log(...)))` trick, it only works for positive numbers.

```python
>>> ks.Series([]).prod()
1.0
>>> ks.Series([1, 2, 3, 4, 5]).prod()
120
>>> ks.Series([1, np.nan, 3, np.nan, 5]).prod()
15.0
```