### PR TITLE
Fix first_valid_index() for Empty object

### DIFF
--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -1675,6 +1675,10 @@ class Frame(object, metaclass=ABCMeta):
         cond = reduce(lambda x, y: x & y, map(lambda x: x.isNotNull(), data_spark_columns))
 
         first_valid_row = sdf.drop(NATURAL_ORDER_COLUMN_NAME).filter(cond).first()
+        # For Empty Series or DataFrame, returns None.
+        if first_valid_row is None:
+            return None
+
         first_valid_idx = tuple(
             first_valid_row[idx_col] for idx_col in self._internal.index_spark_column_names
         )

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -3859,3 +3859,9 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             self.assert_eq(pdf.tail(1001), kdf.tail(1001), almost=True)
             with self.assertRaisesRegex(TypeError, "bad operand type for unary -: 'str'"):
                 kdf.tail("10")
+
+    def test_first_valid_index(self):
+        # Empty DataFrame
+        pdf = pd.Series([], name=0).to_frame()
+        kdf = ks.Series([]).to_frame()
+        self.assert_eq(pdf.first_valid_index(), kdf.first_valid_index())

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -1974,3 +1974,9 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         pser = pd.Series([pd.Timestamp("2020-07-30"), np.nan, pd.Timestamp("2020-07-30")])
         kser = ks.from_pandas(pser)
         self.assert_eq(pser.hasnans, kser.hasnans)
+
+    def test_first_valid_index(self):
+        # Empty Series
+        pser = pd.Series([])
+        kser = ks.from_pandas(pser)
+        self.assert_eq(pser.first_valid_index(), kser.first_valid_index())


### PR DESCRIPTION
`Series.first_valid_index()` and `DataFrame.first_valid_index()` raise Exception for Empty set - but it supposed to return None, not raise Error. -

```python
>>> ks.Series([]).first_valid_index()  # It should return `None`.
Traceback (most recent call last):
...
TypeError: 'NoneType' object is not subscriptable
```

This PR fixed this and added related tests.

```python
>>> ks.Series([]).first_valid_index() is None
True
```