### PR TITLE
Fix read_excel with Spark 3.0 and pandas<1.0.

### DIFF
--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -937,7 +937,7 @@ def read_excel(
 
     def pd_read_excel(io_or_bin):
         return pd.read_excel(
-            io=BytesIO(io_or_bin) if isinstance(io_or_bin, bytearray) else io_or_bin,
+            io=BytesIO(io_or_bin) if isinstance(io_or_bin, (bytes, bytearray)) else io_or_bin,
             sheet_name=sheet_name,
             header=header,
             names=names,


### PR DESCRIPTION
Fixes `read_excel` with Spark 3.0 and pandas<1.0.

```
ValueError: Must explicitly set engine if not passing in buffer or path for io.
```
