### PR TITLE
Make read_excel read from DFS if the underlying Spark is 3.0.0 or above.

### DIFF
--- a/databricks/koalas/tests/test_dataframe_spark_io.py
+++ b/databricks/koalas/tests/test_dataframe_spark_io.py
@@ -18,6 +18,7 @@ from distutils.version import LooseVersion
 
 import numpy as np
 import pandas as pd
+import pyspark
 
 from databricks import koalas as ks
 from databricks.koalas.testing.utils import ReusedSQLTestCase, TestUtils
@@ -207,3 +208,49 @@ class DataFrameSparkIOTest(ReusedSQLTestCase, TestUtils):
                 actual_idx.sort_values(by="f").to_spark().toPandas(),
                 expected_idx.sort_values(by="f").to_spark().toPandas(),
             )
+
+    def test_read_excel(self):
+        with self.temp_dir() as tmp:
+            pdf = self.test_pdf
+
+            path1 = "{}/file1.xlsx".format(tmp)
+            pdf.to_excel(path1)
+
+            self.assert_eq(ks.read_excel(path1), pd.read_excel(path1))
+            self.assert_eq(ks.read_excel(path1, index_col=0), pd.read_excel(path1, index_col=0))
+
+            if LooseVersion(pyspark.__version__) >= LooseVersion("3.0.0"):
+                self.assert_eq(ks.read_excel(tmp), pd.read_excel(path1))
+
+                path2 = "{}/file2.xlsx".format(tmp)
+                pdf.to_excel(path2)
+                self.assert_eq(
+                    ks.read_excel(tmp), pd.concat([pd.read_excel(path1), pd.read_excel(path2)])
+                )
+
+        with self.temp_dir() as tmp:
+            path1 = "{}/file1.xlsx".format(tmp)
+            with pd.ExcelWriter(path1) as writer:
+                pdf.to_excel(writer, sheet_name="Sheet_name_1")
+                pdf.to_excel(writer, sheet_name="Sheet_name_2")
+
+            kdfs = ks.read_excel(path1, sheet_name=["Sheet_name_1", "Sheet_name_2"])
+            pdfs = pd.read_excel(path1, sheet_name=["Sheet_name_1", "Sheet_name_2"])
+            self.assert_eq(kdfs["Sheet_name_1"], pdfs["Sheet_name_1"])
+            self.assert_eq(kdfs["Sheet_name_2"], pdfs["Sheet_name_2"])
+
+            if LooseVersion(pyspark.__version__) >= LooseVersion("3.0.0"):
+                kdfs = ks.read_excel(tmp, sheet_name=["Sheet_name_1", "Sheet_name_2"])
+                pdfs = pd.read_excel(path1, sheet_name=["Sheet_name_1", "Sheet_name_2"])
+                self.assert_eq(kdfs["Sheet_name_1"], pdfs["Sheet_name_1"])
+                self.assert_eq(kdfs["Sheet_name_2"], pdfs["Sheet_name_2"])
+
+                path2 = "{}/file2.xlsx".format(tmp)
+                with pd.ExcelWriter(path2) as writer:
+                    pdf.to_excel(writer, sheet_name="Sheet_name_1")
+                    pdf.to_excel(writer, sheet_name="Sheet_name_2")
+
+                with self.assertRaisesRegex(
+                    ValueError, "Can not read multiple sheets in multiple files."
+                ):
+                    ks.read_excel(tmp, sheet_name=["Sheet_name_1", "Sheet_name_2"])


### PR DESCRIPTION
Currently `ks.read_excel` is trying to read a file in the Driver local file system, but it should read from DFS the same as the other `read_xxx` functions.
This PR uses `binaryFile` file format supported in Spark 3.0, so it only works with Spark 3.0 or above.