### PR TITLE
Upgrade PyArrow to 1.0.0 in CI.

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -95,7 +95,7 @@ jobs:
           - python-version: 3.6
             spark-version: 2.4.6
             pandas-version: 0.25.3
-            pyarrow-version: 1.0.0
+            pyarrow-version: 0.15.1
           - python-version: 3.7
             spark-version: 2.4.6
             pandas-version: 0.25.3
@@ -103,7 +103,7 @@ jobs:
           - python-version: 3.7
             spark-version: 2.4.6
             pandas-version: 1.0.5
-            pyarrow-version: 1.0.0
+            pyarrow-version: 0.15.1
           - python-version: 3.7
             spark-version: 3.0.0
             pandas-version: 0.25.3

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -95,7 +95,7 @@ jobs:
           - python-version: 3.6
             spark-version: 2.4.6
             pandas-version: 0.25.3
-            pyarrow-version: 0.15.1
+            pyarrow-version: 1.0.0
           - python-version: 3.7
             spark-version: 2.4.6
             pandas-version: 0.25.3
@@ -103,7 +103,7 @@ jobs:
           - python-version: 3.7
             spark-version: 2.4.6
             pandas-version: 1.0.5
-            pyarrow-version: 0.15.1
+            pyarrow-version: 1.0.0
           - python-version: 3.7
             spark-version: 3.0.0
             pandas-version: 0.25.3
@@ -111,7 +111,7 @@ jobs:
           - python-version: 3.8
             spark-version: 3.0.0
             pandas-version: 1.0.5
-            pyarrow-version: 0.17.1
+            pyarrow-version: 1.0.0
     env:
       PYTHON_VERSION: ${{ matrix.python-version }}
       SPARK_VERSION: ${{ matrix.spark-version }}

--- a/databricks/koalas/tests/test_dataframe_spark_io.py
+++ b/databricks/koalas/tests/test_dataframe_spark_io.py
@@ -18,6 +18,7 @@ from distutils.version import LooseVersion
 
 import numpy as np
 import pandas as pd
+import pyarrow as pa
 import pyspark
 
 from databricks import koalas as ks
@@ -60,12 +61,16 @@ class DataFrameSparkIOTest(ReusedSQLTestCase, TestUtils):
             check(None, data)
             check(["i32", "i64"], data[["i32", "i64"]])
             check(["i64", "i32"], data[["i64", "i32"]])
-            check(("i32", "i64"), data[["i32", "i64"]])
-            check(["a", "b", "i32", "i64"], data[["i32", "i64"]])
-            check([], pd.DataFrame([]))
-            check(["a"], pd.DataFrame([]))
-            check("i32", pd.DataFrame([]))
-            check("float", data[["f"]])
+
+            if LooseVersion(pa.__version__) < LooseVersion("1.0.0"):
+                # TODO: `pd.read_parquet()` changed the behavior due to PyArrow 1.0.0.
+                #       We might want to adjust the behavior. Let's see how pandas handles it.
+                check(("i32", "i64"), data[["i32", "i64"]])
+                check(["a", "b", "i32", "i64"], data[["i32", "i64"]])
+                check([], pd.DataFrame([]))
+                check(["a"], pd.DataFrame([]))
+                check("i32", pd.DataFrame([]))
+                check("float", data[["f"]])
 
             # check with pyspark patch.
             if LooseVersion("0.21.1") <= LooseVersion(pd.__version__):


### PR DESCRIPTION
PyArrow 1.0.0 was released. We should test against it as well.
Closes #1680.