### PR TITLE
Fix GroupBy.cum~ for matching with pandas' behavior

### DIFF
--- a/databricks/koalas/exceptions.py
+++ b/databricks/koalas/exceptions.py
@@ -19,11 +19,7 @@ Exceptions/Errors used in Koalas.
 """
 
 
-class GroupByError(Exception):
-    pass
-
-
-class DataError(GroupByError):
+class DataError(Exception):
     pass
 
 

--- a/databricks/koalas/exceptions.py
+++ b/databricks/koalas/exceptions.py
@@ -19,6 +19,14 @@ Exceptions/Errors used in Koalas.
 """
 
 
+class GroupByError(Exception):
+    pass
+
+
+class DataError(GroupByError):
+    pass
+
+
 class SparkPandasIndexingError(Exception):
     pass
 

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -997,6 +997,8 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
 
         kdf = ks.DataFrame([["a"], ["b"], ["c"]], columns=["A"])
         self.assertRaises(DataError, lambda: kdf.groupby(["A"]).cummin())
+        kdf = ks.DataFrame([[1, "a"], [2, "b"], [3, "c"]], columns=["A", "B"])
+        self.assertRaises(DataError, lambda: kdf.groupby(["A"])["B"].cummin())
 
     def test_cummax(self):
         pdf = pd.DataFrame(
@@ -1065,6 +1067,8 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
 
         kdf = ks.DataFrame([["a"], ["b"], ["c"]], columns=["A"])
         self.assertRaises(DataError, lambda: kdf.groupby(["A"]).cummax())
+        kdf = ks.DataFrame([[1, "a"], [2, "b"], [3, "c"]], columns=["A", "B"])
+        self.assertRaises(DataError, lambda: kdf.groupby(["A"])["B"].cummax())
 
     def test_cumsum(self):
         pdf = pd.DataFrame(
@@ -1216,6 +1220,8 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
 
         kdf = ks.DataFrame([["a"], ["b"], ["c"]], columns=["A"])
         self.assertRaises(DataError, lambda: kdf.groupby(["A"]).cumprod())
+        kdf = ks.DataFrame([[1, "a"], [2, "b"], [3, "c"]], columns=["A", "B"])
+        self.assertRaises(DataError, lambda: kdf.groupby(["A"])["B"].cumprod())
 
     def test_nsmallest(self):
         pdf = pd.DataFrame(

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -24,7 +24,7 @@ import pandas as pd
 
 from databricks import koalas as ks
 from databricks.koalas.config import option_context
-from databricks.koalas.exceptions import PandasNotImplementedError
+from databricks.koalas.exceptions import PandasNotImplementedError, DataError
 from databricks.koalas.missing.groupby import (
     MissingPandasLikeDataFrameGroupBy,
     MissingPandasLikeSeriesGroupBy,
@@ -909,6 +909,9 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             pdf.groupby([("x", "a"), ("x", "b")]).cummin().sort_index(),
         )
 
+        kdf = ks.DataFrame([["a"], ["b"], ["c"]], columns=["A"])
+        self.assertRaises(DataError, lambda: kdf.groupby(["A"]).cummin())
+
     def test_cummax(self):
         pdf = pd.DataFrame(
             {
@@ -966,6 +969,9 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             pdf.groupby([("x", "a"), ("x", "b")]).cummax().sort_index(),
         )
 
+        kdf = ks.DataFrame([["a"], ["b"], ["c"]], columns=["A"])
+        self.assertRaises(DataError, lambda: kdf.groupby(["A"]).cummax())
+
     def test_cumsum(self):
         pdf = pd.DataFrame(
             {
@@ -1022,6 +1028,9 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             kdf.groupby([("x", "a"), ("x", "b")]).cumsum().sort_index(),
             pdf.groupby([("x", "a"), ("x", "b")]).cumsum().sort_index(),
         )
+
+        kdf = ks.DataFrame([["a"], ["b"], ["c"]], columns=["A"])
+        self.assertRaises(DataError, lambda: kdf.groupby(["A"]).cumsum())
 
     def test_cumprod(self):
         pdf = pd.DataFrame(
@@ -1085,6 +1094,9 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             pdf.groupby([("x", "a"), ("x", "b")]).cumprod().sort_index(),
             almost=True,
         )
+
+        kdf = ks.DataFrame([["a"], ["b"], ["c"]], columns=["A"])
+        self.assertRaises(DataError, lambda: kdf.groupby(["A"]).cumprod())
 
     def test_nsmallest(self):
         pdf = pd.DataFrame(

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -1133,6 +1133,8 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
 
         kdf = ks.DataFrame([["a"], ["b"], ["c"]], columns=["A"])
         self.assertRaises(DataError, lambda: kdf.groupby(["A"]).cumsum())
+        kdf = ks.DataFrame([[1, "a"], [2, "b"], [3, "c"]], columns=["A", "B"])
+        self.assertRaises(DataError, lambda: kdf.groupby(["A"])["B"].cumsum())
 
     def test_cumprod(self):
         pdf = pd.DataFrame(


### PR DESCRIPTION
In pandas, `GroupBy.cum~` raise `DataError` - A custom exception of pandas - when the `DataFrame` has not numeric type columns except group keys.

```python
>>> pdf = pd.DataFrame([[1, 'a'], [2, 'b'], [3, 'c'], [4, 'd'], [5, 'e'], [6, 'f']], columns=['A', 'B'])
>>> pdf
   A  B
0  1  a
1  2  b
2  3  c
3  4  d
4  5  e
5  6  f

>>> pdf.groupby("A").cumsum()
Traceback (most recent call last):
...
pandas.core.base.DataError: No numeric types to aggregate
```

But in Koalas, It has been returning empty `DataFrame` rather than raise any Exceptions.

```python
>>> kdf.groupby("A").cumsum()
    B
5 NaN
4 NaN
0 NaN
2 NaN
1 NaN
3 NaN
```

So, added custom exception `DataError` and managed the logic for matching the behavior with pandas'.