### PR TITLE
Matching behavior with pandas 1.1.2

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -110,7 +110,7 @@ jobs:
             pyarrow-version: 0.15.1
           - python-version: 3.8
             spark-version: 3.0.0
-            pandas-version: 1.0.5
+            pandas-version: 1.1.0
             pyarrow-version: 1.0.0
     env:
       PYTHON_VERSION: ${{ matrix.python-version }}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -114,7 +114,6 @@ jobs:
             pandas-version: 0.25.3
             pyarrow-version: 0.15.1
           - python-version: 3.8
-            spark-version: 3.0.0
             spark-version: 3.0.1
             pandas-version: 1.1.2
             pyarrow-version: 1.0.1

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -115,7 +115,7 @@ jobs:
             pyarrow-version: 0.15.1
           - python-version: 3.8
             spark-version: 3.0.0
-            pandas-version: 1.1.1
+            pandas-version: 1.1.2
             pyarrow-version: 1.0.1
             default-index-type: 'distributed-sequence'
     env:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -110,7 +110,7 @@ jobs:
             pyarrow-version: 0.15.1
           - python-version: 3.8
             spark-version: 3.0.0
-            pandas-version: 1.1.0
+            pandas-version: 1.1.1
             pyarrow-version: 1.0.0
     env:
       PYTHON_VERSION: ${{ matrix.python-version }}

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -2134,10 +2134,15 @@ class Frame(object, metaclass=ABCMeta):
             raise ValueError("Truncate: %s must be after %s" % (after, before))
 
         if isinstance(self, ks.Series):
-            result = first_series(self.to_frame().loc[before:after])
+            if indexes_increasing:
+                result = first_series(self.to_frame().loc[before:after])
+            else:
+                result = first_series(self.to_frame().loc[after:before])
         elif isinstance(self, ks.DataFrame):
-            if axis == 0:
+            if indexes_increasing and axis == 0:
                 result = self.loc[before:after]
+            elif not indexes_increasing and axis == 0:
+                result = self.loc[after:before]
             elif axis == 1:
                 result = self.loc[:, before:after]
 

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -2251,10 +2251,11 @@ class Frame(object, metaclass=ABCMeta):
             else:
                 result = first_series(self.to_frame().loc[after:before]).rename(self.name)
         elif isinstance(self, ks.DataFrame):
-            if indexes_increasing and axis == 0:
-                result = self.loc[before:after]
-            elif not indexes_increasing and axis == 0:
-                result = self.loc[after:before]
+            if axis == 0:
+                if indexes_increasing:
+                    result = self.loc[before:after]
+                else:
+                    result = self.loc[after:before]
             elif axis == 1:
                 result = self.loc[:, before:after]
 

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -2021,7 +2021,10 @@ class GroupBy(object, metaclass=ABCMeta):
                 + F.when(F.count(F.when(col.isNull(), 1).otherwise(None)) >= 1, 1).otherwise(0)
             )
 
-        should_include_groupkeys = isinstance(self, DataFrameGroupBy)
+        # The behavior of GroupBy.nunique has been changed since pandas 1.1.0
+        should_include_groupkeys = False
+        if LooseVersion(pd.__version__) < LooseVersion("1.1.0"):
+            should_include_groupkeys = isinstance(self, DataFrameGroupBy)
         return self._reduce_for_stat_function(
             stat_function, only_numeric=False, should_include_groupkeys=should_include_groupkeys
         )

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -2019,12 +2019,12 @@ class GroupBy(object, metaclass=ABCMeta):
         4   ham       5      x
         5   ham       5      y
 
-        >>> df.groupby('id').nunique().sort_index() # doctest: +NORMALIZE_WHITESPACE
-              id  value1  value2
+        >>> df.groupby('id').nunique().sort_index() # doctest: +SKIP
+              value1  value2
         id
-        egg    1       1       1
-        ham    1       1       2
-        spam   1       2       1
+        egg        1       1
+        ham        1       2
+        spam       2       1
 
         >>> df.groupby('id')['value1'].nunique().sort_index() # doctest: +NORMALIZE_WHITESPACE
         id

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -3531,65 +3531,69 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(kdf.rfloordiv(10), expected_result)
 
     def test_truncate(self):
-        pdf1 = pd.DataFrame(
-            {
-                "A": ["a", "b", "c", "d", "e", "f", "g"],
-                "B": ["h", "i", "j", "k", "l", "m", "n"],
-                "C": ["o", "p", "q", "r", "s", "t", "u"],
-            },
-            index=[-500, -20, -1, 0, 400, 550, 1000],
-        )
-        kdf1 = ks.from_pandas(pdf1)
-        pdf2 = pd.DataFrame(
-            {
-                "A": ["a", "b", "c", "d", "e", "f", "g"],
-                "B": ["h", "i", "j", "k", "l", "m", "n"],
-                "C": ["o", "p", "q", "r", "s", "t", "u"],
-            },
-            index=[1000, 550, 400, 0, -1, -20, -500],
-        )
-        kdf2 = ks.from_pandas(pdf2)
+        # The bug has been fixed in pandas 1.1.0.
+        if LooseVersion(pd.__version__) >= LooseVersion("1.1.0"):
+            pdf1 = pd.DataFrame(
+                {
+                    "A": ["a", "b", "c", "d", "e", "f", "g"],
+                    "B": ["h", "i", "j", "k", "l", "m", "n"],
+                    "C": ["o", "p", "q", "r", "s", "t", "u"],
+                },
+                index=[-500, -20, -1, 0, 400, 550, 1000],
+            )
+            kdf1 = ks.from_pandas(pdf1)
+            pdf2 = pd.DataFrame(
+                {
+                    "A": ["a", "b", "c", "d", "e", "f", "g"],
+                    "B": ["h", "i", "j", "k", "l", "m", "n"],
+                    "C": ["o", "p", "q", "r", "s", "t", "u"],
+                },
+                index=[1000, 550, 400, 0, -1, -20, -500],
+            )
+            kdf2 = ks.from_pandas(pdf2)
 
-        self.assert_eq(kdf1.truncate(), pdf1.truncate())
-        self.assert_eq(kdf1.truncate(before=-20), pdf1.truncate(before=-20))
-        self.assert_eq(kdf1.truncate(after=400), pdf1.truncate(after=400))
-        self.assert_eq(kdf1.truncate(copy=False), pdf1.truncate(copy=False))
-        self.assert_eq(kdf1.truncate(-20, 400, copy=False), pdf1.truncate(-20, 400, copy=False))
-        self.assert_eq(kdf2.truncate(0, 550), pdf2.truncate(0, 550))
-        self.assert_eq(kdf2.truncate(0, 550, copy=False), pdf2.truncate(0, 550, copy=False))
-        # axis = 1
-        self.assert_eq(kdf1.truncate(axis=1), pdf1.truncate(axis=1))
-        self.assert_eq(kdf1.truncate(before="B", axis=1), pdf1.truncate(before="B", axis=1))
-        self.assert_eq(kdf1.truncate(after="A", axis=1), pdf1.truncate(after="A", axis=1))
-        self.assert_eq(kdf1.truncate(copy=False, axis=1), pdf1.truncate(copy=False, axis=1))
-        self.assert_eq(kdf2.truncate("B", "C", axis=1), pdf2.truncate("B", "C", axis=1))
-        self.assert_eq(
-            kdf1.truncate("B", "C", copy=False, axis=1), pdf1.truncate("B", "C", copy=False, axis=1)
-        )
+            self.assert_eq(kdf1.truncate(), pdf1.truncate())
+            self.assert_eq(kdf1.truncate(before=-20), pdf1.truncate(before=-20))
+            self.assert_eq(kdf1.truncate(after=400), pdf1.truncate(after=400))
+            self.assert_eq(kdf1.truncate(copy=False), pdf1.truncate(copy=False))
+            self.assert_eq(kdf1.truncate(-20, 400, copy=False), pdf1.truncate(-20, 400, copy=False))
+            self.assert_eq(kdf2.truncate(0, 550), pdf2.truncate(0, 550))
+            self.assert_eq(kdf2.truncate(0, 550, copy=False), pdf2.truncate(0, 550, copy=False))
+            # axis = 1
+            self.assert_eq(kdf1.truncate(axis=1), pdf1.truncate(axis=1))
+            self.assert_eq(kdf1.truncate(before="B", axis=1), pdf1.truncate(before="B", axis=1))
+            self.assert_eq(kdf1.truncate(after="A", axis=1), pdf1.truncate(after="A", axis=1))
+            self.assert_eq(kdf1.truncate(copy=False, axis=1), pdf1.truncate(copy=False, axis=1))
+            self.assert_eq(kdf2.truncate("B", "C", axis=1), pdf2.truncate("B", "C", axis=1))
+            self.assert_eq(
+                kdf1.truncate("B", "C", copy=False, axis=1),
+                pdf1.truncate("B", "C", copy=False, axis=1),
+            )
 
-        # MultiIndex columns
-        columns = pd.MultiIndex.from_tuples([("A", "Z"), ("B", "X"), ("C", "Z")])
-        pdf1.columns = columns
-        kdf1.columns = columns
-        pdf2.columns = columns
-        kdf2.columns = columns
+            # MultiIndex columns
+            columns = pd.MultiIndex.from_tuples([("A", "Z"), ("B", "X"), ("C", "Z")])
+            pdf1.columns = columns
+            kdf1.columns = columns
+            pdf2.columns = columns
+            kdf2.columns = columns
 
-        self.assert_eq(kdf1.truncate(), pdf1.truncate())
-        self.assert_eq(kdf1.truncate(before=-20), pdf1.truncate(before=-20))
-        self.assert_eq(kdf1.truncate(after=400), pdf1.truncate(after=400))
-        self.assert_eq(kdf1.truncate(copy=False), pdf1.truncate(copy=False))
-        self.assert_eq(kdf1.truncate(-20, 400, copy=False), pdf1.truncate(-20, 400, copy=False))
-        self.assert_eq(kdf2.truncate(0, 550), pdf2.truncate(0, 550))
-        self.assert_eq(kdf2.truncate(0, 550, copy=False), pdf2.truncate(0, 550, copy=False))
-        # axis = 1
-        self.assert_eq(kdf1.truncate(axis=1), pdf1.truncate(axis=1))
-        self.assert_eq(kdf1.truncate(before="B", axis=1), pdf1.truncate(before="B", axis=1))
-        self.assert_eq(kdf1.truncate(after="A", axis=1), pdf1.truncate(after="A", axis=1))
-        self.assert_eq(kdf1.truncate(copy=False, axis=1), pdf1.truncate(copy=False, axis=1))
-        self.assert_eq(kdf2.truncate("B", "C", axis=1), pdf2.truncate("B", "C", axis=1))
-        self.assert_eq(
-            kdf1.truncate("B", "C", copy=False, axis=1), pdf1.truncate("B", "C", copy=False, axis=1)
-        )
+            self.assert_eq(kdf1.truncate(), pdf1.truncate())
+            self.assert_eq(kdf1.truncate(before=-20), pdf1.truncate(before=-20))
+            self.assert_eq(kdf1.truncate(after=400), pdf1.truncate(after=400))
+            self.assert_eq(kdf1.truncate(copy=False), pdf1.truncate(copy=False))
+            self.assert_eq(kdf1.truncate(-20, 400, copy=False), pdf1.truncate(-20, 400, copy=False))
+            self.assert_eq(kdf2.truncate(0, 550), pdf2.truncate(0, 550))
+            self.assert_eq(kdf2.truncate(0, 550, copy=False), pdf2.truncate(0, 550, copy=False))
+            # axis = 1
+            self.assert_eq(kdf1.truncate(axis=1), pdf1.truncate(axis=1))
+            self.assert_eq(kdf1.truncate(before="B", axis=1), pdf1.truncate(before="B", axis=1))
+            self.assert_eq(kdf1.truncate(after="A", axis=1), pdf1.truncate(after="A", axis=1))
+            self.assert_eq(kdf1.truncate(copy=False, axis=1), pdf1.truncate(copy=False, axis=1))
+            self.assert_eq(kdf2.truncate("B", "C", axis=1), pdf2.truncate("B", "C", axis=1))
+            self.assert_eq(
+                kdf1.truncate("B", "C", copy=False, axis=1),
+                pdf1.truncate("B", "C", copy=False, axis=1),
+            )
 
         # Exceptions
         kdf = ks.DataFrame(

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -3579,69 +3579,83 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(kdf.rfloordiv(10), expected_result)
 
     def test_truncate(self):
-        # The bug has been fixed in pandas 1.1.0.
+        pdf1 = pd.DataFrame(
+            {
+                "A": ["a", "b", "c", "d", "e", "f", "g"],
+                "B": ["h", "i", "j", "k", "l", "m", "n"],
+                "C": ["o", "p", "q", "r", "s", "t", "u"],
+            },
+            index=[-500, -20, -1, 0, 400, 550, 1000],
+        )
+        kdf1 = ks.from_pandas(pdf1)
+        pdf2 = pd.DataFrame(
+            {
+                "A": ["a", "b", "c", "d", "e", "f", "g"],
+                "B": ["h", "i", "j", "k", "l", "m", "n"],
+                "C": ["o", "p", "q", "r", "s", "t", "u"],
+            },
+            index=[1000, 550, 400, 0, -1, -20, -500],
+        )
+        kdf2 = ks.from_pandas(pdf2)
+
+        self.assert_eq(kdf1.truncate(), pdf1.truncate())
+        self.assert_eq(kdf1.truncate(before=-20), pdf1.truncate(before=-20))
+        self.assert_eq(kdf1.truncate(after=400), pdf1.truncate(after=400))
+        self.assert_eq(kdf1.truncate(copy=False), pdf1.truncate(copy=False))
+        self.assert_eq(kdf1.truncate(-20, 400, copy=False), pdf1.truncate(-20, 400, copy=False))
+        # The bug for these tests has been fixed in pandas 1.1.0.
         if LooseVersion(pd.__version__) >= LooseVersion("1.1.0"):
-            pdf1 = pd.DataFrame(
-                {
-                    "A": ["a", "b", "c", "d", "e", "f", "g"],
-                    "B": ["h", "i", "j", "k", "l", "m", "n"],
-                    "C": ["o", "p", "q", "r", "s", "t", "u"],
-                },
-                index=[-500, -20, -1, 0, 400, 550, 1000],
-            )
-            kdf1 = ks.from_pandas(pdf1)
-            pdf2 = pd.DataFrame(
-                {
-                    "A": ["a", "b", "c", "d", "e", "f", "g"],
-                    "B": ["h", "i", "j", "k", "l", "m", "n"],
-                    "C": ["o", "p", "q", "r", "s", "t", "u"],
-                },
-                index=[1000, 550, 400, 0, -1, -20, -500],
-            )
-            kdf2 = ks.from_pandas(pdf2)
-
-            self.assert_eq(kdf1.truncate(), pdf1.truncate())
-            self.assert_eq(kdf1.truncate(before=-20), pdf1.truncate(before=-20))
-            self.assert_eq(kdf1.truncate(after=400), pdf1.truncate(after=400))
-            self.assert_eq(kdf1.truncate(copy=False), pdf1.truncate(copy=False))
-            self.assert_eq(kdf1.truncate(-20, 400, copy=False), pdf1.truncate(-20, 400, copy=False))
             self.assert_eq(kdf2.truncate(0, 550), pdf2.truncate(0, 550))
             self.assert_eq(kdf2.truncate(0, 550, copy=False), pdf2.truncate(0, 550, copy=False))
-            # axis = 1
-            self.assert_eq(kdf1.truncate(axis=1), pdf1.truncate(axis=1))
-            self.assert_eq(kdf1.truncate(before="B", axis=1), pdf1.truncate(before="B", axis=1))
-            self.assert_eq(kdf1.truncate(after="A", axis=1), pdf1.truncate(after="A", axis=1))
-            self.assert_eq(kdf1.truncate(copy=False, axis=1), pdf1.truncate(copy=False, axis=1))
-            self.assert_eq(kdf2.truncate("B", "C", axis=1), pdf2.truncate("B", "C", axis=1))
-            self.assert_eq(
-                kdf1.truncate("B", "C", copy=False, axis=1),
-                pdf1.truncate("B", "C", copy=False, axis=1),
+        else:
+            expected_kdf = ks.DataFrame(
+                {"A": ["b", "c", "d"], "B": ["i", "j", "k"], "C": ["p", "q", "r"],},
+                index=[550, 400, 0],
             )
+            self.assert_eq(kdf2.truncate(0, 550), expected_kdf)
+            self.assert_eq(kdf2.truncate(0, 550, copy=False), expected_kdf)
 
-            # MultiIndex columns
-            columns = pd.MultiIndex.from_tuples([("A", "Z"), ("B", "X"), ("C", "Z")])
-            pdf1.columns = columns
-            kdf1.columns = columns
-            pdf2.columns = columns
-            kdf2.columns = columns
+        # axis = 1
+        self.assert_eq(kdf1.truncate(axis=1), pdf1.truncate(axis=1))
+        self.assert_eq(kdf1.truncate(before="B", axis=1), pdf1.truncate(before="B", axis=1))
+        self.assert_eq(kdf1.truncate(after="A", axis=1), pdf1.truncate(after="A", axis=1))
+        self.assert_eq(kdf1.truncate(copy=False, axis=1), pdf1.truncate(copy=False, axis=1))
+        self.assert_eq(kdf2.truncate("B", "C", axis=1), pdf2.truncate("B", "C", axis=1))
+        self.assert_eq(
+            kdf1.truncate("B", "C", copy=False, axis=1),
+            pdf1.truncate("B", "C", copy=False, axis=1),
+        )
 
-            self.assert_eq(kdf1.truncate(), pdf1.truncate())
-            self.assert_eq(kdf1.truncate(before=-20), pdf1.truncate(before=-20))
-            self.assert_eq(kdf1.truncate(after=400), pdf1.truncate(after=400))
-            self.assert_eq(kdf1.truncate(copy=False), pdf1.truncate(copy=False))
-            self.assert_eq(kdf1.truncate(-20, 400, copy=False), pdf1.truncate(-20, 400, copy=False))
+        # MultiIndex columns
+        columns = pd.MultiIndex.from_tuples([("A", "Z"), ("B", "X"), ("C", "Z")])
+        pdf1.columns = columns
+        kdf1.columns = columns
+        pdf2.columns = columns
+        kdf2.columns = columns
+
+        self.assert_eq(kdf1.truncate(), pdf1.truncate())
+        self.assert_eq(kdf1.truncate(before=-20), pdf1.truncate(before=-20))
+        self.assert_eq(kdf1.truncate(after=400), pdf1.truncate(after=400))
+        self.assert_eq(kdf1.truncate(copy=False), pdf1.truncate(copy=False))
+        self.assert_eq(kdf1.truncate(-20, 400, copy=False), pdf1.truncate(-20, 400, copy=False))
+        # The bug for these tests has been fixed in pandas 1.1.0.
+        if LooseVersion(pd.__version__) >= LooseVersion("1.1.0"):
             self.assert_eq(kdf2.truncate(0, 550), pdf2.truncate(0, 550))
             self.assert_eq(kdf2.truncate(0, 550, copy=False), pdf2.truncate(0, 550, copy=False))
-            # axis = 1
-            self.assert_eq(kdf1.truncate(axis=1), pdf1.truncate(axis=1))
-            self.assert_eq(kdf1.truncate(before="B", axis=1), pdf1.truncate(before="B", axis=1))
-            self.assert_eq(kdf1.truncate(after="A", axis=1), pdf1.truncate(after="A", axis=1))
-            self.assert_eq(kdf1.truncate(copy=False, axis=1), pdf1.truncate(copy=False, axis=1))
-            self.assert_eq(kdf2.truncate("B", "C", axis=1), pdf2.truncate("B", "C", axis=1))
-            self.assert_eq(
-                kdf1.truncate("B", "C", copy=False, axis=1),
-                pdf1.truncate("B", "C", copy=False, axis=1),
-            )
+        else:
+            expected_kdf.columns = columns
+            self.assert_eq(kdf2.truncate(0, 550), expected_kdf)
+            self.assert_eq(kdf2.truncate(0, 550, copy=False), expected_kdf)
+        # axis = 1
+        self.assert_eq(kdf1.truncate(axis=1), pdf1.truncate(axis=1))
+        self.assert_eq(kdf1.truncate(before="B", axis=1), pdf1.truncate(before="B", axis=1))
+        self.assert_eq(kdf1.truncate(after="A", axis=1), pdf1.truncate(after="A", axis=1))
+        self.assert_eq(kdf1.truncate(copy=False, axis=1), pdf1.truncate(copy=False, axis=1))
+        self.assert_eq(kdf2.truncate("B", "C", axis=1), pdf2.truncate("B", "C", axis=1))
+        self.assert_eq(
+            kdf1.truncate("B", "C", copy=False, axis=1),
+            pdf1.truncate("B", "C", copy=False, axis=1),
+        )
 
         # Exceptions
         kdf = ks.DataFrame(

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -709,14 +709,23 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         pdf.columns = columns
         kdf.columns = columns
 
-        self.assert_eq(
-            kdf.groupby(("x", "a")).nunique().sort_index(),
-            pdf.groupby(("x", "a")).nunique().sort_index(),
-        )
-        self.assert_eq(
-            kdf.groupby(("x", "a")).nunique(dropna=False).sort_index(),
-            pdf.groupby(("x", "a")).nunique(dropna=False).sort_index(),
-        )
+        if LooseVersion(pd.__version__) < LooseVersion("1.1.0"):
+            expected = ks.DataFrame({("y", "b"): [2, 2]}, index=pd.Index([0, 1], name=("x", "a")))
+            self.assert_eq(
+                kdf.groupby(("x", "a")).nunique().sort_index(), expected,
+            )
+            self.assert_eq(
+                kdf.groupby(("x", "a")).nunique(dropna=False).sort_index(), expected,
+            )
+        elif LooseVersion(pd.__version__) >= LooseVersion("1.1.0"):
+            self.assert_eq(
+                kdf.groupby(("x", "a")).nunique().sort_index(),
+                pdf.groupby(("x", "a")).nunique().sort_index(),
+            )
+            self.assert_eq(
+                kdf.groupby(("x", "a")).nunique(dropna=False).sort_index(),
+                pdf.groupby(("x", "a")).nunique(dropna=False).sort_index(),
+            )
 
     def test_unique(self):
         for pdf in [

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -674,13 +674,20 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             kdf.groupby("a").agg({"b": "nunique"}).sort_index(),
             pdf.groupby("a").agg({"b": "nunique"}).sort_index(),
         )
-        self.assert_eq(
-            kdf.groupby("a").nunique().sort_index(), pdf.groupby("a").nunique().sort_index()
-        )
-        self.assert_eq(
-            kdf.groupby("a").nunique(dropna=False).sort_index(),
-            pdf.groupby("a").nunique(dropna=False).sort_index(),
-        )
+        if LooseVersion(pd.__version__) < LooseVersion("1.1.0"):
+            expected = ks.DataFrame({"b": [2, 2]}, index=pd.Index([0, 1], name="a"))
+            self.assert_eq(kdf.groupby("a").nunique().sort_index(), expected)
+            self.assert_eq(
+                kdf.groupby("a").nunique(dropna=False).sort_index(), expected,
+            )
+        elif LooseVersion(pd.__version__) >= LooseVersion("1.1.0"):
+            self.assert_eq(
+                kdf.groupby("a").nunique().sort_index(), pdf.groupby("a").nunique().sort_index()
+            )
+            self.assert_eq(
+                kdf.groupby("a").nunique(dropna=False).sort_index(),
+                pdf.groupby("a").nunique(dropna=False).sort_index(),
+            )
         self.assert_eq(
             kdf.groupby("a")["b"].nunique().sort_index(),
             pdf.groupby("a")["b"].nunique().sort_index(),

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -680,7 +680,7 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             self.assert_eq(
                 kdf.groupby("a").nunique(dropna=False).sort_index(), expected,
             )
-        elif LooseVersion(pd.__version__) >= LooseVersion("1.1.0"):
+        else:
             self.assert_eq(
                 kdf.groupby("a").nunique().sort_index(), pdf.groupby("a").nunique().sort_index()
             )
@@ -717,7 +717,7 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             self.assert_eq(
                 kdf.groupby(("x", "a")).nunique(dropna=False).sort_index(), expected,
             )
-        elif LooseVersion(pd.__version__) >= LooseVersion("1.1.0"):
+        else:
             self.assert_eq(
                 kdf.groupby(("x", "a")).nunique().sort_index(),
                 pdf.groupby(("x", "a")).nunique().sort_index(),

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -916,9 +916,6 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         datas.append([(5, 100), (4, 200), (3, None), (2, 400), (1, 500)])
         datas.append([(5, 100), (4, 200), (3, 300), (2, 400), (1, None)])
         datas.append([(1, 100), (2, 200), (None, None), (4, 400), (5, 500)])
-        datas.append([(-5, None), (-4, None), (-3, None), (-2, None), (-1, None)])
-        datas.append([(None, "e"), (None, "c"), (None, "b"), (None, "d"), (None, "a")])
-        datas.append([(None, None), (None, None), (None, None), (None, None), (None, None)])
 
         # duplicated index value tests
         datas.append([("x", "d"), ("y", "c"), ("y", "b"), ("z", "a")])
@@ -960,6 +957,21 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
                     expected_increasing_result = not expected_increasing_result
                 self.assert_eq(kmidx.is_monotonic_increasing, expected_increasing_result)
                 self.assert_eq(kmidx.is_monotonic_decreasing, pmidx.is_monotonic_decreasing)
+
+        # The datas below cannot be an arguments for `MultiIndex.from_tuples` in pandas >= 1.1.0.
+        # Refer https://github.com/databricks/koalas/pull/1688#issuecomment-667156560 for detail.
+        datas = []
+        datas.append([(-5, None), (-4, None), (-3, None), (-2, None), (-1, None)])
+        datas.append([(None, "e"), (None, "c"), (None, "b"), (None, "d"), (None, "a")])
+        datas.append([(None, None), (None, None), (None, None), (None, None), (None, None)])
+
+        if LooseVersion(pd.__version__) < LooseVersion("1.1.0"):
+            for data in datas:
+                with self.subTest(data=data):
+                    pmidx = pd.MultiIndex.from_tuples(data)
+                    kmidx = ks.from_pandas(pmidx)
+                    self.assert_eq(kmidx.is_monotonic_increasing, pmidx.is_monotonic_increasing)
+                    self.assert_eq(kmidx.is_monotonic_decreasing, pmidx.is_monotonic_decreasing)
 
     def test_difference(self):
         # Index

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -916,6 +916,12 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         datas.append([(5, 100), (4, 200), (3, None), (2, 400), (1, 500)])
         datas.append([(5, 100), (4, 200), (3, 300), (2, 400), (1, None)])
         datas.append([(1, 100), (2, 200), (None, None), (4, 400), (5, 500)])
+        # The datas below cannot be an arguments for `MultiIndex.from_tuples` in pandas >= 1.1.0.
+        # Refer https://github.com/databricks/koalas/pull/1688#issuecomment-667156560 for detail.
+        if LooseVersion(pd.__version__) < LooseVersion("1.1.0"):
+            datas.append([(-5, None), (-4, None), (-3, None), (-2, None), (-1, None)])
+            datas.append([(None, "e"), (None, "c"), (None, "b"), (None, "d"), (None, "a")])
+            datas.append([(None, None), (None, None), (None, None), (None, None), (None, None)])
 
         # duplicated index value tests
         datas.append([("x", "d"), ("y", "c"), ("y", "b"), ("z", "a")])
@@ -957,21 +963,6 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
                     expected_increasing_result = not expected_increasing_result
                 self.assert_eq(kmidx.is_monotonic_increasing, expected_increasing_result)
                 self.assert_eq(kmidx.is_monotonic_decreasing, pmidx.is_monotonic_decreasing)
-
-        # The datas below cannot be an arguments for `MultiIndex.from_tuples` in pandas >= 1.1.0.
-        # Refer https://github.com/databricks/koalas/pull/1688#issuecomment-667156560 for detail.
-        datas = []
-        datas.append([(-5, None), (-4, None), (-3, None), (-2, None), (-1, None)])
-        datas.append([(None, "e"), (None, "c"), (None, "b"), (None, "d"), (None, "a")])
-        datas.append([(None, None), (None, None), (None, None), (None, None), (None, None)])
-
-        if LooseVersion(pd.__version__) < LooseVersion("1.1.0"):
-            for data in datas:
-                with self.subTest(data=data):
-                    pmidx = pd.MultiIndex.from_tuples(data)
-                    kmidx = ks.from_pandas(pmidx)
-                    self.assert_eq(kmidx.is_monotonic_increasing, pmidx.is_monotonic_increasing)
-                    self.assert_eq(kmidx.is_monotonic_decreasing, pmidx.is_monotonic_decreasing)
 
     def test_difference(self):
         # Index

--- a/databricks/koalas/tests/test_indexing.py
+++ b/databricks/koalas/tests/test_indexing.py
@@ -183,10 +183,17 @@ class IndexingTest(ReusedSQLTestCase):
         pdf = self.pdf.set_index("b", append=True)
         kdf = self.kdf.set_index("b", append=True)
 
-        self.assert_eq(kdf.at[(3, 6), "a"], pdf.at[(3, 6), "a"])
-        self.assert_eq(kdf.at[(3,), "a"], pdf.at[(3,), "a"])
-        self.assert_eq(list(kdf.at[(9, 0), "a"]), list(pdf.at[(9, 0), "a"]))
-        self.assert_eq(list(kdf.at[(9,), "a"]), list(pdf.at[(9,), "a"]))
+        # TODO: seems like a pandas' bug in pandas>=1.1.0
+        if LooseVersion(pd.__version__) < LooseVersion("1.1.0"):
+            self.assert_eq(kdf.at[(3, 6), "a"], pdf.at[(3, 6), "a"])
+            self.assert_eq(kdf.at[(3,), "a"], pdf.at[(3,), "a"])
+            self.assert_eq(list(kdf.at[(9, 0), "a"]), list(pdf.at[(9, 0), "a"]))
+            self.assert_eq(list(kdf.at[(9,), "a"]), list(pdf.at[(9,), "a"]))
+        else:
+            self.assert_eq(kdf.at[(3, 6), "a"], 3)
+            self.assert_eq(kdf.at[(3,), "a"], np.array([3]))
+            self.assert_eq(list(kdf.at[(9, 0), "a"]), [7, 8, 9])
+            self.assert_eq(list(kdf.at[(9,), "a"]), [7, 8, 9])
 
         with self.assertRaises(ValueError):
             kdf.at[3, "a"]
@@ -1127,7 +1134,7 @@ class IndexingTest(ReusedSQLTestCase):
         kdf = ks.from_pandas(pdf)
 
         # Positional iloc search
-        self.assert_eq(kdf[:4], pdf[:4])
+        self.assert_eq(kdf[:4], pdf[:4], almost=True)
         self.assert_eq(kdf[:3], pdf[:3], almost=True)
         self.assert_eq(kdf[3:], pdf[3:], almost=True)
         self.assert_eq(kdf[2:], pdf[2:], almost=True)

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -1284,18 +1284,20 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(pser1.mask(pser1 > 3), kser1.mask(kser1 > 3).sort_index(), almost=True)
 
     def test_truncate(self):
-        pser1 = pd.Series([10, 20, 30, 40, 50, 60, 70], index=[1, 2, 3, 4, 5, 6, 7])
-        kser1 = ks.Series(pser1)
-        pser2 = pd.Series([10, 20, 30, 40, 50, 60, 70], index=[7, 6, 5, 4, 3, 2, 1])
-        kser2 = ks.Series(pser2)
+        # The bug has been fixed in pandas 1.1.0.
+        if LooseVersion(pd.__version__) >= LooseVersion("1.1.0"):
+            pser1 = pd.Series([10, 20, 30, 40, 50, 60, 70], index=[1, 2, 3, 4, 5, 6, 7])
+            kser1 = ks.Series(pser1)
+            pser2 = pd.Series([10, 20, 30, 40, 50, 60, 70], index=[7, 6, 5, 4, 3, 2, 1])
+            kser2 = ks.Series(pser2)
 
-        self.assert_eq(kser1.truncate(), pser1.truncate())
-        self.assert_eq(kser1.truncate(before=2), pser1.truncate(before=2))
-        self.assert_eq(kser1.truncate(after=5), pser1.truncate(after=5))
-        self.assert_eq(kser1.truncate(copy=False), pser1.truncate(copy=False))
-        self.assert_eq(kser1.truncate(2, 5, copy=False), pser1.truncate(2, 5, copy=False))
-        self.assert_eq(kser2.truncate(4, 6), pser2.truncate(4, 6))
-        self.assert_eq(kser2.truncate(4, 6, copy=False), pser2.truncate(4, 6, copy=False))
+            self.assert_eq(kser1.truncate(), pser1.truncate())
+            self.assert_eq(kser1.truncate(before=2), pser1.truncate(before=2))
+            self.assert_eq(kser1.truncate(after=5), pser1.truncate(after=5))
+            self.assert_eq(kser1.truncate(copy=False), pser1.truncate(copy=False))
+            self.assert_eq(kser1.truncate(2, 5, copy=False), pser1.truncate(2, 5, copy=False))
+            self.assert_eq(kser2.truncate(4, 6), pser2.truncate(4, 6))
+            self.assert_eq(kser2.truncate(4, 6, copy=False), pser2.truncate(4, 6, copy=False))
 
         kser = ks.Series([10, 20, 30, 40, 50, 60, 70], index=[1, 2, 3, 4, 3, 2, 1])
         msg = "truncate requires a sorted index"

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -1284,20 +1284,24 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(pser1.mask(pser1 > 3), kser1.mask(kser1 > 3).sort_index(), almost=True)
 
     def test_truncate(self):
-        # The bug has been fixed in pandas 1.1.0.
-        if LooseVersion(pd.__version__) >= LooseVersion("1.1.0"):
-            pser1 = pd.Series([10, 20, 30, 40, 50, 60, 70], index=[1, 2, 3, 4, 5, 6, 7])
-            kser1 = ks.Series(pser1)
-            pser2 = pd.Series([10, 20, 30, 40, 50, 60, 70], index=[7, 6, 5, 4, 3, 2, 1])
-            kser2 = ks.Series(pser2)
+        pser1 = pd.Series([10, 20, 30, 40, 50, 60, 70], index=[1, 2, 3, 4, 5, 6, 7])
+        kser1 = ks.Series(pser1)
+        pser2 = pd.Series([10, 20, 30, 40, 50, 60, 70], index=[7, 6, 5, 4, 3, 2, 1])
+        kser2 = ks.Series(pser2)
 
-            self.assert_eq(kser1.truncate(), pser1.truncate())
-            self.assert_eq(kser1.truncate(before=2), pser1.truncate(before=2))
-            self.assert_eq(kser1.truncate(after=5), pser1.truncate(after=5))
-            self.assert_eq(kser1.truncate(copy=False), pser1.truncate(copy=False))
-            self.assert_eq(kser1.truncate(2, 5, copy=False), pser1.truncate(2, 5, copy=False))
+        self.assert_eq(kser1.truncate(), pser1.truncate())
+        self.assert_eq(kser1.truncate(before=2), pser1.truncate(before=2))
+        self.assert_eq(kser1.truncate(after=5), pser1.truncate(after=5))
+        self.assert_eq(kser1.truncate(copy=False), pser1.truncate(copy=False))
+        self.assert_eq(kser1.truncate(2, 5, copy=False), pser1.truncate(2, 5, copy=False))
+        # The bug for these tests has been fixed in pandas 1.1.0.
+        if LooseVersion(pd.__version__) >= LooseVersion("1.1.0"):
             self.assert_eq(kser2.truncate(4, 6), pser2.truncate(4, 6))
             self.assert_eq(kser2.truncate(4, 6, copy=False), pser2.truncate(4, 6, copy=False))
+        else:
+            expected_kser = ks.Series([20, 30, 40], index=[6, 5, 4])
+            self.assert_eq(kser2.truncate(4, 6), expected_kser)
+            self.assert_eq(kser2.truncate(4, 6, copy=False), expected_kser)
 
         kser = ks.Series([10, 20, 30, 40, 50, 60, 70], index=[1, 2, 3, 4, 3, 2, 1])
         msg = "truncate requires a sorted index"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 # Dependencies in Koalas. When you update don't forget to update setup.py and install.rst in docs.
-pandas>=0.23.2,<1.1.0
+pandas>=0.23.2
 pyarrow>=0.10
 matplotlib>=3.0.0,<3.3.0
 numpy>=1.14,<1.19.0

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     },
     python_requires='>=3.5,<3.9',
     install_requires=[
-        'pandas>=0.23.2,<1.1.0',
+        'pandas>=0.23.2',
         'pyarrow>=0.10',
         'numpy>=1.14,<1.19.0',
         'matplotlib>=3.0.0,<3.3.0',


### PR DESCRIPTION
This should resolve #1685 

- [x] DataFrame.truncate
- [x] AtIndexer with MultiIndex
- [x] GroupBy.nunique
- [x] Index.monotonic
- [x] GroupByRolling.max (Resolved in https://github.com/pandas-dev/pandas/pull/36152)
- [x] GroupByRolling.mean (ditto)
- [x] GroupByRolling.min (ditto)
- [x] GroupByRolling.std (ditto)
- [x] GroupByRolling.sum (ditto)
- [x] GroupByRolling.var (ditto)
- [x] Series.truncate