### PR TITLE
Avoid using undocumented -k syntaxes.

### DIFF
--- a/dev/pytest
+++ b/dev/pytest
@@ -44,12 +44,12 @@ if [ "$#" = 0 ]; then
     if [[ "$SPARK_VERSION" == 2.3* ]] || [[ "$SPARK_VERSION" == 2.4.1* ]] || [[ "$SPARK_VERSION" == 2.4.2* ]]; then
         # Delta requires Spark 2.4.2+. We skip the related doctests.
         if [[ "$SPARK_VERSION" == 2.3* ]]; then
-            $PYTHON_EXECUTABLE -m pytest --cov=databricks --cov-report xml:"$FWDIR/coverage.xml" -k " -melt -to_delta -read_delta -to_clipboard" --verbose --showlocals --color=yes --doctest-modules databricks "${logopts[@]}"
+            $PYTHON_EXECUTABLE -m pytest --cov=databricks --cov-report xml:"$FWDIR/coverage.xml" -k "not (melt or to_delta or read_delta or to_clipboard)" --verbose --showlocals --color=yes --doctest-modules databricks "${logopts[@]}"
         else
-            $PYTHON_EXECUTABLE -m pytest --cov=databricks --cov-report xml:"$FWDIR/coverage.xml" -k "-to_delta -read_delta -to_clipboard" --verbose --showlocals --color=yes --doctest-modules databricks "${logopts[@]}"
+            $PYTHON_EXECUTABLE -m pytest --cov=databricks --cov-report xml:"$FWDIR/coverage.xml" -k "not (to_delta or read_delta or to_clipboard)" --verbose --showlocals --color=yes --doctest-modules databricks "${logopts[@]}"
         fi
     else
-        $PYTHON_EXECUTABLE -m pytest --cov=databricks --cov-report xml:"$FWDIR/coverage.xml" -k " -to_clipboard" --verbose --showlocals --color=yes --doctest-modules databricks "${logopts[@]}"
+        $PYTHON_EXECUTABLE -m pytest --cov=databricks --cov-report xml:"$FWDIR/coverage.xml" -k "not to_clipboard" --verbose --showlocals --color=yes --doctest-modules databricks "${logopts[@]}"
     fi
 else
     $PYTHON_EXECUTABLE -m pytest "$@"


### PR DESCRIPTION
As `pytest 6.0.0` which was released on Jul 28, 2020 dropped undocumented -k syntaxes (https://github.com/pytest-dev/pytest/pull/7210, https://github.com/pytest-dev/pytest/pull/7122), we should use a full sentence query for the parameter:

```
ERROR: Wrong expression passed to '-k': not melt -to_delta -read_delta -to_clipboard: at column 10: expected end of input; got identifier
```