### PR TITLE
Support callable instances to apply as a function, and fix groupby.apply to keep the index when possible

### DIFF
--- a/databricks/koalas/accessors.py
+++ b/databricks/koalas/accessors.py
@@ -20,6 +20,7 @@ import inspect
 from collections import OrderedDict
 from distutils.version import LooseVersion
 from typing import Tuple, Union, TYPE_CHECKING
+import types
 
 import numpy as np
 import pandas as pd
@@ -286,13 +287,20 @@ class KoalasFrameMethods(object):
         1    59069   1048596
         2  9765645  60466196
 
-        You can also use ``np.ufunc`` as input.
+        You can also use ``np.ufunc`` and built-in functions as input.
 
         >>> df.koalas.apply_batch(np.add, args=(10,))
             A   B
         0  11  12
         1  13  14
         2  15  16
+
+        >>> df.koalas.apply_batch(abs)
+           A  B
+        0  1  2
+        1  3  4
+        2  5  6
+
         """
         # TODO: codes here partially duplicate `DataFrame.apply`. Can we deduplicate?
 
@@ -300,11 +308,10 @@ class KoalasFrameMethods(object):
         from databricks.koalas.frame import DataFrame
         from databricks import koalas as ks
 
-        if isinstance(func, np.ufunc):
+        if not isinstance(func, types.FunctionType):
+            assert callable(func), "the first argument should be a callable function."
             f = func
             func = lambda *args, **kwargs: f(*args, **kwargs)
-
-        assert callable(func), "the first argument should be a callable function."
 
         spec = inspect.getfullargspec(func)
         return_sig = spec.annotations.get("return", None)
@@ -481,6 +488,12 @@ class KoalasFrameMethods(object):
         0  2  3
         1  4  5
         2  6  7
+
+        >>> df.koalas.transform_batch(abs)
+           A  B
+        0  1  2
+        1  3  4
+        2  5  6
 
         Note that you should not transform the index. The index information will not change.
 
@@ -760,16 +773,20 @@ class KoalasSeriesMethods(object):
         2    11
         Name: A, dtype: int64
 
-        You can also use ``np.ufunc`` as input.
+        You can also use ``np.ufunc`` and built-in functions as input.
 
         >>> df.A.koalas.transform_batch(np.add, 10)
         0    11
         1    13
         2    15
         Name: A, dtype: int64
-        """
-        from databricks import koalas as ks
 
+        >>> df.A.koalas.transform_batch(abs)
+        0    1
+        1    3
+        2    5
+        Name: A, dtype: int64
+        """
         assert callable(func), "the first argument should be a callable function."
 
         return_sig = None
@@ -799,7 +816,7 @@ class KoalasSeriesMethods(object):
         from databricks.koalas.series import Series
         from databricks import koalas as ks
 
-        if isinstance(func, np.ufunc):
+        if not isinstance(func, types.FunctionType):
             f = func
             func = lambda *args, **kwargs: f(*args, **kwargs)
 

--- a/databricks/koalas/accessors.py
+++ b/databricks/koalas/accessors.py
@@ -295,7 +295,7 @@ class KoalasFrameMethods(object):
         1  13  14
         2  15  16
 
-        >>> df.koalas.apply_batch(abs)
+        >>> (df * -1).koalas.apply_batch(abs)
            A  B
         0  1  2
         1  3  4
@@ -489,7 +489,7 @@ class KoalasFrameMethods(object):
         1  4  5
         2  6  7
 
-        >>> df.koalas.transform_batch(abs)
+        >>> (df * -1).koalas.transform_batch(abs)
            A  B
         0  1  2
         1  3  4
@@ -781,7 +781,7 @@ class KoalasSeriesMethods(object):
         2    15
         Name: A, dtype: int64
 
-        >>> df.A.koalas.transform_batch(abs)
+        >>> (df * -1).A.koalas.transform_batch(abs)
         0    1
         1    3
         2    5

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -23,6 +23,7 @@ import re
 import warnings
 import inspect
 import json
+import types
 from functools import partial, reduce
 import sys
 from itertools import zip_longest
@@ -2269,6 +2270,12 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         2    13
         Name: 0, dtype: int64
 
+        >>> df.apply(max, axis=1)
+        0    9
+        1    9
+        2    9
+        Name: 0, dtype: int64
+
         Returning a list-like will result in a Series
 
         >>> df.apply(lambda x: [1, 2], axis=1)
@@ -2303,11 +2310,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         from databricks.koalas.groupby import GroupBy
         from databricks.koalas.series import first_series
 
-        if isinstance(func, np.ufunc):
+        if not isinstance(func, types.FunctionType):
+            assert callable(func), "the first argument should be a callable function."
             f = func
             func = lambda *args, **kwargs: f(*args, **kwargs)
-
-        assert callable(func), "the first argument should be a callable function."
 
         axis = validate_axis(axis)
         should_return_series = False
@@ -2503,12 +2509,12 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         1  1  4
         2  4  9
 
-        >>> df.transform(lambda x: x ** 2)  # doctest: +NORMALIZE_WHITESPACE
+        >>> df.transform(abs)  # doctest: +NORMALIZE_WHITESPACE
            X
            A  B
         0  0  1
-        1  1  4
-        2  4  9
+        1  1  2
+        2  2  3
 
         You can also specify extra arguments.
 
@@ -2521,7 +2527,11 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         1    21   1044
         2  1044  59069
         """
-        assert callable(func), "the first argument should be a callable function."
+        if not isinstance(func, types.FunctionType):
+            assert callable(func), "the first argument should be a callable function."
+            f = func
+            func = lambda *args, **kwargs: f(*args, **kwargs)
+
         axis = validate_axis(axis)
         if axis != 0:
             raise NotImplementedError('axis should be either 0 or "index" currently.')

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -2509,7 +2509,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         1  1  4
         2  4  9
 
-        >>> df.transform(abs)  # doctest: +NORMALIZE_WHITESPACE
+        >>> (df * -1).transform(abs)  # doctest: +NORMALIZE_WHITESPACE
            X
            A  B
         0  0  1

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -1920,7 +1920,7 @@ class GroupBy(object, metaclass=ABCMeta):
         2    6
         Name: B, dtype: int32
 
-        >>> df.B.groupby(df.A).transform(abs)
+        >>> (df * -1).B.groupby(df.A).transform(abs)
         0    1
         1    2
         2    3

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -1406,6 +1406,10 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             pdf.groupby("b").apply(lambda x: x + x.min()).sort_index(),
         )
         self.assert_eq(
+            kdf.groupby("b").apply(lambda x: len(x)).sort_index(),
+            pdf.groupby("b").apply(lambda x: len(x)).sort_index(),
+        )
+        self.assert_eq(
             kdf.groupby("b")["a"].apply(lambda x, y, z: x + x.min() + y * z, 10, z=20).sort_index(),
             pdf.groupby("b")["a"].apply(lambda x, y, z: x + x.min() + y * z, 10, z=20).sort_index(),
         )
@@ -1422,6 +1426,10 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             pdf.groupby(["b"])["c"].apply(lambda x: 1).sort_index(),
         )
         self.assert_eq(
+            kdf.groupby(["b"])["c"].apply(lambda x: len(x)).sort_index(),
+            pdf.groupby(["b"])["c"].apply(lambda x: len(x)).sort_index(),
+        )
+        self.assert_eq(
             kdf.groupby(kdf.b // 5).apply(lambda x: x + x.min()).sort_index(),
             pdf.groupby(pdf.b // 5).apply(lambda x: x + x.min()).sort_index(),
         )
@@ -1432,6 +1440,10 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         self.assert_eq(
             kdf.groupby(kdf.b // 5)[["a"]].apply(lambda x: x + x.min()).sort_index(),
             pdf.groupby(pdf.b // 5)[["a"]].apply(lambda x: x + x.min()).sort_index(),
+        )
+        self.assert_eq(
+            kdf.groupby(kdf.b // 5)[["a"]].apply(lambda x: len(x)).sort_index(),
+            pdf.groupby(pdf.b // 5)[["a"]].apply(lambda x: len(x)).sort_index(),
         )
 
         with self.assertRaisesRegex(TypeError, "<class 'int'> object is not callable"):
@@ -1449,6 +1461,14 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         self.assert_eq(
             kdf.groupby([("x", "a"), ("x", "b")]).apply(lambda x: x + x.min()).sort_index(),
             pdf.groupby([("x", "a"), ("x", "b")]).apply(lambda x: x + x.min()).sort_index(),
+        )
+        self.assert_eq(
+            kdf.groupby(("x", "b")).apply(lambda x: len(x)).sort_index(),
+            pdf.groupby(("x", "b")).apply(lambda x: len(x)).sort_index(),
+        )
+        self.assert_eq(
+            kdf.groupby([("x", "a"), ("x", "b")]).apply(lambda x: len(x)).sort_index(),
+            pdf.groupby([("x", "a"), ("x", "b")]).apply(lambda x: len(x)).sort_index(),
         )
 
     def test_apply_without_shortcut(self):

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -1406,8 +1406,7 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             pdf.groupby("b").apply(lambda x: x + x.min()).sort_index(),
         )
         self.assert_eq(
-            kdf.groupby("b").apply(lambda x: len(x)).sort_index(),
-            pdf.groupby("b").apply(lambda x: len(x)).sort_index(),
+            kdf.groupby("b").apply(len).sort_index(), pdf.groupby("b").apply(len).sort_index(),
         )
         self.assert_eq(
             kdf.groupby("b")["a"].apply(lambda x, y, z: x + x.min() + y * z, 10, z=20).sort_index(),
@@ -1426,8 +1425,8 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             pdf.groupby(["b"])["c"].apply(lambda x: 1).sort_index(),
         )
         self.assert_eq(
-            kdf.groupby(["b"])["c"].apply(lambda x: len(x)).sort_index(),
-            pdf.groupby(["b"])["c"].apply(lambda x: len(x)).sort_index(),
+            kdf.groupby(["b"])["c"].apply(len).sort_index(),
+            pdf.groupby(["b"])["c"].apply(len).sort_index(),
         )
         self.assert_eq(
             kdf.groupby(kdf.b // 5).apply(lambda x: x + x.min()).sort_index(),
@@ -1442,8 +1441,8 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             pdf.groupby(pdf.b // 5)[["a"]].apply(lambda x: x + x.min()).sort_index(),
         )
         self.assert_eq(
-            kdf.groupby(kdf.b // 5)[["a"]].apply(lambda x: len(x)).sort_index(),
-            pdf.groupby(pdf.b // 5)[["a"]].apply(lambda x: len(x)).sort_index(),
+            kdf.groupby(kdf.b // 5)[["a"]].apply(len).sort_index(),
+            pdf.groupby(pdf.b // 5)[["a"]].apply(len).sort_index(),
         )
 
         with self.assertRaisesRegex(TypeError, "<class 'int'> object is not callable"):
@@ -1463,12 +1462,12 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             pdf.groupby([("x", "a"), ("x", "b")]).apply(lambda x: x + x.min()).sort_index(),
         )
         self.assert_eq(
-            kdf.groupby(("x", "b")).apply(lambda x: len(x)).sort_index(),
-            pdf.groupby(("x", "b")).apply(lambda x: len(x)).sort_index(),
+            kdf.groupby(("x", "b")).apply(len).sort_index(),
+            pdf.groupby(("x", "b")).apply(len).sort_index(),
         )
         self.assert_eq(
-            kdf.groupby([("x", "a"), ("x", "b")]).apply(lambda x: len(x)).sort_index(),
-            pdf.groupby([("x", "a"), ("x", "b")]).apply(lambda x: len(x)).sort_index(),
+            kdf.groupby([("x", "a"), ("x", "b")]).apply(len).sort_index(),
+            pdf.groupby([("x", "a"), ("x", "b")]).apply(len).sort_index(),
         )
 
     def test_apply_without_shortcut(self):


### PR DESCRIPTION
This PR fixes two things.

1. Support `Callable` instances that are not functions:

    ```python
    from databricks import koalas as ks
    ks.DataFrame({'a': [-1, -2, 3, 4]}).apply(abs)
    ```
    ```
       a
    0  1
    1  2
    2  3
    3  4
    ```

2. Keep index name when `DataFrameGroupBy` returns a `Series`:


    ```python
    from databricks import koalas as ks
    ks.DataFrame({'a': [1, 2, 2, 2], 'b': [1, 2, 3, 4]}).groupby("a").apply(len)
    ```
    ```
    a
    1    1
    2    3
    Name: 0, dtype: int64
    ```

Resolves #1684