### PR TITLE
Implement DataFrame.groupby.cumcount

### DIFF
--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -696,7 +696,8 @@ class GroupBy(object, metaclass=ABCMeta):
             should_resolve=True,
         )
         ret -= 1
-        return ret.max(axis=1)
+        # Cast columns to ``"int64"`` to match `pandas.core.groupby.GroupBy.cumcount`.
+        return ret.max(axis=1).astype('int64')
 
     def cummax(self):
         """

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -646,7 +646,9 @@ class GroupBy(object, metaclass=ABCMeta):
 
         Essentially this is equivalent to
 
-        >>> self.apply(lambda x: pd.Series(np.arange(len(x)), x.index))
+        .. code-block:: python
+
+            self.apply(lambda x: pd.Series(np.arange(len(x)), x.index))
 
         Parameters
         ----------

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -642,17 +642,27 @@ class GroupBy(object, metaclass=ABCMeta):
 
     def cumcount(self, ascending=True):
         """
-        Cumulative count for each group.
+        Number each item in each group from 0 to the length of that group - 1.
+
+        Essentially this is equivalent to
+
+        >>> self.apply(lambda x: pd.Series(np.arange(len(x)), x.index))
+
+        Parameters
+        ----------
+        ascending : bool, default True
+            If False, number in reverse, from length of group - 1 to 0.
 
         Returns
         -------
-        Series or DataFrame
+        Series
+            Sequence number of each element within each group.
 
         Examples
         --------
-        >>> df = ks.DataFrame(
-        ...     [['a'], ['a'], ['a'], ['b'], ['b'], ['a']],
-        ...     columns=list('A'))
+
+        >>> df = ks.DataFrame([['a'], ['a'], ['a'], ['b'], ['b'], ['a']],
+        ...                   columns=['A'])
         >>> df
            A
         0  a
@@ -669,7 +679,7 @@ class GroupBy(object, metaclass=ABCMeta):
         4    1
         5    3
         Name: 0, dtype: int64
-        >>> df.groupby('A').cumcount(ascending=False)
+        >>> df.groupby('A').cumcount(ascending=False).sort_index()
         0    3
         1    2
         2    1

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -681,7 +681,8 @@ class GroupBy(object, metaclass=ABCMeta):
         """
         ret = self._apply_series_op(
             lambda sg: sg._kser._cum(
-                F.count, True, part_cols=sg._groupkeys_scols, ascending=ascending),
+                F.count, True, part_cols=sg._groupkeys_scols, ascending=ascending
+            ),
             should_resolve=True,
         )
         ret -= 1

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -640,6 +640,53 @@ class GroupBy(object, metaclass=ABCMeta):
             lambda sg: sg._kser._diff(periods, part_cols=sg._groupkeys_scols)
         )
 
+    def cumcount(self, ascending=True):
+        """
+        Cumulative count for each group.
+
+        Returns
+        -------
+        Series or DataFrame
+
+        Examples
+        --------
+        >>> df = ks.DataFrame(
+        ...     [['a'], ['a'], ['a'], ['b'], ['b'], ['a']],
+        ...     columns=list('A'))
+        >>> df
+           A
+        0  a
+        1  a
+        2  a
+        3  b
+        4  b
+        5  a
+        >>> df.groupby('A').cumcount().sort_index()
+        0    0
+        1    1
+        2    2
+        3    0
+        4    1
+        5    3
+        Name: 0, dtype: int64
+        >>> df.groupby('A').cumcount(ascending=False)
+        0    3
+        1    2
+        2    1
+        3    1
+        4    0
+        5    0
+        Name: 0, dtype: int64
+
+        """
+        ret = self._apply_series_op(
+            lambda sg: sg._kser._cum(
+                F.count, True, part_cols=sg._groupkeys_scols, ascending=ascending),
+            should_resolve=True,
+        )
+        ret -= 1
+        return ret.max(axis=1)
+
     def cummax(self):
         """
         Cumulative max for each group.

--- a/databricks/koalas/missing/groupby.py
+++ b/databricks/koalas/missing/groupby.py
@@ -94,7 +94,6 @@ class MissingPandasLikeSeriesGroupBy(object):
     # Functions
     agg = _unsupported_function("agg")
     aggregate = _unsupported_function("aggregate")
-    cumcount = _unsupported_function("cumcount")
     describe = _unsupported_function("describe")
     get_group = _unsupported_function("get_group")
     median = _unsupported_function("median")

--- a/databricks/koalas/missing/groupby.py
+++ b/databricks/koalas/missing/groupby.py
@@ -57,7 +57,6 @@ class MissingPandasLikeDataFrameGroupBy(object):
 
     # Functions
     boxplot = _unsupported_function("boxplot")
-    cumcount = _unsupported_function("cumcount")
     get_group = _unsupported_function("get_group")
     median = _unsupported_function("median")
     ngroup = _unsupported_function("ngroup")

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -5018,14 +5018,21 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
     prod = product
 
-    def _cum(self, func, skipna, part_cols=()):
+    def _cum(self, func, skipna, part_cols=(), ascending=True):
         # This is used to cummin, cummax, cumsum, etc.
 
-        window = (
-            Window.orderBy(NATURAL_ORDER_COLUMN_NAME)
-            .partitionBy(*part_cols)
-            .rowsBetween(Window.unboundedPreceding, Window.currentRow)
-        )
+        if ascending:
+            window = (
+                Window.orderBy(F.asc(NATURAL_ORDER_COLUMN_NAME))
+                .partitionBy(*part_cols)
+                .rowsBetween(Window.unboundedPreceding, Window.currentRow)
+            )
+        else:
+            window = (
+                Window.orderBy(F.desc(NATURAL_ORDER_COLUMN_NAME))
+                .partitionBy(*part_cols)
+                .rowsBetween(Window.unboundedPreceding, Window.currentRow)
+            )
 
         if skipna:
             # There is a behavior difference between pandas and PySpark. In case of cummax,

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -2200,26 +2200,6 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
                 repr(pdf3.transpose().sort_index()), repr(kdf3.transpose().sort_index())
             )
 
-    def _test_cumcount(self, pdf, kdf):
-        for column in pdf.columns:
-            self.assert_eq(pdf.groupby(column).cumcount(), kdf.groupby(column).cumcount())
-            self.assert_eq(
-                pdf.groupby(column).cumcount(ascending=False),
-                kdf.groupby(column).cumcount(ascending=False),
-            )
-            self.assert_eq(
-                pdf.groupby(column).cumcount().sum(), kdf.groupby(column).cumcount().sum()
-            )
-
-    def test_cumcount(self):
-        pdf = pd.DataFrame(
-            [[1, None, 4], [1, 0.1, 3], [1, 20.0, 2], [4, None, 1]],
-            columns=list("ABC"),
-            index=np.random.rand(4),
-        )
-        kdf = ks.from_pandas(pdf)
-        self._test_cumcount(pdf, kdf)
-
     def _test_cummin(self, pdf, kdf):
         self.assert_eq(pdf.cummin(), kdf.cummin())
         self.assert_eq(pdf.cummin(skipna=False), kdf.cummin(skipna=False))

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -2200,6 +2200,26 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
                 repr(pdf3.transpose().sort_index()), repr(kdf3.transpose().sort_index())
             )
 
+    def _test_cumcount(self, pdf, kdf):
+        for column in pdf.columns:
+            self.assert_eq(pdf.groupby(column).cumcount(), kdf.groupby(column).cumcount())
+            self.assert_eq(
+                pdf.groupby(column).cumcount(ascending=False),
+                kdf.groupby(column).cumcount(ascending=False),
+            )
+            self.assert_eq(
+                pdf.groupby(column).cumcount().sum(), kdf.groupby(column).cumcount().sum()
+            )
+
+    def test_cumcount(self):
+        pdf = pd.DataFrame(
+            [[1, None, 4], [1, 0.1, 3], [1, 20.0, 2], [4, None, 1]],
+            columns=list("ABC"),
+            index=np.random.rand(4),
+        )
+        kdf = ks.from_pandas(pdf)
+        self._test_cumcount(pdf, kdf)
+
     def _test_cummin(self, pdf, kdf):
         self.assert_eq(pdf.cummin(), kdf.cummin())
         self.assert_eq(pdf.cummin(skipna=False), kdf.cummin(skipna=False))

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -852,6 +852,70 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             pdf.groupby([("x", "a"), ("x", "b")]).rank().sort_index(),
         )
 
+    def test_cumcount(self):
+        pdf = pd.DataFrame(
+            {"a": [1, 1, 1, 4] * 3, "b": [None, 0.1, 20.0, None] * 3, "c": [4, 3, 2, 1] * 3},
+            index=np.random.rand(4 * 3),
+        )
+        kdf = ks.from_pandas(pdf)
+
+        self.assert_eq(
+            kdf.groupby("b").cumcount().sort_index(), pdf.groupby("b").cumcount().sort_index()
+        )
+        # TODO: Enable the following test when ks.groupby(dropna=True)
+        # is implemented (see #1007)
+        # self.assert_eq(
+        #    kdf.groupby(["a", "b"]).cumcount().sort_index(),
+        #    pdf.groupby(["a", "b"]).cumcount().sort_index(),
+        # )
+        self.assert_eq(
+            kdf.groupby(["a", "c"]).cumcount().sort_index(),
+            pdf.groupby(["a", "c"]).cumcount().sort_index(),
+        )
+        self.assert_eq(
+            kdf.groupby(["b"])["a"].cumcount().sort_index(),
+            pdf.groupby(["b"])["a"].cumcount().sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            kdf.groupby(["b"])[["a", "c"]].cumcount().sort_index(),
+            pdf.groupby(["b"])[["a", "c"]].cumcount().sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            kdf.groupby(kdf.b // 5).cumcount().sort_index(),
+            pdf.groupby(pdf.b // 5).cumcount().sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            kdf.groupby(kdf.b // 5)["a"].cumcount().sort_index(),
+            pdf.groupby(pdf.b // 5)["a"].cumcount().sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            kdf.groupby("b").cumcount().sum(), pdf.groupby("b").cumcount().sum(),
+        )
+
+        # multi-index columns
+        columns = pd.MultiIndex.from_tuples([("x", "a"), ("x", "b"), ("y", "c")])
+        pdf.columns = columns
+        kdf.columns = columns
+
+        self.assert_eq(
+            kdf.groupby(("x", "b")).cumcount().sort_index(),
+            pdf.groupby(("x", "b")).cumcount().sort_index(),
+        )
+        # TODO: Enable the following test when ks.groupby(dropna=True)
+        # is implemented (see #1007)
+        # self.assert_eq(
+        #    kdf.groupby([("x", "a"), ("x", "b")]).cumcount().sort_index(),
+        #    pdf.groupby([("x", "a"), ("x", "b")]).cumcount().sort_index(),
+        # )
+        self.assert_eq(
+            kdf.groupby([("x", "a"), ("y", "c")]).cumcount().sort_index(),
+            pdf.groupby([("x", "a"), ("y", "c")]).cumcount().sort_index(),
+        )
+
     def test_cummin(self):
         pdf = pd.DataFrame(
             {

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -854,23 +854,21 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
 
     def test_cumcount(self):
         pdf = pd.DataFrame(
-            {"a": [1, 1, 1, 4] * 3, "b": [None, 0.1, 20.0, None] * 3, "c": [4, 3, 2, 1] * 3},
-            index=np.random.rand(4 * 3),
+            {
+                "a": [1, 2, 3, 4, 5, 6] * 3,
+                "b": [1, 1, 2, 3, 5, 8] * 3,
+                "c": [1, 4, 9, 16, 25, 36] * 3,
+            },
+            index=np.random.rand(6 * 3),
         )
         kdf = ks.from_pandas(pdf)
 
         self.assert_eq(
             kdf.groupby("b").cumcount().sort_index(), pdf.groupby("b").cumcount().sort_index()
         )
-        # TODO: Enable the following test when ks.groupby(dropna=True)
-        # is implemented (see #1007)
-        # self.assert_eq(
-        #    kdf.groupby(["a", "b"]).cumcount().sort_index(),
-        #    pdf.groupby(["a", "b"]).cumcount().sort_index(),
-        # )
         self.assert_eq(
-            kdf.groupby(["a", "c"]).cumcount().sort_index(),
-            pdf.groupby(["a", "c"]).cumcount().sort_index(),
+            kdf.groupby(["a", "b"]).cumcount().sort_index(),
+            pdf.groupby(["a", "b"]).cumcount().sort_index(),
         )
         self.assert_eq(
             kdf.groupby(["b"])["a"].cumcount().sort_index(),
@@ -905,15 +903,9 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             kdf.groupby(("x", "b")).cumcount().sort_index(),
             pdf.groupby(("x", "b")).cumcount().sort_index(),
         )
-        # TODO: Enable the following test when ks.groupby(dropna=True)
-        # is implemented (see #1007)
-        # self.assert_eq(
-        #    kdf.groupby([("x", "a"), ("x", "b")]).cumcount().sort_index(),
-        #    pdf.groupby([("x", "a"), ("x", "b")]).cumcount().sort_index(),
-        # )
         self.assert_eq(
-            kdf.groupby([("x", "a"), ("y", "c")]).cumcount().sort_index(),
-            pdf.groupby([("x", "a"), ("y", "c")]).cumcount().sort_index(),
+            kdf.groupby([("x", "a"), ("x", "b")]).cumcount().sort_index(),
+            pdf.groupby([("x", "a"), ("x", "b")]).cumcount().sort_index(),
         )
 
     def test_cummin(self):

--- a/docs/source/reference/groupby.rst
+++ b/docs/source/reference/groupby.rst
@@ -33,6 +33,7 @@ Computations / Descriptive Stats
    GroupBy.all
    GroupBy.any
    GroupBy.count
+   GroupBy.cumcount
    GroupBy.cummax
    GroupBy.cummin
    GroupBy.cumprod


### PR DESCRIPTION
Here is an example of the implementation in analogy of the one from [the pandas docs](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.core.groupby.GroupBy.cumcount.html):

```python
>>> df = ks.DataFrame(
...     [['a'], ['a'], ['a'], ['b'], ['b'], ['a']],
...     columns=list('A'))
>>> df
   A
0  a
1  a
2  a
3  b
4  b
5  a
>>> df.groupby('A').cumcount(ascending=False).sort_index()
0    3
1    2
2    1
3    1
4    0
5    0
Name: A, dtype: int64
>>> df.groupby('A').cumcount().sort_index()
0    0
1    1
2    2
3    0
4    1
5    3
Name: A, dtype: int64
```

The tests are the same like for the other `cumxxx` tests for now.

Nevertheless, it so far does not work the case of nulls and multiple columns within the groupby (thank you for finding this @itholic):
```python
>>> df = ks.DataFrame({"a": [1, 1, 1, 4], "b": [None, 0.1, 20.0, None], "c": [4, 3, 2, 1]})
>>> df
   a     b  c
0  1   NaN  4
1  1   0.1  3
2  1  20.0  2
3  4   NaN  1
>>> df.groupby(["a", "b"]).cumcount().sort_index()
0    0
1    0
2    0
3    0
Name: a, dtype: int64
>>> df.to_pandas().groupby(["a", "b"]).cumcount().sort_index()
0    0
1    0
2    0
3    1
dtype: int64
```

This will also work, when groupby supports a default `dropna=True` argument in #1007 