### PR TITLE
Support axis=1 for DataFrame.dropna().

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -4554,6 +4554,14 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
              name        toy        born
         1  Batman  Batmobile  1940-04-25
 
+        Drop the columns where at least one element is missing.
+
+        >>> df.dropna(axis='columns')
+               name
+        0    Alfred
+        1    Batman
+        2  Catwoman
+
         Drop the rows where all elements are missing.
 
         >>> df.dropna(how='all')

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -4681,15 +4681,17 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 column_labels = [
                     label
                     for label, cnt in zip(internal.column_labels, counts)
-                    if cnt >= int(thresh)
+                    if (cnt or 0) >= int(thresh)
                 ]
             elif how == "any":
                 column_labels = [
-                    label for label, cnt in zip(internal.column_labels, counts) if cnt == counts[-1]
+                    label
+                    for label, cnt in zip(internal.column_labels, counts)
+                    if (cnt or 0) == counts[-1]
                 ]
             elif how == "all":
                 column_labels = [
-                    label for label, cnt in zip(internal.column_labels, counts) if cnt > 0
+                    label for label, cnt in zip(internal.column_labels, counts) if (cnt or 0) > 0
                 ]
 
             kdf = self[column_labels]

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -708,6 +708,15 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         self._test_dropna(pdf, axis=0)
 
+        # empty
+        pdf = pd.DataFrame(index=np.random.rand(6))
+        kdf = ks.from_pandas(pdf)
+
+        self.assert_eq(kdf.dropna(), pdf.dropna())
+        self.assert_eq(kdf.dropna(how="all"), pdf.dropna(how="all"))
+        self.assert_eq(kdf.dropna(thresh=0), pdf.dropna(thresh=0))
+        self.assert_eq(kdf.dropna(thresh=1), pdf.dropna(thresh=1))
+
         with self.assertRaisesRegex(ValueError, "No axis named foo"):
             kdf.dropna(axis="foo")
 
@@ -728,6 +737,15 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         ).T
 
         self._test_dropna(pdf, axis=1)
+
+        # empty
+        pdf = pd.DataFrame({"x": [], "y": [], "z": []})
+        kdf = ks.from_pandas(pdf)
+
+        self.assert_eq(kdf.dropna(axis=1), pdf.dropna(axis=1))
+        self.assert_eq(kdf.dropna(axis=1, how="all"), pdf.dropna(axis=1, how="all"))
+        self.assert_eq(kdf.dropna(axis=1, thresh=0), pdf.dropna(axis=1, thresh=0))
+        self.assert_eq(kdf.dropna(axis=1, thresh=1), pdf.dropna(axis=1, thresh=1))
 
     def test_dtype(self):
         pdf = pd.DataFrame(


### PR DESCRIPTION
Adding support `axis=1` or `axis='column'` for `DataFrame.dropna()`.

```py
>>> kdf = ks.DataFrame({"name": ['Alfred', 'Batman', 'Catwoman'],
...                     "toy": [None, 'Batmobile', 'Bullwhip'],
...                     "born": [None, "1940-04-25", None]},
...                    columns=['name', 'toy', 'born'])
>>> kdf
       name        toy        born
0    Alfred       None        None
1    Batman  Batmobile  1940-04-25
2  Catwoman   Bullwhip        None
>>> kdf.dropna(axis='columns')
       name
0    Alfred
1    Batman
2  Catwoman
```

Resolves #1053.