### PR TITLE
include pandas Index object in dataframe indexing options

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -10094,7 +10094,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         if key is None:
             raise KeyError("none key")
-        if isinstance(key, (str, tuple, list)):
+        if isinstance(key, Series):
+            return self.loc[key.astype(bool)]
+        elif isinstance(key, str) or is_list_like(key):
+            key = list(key) if is_list_like(key) else key
             return self.loc[:, key]
         elif isinstance(key, slice):
             if any(type(n) == int or None for n in [key.start, key.stop]):
@@ -10102,8 +10105,6 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 # with ints.
                 return self.iloc[key]
             return self.loc[key]
-        elif isinstance(key, Series):
-            return self.loc[key.astype(bool)]
         raise NotImplementedError(key)
 
     def __setitem__(self, key, value):

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -10096,9 +10096,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             raise KeyError("none key")
         if isinstance(key, Series):
             return self.loc[key.astype(bool)]
-        elif isinstance(key, str) or is_list_like(key):
-            key = list(key) if is_list_like(key) else key
+        elif isinstance(key, (str, tuple)):
             return self.loc[:, key]
+        elif is_list_like(key):
+            return self.loc[:, list(key)]
         elif isinstance(key, slice):
             if any(type(n) == int or None for n in [key.start, key.stop]):
                 # Seems like pandas Frame always uses int as positional search when slicing

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -84,7 +84,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         pdf, kdf = self.df_pair
         column_mask = pdf.columns.isin(["a", "b"])
         index_cols = pdf.columns[column_mask]
-        self.assert_eq(pdf[index_cols].shape, kdf[index_cols].shape)
+        self.assert_eq(kdf[index_cols], pdf[index_cols])
 
     def test_inplace(self):
         pdf, kdf = self.df_pair

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -80,6 +80,12 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         kser = ks.from_pandas(pser)
         self.assert_eq(pd.DataFrame(pser), ks.DataFrame(kser))
 
+        # check kdf[pd.Index]
+        pdf, kdf = self.df_pair
+        column_mask = pdf.columns.isin(["a", "b"])
+        index_cols = pdf.columns[column_mask]
+        self.assert_eq(pdf[index_cols].shape, kdf[index_cols].shape)
+
     def test_inplace(self):
         pdf, kdf = self.df_pair
 


### PR DESCRIPTION
(supersedes previous #1697)

This PR attempts to address an issue I see with column selection of Koalas DataFrames. Pandas allows use of a Pandas Index object for selecting columns, e.g.

```
column_mask = entity.df.columns.isin([variable.id for variable in entity.variables])
index_cols = entity.df.columns[column_mask] 
dtypes = entity.df[index_cols].dtypes.astype(str).to_dict() 
```
will work fine in Pandas but fail with Koalas as the type check in the DataFrame's getitem method does not include the Pandas Index type.

The changes here extend column indexing to all list like objects.

I've added to the test_dataframe test to reflect.