### PR TITLE
Implemented last_valid_index for DataFrame and Series

### DIFF
--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -1692,6 +1692,10 @@ class Frame(object, metaclass=ABCMeta):
         -------
         scalar : type of index
 
+        Notes
+        -----
+        This API only works with PySpark >= 3.0.
+
         Examples
         --------
 

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -1712,7 +1712,7 @@ class Frame(object, metaclass=ABCMeta):
         E  3.0  3.0  400.0
         R  NaN  NaN    NaN
 
-        >>> kdf.last_valid_index()
+        >>> kdf.last_valid_index()  # doctest: +SKIP
         'E'
 
         Support for MultiIndex columns
@@ -1726,7 +1726,7 @@ class Frame(object, metaclass=ABCMeta):
         E  3.0  3.0  400.0
         R  NaN  NaN    NaN
 
-        >>> kdf.last_valid_index()
+        >>> kdf.last_valid_index()  # doctest: +SKIP
         'E'
 
         Support for Series.
@@ -1740,7 +1740,7 @@ class Frame(object, metaclass=ABCMeta):
         500    NaN
         Name: 0, dtype: float64
 
-        >>> s.last_valid_index()
+        >>> s.last_valid_index()  # doctest: +SKIP
         300
 
         Support for MultiIndex
@@ -1762,7 +1762,7 @@ class Frame(object, metaclass=ABCMeta):
                 length      NaN
         Name: 0, dtype: float64
 
-        >>> s.last_valid_index()
+        >>> s.last_valid_index()  # doctest: +SKIP
         ('cow', 'weight')
         """
         sdf = self._internal.spark_frame

--- a/databricks/koalas/missing/frame.py
+++ b/databricks/koalas/missing/frame.py
@@ -53,7 +53,6 @@ class _MissingPandasLikeDataFrame(object):
     interpolate = _unsupported_function("interpolate")
     itertuples = _unsupported_function("itertuples")
     last = _unsupported_function("last")
-    last_valid_index = _unsupported_function("last_valid_index")
     lookup = _unsupported_function("lookup")
     mode = _unsupported_function("mode")
     prod = _unsupported_function("prod")

--- a/databricks/koalas/missing/series.py
+++ b/databricks/koalas/missing/series.py
@@ -49,7 +49,6 @@ class MissingPandasLikeSeries(object):
     infer_objects = _unsupported_function("infer_objects")
     interpolate = _unsupported_function("interpolate")
     last = _unsupported_function("last")
-    last_valid_index = _unsupported_function("last_valid_index")
     reindex = _unsupported_function("reindex")
     reindex_like = _unsupported_function("reindex_like")
     rename_axis = _unsupported_function("rename_axis")

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -3859,3 +3859,23 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             self.assert_eq(pdf.tail(1001), kdf.tail(1001), almost=True)
             with self.assertRaisesRegex(TypeError, "bad operand type for unary -: 'str'"):
                 kdf.tail("10")
+
+    def test_last_valid_index(self):
+        # `pyspark.sql.dataframe.DataFrame.tail` is new in pyspark >= 3.0.
+        if LooseVersion(pyspark.__version__) >= LooseVersion("3.0"):
+            pdf = pd.DataFrame(
+                {"a": [1, 2, 3, None], "b": [1.0, 2.0, 3.0, None], "c": [100, 200, 400, None]},
+                index=["Q", "W", "E", "R"],
+            )
+            kdf = ks.from_pandas(pdf)
+            self.assert_eq(pdf.last_valid_index(), kdf.last_valid_index())
+
+            # MultiIndex columns
+            pdf.columns = pd.MultiIndex.from_tuples([("a", "x"), ("b", "y"), ("c", "z")])
+            kdf = ks.from_pandas(pdf)
+            self.assert_eq(pdf.last_valid_index(), kdf.last_valid_index())
+
+            # Empty Series
+            pdf = pd.Series([], name=0).to_frame()
+            kdf = ks.Series([]).to_frame()
+            self.assert_eq(pdf.last_valid_index(), kdf.last_valid_index())

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -1974,3 +1974,24 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         pser = pd.Series([pd.Timestamp("2020-07-30"), np.nan, pd.Timestamp("2020-07-30")])
         kser = ks.from_pandas(pser)
         self.assert_eq(pser.hasnans, kser.hasnans)
+
+    def test_last_valid_index(self):
+        # `pyspark.sql.dataframe.DataFrame.tail` is new in pyspark >= 3.0.
+        if LooseVersion(pyspark.__version__) >= LooseVersion("3.0"):
+            pser = pd.Series([250, 1.5, 320, 1, 0.3, None, None, None, None])
+            kser = ks.from_pandas(pser)
+            self.assert_eq(pser.last_valid_index(), kser.last_valid_index())
+
+            # MultiIndex columns
+            midx = pd.MultiIndex(
+                [["lama", "cow", "falcon"], ["speed", "weight", "length"]],
+                [[0, 0, 0, 1, 1, 1, 2, 2, 2], [0, 1, 2, 0, 1, 2, 0, 1, 2]],
+            )
+            pser.index = midx
+            kser = ks.from_pandas(pser)
+            self.assert_eq(pser.last_valid_index(), kser.last_valid_index())
+
+            # Empty Series
+            pser = pd.Series([])
+            kser = ks.from_pandas(pser)
+            self.assert_eq(pser.last_valid_index(), kser.last_valid_index())

--- a/docs/source/reference/frame.rst
+++ b/docs/source/reference/frame.rst
@@ -224,6 +224,7 @@ Time series-related
 
    DataFrame.shift
    DataFrame.first_valid_index
+   DataFrame.last_valid_index
 
 Serialization / IO / Conversion
 -------------------------------

--- a/docs/source/reference/series.rst
+++ b/docs/source/reference/series.rst
@@ -219,6 +219,7 @@ Time series-related
    Series.asof
    Series.shift
    Series.first_valid_index
+   Series.last_valid_index
 
 Spark-related
 -------------


### PR DESCRIPTION
This PR proposes an implementation of `DataFrame.last_valid_index` and `Series.last_valid_index`

```python
# DataFrame
>>> kdf = ks.DataFrame({'a': [1, 2, 3, None],
...                     'b': [1.0, 2.0, 3.0, None],
...                     'c': [100, 200, 400, None]},
...                     index=['Q', 'W', 'E', 'R'])
>>> kdf
     a    b      c
Q  1.0  1.0  100.0
W  2.0  2.0  200.0
E  3.0  3.0  400.0
R  NaN  NaN    NaN

>>> kdf.last_valid_index()
'E'

# Series
>>> s = ks.Series([1, 2, 3, None, None], index=[100, 200, 300, 400, 500])
>>> s
100    1.0
200    2.0
300    3.0
400    NaN
500    NaN
Name: 0, dtype: float64

>>> s.last_valid_index()
300
```