### PR TITLE
Try to read pandas metadata in read_parquet if index_col is None.

### DIFF
--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -629,9 +629,7 @@ def read_spark_io(
     return DataFrame(InternalFrame(spark_frame=sdf, index_map=index_map))
 
 
-def read_parquet(
-    path, columns=None, index_col=None, read_pandas_metadata=False, **options
-) -> DataFrame:
+def read_parquet(path, columns=None, index_col=None, pandas_metadata=False, **options) -> DataFrame:
     """Load a parquet object from the file path, returning a DataFrame.
 
     Parameters
@@ -642,8 +640,8 @@ def read_parquet(
         If not None, only these columns will be read from the file.
     index_col : str or list of str, optional, default: None
         Index column of table in Spark.
-    read_pandas_metadata : bool, default: False
-        If True, try to read pandas metadata from the file stored by pandas.
+    pandas_metadata : bool, default: False
+        If True, try to respect the metadata if the Parquet file is written from pandas.
     options : dict
         All other options passed directly into Spark's data source.
 
@@ -682,7 +680,7 @@ def read_parquet(
 
     index_names = None
 
-    if index_col is None and read_pandas_metadata:
+    if index_col is None and pandas_metadata:
         if LooseVersion(pyspark.__version__) < LooseVersion("3.0.0"):
             raise ValueError("read_pandas_metadata is not supported with Spark < 3.0.")
 

--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -684,7 +684,7 @@ def read_parquet(
 
     if index_col is None and read_pandas_metadata:
         if LooseVersion(pyspark.__version__) < LooseVersion("3.0.0"):
-            raise ValueError("read_pandas_metadata=True is not supported with Spark < 3.0.")
+            raise ValueError("read_pandas_metadata is not supported with Spark < 3.0.")
 
         # Try to read pandas metadata
 

--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -682,7 +682,7 @@ def read_parquet(path, columns=None, index_col=None, pandas_metadata=False, **op
 
     if index_col is None and pandas_metadata:
         if LooseVersion(pyspark.__version__) < LooseVersion("3.0.0"):
-            raise ValueError("read_pandas_metadata is not supported with Spark < 3.0.")
+            raise ValueError("pandas_metadata is not supported with Spark < 3.0.")
 
         # Try to read pandas metadata
 

--- a/databricks/koalas/tests/test_dataframe_spark_io.py
+++ b/databricks/koalas/tests/test_dataframe_spark_io.py
@@ -103,21 +103,21 @@ class DataFrameSparkIOTest(ReusedSQLTestCase, TestUtils):
             path1 = "{}/file1.parquet".format(tmp)
             expected1.to_parquet(path1)
 
-            self.assert_eq(ks.read_parquet(path1), expected1)
+            self.assert_eq(ks.read_parquet(path1, read_pandas_metadata=True), expected1)
 
             expected2 = expected1.reset_index()
 
             path2 = "{}/file2.parquet".format(tmp)
             expected2.to_parquet(path2)
 
-            self.assert_eq(ks.read_parquet(path2), expected2)
+            self.assert_eq(ks.read_parquet(path2, read_pandas_metadata=True), expected2)
 
             expected3 = expected2.set_index("index", append=True)
 
             path3 = "{}/file3.parquet".format(tmp)
             expected3.to_parquet(path3)
 
-            self.assert_eq(ks.read_parquet(path3), expected3)
+            self.assert_eq(ks.read_parquet(path3, read_pandas_metadata=True), expected3)
 
     def test_parquet_write(self):
         with self.temp_dir() as tmp:

--- a/databricks/koalas/tests/test_dataframe_spark_io.py
+++ b/databricks/koalas/tests/test_dataframe_spark_io.py
@@ -103,21 +103,21 @@ class DataFrameSparkIOTest(ReusedSQLTestCase, TestUtils):
             path1 = "{}/file1.parquet".format(tmp)
             expected1.to_parquet(path1)
 
-            self.assert_eq(ks.read_parquet(path1, read_pandas_metadata=True), expected1)
+            self.assert_eq(ks.read_parquet(path1, pandas_metadata=True), expected1)
 
             expected2 = expected1.reset_index()
 
             path2 = "{}/file2.parquet".format(tmp)
             expected2.to_parquet(path2)
 
-            self.assert_eq(ks.read_parquet(path2, read_pandas_metadata=True), expected2)
+            self.assert_eq(ks.read_parquet(path2, pandas_metadata=True), expected2)
 
             expected3 = expected2.set_index("index", append=True)
 
             path3 = "{}/file3.parquet".format(tmp)
             expected3.to_parquet(path3)
 
-            self.assert_eq(ks.read_parquet(path3, read_pandas_metadata=True), expected3)
+            self.assert_eq(ks.read_parquet(path3, pandas_metadata=True), expected3)
 
     def test_parquet_write(self):
         with self.temp_dir() as tmp:


### PR DESCRIPTION
If a parquet file is stored by pandas, there is a metadata to describe index columns.
We can read it and use as `index_col` if it's not specified.
Resolves #1645.