### PR TITLE
expanded allowable types for kdf indexing to include pandas Index object

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -10094,7 +10094,11 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         if key is None:
             raise KeyError("none key")
-        if isinstance(key, (str, tuple, list, pd.Index)):
+
+        if isinstance(key, Series):
+            return self.loc[key.astype(bool)]
+        elif isinstance(key, str) or is_list_like(key):
+            key = list(key) if is_list_like(key) else key
             return self.loc[:, key]
         elif isinstance(key, slice):
             if any(type(n) == int or None for n in [key.start, key.stop]):
@@ -10102,8 +10106,6 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 # with ints.
                 return self.iloc[key]
             return self.loc[key]
-        elif isinstance(key, Series):
-            return self.loc[key.astype(bool)]
         raise NotImplementedError(key)
 
     def __setitem__(self, key, value):

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -10094,7 +10094,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         if key is None:
             raise KeyError("none key")
-        if isinstance(key, (str, tuple, list)):
+        if isinstance(key, (str, tuple, list, pd.Index)):
             return self.loc[:, key]
         elif isinstance(key, slice):
             if any(type(n) == int or None for n in [key.start, key.stop]):

--- a/databricks/koalas/missing/series.py
+++ b/databricks/koalas/missing/series.py
@@ -50,8 +50,6 @@ class MissingPandasLikeSeries(object):
     interpolate = _unsupported_function("interpolate")
     last = _unsupported_function("last")
     last_valid_index = _unsupported_function("last_valid_index")
-    prod = _unsupported_function("prod")
-    product = _unsupported_function("product")
     reindex = _unsupported_function("reindex")
     reindex_like = _unsupported_function("reindex_like")
     rename_axis = _unsupported_function("rename_axis")

--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -23,13 +23,17 @@ from collections.abc import Iterable
 from distutils.version import LooseVersion
 from functools import reduce
 from io import BytesIO
+import json
 
 import numpy as np
 import pandas as pd
 from pandas.api.types import is_datetime64_dtype, is_datetime64tz_dtype, is_list_like
+import pyarrow as pa
+import pyarrow.parquet as pq
 import pyspark
 from pyspark import sql as spark
 from pyspark.sql import functions as F
+from pyspark.sql.functions import pandas_udf, PandasUDFType
 from pyspark.sql.types import (
     ByteType,
     ShortType,
@@ -625,7 +629,7 @@ def read_spark_io(
     return DataFrame(InternalFrame(spark_frame=sdf, index_map=index_map))
 
 
-def read_parquet(path, columns=None, index_col=None, **options) -> DataFrame:
+def read_parquet(path, columns=None, index_col=None, pandas_metadata=False, **options) -> DataFrame:
     """Load a parquet object from the file path, returning a DataFrame.
 
     Parameters
@@ -636,6 +640,8 @@ def read_parquet(path, columns=None, index_col=None, **options) -> DataFrame:
         If not None, only these columns will be read from the file.
     index_col : str or list of str, optional, default: None
         Index column of table in Spark.
+    pandas_metadata : bool, default: False
+        If True, try to respect the metadata if the Parquet file is written from pandas.
     options : dict
         All other options passed directly into Spark's data source.
 
@@ -672,6 +678,44 @@ def read_parquet(path, columns=None, index_col=None, **options) -> DataFrame:
     if columns is not None:
         columns = list(columns)
 
+    index_names = None
+
+    if index_col is None and pandas_metadata:
+        if LooseVersion(pyspark.__version__) < LooseVersion("3.0.0"):
+            raise ValueError("pandas_metadata is not supported with Spark < 3.0.")
+
+        # Try to read pandas metadata
+
+        @pandas_udf("index_col array<string>, index_names array<string>", PandasUDFType.SCALAR)
+        def read_index_metadata(pser):
+            binary = pser.iloc[0]
+            metadata = pq.ParquetFile(pa.BufferReader(binary)).metadata.metadata
+            if b"pandas" in metadata:
+                pandas_metadata = json.loads(metadata[b"pandas"].decode("utf8"))
+                if all(isinstance(col, str) for col in pandas_metadata["index_columns"]):
+                    index_col = []
+                    index_names = []
+                    for col in pandas_metadata["index_columns"]:
+                        index_col.append(col)
+                        for column in pandas_metadata["columns"]:
+                            if column["field_name"] == col:
+                                index_names.append(column["name"])
+                                break
+                        else:
+                            index_names.append(None)
+                    return pd.DataFrame({"index_col": [index_col], "index_names": [index_names]})
+            return pd.DataFrame({"index_col": [None], "index_names": [None]})
+
+        index_col, index_names = (
+            default_session()
+            .read.format("binaryFile")
+            .load(path)
+            .limit(1)
+            .select(read_index_metadata("content").alias("index_metadata"))
+            .select("index_metadata.*")
+            .head()
+        )
+
     kdf = read_spark_io(path=path, format="parquet", options=options, index_col=index_col)
 
     if columns is not None:
@@ -681,7 +725,10 @@ def read_parquet(path, columns=None, index_col=None, **options) -> DataFrame:
         else:
             sdf = default_session().createDataFrame([], schema=StructType())
             index_map = _get_index_map(sdf, index_col)
-            return DataFrame(InternalFrame(spark_frame=sdf, index_map=index_map))
+            kdf = DataFrame(InternalFrame(spark_frame=sdf, index_map=index_map))
+
+    if index_names is not None:
+        kdf.index.names = index_names
 
     return kdf
 

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -44,6 +44,7 @@ from pyspark.sql.types import (
     NumericType,
     StringType,
     StructType,
+    IntegralType,
 )
 from pyspark.sql.window import Window
 
@@ -4961,6 +4962,61 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         Name: 0, dtype: int64
         """
         return first_series(self.to_frame().tail(n=n))
+
+    def product(self, min_count=0):
+        """
+        Return the product of the values.
+
+        .. note:: unlike pandas', Koalas' emulates product by ``exp(sum(log(...)))``
+            trick. Therefore, it only works for positive numbers.
+
+        Parameters
+        ----------
+        min_count : int, default 0
+            The required number of valid values to perform the operation. If fewer than
+            ``min_count`` non-NA values are present the result will be NA.
+
+        Examples
+        --------
+        >>> ks.Series([1, 2, 3, 4, 5]).prod()
+        120
+
+        By default, the product of an empty or all-NA Series is ``1``
+
+        >>> ks.Series([]).prod()
+        1.0
+
+        This can be controlled with the ``min_count`` parameter
+
+        >>> ks.Series([]).prod(min_count=1)
+        nan
+        """
+        # When number of valid values is fewer than `min_count`, pandas returns np.nan
+        if (min_count > 0) and (len(self.dropna()) < min_count):
+            return np.nan
+
+        data_type = self.spark.data_type
+        if isinstance(data_type, BooleanType):
+            return self.all()
+        elif isinstance(data_type, NumericType):
+            spark_frame = self._internal.spark_frame
+            spark_column = self.spark.column
+
+            cond = F.when(spark_column.isNull(), F.lit(1)).otherwise(spark_column)
+            spark_frame = spark_frame.select(F.exp(F.sum(F.log(cond))))
+
+            result = spark_frame.head(1)[0][0]
+            if result is None:
+                # When Series is empty, pandas returns 1.0
+                return 1.0
+            elif isinstance(data_type, IntegralType):
+                return int(round(result))
+            else:
+                return result
+        else:
+            raise TypeError("cannot perform prod with type {}".format(self.dtype))
+
+    prod = product
 
     def _cum(self, func, skipna, part_cols=()):
         # This is used to cummin, cummax, cumsum, etc.

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -80,6 +80,12 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         kser = ks.from_pandas(pser)
         self.assert_eq(pd.DataFrame(pser), ks.DataFrame(kser))
 
+        # check kdf[pd.Index]
+        pdf, kdf = self.df_pair
+        column_mask = pdf.columns.isin(["a", "b"])
+        index_cols = pdf.columns[column_mask]
+        self.assert_eq(pdf[index_cols].shape, kdf[index_cols].shape)
+
     def test_inplace(self):
         pdf, kdf = self.df_pair
 

--- a/databricks/koalas/tests/test_dataframe_spark_io.py
+++ b/databricks/koalas/tests/test_dataframe_spark_io.py
@@ -15,6 +15,7 @@
 #
 
 from distutils.version import LooseVersion
+import unittest
 
 import numpy as np
 import pandas as pd
@@ -91,6 +92,33 @@ class DataFrameSparkIOTest(ReusedSQLTestCase, TestUtils):
                 actual_idx.sort_values(by="f").to_spark().toPandas(),
                 expected_idx.sort_values(by="f").to_spark().toPandas(),
             )
+
+    @unittest.skipIf(
+        LooseVersion(pyspark.__version__) < LooseVersion("3.0.0"),
+        "The test only works with Spark>=3.0",
+    )
+    def test_parquet_read_with_pandas_metadata(self):
+        with self.temp_dir() as tmp:
+            expected1 = self.test_pdf
+
+            path1 = "{}/file1.parquet".format(tmp)
+            expected1.to_parquet(path1)
+
+            self.assert_eq(ks.read_parquet(path1, pandas_metadata=True), expected1)
+
+            expected2 = expected1.reset_index()
+
+            path2 = "{}/file2.parquet".format(tmp)
+            expected2.to_parquet(path2)
+
+            self.assert_eq(ks.read_parquet(path2, pandas_metadata=True), expected2)
+
+            expected3 = expected2.set_index("index", append=True)
+
+            path3 = "{}/file3.parquet".format(tmp)
+            expected3.to_parquet(path3)
+
+            self.assert_eq(ks.read_parquet(path3, pandas_metadata=True), expected3)
 
     def test_parquet_write(self):
         with self.temp_dir() as tmp:

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -1895,6 +1895,67 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
             with self.assertRaisesRegex(TypeError, "bad operand type for unary -: 'str'"):
                 kser.tail("10")
 
+    def test_product(self):
+        pser = pd.Series([10, 20, 30, 40, 50])
+        kser = ks.from_pandas(pser)
+        self.assert_eq(pser.prod(), kser.prod())
+
+        # Containing NA values
+        pser = pd.Series([10, np.nan, 30, np.nan, 50])
+        kser = ks.from_pandas(pser)
+        self.assert_eq(pser.prod(), kser.prod(), almost=True)
+
+        # All-NA values
+        pser = pd.Series([np.nan, np.nan, np.nan])
+        kser = ks.from_pandas(pser)
+        self.assert_eq(pser.prod(), kser.prod())
+
+        # Empty Series
+        pser = pd.Series([])
+        kser = ks.from_pandas(pser)
+        self.assert_eq(pser.prod(), kser.prod())
+
+        # Boolean Series
+        pser = pd.Series([True, True, True])
+        kser = ks.from_pandas(pser)
+        self.assert_eq(pser.prod(), kser.prod())
+
+        pser = pd.Series([False, False, False])
+        kser = ks.from_pandas(pser)
+        self.assert_eq(pser.prod(), kser.prod())
+
+        pser = pd.Series([True, False, True])
+        kser = ks.from_pandas(pser)
+        self.assert_eq(pser.prod(), kser.prod())
+
+        # With `min_count` parameter
+        pser = pd.Series([10, 20, 30, 40, 50])
+        kser = ks.from_pandas(pser)
+        self.assert_eq(pser.prod(min_count=5), kser.prod(min_count=5))
+        # Using `repr` since the result of below will be `np.nan`.
+        self.assert_eq(repr(pser.prod(min_count=6)), repr(kser.prod(min_count=6)))
+
+        pser = pd.Series([10, np.nan, 30, np.nan, 50])
+        kser = ks.from_pandas(pser)
+        self.assert_eq(pser.prod(min_count=3), kser.prod(min_count=3), almost=True)
+        # ditto.
+        self.assert_eq(repr(pser.prod(min_count=4)), repr(kser.prod(min_count=4)))
+
+        pser = pd.Series([np.nan, np.nan, np.nan])
+        kser = ks.from_pandas(pser)
+        # ditto.
+        self.assert_eq(repr(pser.prod(min_count=1)), repr(kser.prod(min_count=1)))
+
+        pser = pd.Series([])
+        kser = ks.from_pandas(pser)
+        # ditto.
+        self.assert_eq(repr(pser.prod(min_count=1)), repr(kser.prod(min_count=1)))
+
+        with self.assertRaisesRegex(TypeError, "cannot perform prod with type object"):
+            ks.Series(["a", "b", "c"]).prod()
+        with self.assertRaisesRegex(TypeError, "cannot perform prod with type datetime64"):
+            ks.Series([pd.Timestamp("2016-01-01") for _ in range(3)]).prod()
+
     def test_hasnans(self):
         # BooleanType
         pser = pd.Series([True, False, True, True])

--- a/docs/source/reference/series.rst
+++ b/docs/source/reference/series.rst
@@ -88,6 +88,7 @@ Binary operator functions
    Series.ge
    Series.ne
    Series.eq
+   Series.product
    Series.dot
 
 Function application, GroupBy & Window
@@ -134,6 +135,7 @@ Computations / Descriptive Stats
    Series.nlargest
    Series.nsmallest
    Series.pct_change
+   Series.prod
    Series.nunique
    Series.is_unique
    Series.quantile


### PR DESCRIPTION
This PR attempts to address an issue I see with column selection of Koalas DataFrames. Pandas allows use of a Pandas Index object for selecting columns, e.g.

```python
column_mask = entity.df.columns.isin([variable.id for variable in entity.variables])
index_cols = entity.df.columns[column_mask] 
dtypes = entity.df[index_cols].dtypes.astype(str).to_dict() 
```

will work fine in Pandas but fail with Koalas as the type check in the DataFrame's __getitem__ method does not include the Pandas Index type.

If I feed a Panads Index to the Koalas DataFrame.loc method like `entity.df.loc[:, index_cols]` it works. 

I propose expanding the list of allowable types when getting an item from the Frame class, e.g.
`if isinstance(key, (str, tuple, list)):` -> `if isinstance(key, (str, tuple, list, pd.Index)):` to bring it (more) in line with pandas.

I've added to the test_dataframe test to reflect but could break this out if required.

FYI, this is a blocker to running a basic featuretools demo with the proposed Koalas backend.