### PR TITLE
Set the upper bound for pandas.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 # Dependencies in Koalas. When you update don't forget to update setup.py and install.rst in docs.
-pandas>=0.23.2
+pandas>=0.23.2,<1.1.0
 pyarrow>=0.10
 matplotlib>=3.0.0,<3.3.0
 numpy>=1.14,<1.19.0

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     },
     python_requires='>=3.5,<3.9',
     install_requires=[
-        'pandas>=0.23.2',
+        'pandas>=0.23.2,<1.1.0',
         'pyarrow>=0.10',
         'numpy>=1.14',
         'matplotlib>=3.0.0',


### PR DESCRIPTION
Setting the upper bound for pandas as the behavior changed in pandas 1.1.0.
Fixing the behavior to follow pandas 1.1.0 is working at #1688.