### PR TITLE
Support non-named Series.

### DIFF
--- a/databricks/koalas/accessors.py
+++ b/databricks/koalas/accessors.py
@@ -479,7 +479,7 @@ class KoalasFrameMethods(object):
         0    3
         1    5
         2    7
-        Name: 0, dtype: int32
+        dtype: int32
 
         You can also omit the type hints so Koalas infers the return schema as below:
 
@@ -639,7 +639,7 @@ class KoalasFrameMethods(object):
                 )
                 columns = self._kdf._internal.spark_columns
                 internal = self._kdf._internal.copy(
-                    column_labels=[(SPARK_DEFAULT_SERIES_NAME,)],
+                    column_labels=[None],
                     data_spark_columns=[
                         (pudf(F.struct(*columns)) if should_by_pass else pudf(*columns)).alias(
                             SPARK_DEFAULT_SERIES_NAME

--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -1078,8 +1078,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
 
         For Index
 
-        >>> from databricks.koalas.indexes import Index
-        >>> idx = Index([3, 1, 2, 3, 4, np.nan])
+        >>> idx = ks.Index([3, 1, 2, 3, 4, np.nan])
         >>> idx
         Float64Index([3.0, 1.0, 2.0, 3.0, 4.0, nan], dtype='float64')
 
@@ -1088,7 +1087,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
         2.0    1
         3.0    2
         4.0    1
-        Name: count, dtype: int64
+        dtype: int64
 
         **sort**
 
@@ -1099,7 +1098,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
         2.0    1
         3.0    2
         4.0    1
-        Name: count, dtype: int64
+        dtype: int64
 
         **normalize**
 
@@ -1111,7 +1110,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
         2.0    0.2
         3.0    0.4
         4.0    0.2
-        Name: count, dtype: float64
+        dtype: float64
 
         **dropna**
 
@@ -1123,7 +1122,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
         3.0    2
         4.0    1
         NaN    1
-        Name: count, dtype: int64
+        dtype: int64
 
         For MultiIndex.
 
@@ -1150,7 +1149,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
         (falcon, length)    2
         (falcon, weight)    1
         (lama, weight)      3
-        Name: count, dtype: int64
+        dtype: int64
 
         >>> s.index.value_counts(normalize=True).sort_index()
         (cow, length)       0.111111
@@ -1158,11 +1157,11 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
         (falcon, length)    0.222222
         (falcon, weight)    0.111111
         (lama, weight)      0.333333
-        Name: count, dtype: float64
+        dtype: float64
 
         If Index has name, keep the name up.
 
-        >>> idx = Index([0, 0, 0, 1, 1, 2, 3], name='koalas')
+        >>> idx = ks.Index([0, 0, 0, 1, 1, 2, 3], name='koalas')
         >>> idx.value_counts().sort_index()
         0    3
         1    2
@@ -1192,21 +1191,13 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
             sum = sdf_dropna.count()
             sdf = sdf.withColumn("count", F.col("count") / F.lit(sum))
 
-        column_labels = self._internal.column_labels
-        if (column_labels[0] is None) or (None in column_labels[0]):
-            internal = InternalFrame(
-                spark_frame=sdf,
-                index_map=OrderedDict({index_name: None}),
-                data_spark_columns=[scol_for(sdf, "count")],
-            )
-        else:
-            internal = InternalFrame(
-                spark_frame=sdf,
-                index_map=OrderedDict({index_name: None}),
-                column_labels=column_labels,
-                data_spark_columns=[scol_for(sdf, "count")],
-                column_label_names=self._internal.column_label_names,
-            )
+        internal = InternalFrame(
+            spark_frame=sdf,
+            index_map=OrderedDict({index_name: None}),
+            column_labels=self._internal.column_labels,
+            data_spark_columns=[scol_for(sdf, "count")],
+            column_label_names=self._internal.column_label_names,
+        )
 
         return first_series(DataFrame(internal))
 

--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -681,12 +681,12 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
         >>> ser
         0    1
         1    2
-        Name: 0, dtype: int32
+        dtype: int32
 
         >>> ser.astype('int64')
         0    1
         1    2
-        Name: 0, dtype: int64
+        dtype: int64
 
         >>> ser.rename("a").to_frame().set_index("a").index.astype('int64')
         Int64Index([1, 2], dtype='int64', name='a')
@@ -772,7 +772,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
         0    False
         1    False
         2     True
-        Name: 0, dtype: bool
+        dtype: bool
 
         >>> ser.rename("a").to_frame().set_index("a").index.isna()
         Index([False, False, True], dtype='object', name='a')
@@ -811,13 +811,13 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
         0    5.0
         1    6.0
         2    NaN
-        Name: 0, dtype: float64
+        dtype: float64
 
         >>> ser.notna()
         0     True
         1     True
         2    False
-        Name: 0, dtype: bool
+        dtype: bool
 
         >>> ser.rename("a").to_frame().set_index("a").index.notna()
         Index([True, True, False], dtype='object', name='a')
@@ -1313,13 +1313,13 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
         2    300
         3    400
         4    500
-        Name: 0, dtype: int64
+        dtype: int64
 
         >>> kser.take([0, 2, 4]).sort_index()
         0    100
         2    300
         4    500
-        Name: 0, dtype: int64
+        dtype: int64
 
         Index
 

--- a/databricks/koalas/datetimes.py
+++ b/databricks/koalas/datetimes.py
@@ -167,7 +167,7 @@ class DatetimeMethods(object):
         2017-01-06    4
         2017-01-07    5
         2017-01-08    6
-        Name: 0, dtype: int64
+        dtype: int64
         """
 
         def pandas_dayofweek(s) -> "ks.Series[np.int64]":
@@ -228,13 +228,13 @@ class DatetimeMethods(object):
         0   2018-02-27
         1   2018-02-28
         2   2018-03-01
-        Name: 0, dtype: datetime64[ns]
+        dtype: datetime64[ns]
 
         >>> s.dt.is_month_start
         0    False
         1    False
         2     True
-        Name: 0, dtype: bool
+        dtype: bool
         """
 
         def pandas_is_month_start(s) -> "ks.Series[bool]":
@@ -267,13 +267,13 @@ class DatetimeMethods(object):
         0   2018-02-27
         1   2018-02-28
         2   2018-03-01
-        Name: 0, dtype: datetime64[ns]
+        dtype: datetime64[ns]
 
         >>> s.dt.is_month_end
         0    False
         1     True
         2    False
-        Name: 0, dtype: bool
+        dtype: bool
         """
 
         def pandas_is_month_end(s) -> "ks.Series[bool]":
@@ -406,13 +406,13 @@ class DatetimeMethods(object):
         0   2017-12-30
         1   2017-12-31
         2   2018-01-01
-        Name: 0, dtype: datetime64[ns]
+        dtype: datetime64[ns]
 
         >>> dates.dt.is_year_start
         0    False
         1    False
         2     True
-        Name: 0, dtype: bool
+        dtype: bool
         """
 
         def pandas_is_year_start(s) -> "ks.Series[bool]":
@@ -445,13 +445,13 @@ class DatetimeMethods(object):
         0   2017-12-30
         1   2017-12-31
         2   2018-01-01
-        Name: 0, dtype: datetime64[ns]
+        dtype: datetime64[ns]
 
         >>> dates.dt.is_year_end
         0    False
         1     True
         2    False
-        Name: 0, dtype: bool
+        dtype: bool
         """
 
         def pandas_is_year_end(s) -> "ks.Series[bool]":
@@ -484,13 +484,13 @@ class DatetimeMethods(object):
         0   2012-12-31
         1   2013-12-31
         2   2014-12-31
-        Name: 0, dtype: datetime64[ns]
+        dtype: datetime64[ns]
 
         >>> dates_series.dt.is_leap_year
         0     True
         1    False
         2    False
-        Name: 0, dtype: bool
+        dtype: bool
         """
 
         def pandas_is_leap_year(s) -> "ks.Series[bool]":
@@ -561,7 +561,7 @@ class DatetimeMethods(object):
         0   2012-01-31
         1   2012-02-29
         2   2012-03-31
-        Name: 0, dtype: datetime64[ns]
+        dtype: datetime64[ns]
         """
 
         def pandas_normalize(s) -> "ks.Series[np.datetime64]":
@@ -603,13 +603,13 @@ class DatetimeMethods(object):
         0   2018-03-10 09:00:00
         1   2018-03-10 09:00:01
         2   2018-03-10 09:00:02
-        Name: 0, dtype: datetime64[ns]
+        dtype: datetime64[ns]
 
         >>> series.dt.strftime('%B %d, %Y, %r')
         0    March 10, 2018, 09:00:00 AM
         1    March 10, 2018, 09:00:01 AM
         2    March 10, 2018, 09:00:02 AM
-        Name: 0, dtype: object
+        dtype: object
         """
 
         def pandas_strftime(s) -> "ks.Series[str]":
@@ -658,13 +658,13 @@ class DatetimeMethods(object):
         0   2018-01-01 11:59:00
         1   2018-01-01 12:00:00
         2   2018-01-01 12:01:00
-        Name: 0, dtype: datetime64[ns]
+        dtype: datetime64[ns]
 
         >>> series.dt.round("H")
         0   2018-01-01 12:00:00
         1   2018-01-01 12:00:00
         2   2018-01-01 12:00:00
-        Name: 0, dtype: datetime64[ns]
+        dtype: datetime64[ns]
         """
 
         def pandas_round(s) -> "ks.Series[np.datetime64]":
@@ -713,13 +713,13 @@ class DatetimeMethods(object):
         0   2018-01-01 11:59:00
         1   2018-01-01 12:00:00
         2   2018-01-01 12:01:00
-        Name: 0, dtype: datetime64[ns]
+        dtype: datetime64[ns]
 
         >>> series.dt.floor("H")
         0   2018-01-01 11:00:00
         1   2018-01-01 12:00:00
         2   2018-01-01 12:00:00
-        Name: 0, dtype: datetime64[ns]
+        dtype: datetime64[ns]
         """
 
         def pandas_floor(s) -> "ks.Series[np.datetime64]":
@@ -768,13 +768,13 @@ class DatetimeMethods(object):
         0   2018-01-01 11:59:00
         1   2018-01-01 12:00:00
         2   2018-01-01 12:01:00
-        Name: 0, dtype: datetime64[ns]
+        dtype: datetime64[ns]
 
         >>> series.dt.ceil("H")
         0   2018-01-01 12:00:00
         1   2018-01-01 12:00:00
         2   2018-01-01 13:00:00
-        Name: 0, dtype: datetime64[ns]
+        dtype: datetime64[ns]
         """
 
         def pandas_ceil(s) -> "ks.Series[np.datetime64]":
@@ -804,13 +804,13 @@ class DatetimeMethods(object):
         0   2018-01-31
         1   2018-02-28
         2   2018-03-31
-        Name: 0, dtype: datetime64[ns]
+        dtype: datetime64[ns]
 
         >>> series.dt.month_name()
         0     January
         1    February
         2       March
-        Name: 0, dtype: object
+        dtype: object
         """
 
         def pandas_month_name(s) -> "ks.Series[str]":
@@ -840,13 +840,13 @@ class DatetimeMethods(object):
         0   2018-01-01
         1   2018-01-02
         2   2018-01-03
-        Name: 0, dtype: datetime64[ns]
+        dtype: datetime64[ns]
 
         >>> series.dt.day_name()
         0       Monday
         1      Tuesday
         2    Wednesday
-        Name: 0, dtype: object
+        dtype: object
         """
 
         def pandas_day_name(s) -> "ks.Series[str]":

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -1066,14 +1066,14 @@ class Frame(object, metaclass=ABCMeta):
         >>> df.mean()
         a    2.0
         b    0.2
-        Name: 0, dtype: float64
+        dtype: float64
 
         >>> df.mean(axis=1)
         0    0.55
         1    1.10
         2    1.65
         3     NaN
-        Name: 0, dtype: float64
+        dtype: float64
 
         On a Series:
 
@@ -1111,14 +1111,14 @@ class Frame(object, metaclass=ABCMeta):
         >>> df.sum()
         a    6.0
         b    0.6
-        Name: 0, dtype: float64
+        dtype: float64
 
         >>> df.sum(axis=1)
         0    1.1
         1    2.2
         2    3.3
         3    0.0
-        Name: 0, dtype: float64
+        dtype: float64
 
         On a Series:
 
@@ -1195,7 +1195,7 @@ class Frame(object, metaclass=ABCMeta):
         >>> df.kurtosis()
         a   -1.5
         b   -1.5
-        Name: 0, dtype: float64
+        dtype: float64
 
         On a Series:
 
@@ -1236,14 +1236,14 @@ class Frame(object, metaclass=ABCMeta):
         >>> df.min()
         a    1.0
         b    0.1
-        Name: 0, dtype: float64
+        dtype: float64
 
         >>> df.min(axis=1)
         0    0.1
         1    0.2
         2    0.3
         3    NaN
-        Name: 0, dtype: float64
+        dtype: float64
 
         On a Series:
 
@@ -1282,14 +1282,14 @@ class Frame(object, metaclass=ABCMeta):
         >>> df.max()
         a    3.0
         b    0.3
-        Name: 0, dtype: float64
+        dtype: float64
 
         >>> df.max(axis=1)
         0    1.0
         1    2.0
         2    3.0
         3    NaN
-        Name: 0, dtype: float64
+        dtype: float64
 
         On a Series:
 
@@ -1327,14 +1327,14 @@ class Frame(object, metaclass=ABCMeta):
         >>> df.std()
         a    1.0
         b    0.1
-        Name: 0, dtype: float64
+        dtype: float64
 
         >>> df.std(axis=1)
         0    0.636396
         1    1.272792
         2    1.909188
         3         NaN
-        Name: 0, dtype: float64
+        dtype: float64
 
         On a Series:
 
@@ -1372,14 +1372,14 @@ class Frame(object, metaclass=ABCMeta):
         >>> df.var()
         a    1.00
         b    0.01
-        Name: 0, dtype: float64
+        dtype: float64
 
         >>> df.var(axis=1)
         0    0.405
         1    1.620
         2    3.645
         3      NaN
-        Name: 0, dtype: float64
+        dtype: float64
 
         On a Series:
 
@@ -1429,7 +1429,7 @@ class Frame(object, metaclass=ABCMeta):
         1    2.00
         2    3.33
         3    4.00
-        Name: 0, dtype: float64
+        dtype: float64
 
         Absolute numeric values in a DataFrame.
 
@@ -1643,7 +1643,7 @@ class Frame(object, metaclass=ABCMeta):
         300    3.0
         400    4.0
         500    5.0
-        Name: 0, dtype: float64
+        dtype: float64
 
         >>> s.first_valid_index()
         300
@@ -1665,7 +1665,7 @@ class Frame(object, metaclass=ABCMeta):
         falcon  speed     320.0
                 weight      1.0
                 length      0.3
-        Name: 0, dtype: float64
+        dtype: float64
 
         >>> s.first_valid_index()
         ('cow', 'weight')
@@ -1724,7 +1724,7 @@ class Frame(object, metaclass=ABCMeta):
         >>> df.median()
         a    25.0
         b     3.0
-        Name: 0, dtype: float64
+        dtype: float64
 
         On a Series:
 
@@ -1750,7 +1750,7 @@ class Frame(object, metaclass=ABCMeta):
         >>> df.median()
         x  a    25.0
         y  b     3.0
-        Name: 0, dtype: float64
+        dtype: float64
 
         >>> df.median(axis=1)
         0    12.5
@@ -1758,7 +1758,7 @@ class Frame(object, metaclass=ABCMeta):
         2    14.0
         3    18.5
         4    15.5
-        Name: 0, dtype: float64
+        dtype: float64
 
         On a Series:
 
@@ -1918,7 +1918,7 @@ class Frame(object, metaclass=ABCMeta):
         >>> even_primes = primes[primes % 2 == 0]
         >>> even_primes
         0    2
-        Name: 0, dtype: int64
+        dtype: int64
 
         >>> even_primes.squeeze()
         2
@@ -1930,13 +1930,13 @@ class Frame(object, metaclass=ABCMeta):
         1    3
         2    5
         3    7
-        Name: 0, dtype: int64
+        dtype: int64
 
         >>> odd_primes.squeeze()
         1    3
         2    5
         3    7
-        Name: 0, dtype: int64
+        dtype: int64
 
         Squeezing is even more effective when used with DataFrames.
 
@@ -1965,21 +1965,21 @@ class Frame(object, metaclass=ABCMeta):
         Slicing a single row from a single column will produce a single
         scalar DataFrame:
 
-        >>> df_0a = df.loc[[0], ['a']]
-        >>> df_0a
+        >>> df_1a = df.loc[[1], ['a']]
+        >>> df_1a
            a
-        0  1
+        1  3
 
         Squeezing the rows produces a single scalar Series:
 
-        >>> df_0a.squeeze('rows')
-        a    1
-        Name: 0, dtype: int64
+        >>> df_1a.squeeze('rows')
+        a    3
+        Name: 1, dtype: int64
 
         Squeezing all axes will project directly into a scalar:
 
-        >>> df_0a.squeeze()
-        1
+        >>> df_1a.squeeze()
+        3
         """
         if axis is not None:
             axis = "index" if axis == "rows" else axis
@@ -2091,14 +2091,14 @@ class Frame(object, metaclass=ABCMeta):
         5    50
         6    60
         7    70
-        Name: 0, dtype: int64
+        dtype: int64
 
         >>> s.truncate(2, 5)
         2    20
         3    30
         4    40
         5    50
-        Name: 0, dtype: int64
+        dtype: int64
 
         A Series has index that sorted strings.
 
@@ -2112,14 +2112,14 @@ class Frame(object, metaclass=ABCMeta):
         e    50
         f    60
         g    70
-        Name: 0, dtype: int64
+        dtype: int64
 
         >>> s.truncate('b', 'e')
         b    20
         c    30
         d    40
         e    50
-        Name: 0, dtype: int64
+        dtype: int64
         """
         from databricks.koalas.series import first_series
 
@@ -2134,7 +2134,7 @@ class Frame(object, metaclass=ABCMeta):
             raise ValueError("Truncate: %s must be after %s" % (after, before))
 
         if isinstance(self, ks.Series):
-            result = first_series(self.to_frame().loc[before:after])
+            result = first_series(self.to_frame().loc[before:after]).rename(self.name)
         elif isinstance(self, ks.DataFrame):
             if axis == 0:
                 result = self.loc[before:after]

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -1446,7 +1446,6 @@ class Frame(object, metaclass=ABCMeta):
         2  6  30   30
         3  7  40   50
         """
-        # TODO: The first example above should not have "Name: 0".
         return self._apply_series_op(lambda kser: kser._with_new_scol(F.abs(kser.spark.column)))
 
     # TODO: by argument only support the grouping name and as_index only for now. Documentation

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -2253,20 +2253,20 @@ class Frame(object, metaclass=ABCMeta):
 
         For Series
 
-        >>> kser = kdf.C
+        >>> kser = ks.Series([None, None, None, 1])
         >>> kser
         0    NaN
         1    NaN
         2    NaN
         3    1.0
-        Name: C, dtype: float64
+        dtype: float64
 
         >>> kser.bfill()
         0    1.0
         1    1.0
         2    1.0
         3    1.0
-        Name: C, dtype: float64
+        dtype: float64
         """
         return self.fillna(method="bfill", axis=axis, inplace=inplace, limit=limit)
 
@@ -2325,20 +2325,20 @@ class Frame(object, metaclass=ABCMeta):
 
         For Series
 
-        >>> kser = kdf.B
+        >>> kser = ks.Series([2, 4, None, 3])
         >>> kser
         0    2.0
         1    4.0
         2    NaN
         3    3.0
-        Name: B, dtype: float64
+        dtype: float64
 
         >>> kser.ffill()
         0    2.0
         1    4.0
         2    4.0
         3    3.0
-        Name: B, dtype: float64
+        dtype: float64
         """
         return self.fillna(method="ffill", axis=axis, inplace=inplace, limit=limit)
 

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -681,7 +681,7 @@ class GroupBy(object, metaclass=ABCMeta):
         3    0
         4    1
         5    3
-        Name: A, dtype: int64
+        dtype: int64
         >>> df.groupby('A').cumcount(ascending=False).sort_index()
         0    3
         1    2
@@ -689,11 +689,10 @@ class GroupBy(object, metaclass=ABCMeta):
         3    1
         4    0
         5    0
-        Name: A, dtype: int64
-
+        dtype: int64
         """
         ret = (
-            self._groupkeys[0]
+            self._groupkeys[0].rename()
             .spark.transform(lambda _: F.lit(0))
             ._cum(F.count, True, part_cols=self._groupkeys_scols, ascending=ascending)
             - 1
@@ -743,7 +742,6 @@ class GroupBy(object, metaclass=ABCMeta):
         2    4
         3    1
         Name: C, dtype: int64
-
         """
         return self._apply_series_op(
             lambda sg: sg._kser._cum(F.max, True, part_cols=sg._groupkeys_scols),
@@ -840,7 +838,6 @@ class GroupBy(object, metaclass=ABCMeta):
         2     2.0
         3    10.0
         Name: B, dtype: float64
-
         """
         return self._apply_series_op(
             lambda sg: sg._kser._cumprod(True, part_cols=sg._groupkeys_scols), should_resolve=True
@@ -888,7 +885,6 @@ class GroupBy(object, metaclass=ABCMeta):
         2    20.1
         3    10.0
         Name: B, dtype: float64
-
         """
         return self._apply_series_op(
             lambda sg: sg._kser._cum(F.sum, True, part_cols=sg._groupkeys_scols),

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -692,7 +692,8 @@ class GroupBy(object, metaclass=ABCMeta):
         dtype: int64
         """
         ret = (
-            self._groupkeys[0].rename()
+            self._groupkeys[0]
+            .rename()
             .spark.transform(lambda _: F.lit(0))
             ._cum(F.count, True, part_cols=self._groupkeys_scols, ascending=ascending)
             - 1
@@ -1053,7 +1054,7 @@ class GroupBy(object, metaclass=ABCMeta):
         )
 
         if is_series_groupby:
-            name = self._kser.name
+            name = kdf.columns[-1]
             pandas_apply = SelectionMixin._builtin_table.get(func, func)
         else:
             f = SelectionMixin._builtin_table.get(func, func)
@@ -1073,18 +1074,21 @@ class GroupBy(object, metaclass=ABCMeta):
                 pser_or_pdf = pdf.groupby(groupkey_names).apply(pandas_apply, *args, **kwargs)
             kser_or_kdf = ks.from_pandas(pser_or_pdf)
             if len(pdf) <= limit:
-                if isinstance(kser_or_kdf, ks.Series) and not is_series_groupby:
-                    # Restore grouping names as the index name
-                    groupkey_scol_name = zip(
-                        self._groupkeys, kser_or_kdf._internal.index_map.items()
-                    )
-                    internal = kser_or_kdf._internal.copy(
-                        index_map=OrderedDict(
-                            (scol_name, (s.name,) if isinstance(s.name, str) else s.name)
-                            for s, (scol_name, name) in groupkey_scol_name
+                if isinstance(kser_or_kdf, ks.Series):
+                    if is_series_groupby:
+                        kser_or_kdf = kser_or_kdf.rename(self._kser.name)
+                    else:
+                        # Restore grouping names as the index name
+                        groupkey_scol_name = zip(
+                            self._groupkeys, kser_or_kdf._internal.index_map.items()
                         )
-                    )
-                    kser_or_kdf = first_series(DataFrame(internal))
+                        internal = kser_or_kdf._internal.copy(
+                            index_map=OrderedDict(
+                                (scol_name, (s.name,) if isinstance(s.name, str) else s.name)
+                                for s, (scol_name, name) in groupkey_scol_name
+                            )
+                        )
+                        kser_or_kdf = first_series(DataFrame(internal))
                 return kser_or_kdf
 
             if isinstance(kser_or_kdf, ks.Series):
@@ -1169,7 +1173,10 @@ class GroupBy(object, metaclass=ABCMeta):
             internal = InternalFrame(spark_frame=sdf, index_map=None)
 
         if should_return_series:
-            return first_series(DataFrame(internal))
+            kser = first_series(DataFrame(internal))
+            if is_series_groupby:
+                kser = kser.rename(self._kser.name)
+            return kser
         else:
             return DataFrame(internal)
 
@@ -1241,10 +1248,9 @@ class GroupBy(object, metaclass=ABCMeta):
         )
 
         if is_series_groupby:
-            name = self._kser.name
 
             def pandas_filter(pdf):
-                return pd.DataFrame(pdf.groupby(groupkey_names)[name].filter(func))
+                return pd.DataFrame(pdf.groupby(groupkey_names)[pdf.columns[-1]].filter(func))
 
         else:
             f = SelectionMixin._builtin_table.get(func, func)
@@ -2027,7 +2033,7 @@ class GroupBy(object, metaclass=ABCMeta):
                 retain_index=True,
             )
             # If schema is inferred, we can restore indexes too.
-            internal = kdf.drop(groupkey_labels, axis=1)._internal.with_new_sdf(sdf)
+            internal = kdf_from_pandas._internal.with_new_sdf(sdf)
         else:
             return_type = infer_return_type(func).tpe
             data_columns = kdf._internal.data_spark_column_names
@@ -2545,7 +2551,9 @@ class SeriesGroupBy(GroupBy):
         return MissingPandasLikeSeriesGroupBy.aggregate(self, *args, **kwargs)
 
     def transform(self, func, *args, **kwargs):
-        return first_series(super(SeriesGroupBy, self).transform(func, *args, **kwargs))
+        return first_series(super(SeriesGroupBy, self).transform(func, *args, **kwargs)).rename(
+            self._kser.name
+        )
 
     transform.__doc__ = GroupBy.transform.__doc__
 
@@ -2560,7 +2568,7 @@ class SeriesGroupBy(GroupBy):
     idxmax.__doc__ = GroupBy.idxmax.__doc__
 
     def head(self, n=5):
-        return first_series(super(SeriesGroupBy, self).head(n))
+        return first_series(super(SeriesGroupBy, self).head(n)).rename(self._kser.name)
 
     head.__doc__ = GroupBy.head.__doc__
 

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -931,7 +931,7 @@ class GroupBy(object, metaclass=ABCMeta):
         A
         a    2
         b    1
-        Name: 0, dtype: int64
+        dtype: int64
 
         In case of Series, it works as below.
 

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -20,7 +20,7 @@ Wrappers for Indexes to behave similar to pandas Index, MultiIndex.
 from collections import OrderedDict
 from distutils.version import LooseVersion
 from functools import partial
-from typing import Any, List, Tuple, Union
+from typing import Any, List, Optional, Tuple, Union
 import warnings
 
 import pandas as pd
@@ -688,7 +688,7 @@ class Index(IndexOpsMixin):
             [None]
             if len(kdf._internal.index_map) > 1 or name is None
             else [name if isinstance(name, tuple) else (name,)]
-        )  # type: List[Tuple[str, ...]]
+        )  # type: List[Optional[Tuple[str, ...]]]
         internal = kdf._internal.copy(
             column_labels=column_labels, data_spark_columns=[scol], column_label_names=None
         )

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -685,9 +685,7 @@ class Index(IndexOpsMixin):
         elif len(kdf._internal.index_map) == 1:
             name = self.name
         column_labels = (
-            [None]
-            if len(kdf._internal.index_map) > 1 or name is None
-            else [name if isinstance(name, tuple) else (name,)]
+            [None] if name is None else [name if isinstance(name, tuple) else (name,)]
         )  # type: List[Optional[Tuple[str, ...]]]
         internal = kdf._internal.copy(
             column_labels=column_labels, data_spark_columns=[scol], column_label_names=None

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -666,7 +666,7 @@ class Index(IndexOpsMixin):
 
         Examples
         --------
-        >>> df = ks.DataFrame([(.2, .3), (.0, .6), (.6, .0), (.2, .1)],
+        >>> df = pd.DataFrame([(.2, .3), (.0, .6), (.6, .0), (.2, .1)],
         ...                   columns=['dogs', 'cats'],
         ...                   index=list('abcd'))
         >>> df['dogs'].index.to_series()
@@ -674,7 +674,7 @@ class Index(IndexOpsMixin):
         b    b
         c    c
         d    d
-        Name: 0, dtype: object
+        dtype: object
         """
         if not is_hashable(name):
             raise TypeError("Series.name must be a hashable type")
@@ -685,7 +685,7 @@ class Index(IndexOpsMixin):
         elif len(kdf._internal.index_map) == 1:
             name = self.name
         column_labels = (
-            [(SPARK_DEFAULT_SERIES_NAME,)]
+            [None]
             if len(kdf._internal.index_map) > 1 or name is None
             else [name if isinstance(name, tuple) else (name,)]
         )  # type: List[Tuple[str, ...]]
@@ -893,7 +893,7 @@ class Index(IndexOpsMixin):
         falcon  weight    320.0
                 weight      1.0
                 length      NaN
-        Name: 0, dtype: float64
+        dtype: float64
 
         >>> s.index.dropna()  # doctest: +SKIP
         MultiIndex([(   'cow', 'weight'),
@@ -1907,7 +1907,8 @@ class Index(IndexOpsMixin):
                         "Union between Index and MultiIndex is not yet supported"
                     )
                 elif isinstance(other, Series):
-                    other = other.to_frame().set_index(other.name).index
+                    other = other.to_frame()
+                    other = other.set_index(other.columns[0]).index
                 elif isinstance(other, DataFrame):
                     raise ValueError("Index data must be 1-dimensional")
                 else:

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -666,7 +666,7 @@ class Index(IndexOpsMixin):
 
         Examples
         --------
-        >>> df = pd.DataFrame([(.2, .3), (.0, .6), (.6, .0), (.2, .1)],
+        >>> df = ks.DataFrame([(.2, .3), (.0, .6), (.6, .0), (.2, .1)],
         ...                   columns=['dogs', 'cats'],
         ...                   index=list('abcd'))
         >>> df['dogs'].index.to_series()
@@ -1317,11 +1317,11 @@ class Index(IndexOpsMixin):
 
         Examples
         --------
-        >>> idx = pd.Index([3, 2, 1])
+        >>> idx = ks.Index([3, 2, 1])
         >>> idx.max()
         3
 
-        >>> idx = pd.Index(['c', 'b', 'a'])
+        >>> idx = ks.Index(['c', 'b', 'a'])
         >>> idx.max()
         'c'
 

--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -2088,7 +2088,7 @@ def concat(objs, axis=0, join="outer", ignore_index=False, sort=False):
     if should_return_series:
         # If all input were Series, we should return Series.
         if len(series_names) == 1:
-            name = list(series_names)[0]
+            name = series_names.pop()
         else:
             name = None
         return first_series(result_kdf).rename(name)

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -1221,7 +1221,6 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         kdf = kdf.reset_index(level=level, drop=drop)
         if drop:
             if inplace:
-                self._column_label = kser._column_label
                 self._update_anchor(kdf)
             else:
                 return first_series(kdf)

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -341,13 +341,13 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
     def __init__(self, data=None, index=None, dtype=None, name=None, copy=False, fastpath=False):
         if isinstance(data, DataFrame):
-            assert index is not None
             assert dtype is None
             assert name is None
             assert not copy
             assert not fastpath
-            anchor = data
-            column_label = index
+
+            super(Series, self).__init__(data)
+            self._column_label = index
         else:
             if isinstance(data, pd.Series):
                 assert index is None
@@ -360,12 +360,14 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
                 s = pd.Series(
                     data=data, index=index, dtype=dtype, name=name, copy=copy, fastpath=fastpath
                 )
-            anchor = DataFrame(s)
-            column_label = anchor._internal.column_labels[0]
-            anchor._kseries = {column_label: self}
+            internal = InternalFrame.from_pandas(pd.DataFrame(s))
+            if s.name is None:
+                internal = internal.copy(column_labels=[None])
+            anchor = DataFrame(internal)
 
-        super(Series, self).__init__(anchor)
-        self._column_label = column_label
+            super(Series, self).__init__(anchor)
+            self._column_label = anchor._internal.column_labels[0]
+            anchor._kseries = {self._column_label: self}
 
     @property
     def _internal(self) -> InternalFrame:
@@ -843,7 +845,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         2     True
         3    False
         4    False
-        Name: 0, dtype: bool
+        dtype: bool
 
         With `inclusive` set to ``False`` boundary values are excluded:
 
@@ -853,7 +855,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         2    False
         3    False
         4    False
-        Name: 0, dtype: bool
+        dtype: bool
 
         `left` and `right` can be any scalar value:
 
@@ -863,7 +865,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         1     True
         2     True
         3    False
-        Name: 0, dtype: bool
+        dtype: bool
         """
         if inclusive:
             lmask = self >= left
@@ -919,7 +921,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         1       dog
         2      None
         3    rabbit
-        Name: 0, dtype: object
+        dtype: object
 
         ``map`` accepts a ``dict``. Values that are not found
         in the ``dict`` are converted to ``None``, unless the dict has a default
@@ -930,7 +932,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         1     puppy
         2      None
         3      None
-        Name: 0, dtype: object
+        dtype: object
 
         It also accepts a function:
 
@@ -942,7 +944,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         1       I am a dog
         2      I am a None
         3    I am a rabbit
-        Name: 0, dtype: object
+        dtype: object
         """
         if isinstance(arg, dict):
             is_start = True
@@ -990,12 +992,12 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         >>> ser
         0    1
         1    2
-        Name: 0, dtype: int32
+        dtype: int32
 
         >>> ser.astype('int64')
         0    1
         1    2
-        Name: 0, dtype: int64
+        dtype: int64
         """
         from databricks.koalas.typedef import as_spark_type
 
@@ -1069,7 +1071,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         0    1
         1    2
         2    3
-        Name: 0, dtype: int64
+        dtype: int64
 
         >>> s.rename("my_name")  # scalar, changes Series.name
         0    1
@@ -1078,7 +1080,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         Name: my_name, dtype: int64
         """
         if index is None:
-            index = self._column_label
+            pass
         elif not isinstance(index, tuple):
             index = (index,)
         scol = self.spark.column.alias(name_like_string(index))
@@ -1164,17 +1166,16 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         Examples
         --------
-        >>> s = ks.Series([1, 2, 3, 4], name='foo',
-        ...               index=pd.Index(['a', 'b', 'c', 'd'], name='idx'))
+        >>> s = ks.Series([1, 2, 3, 4], index=pd.Index(['a', 'b', 'c', 'd'], name='idx'))
 
         Generate a DataFrame with default index.
 
         >>> s.reset_index()
-          idx  foo
-        0   a    1
-        1   b    2
-        2   c    3
-        3   d    4
+          idx  0
+        0   a  1
+        1   b  2
+        2   c  3
+        3   d  4
 
         To specify the name of the new column use `name`.
 
@@ -1192,7 +1193,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         1    2
         2    3
         3    4
-        Name: foo, dtype: int64
+        dtype: int64
 
         To update the Series in place, without generating a new one
         set `inplace` to True. Note that it also requires ``drop=True``.
@@ -1203,19 +1204,24 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         1    2
         2    3
         3    4
-        Name: foo, dtype: int64
+        dtype: int64
         """
         inplace = validate_bool_kwarg(inplace, "inplace")
         if inplace and not drop:
             raise TypeError("Cannot reset_index inplace on a Series to create a DataFrame")
 
         if name is not None:
-            kdf = self.rename(name).to_frame()
+            kser = self.rename(name)
         else:
-            kdf = self.to_frame()
+            kser = self
+        if drop:
+            kdf = kser._kdf[[kser.name]]
+        else:
+            kdf = kser.to_frame()
         kdf = kdf.reset_index(level=level, drop=drop)
         if drop:
             if inplace:
+                self._column_label = kser._column_label
                 self._update_anchor(kdf)
             else:
                 return first_series(kdf)
@@ -1695,14 +1701,14 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         0    1.0
         1    2.0
         2    NaN
-        Name: 0, dtype: float64
+        dtype: float64
 
         Drop NA values from a Series.
 
         >>> ser.dropna()
         0    1.0
         1    2.0
-        Name: 0, dtype: float64
+        dtype: float64
 
         Keep the Series with valid entries in the same variable.
 
@@ -1710,11 +1716,11 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         >>> ser
         0    1.0
         1    2.0
-        Name: 0, dtype: float64
+        dtype: float64
         """
         inplace = validate_bool_kwarg(inplace, "inplace")
         # TODO: last two examples from pandas produce different results.
-        kdf = self.to_frame().dropna(axis=axis, inplace=False)
+        kdf = self._kdf[[self.name]].dropna(axis=axis, inplace=False)
         if inplace:
             self._update_anchor(kdf)
         else:
@@ -1744,7 +1750,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         0    1
         1    2
         2    3
-        Name: 0, dtype: int64
+        dtype: int64
 
         Notes
         -----
@@ -1808,31 +1814,31 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         A    0
         B    1
         C    2
-        Name: 0, dtype: int64
+        dtype: int64
 
         Drop single label A
 
         >>> s.drop('A')
         B    1
         C    2
-        Name: 0, dtype: int64
+        dtype: int64
 
         Drop labels B and C
 
         >>> s.drop(labels=['B', 'C'])
         A    0
-        Name: 0, dtype: int64
+        dtype: int64
 
         With 'index' rather than 'labels' returns exactly same result.
 
         >>> s.drop(index='A')
         B    1
         C    2
-        Name: 0, dtype: int64
+        dtype: int64
 
         >>> s.drop(index=['B', 'C'])
         A    0
-        Name: 0, dtype: int64
+        dtype: int64
 
         Also support for MultiIndex
 
@@ -1852,7 +1858,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         falcon  speed     320.0
                 weight      1.0
                 length      0.3
-        Name: 0, dtype: float64
+        dtype: float64
 
         >>> s.drop(labels='weight', level=1)
         lama    speed      45.0
@@ -1861,7 +1867,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
                 length      1.5
         falcon  speed     320.0
                 length      0.3
-        Name: 0, dtype: float64
+        dtype: float64
 
         >>> s.drop(('lama', 'weight'))
         lama    speed      45.0
@@ -1872,7 +1878,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         falcon  speed     320.0
                 weight      1.0
                 length      0.3
-        Name: 0, dtype: float64
+        dtype: float64
 
         >>> s.drop([('lama', 'speed'), ('falcon', 'weight')])
         lama    weight    200.0
@@ -1882,7 +1888,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
                 length      1.5
         falcon  speed     320.0
                 length      0.3
-        Name: 0, dtype: float64
+        dtype: float64
         """
         return first_series(self._drop(labels=labels, index=index, level=level))
 
@@ -1976,7 +1982,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         1     bee
         Name: animal, dtype: object
         """
-        return first_series(self.to_dataframe().head(n))
+        return first_series(self.to_frame().head(n)).rename(self.name)
 
     # TODO: Categorical type isn't supported (due to PySpark's limitation) and
     # some doctests related with timestamps were not added.
@@ -2011,7 +2017,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         >>> ks.Series([pd.Timestamp('2016-01-01') for _ in range(3)]).unique()
         0   2016-01-01
-        Name: 0, dtype: datetime64[ns]
+        dtype: datetime64[ns]
 
         >>> kser.name = ('x', 'a')
         >>> kser.unique().sort_values()  # doctest: +NORMALIZE_WHITESPACE, +ELLIPSIS
@@ -2063,7 +2069,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         2     3.0
         3    10.0
         4     5.0
-        Name: 0, dtype: float64
+        dtype: float64
 
         Sort values ascending order (default behaviour)
 
@@ -2073,7 +2079,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         4     5.0
         3    10.0
         0     NaN
-        Name: 0, dtype: float64
+        dtype: float64
 
         Sort values descending order
 
@@ -2083,7 +2089,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         2     3.0
         1     1.0
         0     NaN
-        Name: 0, dtype: float64
+        dtype: float64
 
         Sort values inplace
 
@@ -2094,7 +2100,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         2     3.0
         1     1.0
         0     NaN
-        Name: 0, dtype: float64
+        dtype: float64
 
         Sort values putting NAs first
 
@@ -2104,7 +2110,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         2     3.0
         4     5.0
         3    10.0
-        Name: 0, dtype: float64
+        dtype: float64
 
         Sort a series of strings
 
@@ -2115,7 +2121,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         2    d
         3    a
         4    c
-        Name: 0, dtype: object
+        dtype: object
 
         >>> s.sort_values()
         3    a
@@ -2123,11 +2129,11 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         4    c
         2    d
         0    z
-        Name: 0, dtype: object
+        dtype: object
         """
         inplace = validate_bool_kwarg(inplace, "inplace")
-        kdf = self.to_frame().sort_values(
-            by=self.name, ascending=ascending, na_position=na_position
+        kdf = self._kdf[[self.name]]._sort(
+            by=[self.spark.column], ascending=ascending, inplace=False, na_position=na_position
         )
 
         if inplace:
@@ -2175,26 +2181,26 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         a      1.0
         b      2.0
         NaN    NaN
-        Name: 0, dtype: float64
+        dtype: float64
 
         >>> df.sort_index(ascending=False)
         b      2.0
         a      1.0
         NaN    NaN
-        Name: 0, dtype: float64
+        dtype: float64
 
         >>> df.sort_index(na_position='first')
         NaN    NaN
         a      1.0
         b      2.0
-        Name: 0, dtype: float64
+        dtype: float64
 
         >>> df.sort_index(inplace=True)
         >>> df
         a      1.0
         b      2.0
         NaN    NaN
-        Name: 0, dtype: float64
+        dtype: float64
 
         >>> df = ks.Series(range(4), index=[['b', 'b', 'a', 'a'], [1, 0, 1, 0]], name='0')
 
@@ -2220,7 +2226,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         Name: 0, dtype: int64
         """
         inplace = validate_bool_kwarg(inplace, "inplace")
-        kdf = self.to_frame().sort_index(
+        kdf = self._kdf[[self.name]].sort_index(
             axis=axis, level=level, ascending=ascending, kind=kind, na_position=na_position
         )
 
@@ -2261,17 +2267,17 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         1    2
         2    3
         3    4
-        Name: 0, dtype: int64
+        dtype: int64
 
         >>> s.add_prefix('item_')
         item_0    1
         item_1    2
         item_2    3
         item_3    4
-        Name: 0, dtype: int64
+        dtype: int64
         """
         assert isinstance(prefix, str)
-        internal = self.to_frame()._internal
+        internal = self._internal
         sdf = internal.spark_frame.select(
             [
                 F.concat(F.lit(prefix), index_spark_column).alias(index_spark_column_name)
@@ -2314,17 +2320,17 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         1    2
         2    3
         3    4
-        Name: 0, dtype: int64
+        dtype: int64
 
         >>> s.add_suffix('_item')
         0_item    1
         1_item    2
         2_item    3
         3_item    4
-        Name: 0, dtype: int64
+        dtype: int64
         """
         assert isinstance(suffix, str)
-        internal = self.to_frame()._internal
+        internal = self._internal
         sdf = internal.spark_frame.select(
             [
                 F.concat(index_spark_column, F.lit(suffix)).alias(index_spark_column_name)
@@ -2421,7 +2427,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         5    6.0
         6    7.0
         7    8.0
-        Name: 0, dtype: float64
+        dtype: float64
 
         The `n` largest elements where ``n=5`` by default.
 
@@ -2431,15 +2437,15 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         2    3.0
         3    4.0
         5    6.0
-        Name: 0, dtype: float64
+        dtype: float64
 
         >>> s.nsmallest(3)
         0    1.0
         1    2.0
         2    3.0
-        Name: 0, dtype: float64
+        dtype: float64
         """
-        return first_series(self.to_frame().nsmallest(n=n, columns=self.name))
+        return self.sort_values(ascending=True).head(n)  # type: ignore
 
     def nlargest(self, n: int = 5) -> "Series":
         """
@@ -2481,7 +2487,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         5    6.0
         6    7.0
         7    8.0
-        Name: 0, dtype: float64
+        dtype: float64
 
         The `n` largest elements where ``n=5`` by default.
 
@@ -2491,17 +2497,17 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         5    6.0
         3    4.0
         2    3.0
-        Name: 0, dtype: float64
+        dtype: float64
 
         >>> s.nlargest(n=3)
         7    8.0
         6    7.0
         5    6.0
-        Name: 0, dtype: float64
+        dtype: float64
 
 
         """
-        return first_series(self.to_frame().nlargest(n=n, columns=self.name))
+        return self.sort_values(ascending=False).head(n)  # type: ignore
 
     def count(self):
         """
@@ -2560,7 +2566,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         0    4
         1    5
         2    6
-        Name: 0, dtype: int64
+        dtype: int64
 
         >>> s1.append(s3)
         0    1
@@ -2569,7 +2575,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         3    4
         4    5
         5    6
-        Name: 0, dtype: int64
+        dtype: int64
 
         With ignore_index set to True:
 
@@ -2580,11 +2586,11 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         3    4
         4    5
         5    6
-        Name: 0, dtype: int64
+        dtype: int64
         """
         return first_series(
-            self.to_dataframe().append(to_append.to_dataframe(), ignore_index, verify_integrity)
-        )
+            self.to_frame().append(to_append.to_frame(), ignore_index, verify_integrity)
+        ).rename(self.name)
 
     def sample(
         self,
@@ -2650,7 +2656,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         London      20
         New York    21
         Helsinki    12
-        Name: 0, dtype: int64
+        dtype: int64
 
 
         Square the values by defining a function and passing it as an
@@ -2662,7 +2668,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         London      400
         New York    441
         Helsinki    144
-        Name: 0, dtype: int64
+        dtype: int64
 
 
         Define a custom function that needs additional positional
@@ -2676,7 +2682,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         London      15
         New York    16
         Helsinki     7
-        Name: 0, dtype: int64
+        dtype: int64
 
 
         Define a custom function that takes keyword arguments
@@ -2691,7 +2697,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         London      95
         New York    96
         Helsinki    87
-        Name: 0, dtype: int64
+        dtype: int64
 
 
         Use a function from the Numpy library
@@ -2702,7 +2708,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         London      2.995732
         New York    3.044522
         Helsinki    2.484907
-        Name: 0, dtype: float64
+        dtype: float64
 
 
         You can omit the type hint and let Koalas infer its type.
@@ -2711,7 +2717,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         London      2.995732
         New York    3.044522
         Helsinki    2.484907
-        Name: 0, dtype: float64
+        dtype: float64
 
         """
         assert callable(func), "the first argument should be a callable function."
@@ -2781,10 +2787,10 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         >>> s.agg(['min', 'max'])
         max    4
         min    1
-        Name: 0, dtype: int64
+        dtype: int64
         """
         if isinstance(func, list):
-            return self.to_frame().agg(func)[self.name]
+            return first_series(self.to_frame().agg(func)).rename(self.name)
         elif isinstance(func, str):
             return getattr(self, func)()
         else:
@@ -2806,13 +2812,13 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         0    1
         1    2
         2    3
-        Name: 0, dtype: int64
+        dtype: int64
 
         >>> s.transpose()
         0    1
         1    2
         2    3
-        Name: 0, dtype: int64
+        dtype: int64
         """
         return self.copy()
 
@@ -2863,7 +2869,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         0    0
         1    1
         2    2
-        Name: 0, dtype: int64
+        dtype: int64
 
         >>> def sqrt(x) -> float:
         ...     return np.sqrt(x)
@@ -2871,7 +2877,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         0    0.000000
         1    1.000000
         2    1.414214
-        Name: 0, dtype: float32
+        dtype: float32
 
         Even though the resulting instance must have the same length as the
         input, it is possible to provide several input functions:
@@ -2992,13 +2998,13 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         0.25    2
         0.5     3
         0.75    4
-        Name: 0, dtype: int64
+        dtype: int64
 
         >>> (s + 1).quantile([.25, .5, .75])
         0.25    3
         0.5     4
         0.75    5
-        Name: 0, dtype: int64
+        dtype: int64
         """
         if not isinstance(accuracy, int):
             raise ValueError("accuracy must be an integer; however, got [%s]" % type(accuracy))
@@ -3205,7 +3211,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
     filter.__doc__ = DataFrame.filter.__doc__
 
     def describe(self, percentiles: Optional[List[float]] = None) -> "Series":
-        return first_series(self.to_dataframe().describe(percentiles))
+        return first_series(self.to_frame().describe(percentiles)).rename(self.name)
 
     describe.__doc__ = DataFrame.describe.__doc__
 
@@ -3326,7 +3332,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         C    4.0
         D    3.0
         E    5.0
-        Name: 0, dtype: float64
+        dtype: float64
 
         >>> s.idxmax()
         'E'
@@ -3348,7 +3354,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
                d         NaN
         b      e         4.0
                f         5.0
-        Name: 0, dtype: float64
+        dtype: float64
 
         >>> s.idxmax()
         ('b', 'f')
@@ -3364,7 +3370,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         2     100
         1       1
         8     100
-        Name: 0, dtype: int64
+        dtype: int64
 
         >>> s.idxmax()
         3
@@ -3434,7 +3440,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         B    NaN
         C    4.0
         D    0.0
-        Name: 0, dtype: float64
+        dtype: float64
 
         >>> s.idxmin()
         'D'
@@ -3456,7 +3462,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
                d         NaN
         b      e         4.0
                f         0.0
-        Name: 0, dtype: float64
+        dtype: float64
 
         >>> s.idxmin()
         ('b', 'f')
@@ -3472,7 +3478,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         2     100
         1       1
         8     100
-        Name: 0, dtype: int64
+        dtype: int64
 
         >>> s.idxmin()
         10
@@ -3519,7 +3525,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         A    0
         B    1
         C    2
-        Name: 0, dtype: int64
+        dtype: int64
 
         >>> s.pop('A')
         0
@@ -3527,23 +3533,23 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         >>> s
         B    1
         C    2
-        Name: 0, dtype: int64
+        dtype: int64
 
         >>> s = ks.Series(data=np.arange(3), index=['A', 'A', 'C'])
         >>> s
         A    0
         A    1
         C    2
-        Name: 0, dtype: int64
+        dtype: int64
 
         >>> s.pop('A')
         A    0
         A    1
-        Name: 0, dtype: int64
+        dtype: int64
 
         >>> s
         C    2
-        Name: 0, dtype: int64
+        dtype: int64
 
         Also support for MultiIndex
 
@@ -3563,13 +3569,13 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         falcon  speed     320.0
                 weight      1.0
                 length      0.3
-        Name: 0, dtype: float64
+        dtype: float64
 
         >>> s.pop('lama')
         speed      45.0
         weight    200.0
         length      1.2
-        Name: 0, dtype: float64
+        dtype: float64
 
         >>> s
         cow     speed      30.0
@@ -3578,7 +3584,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         falcon  speed     320.0
                 weight      1.0
                 length      0.3
-        Name: 0, dtype: float64
+        dtype: float64
 
         Also support for MultiIndex with several indexs.
 
@@ -3601,13 +3607,13 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         b  falcon  speed     320.0
                    speed       1.0
                    length      0.3
-        Name: 0, dtype: float64
+        dtype: float64
 
         >>> s.pop(('a', 'lama'))
         speed      45.0
         weight    200.0
         length      1.2
-        Name: 0, dtype: float64
+        dtype: float64
 
         >>> s
         a  cow     speed      30.0
@@ -3616,12 +3622,12 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         b  falcon  speed     320.0
                    speed       1.0
                    length      0.3
-        Name: 0, dtype: float64
+        dtype: float64
 
         >>> s.pop(('b', 'falcon', 'speed'))
         (b, falcon, speed)    320.0
         (b, falcon, speed)      1.0
-        Name: 0, dtype: float64
+        dtype: float64
         """
         if not isinstance(item, (str, tuple)):
             raise ValueError("'key' should be string or tuple that contains strings")
@@ -3652,14 +3658,14 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             pdf = sdf.limit(2).toPandas()
             length = len(pdf)
             if length == 1:
-                return pdf[self.name].iloc[0]
+                return pdf[self._internal.data_spark_column_names[0]].iloc[0]
 
             item_string = name_like_string(item)
             sdf = sdf.withColumn(SPARK_DEFAULT_INDEX_NAME, F.lit(str(item_string)))
             internal = InternalFrame(
                 spark_frame=sdf, index_map=OrderedDict({SPARK_DEFAULT_INDEX_NAME: None})
             )
-            return first_series(DataFrame(internal))
+            return first_series(DataFrame(internal)).rename(self.name)
         else:
             internal = internal.copy(
                 spark_frame=sdf,
@@ -3687,12 +3693,12 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         >>> s
         a    1
         b    2
-        Name: 0, dtype: int64
+        dtype: int64
         >>> s_copy = s.copy()
         >>> s_copy
         a    1
         b    2
-        Name: 0, dtype: int64
+        dtype: int64
         """
         return first_series(DataFrame(self._internal))
 
@@ -3724,11 +3730,11 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         5    NaN
         6    NaN
         7    NaN
-        Name: 0, dtype: float64
+        dtype: float64
 
         >>> s.mode()
         0    1.0
-        Name: 0, dtype: float64
+        dtype: float64
 
         If there are several same modes, all items are shown
 
@@ -3749,14 +3755,14 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         11    NaN
         12    NaN
         13    NaN
-        Name: 0, dtype: float64
+        dtype: float64
 
         >>> s.mode().sort_values()  # doctest: +NORMALIZE_WHITESPACE, +ELLIPSIS
         <BLANKLINE>
         ...  1.0
         ...  2.0
         ...  3.0
-        Name: 0, dtype: float64
+        dtype: float64
 
         With 'dropna' set to 'False', we can also see NaN in the result
 
@@ -3766,7 +3772,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         ...  2.0
         ...  3.0
         ...  NaN
-        Name: 0, dtype: float64
+        dtype: float64
         """
         ser_count = self.value_counts(dropna=dropna, sort=False)
         sdf_count = ser_count._internal.spark_frame
@@ -3869,7 +3875,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         2    2
         3    3
         4    4
-        Name: 0, dtype: int64
+        dtype: int64
 
         >>> s.replace(0, 5)
         0    5
@@ -3877,7 +3883,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         2    2
         3    3
         4    4
-        Name: 0, dtype: int64
+        dtype: int64
 
         List-like `to_replace`
 
@@ -3887,7 +3893,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         2       2
         3       3
         4    5000
-        Name: 0, dtype: int64
+        dtype: int64
 
         >>> s.replace([1, 2, 3], [10, 20, 30])
         0     0
@@ -3895,7 +3901,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         2    20
         3    30
         4     4
-        Name: 0, dtype: int64
+        dtype: int64
 
         Dict-like `to_replace`
 
@@ -3905,7 +3911,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         2    2000
         3    3000
         4    4000
-        Name: 0, dtype: int64
+        dtype: int64
 
         Also support for MultiIndex
 
@@ -3925,7 +3931,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         falcon  speed     320.0
                 weight      1.0
                 length      0.3
-        Name: 0, dtype: float64
+        dtype: float64
 
         >>> s.replace(45, 450)
         lama    speed     450.0
@@ -3937,7 +3943,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         falcon  speed     320.0
                 weight      1.0
                 length      0.3
-        Name: 0, dtype: float64
+        dtype: float64
 
         >>> s.replace([45, 30, 320], 500)
         lama    speed     500.0
@@ -3949,7 +3955,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         falcon  speed     500.0
                 weight      1.0
                 length      0.3
-        Name: 0, dtype: float64
+        dtype: float64
 
         >>> s.replace({45: 450, 30: 300})
         lama    speed     450.0
@@ -3961,7 +3967,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         falcon  speed     320.0
                 weight      1.0
                 length      0.3
-        Name: 0, dtype: float64
+        dtype: float64
         """
         if to_replace is None:
             return self
@@ -4012,7 +4018,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         0    4
         1    5
         2    6
-        Name: 0, dtype: int64
+        dtype: int64
 
         >>> s = ks.Series(['a', 'b', 'c'])
         >>> s.update(ks.Series(['d', 'e'], index=[0, 2]))
@@ -4020,7 +4026,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         0    d
         1    b
         2    e
-        Name: 0, dtype: object
+        dtype: object
 
         >>> s = ks.Series([1, 2, 3])
         >>> s.update(ks.Series([4, 5, 6, 7, 8]))
@@ -4028,28 +4034,28 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         0    4
         1    5
         2    6
-        Name: 0, dtype: int64
+        dtype: int64
 
         >>> s = ks.Series([1, 2, 3], index=[10, 11, 12])
         >>> s
         10    1
         11    2
         12    3
-        Name: 0, dtype: int64
+        dtype: int64
 
         >>> s.update(ks.Series([4, 5, 6]))
         >>> s.sort_index()
         10    1
         11    2
         12    3
-        Name: 0, dtype: int64
+        dtype: int64
 
         >>> s.update(ks.Series([4, 5, 6], index=[11, 12, 13]))
         >>> s.sort_index()
         10    1
         11    4
         12    5
-        Name: 0, dtype: int64
+        dtype: int64
 
         If ``other`` contains NaNs the corresponding values are not updated
         in the original Series.
@@ -4060,7 +4066,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         0    4.0
         1    2.0
         2    6.0
-        Name: 0, dtype: float64
+        dtype: float64
 
         >>> reset_option("compute.ops_on_diff_frames")
         """
@@ -4069,8 +4075,8 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         combined = combine_frames(self._kdf, other.to_frame(), how="leftouter")
 
-        this_scol = combined["this"]._internal.spark_column_for(self._column_label)
-        that_scol = combined["that"]._internal.spark_column_for(other._column_label)
+        this_scol = combined["this"]._internal.data_spark_columns[0]
+        that_scol = combined["that"]._internal.data_spark_columns[0]
 
         scol = (
             F.when(that_scol.isNotNull(), that_scol)
@@ -4111,7 +4117,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         2    2.0
         3    3.0
         4    4.0
-        Name: 0, dtype: float64
+        dtype: float64
 
         >>> s1.where(s1 > 1, 10).sort_index()
         0    10
@@ -4119,7 +4125,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         2     2
         3     3
         4     4
-        Name: 0, dtype: int64
+        dtype: int64
 
         >>> s1.where(s1 > 1, s1 + 100).sort_index()
         0    100
@@ -4127,7 +4133,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         2      2
         3      3
         4      4
-        Name: 0, dtype: int64
+        dtype: int64
 
         >>> s1.where(s1 > 1, s2).sort_index()
         0    100
@@ -4135,7 +4141,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         2      2
         3      3
         4      4
-        Name: 0, dtype: int64
+        dtype: int64
 
         >>> reset_option("compute.ops_on_diff_frames")
         """
@@ -4168,10 +4174,10 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             condition = (
                 F.when(
                     kdf[tmp_cond_col].spark.column,
-                    kdf[self._internal.column_labels[0]].spark.column,
+                    kdf._kser_for(kdf._internal.column_labels[0]).spark.column,
                 )
                 .otherwise(kdf[tmp_other_col].spark.column)
-                .alias(self._internal.data_spark_column_names[0])
+                .alias(kdf._internal.data_spark_column_names[0])
             )
 
             internal = kdf._internal.with_new_columns(
@@ -4217,7 +4223,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         2    NaN
         3    NaN
         4    NaN
-        Name: 0, dtype: float64
+        dtype: float64
 
         >>> s1.mask(s1 > 1, 10).sort_index()
         0     0
@@ -4225,7 +4231,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         2    10
         3    10
         4    10
-        Name: 0, dtype: int64
+        dtype: int64
 
         >>> s1.mask(s1 > 1, s1 + 100).sort_index()
         0      0
@@ -4233,7 +4239,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         2    102
         3    103
         4    104
-        Name: 0, dtype: int64
+        dtype: int64
 
         >>> s1.mask(s1 > 1, s2).sort_index()
         0      0
@@ -4241,7 +4247,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         2    300
         3    400
         4    500
-        Name: 0, dtype: int64
+        dtype: int64
 
         >>> reset_option("compute.ops_on_diff_frames")
         """
@@ -4288,7 +4294,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         c  falcon  speed     320.0
                    weight      1.0
                    length      0.3
-        Name: 0, dtype: float64
+        dtype: float64
 
         Get values at specified index
 
@@ -4296,7 +4302,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         lama  speed      45.0
               weight    200.0
               length      1.2
-        Name: 0, dtype: float64
+        dtype: float64
 
         Get values at several indexes
 
@@ -4304,7 +4310,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         speed      45.0
         weight    200.0
         length      1.2
-        Name: 0, dtype: float64
+        dtype: float64
 
         Get values at specified index and level
 
@@ -4312,7 +4318,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         a  speed      45.0
            weight    200.0
            length      1.2
-        Name: 0, dtype: float64
+        dtype: float64
         """
         if not isinstance(key, tuple):
             key = (key,)
@@ -4333,7 +4339,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             pdf = sdf.limit(2).toPandas()
             length = len(pdf)
             if length == 1:
-                return pdf[self.name].iloc[0]
+                return pdf[self._internal.data_spark_column_names[0]].iloc[0]
 
         index_map = list(internal.index_map.items())
         index_map = index_map[:level] + index_map[level + len(key) :]
@@ -4371,25 +4377,25 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         2    90
         4    91
         1    85
-        Name: 0, dtype: int64
+        dtype: int64
 
         >>> kser.pct_change()
         2         NaN
         4    0.011111
         1   -0.065934
-        Name: 0, dtype: float64
+        dtype: float64
 
         >>> kser.sort_index().pct_change()
         1         NaN
         2    0.058824
         4    0.011111
-        Name: 0, dtype: float64
+        dtype: float64
 
         >>> kser.pct_change(periods=2)
         2         NaN
         4         NaN
         1   -0.055556
-        Name: 0, dtype: float64
+        dtype: float64
         """
         scol = self.spark.column
 
@@ -4428,7 +4434,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         >>> s1.combine_first(s2)
         0    1.0
         1    4.0
-        Name: 0, dtype: float64
+        dtype: float64
         """
         if not isinstance(other, ks.Series):
             raise ValueError("`combine_first` only allows `Series` for parameter `other`")
@@ -4439,8 +4445,8 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         else:
             with option_context("compute.ops_on_diff_frames", True):
                 combined = combine_frames(self.to_frame(), other)
-            this = combined["this"]._internal.spark_column_for(self._column_label)
-            that = combined["that"]._internal.spark_column_for(other._column_label)
+            this = combined["this"]._internal.data_spark_columns[0]
+            that = combined["that"]._internal.data_spark_columns[0]
         # If `self` has missing value, use value of `other`
         cond = F.when(this.isNull(), that).otherwise(this)
         # If `self` and `other` come from same frame, the anchor should be kept
@@ -4561,7 +4567,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         0    a
         1    b
         2    c
-        Name: 0, dtype: object
+        dtype: object
         >>> s.repeat(2)
         0    a
         1    b
@@ -4569,9 +4575,9 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         0    a
         1    b
         2    c
-        Name: 0, dtype: object
+        dtype: object
         >>> ks.Series([1, 2, 3]).repeat(0)
-        Series([], Name: 0, dtype: int64)
+        Series([], dtype: int64)
         """
         if not isinstance(repeats, (int, Series)):
             raise ValueError(
@@ -4589,7 +4595,11 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
                 kdf = self.to_frame()
                 temp_repeats = verify_temp_column_name(kdf, "__temp_repeats__")
                 kdf[temp_repeats] = repeats
-                return kdf[self.name].repeat(kdf[temp_repeats])
+                return (
+                    kdf._kser_for(kdf._internal.column_labels[0])
+                    .repeat(kdf[temp_repeats])
+                    .rename(self.name)
+                )
             else:
                 scol = F.explode(
                     SF.array_repeat(self.spark.column, repeats.astype(int).spark.column)
@@ -4606,9 +4616,11 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
             kdf = self.to_frame()
             if repeats == 0:
-                return first_series(DataFrame(kdf._internal.with_filter(F.lit(False))))
+                return first_series(DataFrame(kdf._internal.with_filter(F.lit(False)))).rename(
+                    self.name
+                )
             else:
-                return first_series(ks.concat([kdf] * repeats))
+                return first_series(ks.concat([kdf] * repeats)).rename(self.name)
 
     def asof(self, where):
         """
@@ -4649,7 +4661,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         20    2.0
         30    NaN
         40    4.0
-        Name: 0, dtype: float64
+        dtype: float64
 
         A scalar `where`.
 
@@ -4663,7 +4675,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         >>> s.asof([5, 20]).sort_index()
         5     NaN
         20    2.0
-        Name: 0, dtype: float64
+        dtype: float64
 
         Missing values are not considered. The following is ``2.0``, not
         NaN, even though NaN is at the index location for ``30``.
@@ -4708,7 +4720,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         1    2
         2    3
         3    4
-        Name: 0, dtype: int64
+        dtype: int64
 
         >>> s.mad()
         1.0
@@ -4752,7 +4764,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
              b    2
         two  a    3
              b    4
-        Name: 0, dtype: int64
+        dtype: int64
 
         >>> s.unstack(level=-1).sort_index()
              a  b
@@ -4897,7 +4909,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         x        a          1
                  b          2
         y        c          3
-        Name: 0, dtype: int64
+        dtype: int64
 
         Removing specific index level by level
 
@@ -4906,7 +4918,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         a    1
         b    2
         c    3
-        Name: 0, dtype: int64
+        dtype: int64
 
         Removing specific index level by name
 
@@ -4915,9 +4927,9 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         x    1
         x    2
         y    3
-        Name: 0, dtype: int64
+        dtype: int64
         """
-        return first_series(self.to_frame().droplevel(level=level, axis=0))
+        return first_series(self.to_frame().droplevel(level=level, axis=0)).rename(self.name)
 
     def tail(self, n=5):
         """
@@ -4953,15 +4965,15 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         2    3
         3    4
         4    5
-        Name: 0, dtype: int64
+        dtype: int64
 
         >>> kser.tail(3)  # doctest: +SKIP
         2    3
         3    4
         4    5
-        Name: 0, dtype: int64
+        dtype: int64
         """
-        return first_series(self.to_frame().tail(n=n))
+        return first_series(self.to_frame().tail(n=n)).rename(self.name)
 
     def product(self, min_count=0):
         """

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -1210,13 +1210,12 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         if inplace and not drop:
             raise TypeError("Cannot reset_index inplace on a Series to create a DataFrame")
 
-        if not drop and name is not None:
-            kser = self.rename(name)
+        if drop:
+            kdf = self._kdf[[self.name]]
         else:
             kser = self
-        if drop:
-            kdf = kser._kdf[[kser.name]]
-        else:
+            if name is not None:
+                kser = kser.rename(name)
             kdf = kser.to_frame()
         kdf = kdf.reset_index(level=level, drop=drop)
         if drop:

--- a/databricks/koalas/spark/accessors.py
+++ b/databricks/koalas/spark/accessors.py
@@ -188,9 +188,7 @@ class SparkIndexOpsMethods(object):
 
         sdf = self._data._internal.spark_frame.drop(*HIDDEN_COLUMNS).select(output)
         # Lose index.
-        kdf = DataFrame(sdf)
-        kdf.columns = [self._data.name]
-        return first_series(kdf)
+        return first_series(DataFrame(sdf)).rename(self._data.name)
 
 
 class SparkFrameMethods(object):

--- a/databricks/koalas/spark/accessors.py
+++ b/databricks/koalas/spark/accessors.py
@@ -426,7 +426,7 @@ class SparkFrameMethods(object):
         ...
         dogs    4
         cats    4
-        Name: 0, dtype: int64
+        dtype: int64
 
         >>> df = df.spark.cache()
         >>> df.to_pandas().mean(axis=1)
@@ -480,7 +480,7 @@ class SparkFrameMethods(object):
         Memory Serialized 1x Replicated
         dogs    4
         cats    4
-        Name: 0, dtype: int64
+        dtype: int64
 
         Set the StorageLevel to `DISK_ONLY`.
 
@@ -491,7 +491,7 @@ class SparkFrameMethods(object):
         Disk Serialized 1x Replicated
         dogs    4
         cats    4
-        Name: 0, dtype: int64
+        dtype: int64
 
         If a StorageLevel is not given, it uses `MEMORY_AND_DISK` by default.
 
@@ -502,7 +502,7 @@ class SparkFrameMethods(object):
         Disk Memory Serialized 1x Replicated
         dogs    4
         cats    4
-        Name: 0, dtype: int64
+        dtype: int64
 
         >>> df = df.spark.persist()
         >>> df.to_pandas().mean(axis=1)

--- a/databricks/koalas/strings.py
+++ b/databricks/koalas/strings.py
@@ -52,14 +52,14 @@ class StringMethods(object):
         1              CAPITALS
         2    this is a sentence
         3              SwApCaSe
-        Name: 0, dtype: object
+        dtype: object
 
         >>> s.str.capitalize()
         0                 Lower
         1              Capitals
         2    This is a sentence
         3              Swapcase
-        Name: 0, dtype: object
+        dtype: object
         """
 
         def pandas_capitalize(s) -> "ks.Series[str]":
@@ -79,14 +79,14 @@ class StringMethods(object):
         1              CAPITALS
         2    this is a sentence
         3              SwApCaSe
-        Name: 0, dtype: object
+        dtype: object
 
         >>> s.str.title()
         0                 Lower
         1              Capitals
         2    This Is A Sentence
         3              Swapcase
-        Name: 0, dtype: object
+        dtype: object
         """
 
         def pandas_title(s) -> "ks.Series[str]":
@@ -106,14 +106,14 @@ class StringMethods(object):
         1              CAPITALS
         2    this is a sentence
         3              SwApCaSe
-        Name: 0, dtype: object
+        dtype: object
 
         >>> s.str.lower()
         0                 lower
         1              capitals
         2    this is a sentence
         3              swapcase
-        Name: 0, dtype: object
+        dtype: object
         """
         return column_op(lambda c: F.lower(c))(self._data).alias(self._data.name)
 
@@ -129,14 +129,14 @@ class StringMethods(object):
         1              CAPITALS
         2    this is a sentence
         3              SwApCaSe
-        Name: 0, dtype: object
+        dtype: object
 
         >>> s.str.upper()
         0                 LOWER
         1              CAPITALS
         2    THIS IS A SENTENCE
         3              SWAPCASE
-        Name: 0, dtype: object
+        dtype: object
         """
         return column_op(lambda c: F.upper(c))(self._data).alias(self._data.name)
 
@@ -152,14 +152,14 @@ class StringMethods(object):
         1              CAPITALS
         2    this is a sentence
         3              SwApCaSe
-        Name: 0, dtype: object
+        dtype: object
 
         >>> s.str.swapcase()
         0                 LOWER
         1              capitals
         2    THIS IS A SENTENCE
         3              sWaPcAsE
-        Name: 0, dtype: object
+        dtype: object
         """
 
         def pandas_swapcase(s) -> "ks.Series[str]":
@@ -194,14 +194,14 @@ class StringMethods(object):
         1    Bear
         2     cat
         3    None
-        Name: 0, dtype: object
+        dtype: object
 
         >>> s.str.startswith('b')
         0     True
         1    False
         2    False
         3     None
-        Name: 0, dtype: object
+        dtype: object
 
         Specifying na to be False instead of None.
 
@@ -210,7 +210,7 @@ class StringMethods(object):
         1    False
         2    False
         3    False
-        Name: 0, dtype: bool
+        dtype: bool
         """
 
         def pandas_startswith(s) -> "ks.Series[bool]":
@@ -245,14 +245,14 @@ class StringMethods(object):
         1    Bear
         2     cat
         3    None
-        Name: 0, dtype: object
+        dtype: object
 
         >>> s.str.endswith('t')
         0     True
         1    False
         2     True
         3     None
-        Name: 0, dtype: object
+        dtype: object
 
         Specifying na to be False instead of None.
 
@@ -261,7 +261,7 @@ class StringMethods(object):
         1    False
         2     True
         3    False
-        Name: 0, dtype: bool
+        dtype: bool
         """
 
         def pandas_endswith(s) -> "ks.Series[bool]":
@@ -295,25 +295,25 @@ class StringMethods(object):
         0      1. Ant.
         1    2. Bee!\\t
         2         None
-        Name: 0, dtype: object
+        dtype: object
 
         >>> s.str.strip()
         0    1. Ant.
         1    2. Bee!
         2       None
-        Name: 0, dtype: object
+        dtype: object
 
         >>> s.str.strip('12.')
         0        Ant
         1     Bee!\\t
         2       None
-        Name: 0, dtype: object
+        dtype: object
 
         >>> s.str.strip('.!\\t')
         0    1. Ant
         1    2. Bee
         2      None
-        Name: 0, dtype: object
+        dtype: object
         """
 
         def pandas_strip(s) -> "ks.Series[str]":
@@ -347,13 +347,13 @@ class StringMethods(object):
         0      1. Ant.
         1    2. Bee!\\t
         2         None
-        Name: 0, dtype: object
+        dtype: object
 
         >>> s.str.lstrip('12.')
         0       Ant.
         1     Bee!\\t
         2       None
-        Name: 0, dtype: object
+        dtype: object
         """
 
         def pandas_lstrip(s) -> "ks.Series[str]":
@@ -387,13 +387,13 @@ class StringMethods(object):
         0      1. Ant.
         1    2. Bee!\\t
         2         None
-        Name: 0, dtype: object
+        dtype: object
 
         >>> s.str.rstrip('.!\\t')
         0    1. Ant
         1    2. Bee
         2      None
-        Name: 0, dtype: object
+        dtype: object
         """
 
         def pandas_rstrip(s) -> "ks.Series[str]":
@@ -421,33 +421,33 @@ class StringMethods(object):
         >>> s1
         0    String
         1       123
-        Name: 0, dtype: object
+        dtype: object
 
         >>> s1.str.get(1)
         0    t
         1    2
-        Name: 0, dtype: object
+        dtype: object
 
         >>> s1.str.get(-1)
         0    g
         1    3
-        Name: 0, dtype: object
+        dtype: object
 
         >>> s2 = ks.Series([["a", "b", "c"], ["x", "y"]])
         >>> s2
         0    [a, b, c]
         1       [x, y]
-        Name: 0, dtype: object
+        dtype: object
 
         >>> s2.str.get(0)
         0    a
         1    x
-        Name: 0, dtype: object
+        dtype: object
 
         >>> s2.str.get(2)
         0       c
         1    None
-        Name: 0, dtype: object
+        dtype: object
         """
 
         def pandas_get(s) -> "ks.Series[str]":
@@ -472,7 +472,7 @@ class StringMethods(object):
         1     True
         2     True
         3    False
-        Name: 0, dtype: bool
+        dtype: bool
 
         Note that checks against characters mixed with any additional
         punctuation or whitespace will evaluate to false for an alphanumeric
@@ -483,7 +483,7 @@ class StringMethods(object):
         0    False
         1    False
         2    False
-        Name: 0, dtype: bool
+        dtype: bool
         """
 
         def pandas_isalnum(s) -> "ks.Series[bool]":
@@ -508,7 +508,7 @@ class StringMethods(object):
         1    False
         2    False
         3    False
-        Name: 0, dtype: bool
+        dtype: bool
         """
 
         def pandas_isalpha(s) -> "ks.Series[bool]":
@@ -536,7 +536,7 @@ class StringMethods(object):
         1    False
         2    False
         3    False
-        Name: 0, dtype: bool
+        dtype: bool
 
         The s.str.isdigit method is the same as s.str.isdecimal but also
         includes special digits, like superscripted and subscripted digits in
@@ -547,7 +547,7 @@ class StringMethods(object):
         1     True
         2    False
         3    False
-        Name: 0, dtype: bool
+        dtype: bool
 
         The s.str.isnumeric method is the same as s.str.isdigit but also
         includes other characters that can represent quantities such as unicode
@@ -558,7 +558,7 @@ class StringMethods(object):
         1     True
         2     True
         3    False
-        Name: 0, dtype: bool
+        dtype: bool
         """
 
         def pandas_isdigit(s) -> "ks.Series[bool]":
@@ -581,7 +581,7 @@ class StringMethods(object):
         0     True
         1     True
         2    False
-        Name: 0, dtype: bool
+        dtype: bool
         """
 
         def pandas_isspace(s) -> "ks.Series[bool]":
@@ -605,7 +605,7 @@ class StringMethods(object):
         1    False
         2    False
         3    False
-        Name: 0, dtype: bool
+        dtype: bool
         """
 
         def pandas_isspace(s) -> "ks.Series[bool]":
@@ -629,7 +629,7 @@ class StringMethods(object):
         1    False
         2     True
         3    False
-        Name: 0, dtype: bool
+        dtype: bool
         """
 
         def pandas_isspace(s) -> "ks.Series[bool]":
@@ -659,7 +659,7 @@ class StringMethods(object):
         1     True
         2    False
         3    False
-        Name: 0, dtype: bool
+        dtype: bool
         """
 
         def pandas_istitle(s) -> "ks.Series[bool]":
@@ -683,7 +683,7 @@ class StringMethods(object):
         1    False
         2     True
         3    False
-        Name: 0, dtype: bool
+        dtype: bool
 
         >>> s2 = ks.Series(['23', '³', '⅕', ''])
 
@@ -695,7 +695,7 @@ class StringMethods(object):
         1    False
         2    False
         3    False
-        Name: 0, dtype: bool
+        dtype: bool
 
         The s2.str.isdigit method is the same as s2.str.isdecimal but also
         includes special digits, like superscripted and subscripted digits in
@@ -706,7 +706,7 @@ class StringMethods(object):
         1     True
         2    False
         3    False
-        Name: 0, dtype: bool
+        dtype: bool
 
         The s2.str.isnumeric method is the same as s2.str.isdigit but also
         includes other characters that can represent quantities such as unicode
@@ -717,7 +717,7 @@ class StringMethods(object):
         1     True
         2     True
         3    False
-        Name: 0, dtype: bool
+        dtype: bool
         """
 
         def pandas_isnumeric(s) -> "ks.Series[bool]":
@@ -745,7 +745,7 @@ class StringMethods(object):
         1    False
         2    False
         3    False
-        Name: 0, dtype: bool
+        dtype: bool
 
         The s.str.isdigit method is the same as s.str.isdecimal but also
         includes special digits, like superscripted and subscripted digits in
@@ -756,7 +756,7 @@ class StringMethods(object):
         1     True
         2    False
         3    False
-        Name: 0, dtype: bool
+        dtype: bool
 
         The s.str.isnumeric method is the same as s.str.isdigit but also
         includes other characters that can represent quantities such as unicode
@@ -767,7 +767,7 @@ class StringMethods(object):
         1     True
         2     True
         3    False
-        Name: 0, dtype: bool
+        dtype: bool
         """
 
         def pandas_isdecimal(s) -> "ks.Series[bool]":
@@ -804,12 +804,12 @@ class StringMethods(object):
         >>> s
         0    caribou
         1      tiger
-        Name: 0, dtype: object
+        dtype: object
 
         >>> s.str.center(width=10, fillchar='-')
         0    -caribou--
         1    --tiger---
-        Name: 0, dtype: object
+        dtype: object
         """
 
         def pandas_center(s) -> "ks.Series[str]":
@@ -859,7 +859,7 @@ class StringMethods(object):
         2    False
         3    False
         4     None
-        Name: 0, dtype: object
+        dtype: object
 
         Specifying case sensitivity using case.
 
@@ -869,7 +869,7 @@ class StringMethods(object):
         2    False
         3    False
         4     None
-        Name: 0, dtype: object
+        dtype: object
 
         Specifying na to be False instead of NaN replaces NaN values with
         False. If Series does not contain NaN values the resultant dtype will
@@ -881,7 +881,7 @@ class StringMethods(object):
         2    False
         3    False
         4    False
-        Name: 0, dtype: bool
+        dtype: bool
 
         Returning ‘house’ or ‘dog’ when either expression occurs in a string.
 
@@ -891,7 +891,7 @@ class StringMethods(object):
         2     True
         3    False
         4     None
-        Name: 0, dtype: object
+        dtype: object
 
         Ignoring case sensitivity using flags with regex.
 
@@ -902,7 +902,7 @@ class StringMethods(object):
         2     True
         3    False
         4     None
-        Name: 0, dtype: object
+        dtype: object
 
         Returning any digit using regular expression.
 
@@ -912,7 +912,7 @@ class StringMethods(object):
         2    False
         3     True
         4     None
-        Name: 0, dtype: object
+        dtype: object
 
         Ensure pat is a not a literal pattern when regex is set to True.
         Note in the following example one might expect only s2[1] and s2[3]
@@ -926,7 +926,7 @@ class StringMethods(object):
         2    False
         3     True
         4    False
-        Name: 0, dtype: bool
+        dtype: bool
         """
 
         def pandas_contains(s) -> "ks.Series[bool]":
@@ -964,7 +964,7 @@ class StringMethods(object):
         4    NaN
         5    0.0
         6    1.0
-        Name: 0, dtype: float64
+        dtype: float64
 
         Escape '$' to find the literal dollar sign.
 
@@ -976,7 +976,7 @@ class StringMethods(object):
         3    2
         4    2
         5    0
-        Name: 0, dtype: int32
+        dtype: int32
         """
 
         def pandas_count(s) -> "ks.Series[int]":
@@ -1037,25 +1037,25 @@ class StringMethods(object):
         0    0
         1    2
         2    1
-        Name: 0, dtype: int32
+        dtype: int32
 
         >>> s.str.find('a', start=2)
         0   -1
         1    2
         2    3
-        Name: 0, dtype: int32
+        dtype: int32
 
         >>> s.str.find('a', end=1)
         0    0
         1   -1
         2   -1
-        Name: 0, dtype: int32
+        dtype: int32
 
         >>> s.str.find('a', start=2, end=2)
         0   -1
         1   -1
         2   -1
-        Name: 0, dtype: int32
+        dtype: int32
         """
 
         def pandas_find(s) -> "ks.Series[int]":
@@ -1093,7 +1093,7 @@ class StringMethods(object):
         0          []
         1    [Monkey]
         2          []
-        Name: 0, dtype: object
+        dtype: object
 
         On the other hand, the search for the pattern ‘MONKEY’ doesn’t return
         any match:
@@ -1102,7 +1102,7 @@ class StringMethods(object):
         0    []
         1    []
         2    []
-        Name: 0, dtype: object
+        dtype: object
 
         Flags can be added to the pattern or regular expression. For instance,
         to find the pattern ‘MONKEY’ ignoring the case:
@@ -1112,7 +1112,7 @@ class StringMethods(object):
         0          []
         1    [Monkey]
         2          []
-        Name: 0, dtype: object
+        dtype: object
 
         When the pattern matches more than one string in the Series, all
         matches are returned:
@@ -1121,7 +1121,7 @@ class StringMethods(object):
         0    [on]
         1    [on]
         2      []
-        Name: 0, dtype: object
+        dtype: object
 
         Regular expressions are supported too. For instance, the search for all
         the strings ending with the word ‘on’ is shown next:
@@ -1130,7 +1130,7 @@ class StringMethods(object):
         0    [on]
         1      []
         2      []
-        Name: 0, dtype: object
+        dtype: object
 
         If the pattern is found more than once in the same string, then a list
         of multiple strings is returned:
@@ -1139,7 +1139,7 @@ class StringMethods(object):
         0        []
         1        []
         2    [b, b]
-        Name: 0, dtype: object
+        dtype: object
         """
         # type hint does not support to specify array type yet.
         pudf = pandas_udf(
@@ -1180,7 +1180,7 @@ class StringMethods(object):
         0    0
         1    2
         2    1
-        Name: 0, dtype: int64
+        dtype: int64
 
         The following expression throws an exception:
 
@@ -1226,14 +1226,14 @@ class StringMethods(object):
         >>> s
         0    [lion, elephant, zebra]
         1           [cat, None, dog]
-        Name: 0, dtype: object
+        dtype: object
 
         Join all lists using a ‘-‘. The list containing None will produce None.
 
         >>> s.str.join('-')
         0    lion-elephant-zebra
         1                   None
-        Name: 0, dtype: object
+        dtype: object
         """
 
         def pandas_join(s) -> "ks.Series[str]":
@@ -1262,13 +1262,13 @@ class StringMethods(object):
         >>> s1.str.len()
         0    3
         1    6
-        Name: 0, dtype: int64
+        dtype: int64
 
         >>> s2 = ks.Series([["a", "b", "c"], []])
         >>> s2.str.len()
         0    3
         1    0
-        Name: 0, dtype: int64
+        dtype: int64
         """
         if isinstance(self._data.spark.data_type, (ArrayType, MapType)):
             return column_op(lambda c: F.size(c).cast(LongType()))(self._data).alias(
@@ -1302,12 +1302,12 @@ class StringMethods(object):
         >>> s
         0    caribou
         1      tiger
-        Name: 0, dtype: object
+        dtype: object
 
         >>> s.str.ljust(width=10, fillchar='-')
         0    caribou---
         1    tiger-----
-        Name: 0, dtype: object
+        dtype: object
         """
 
         def pandas_ljust(s) -> "ks.Series[str]":
@@ -1348,7 +1348,7 @@ class StringMethods(object):
         2    False
         3    False
         4     None
-        Name: 0, dtype: object
+        dtype: object
 
         >>> s.str.match('mouse|dog', case=False)
         0     True
@@ -1356,7 +1356,7 @@ class StringMethods(object):
         2    False
         3    False
         4     None
-        Name: 0, dtype: object
+        dtype: object
 
         >>> s.str.match('.+and.+', na=True)
         0    False
@@ -1364,7 +1364,7 @@ class StringMethods(object):
         2     True
         3    False
         4     True
-        Name: 0, dtype: bool
+        dtype: bool
 
         >>> import re
         >>> s.str.match('MOUSE', flags=re.IGNORECASE)
@@ -1373,7 +1373,7 @@ class StringMethods(object):
         2    False
         3    False
         4     None
-        Name: 0, dtype: object
+        dtype: object
         """
 
         def pandas_match(s) -> "ks.Series[bool]":
@@ -1429,22 +1429,22 @@ class StringMethods(object):
         >>> s
         0    caribou
         1      tiger
-        Name: 0, dtype: object
+        dtype: object
 
         >>> s.str.pad(width=10)
         0       caribou
         1         tiger
-        Name: 0, dtype: object
+        dtype: object
 
         >>> s.str.pad(width=10, side='right', fillchar='-')
         0    caribou---
         1    tiger-----
-        Name: 0, dtype: object
+        dtype: object
 
         >>> s.str.pad(width=10, side='both', fillchar='-')
         0    -caribou--
         1    --tiger---
-        Name: 0, dtype: object
+        dtype: object
         """
 
         def pandas_pad(s) -> "ks.Series[str]":
@@ -1481,7 +1481,7 @@ class StringMethods(object):
         0    a
         1    b
         2    c
-        Name: 0, dtype: object
+        dtype: object
 
         Single int repeats string in Series
 
@@ -1489,7 +1489,7 @@ class StringMethods(object):
         0    aa
         1    bb
         2    cc
-        Name: 0, dtype: object
+        dtype: object
         """
         if not isinstance(repeats, int):
             raise ValueError("repeats expects an int parameter")
@@ -1544,7 +1544,7 @@ class StringMethods(object):
         0     bao
         1     baz
         2    None
-        Name: 0, dtype: object
+        dtype: object
 
         When pat is a string and regex is False, every pat is replaced with
         repl as with :func:`str.replace`:
@@ -1553,7 +1553,7 @@ class StringMethods(object):
         0     bao
         1     fuz
         2    None
-        Name: 0, dtype: object
+        dtype: object
 
         When repl is a callable, it is called on every pat using
         :func:`re.sub`. The callable should expect one positional argument (a
@@ -1566,7 +1566,7 @@ class StringMethods(object):
         0    oof 123
         1    rab zab
         2       None
-        Name: 0, dtype: object
+        dtype: object
 
         Using regex groups (extract second group and swap case):
 
@@ -1575,7 +1575,7 @@ class StringMethods(object):
         >>> ks.Series(['One Two Three', 'Foo Bar Baz']).str.replace(pat, repl)
         0    tWO
         1    bAR
-        Name: 0, dtype: object
+        dtype: object
 
         Using a compiled regex with flags:
 
@@ -1585,7 +1585,7 @@ class StringMethods(object):
         0     foo
         1     bar
         2    None
-        Name: 0, dtype: object
+        dtype: object
         """
 
         def pandas_replace(s) -> "ks.Series[str]":
@@ -1622,25 +1622,25 @@ class StringMethods(object):
         0    0
         1    2
         2    5
-        Name: 0, dtype: int32
+        dtype: int32
 
         >>> s.str.rfind('a', start=2)
         0   -1
         1    2
         2    5
-        Name: 0, dtype: int32
+        dtype: int32
 
         >>> s.str.rfind('a', end=1)
         0    0
         1   -1
         2   -1
-        Name: 0, dtype: int32
+        dtype: int32
 
         >>> s.str.rfind('a', start=2, end=2)
         0   -1
         1   -1
         2   -1
-        Name: 0, dtype: int32
+        dtype: int32
         """
 
         def pandas_rfind(s) -> "ks.Series[int]":
@@ -1679,7 +1679,7 @@ class StringMethods(object):
         0    0
         1    2
         2    5
-        Name: 0, dtype: int64
+        dtype: int64
 
         The following expression throws an exception:
 
@@ -1714,17 +1714,17 @@ class StringMethods(object):
         >>> s
         0    caribou
         1      tiger
-        Name: 0, dtype: object
+        dtype: object
 
         >>> s.str.rjust(width=10)
         0       caribou
         1         tiger
-        Name: 0, dtype: object
+        dtype: object
 
         >>> s.str.rjust(width=10, fillchar='-')
         0    ---caribou
         1    -----tiger
-        Name: 0, dtype: object
+        dtype: object
         """
 
         def pandas_rjust(s) -> "ks.Series[str]":
@@ -1763,31 +1763,31 @@ class StringMethods(object):
         0        koala
         1          fox
         2    chameleon
-        Name: 0, dtype: object
+        dtype: object
 
         >>> s.str.slice(start=1)
         0        oala
         1          ox
         2    hameleon
-        Name: 0, dtype: object
+        dtype: object
 
         >>> s.str.slice(stop=2)
         0    ko
         1    fo
         2    ch
-        Name: 0, dtype: object
+        dtype: object
 
         >>> s.str.slice(step=2)
         0      kaa
         1       fx
         2    caeen
-        Name: 0, dtype: object
+        dtype: object
 
         >>> s.str.slice(start=0, stop=5, step=3)
         0    kl
         1     f
         2    cm
-        Name: 0, dtype: object
+        dtype: object
         """
 
         def pandas_slice(s) -> "ks.Series[str]":
@@ -1827,7 +1827,7 @@ class StringMethods(object):
         2      abc
         3     abdc
         4    abcde
-        Name: 0, dtype: object
+        dtype: object
 
         Specify just start, meaning replace start until the end of the string
         with repl.
@@ -1838,7 +1838,7 @@ class StringMethods(object):
         2    aX
         3    aX
         4    aX
-        Name: 0, dtype: object
+        dtype: object
 
         Specify just stop, meaning the start of the string to stop is replaced
         with repl, and the rest of the string is included.
@@ -1849,7 +1849,7 @@ class StringMethods(object):
         2      Xc
         3     Xdc
         4    Xcde
-        Name: 0, dtype: object
+        dtype: object
 
         Specify start and stop, meaning the slice from start to stop is
         replaced with repl. Everything before or after start and stop is
@@ -1861,7 +1861,7 @@ class StringMethods(object):
         2      aX
         3     aXc
         4    aXde
-        Name: 0, dtype: object
+        dtype: object
         """
 
         def pandas_slice_replace(s) -> "ks.Series[str]":
@@ -1929,7 +1929,7 @@ class StringMethods(object):
         0                   [this, is, a, regular, sentence]
         1    [https://docs.python.org/3/tutorial/index.html]
         2                                               None
-        Name: 0, dtype: object
+        dtype: object
 
         Without the n parameter, the outputs of rsplit and split are identical.
 
@@ -1937,7 +1937,7 @@ class StringMethods(object):
         0                   [this, is, a, regular, sentence]
         1    [https://docs.python.org/3/tutorial/index.html]
         2                                               None
-        Name: 0, dtype: object
+        dtype: object
 
         The n parameter can be used to limit the number of splits on the
         delimiter. The outputs of split and rsplit are different.
@@ -1946,13 +1946,13 @@ class StringMethods(object):
         0                     [this, is, a regular sentence]
         1    [https://docs.python.org/3/tutorial/index.html]
         2                                               None
-        Name: 0, dtype: object
+        dtype: object
 
         >>> s.str.rsplit(n=2)
         0                     [this is a, regular, sentence]
         1    [https://docs.python.org/3/tutorial/index.html]
         2                                               None
-        Name: 0, dtype: object
+        dtype: object
 
         The pat parameter can be used to split by other characters.
 
@@ -1960,7 +1960,7 @@ class StringMethods(object):
         0                         [this is a regular sentence]
         1    [https:, , docs.python.org, 3, tutorial, index...
         2                                                 None
-        Name: 0, dtype: object
+        dtype: object
 
         When using ``expand=True``, the split elements will expand out into
         separate columns. If NaN is present, it is propagated throughout
@@ -2071,7 +2071,7 @@ class StringMethods(object):
         0                   [this, is, a, regular, sentence]
         1    [https://docs.python.org/3/tutorial/index.html]
         2                                               None
-        Name: 0, dtype: object
+        dtype: object
 
         Without the n parameter, the outputs of rsplit and split are identical.
 
@@ -2079,7 +2079,7 @@ class StringMethods(object):
         0                   [this, is, a, regular, sentence]
         1    [https://docs.python.org/3/tutorial/index.html]
         2                                               None
-        Name: 0, dtype: object
+        dtype: object
 
         The n parameter can be used to limit the number of splits on the
         delimiter. The outputs of split and rsplit are different.
@@ -2088,13 +2088,13 @@ class StringMethods(object):
         0                     [this, is, a regular sentence]
         1    [https://docs.python.org/3/tutorial/index.html]
         2                                               None
-        Name: 0, dtype: object
+        dtype: object
 
         >>> s.str.rsplit(n=2)
         0                     [this is a, regular, sentence]
         1    [https://docs.python.org/3/tutorial/index.html]
         2                                               None
-        Name: 0, dtype: object
+        dtype: object
 
         When using ``expand=True``, the split elements will expand out into
         separate columns. If NaN is present, it is propagated throughout
@@ -2172,7 +2172,7 @@ class StringMethods(object):
         0      dg
         1     cXt
         2    bYrd
-        Name: 0, dtype: object
+        dtype: object
         """
 
         def pandas_translate(s) -> "ks.Series[str]":
@@ -2223,7 +2223,7 @@ class StringMethods(object):
         >>> s.str.wrap(12)
         0             line to be\\nwrapped
         1    another line\\nto be\\nwrapped
-        Name: 0, dtype: object
+        dtype: object
         """
 
         def pandas_wrap(s) -> "ks.Series[str]":
@@ -2261,7 +2261,7 @@ class StringMethods(object):
         1       1
         2    1000
         3    None
-        Name: 0, dtype: object
+        dtype: object
 
         Note that NaN is not a string, therefore it is converted to NaN. The
         minus sign in '-1' is treated as a regular character and the zero is
@@ -2273,7 +2273,7 @@ class StringMethods(object):
         1     001
         2    1000
         3    None
-        Name: 0, dtype: object
+        dtype: object
         """
 
         def pandas_zfill(s) -> "ks.Series[str]":

--- a/databricks/koalas/testing/utils.py
+++ b/databricks/koalas/testing/utils.py
@@ -145,6 +145,7 @@ class ReusedSQLTestCase(unittest.TestCase, SQLTestUtils):
                 + "\n\nLeft:\n%s\n%s" % (left, left.dtype)
                 + "\n\nRight:\n%s\n%s" % (right, right.dtype)
             )
+            self.assertEqual(str(left.name), str(right.name), msg=msg)
             self.assertTrue((left == right).all(), msg=msg)
         elif isinstance(left, pd.Index) and isinstance(right, pd.Index):
             msg = (
@@ -183,6 +184,7 @@ class ReusedSQLTestCase(unittest.TestCase, SQLTestUtils):
                 + "\n\nLeft:\n%s\n%s" % (left, left.dtype)
                 + "\n\nRight:\n%s\n%s" % (right, right.dtype)
             )
+            self.assertEqual(str(left.name), str(right.name), msg=msg)
             self.assertEqual(len(left), len(right), msg=msg)
             for lnull, rnull in zip(left.isnull(), right.isnull()):
                 self.assertEqual(lnull, rnull, msg=msg)

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -897,26 +897,34 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             self.assert_eq(
                 kdf.groupby(["b"])["a"].cumcount(ascending=ascending).sort_index(),
                 pdf.groupby(["b"])["a"].cumcount(ascending=ascending).sort_index(),
-                almost=True,
             )
             self.assert_eq(
                 kdf.groupby(["b"])[["a", "c"]].cumcount(ascending=ascending).sort_index(),
                 pdf.groupby(["b"])[["a", "c"]].cumcount(ascending=ascending).sort_index(),
-                almost=True,
             )
             self.assert_eq(
                 kdf.groupby(kdf.b // 5).cumcount(ascending=ascending).sort_index(),
                 pdf.groupby(pdf.b // 5).cumcount(ascending=ascending).sort_index(),
-                almost=True,
             )
             self.assert_eq(
                 kdf.groupby(kdf.b // 5)["a"].cumcount(ascending=ascending).sort_index(),
                 pdf.groupby(pdf.b // 5)["a"].cumcount(ascending=ascending).sort_index(),
-                almost=True,
             )
             self.assert_eq(
                 kdf.groupby("b").cumcount(ascending=ascending).sum(),
                 pdf.groupby("b").cumcount(ascending=ascending).sum(),
+            )
+            self.assert_eq(
+                kdf.a.rename().groupby(kdf.b).cumcount(ascending=ascending).sort_index(),
+                pdf.a.rename().groupby(pdf.b).cumcount(ascending=ascending).sort_index(),
+            )
+            self.assert_eq(
+                kdf.a.groupby(kdf.b.rename()).cumcount(ascending=ascending).sort_index(),
+                pdf.a.groupby(pdf.b.rename()).cumcount(ascending=ascending).sort_index(),
+            )
+            self.assert_eq(
+                kdf.a.rename().groupby(kdf.b.rename()).cumcount(ascending=ascending).sort_index(),
+                pdf.a.rename().groupby(pdf.b.rename()).cumcount(ascending=ascending).sort_index(),
             )
 
         # multi-index columns
@@ -955,26 +963,34 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         self.assert_eq(
             kdf.groupby(["b"])["a"].cummin().sort_index(),
             pdf.groupby(["b"])["a"].cummin().sort_index(),
-            almost=True,
         )
         self.assert_eq(
             kdf.groupby(["b"])[["a", "c"]].cummin().sort_index(),
             pdf.groupby(["b"])[["a", "c"]].cummin().sort_index(),
-            almost=True,
         )
         self.assert_eq(
             kdf.groupby(kdf.b // 5).cummin().sort_index(),
             pdf.groupby(pdf.b // 5).cummin().sort_index(),
-            almost=True,
         )
         self.assert_eq(
             kdf.groupby(kdf.b // 5)["a"].cummin().sort_index(),
             pdf.groupby(pdf.b // 5)["a"].cummin().sort_index(),
-            almost=True,
         )
         self.assert_eq(
             kdf.groupby("b").cummin().sum().sort_index(),
             pdf.groupby("b").cummin().sum().sort_index(),
+        )
+        self.assert_eq(
+            kdf.a.rename().groupby(kdf.b).cummin().sort_index(),
+            pdf.a.rename().groupby(pdf.b).cummin().sort_index(),
+        )
+        self.assert_eq(
+            kdf.a.groupby(kdf.b.rename()).cummin().sort_index(),
+            pdf.a.groupby(pdf.b.rename()).cummin().sort_index(),
+        )
+        self.assert_eq(
+            kdf.a.rename().groupby(kdf.b.rename()).cummin().sort_index(),
+            pdf.a.rename().groupby(pdf.b.rename()).cummin().sort_index(),
         )
 
         # multi-index columns
@@ -1012,26 +1028,34 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         self.assert_eq(
             kdf.groupby(["b"])["a"].cummax().sort_index(),
             pdf.groupby(["b"])["a"].cummax().sort_index(),
-            almost=True,
         )
         self.assert_eq(
             kdf.groupby(["b"])[["a", "c"]].cummax().sort_index(),
             pdf.groupby(["b"])[["a", "c"]].cummax().sort_index(),
-            almost=True,
         )
         self.assert_eq(
             kdf.groupby(kdf.b // 5).cummax().sort_index(),
             pdf.groupby(pdf.b // 5).cummax().sort_index(),
-            almost=True,
         )
         self.assert_eq(
             kdf.groupby(kdf.b // 5)["a"].cummax().sort_index(),
             pdf.groupby(pdf.b // 5)["a"].cummax().sort_index(),
-            almost=True,
         )
         self.assert_eq(
             kdf.groupby("b").cummax().sum().sort_index(),
             pdf.groupby("b").cummax().sum().sort_index(),
+        )
+        self.assert_eq(
+            kdf.a.rename().groupby(kdf.b).cummax().sort_index(),
+            pdf.a.rename().groupby(pdf.b).cummax().sort_index(),
+        )
+        self.assert_eq(
+            kdf.a.groupby(kdf.b.rename()).cummax().sort_index(),
+            pdf.a.groupby(pdf.b.rename()).cummax().sort_index(),
+        )
+        self.assert_eq(
+            kdf.a.rename().groupby(kdf.b.rename()).cummax().sort_index(),
+            pdf.a.rename().groupby(pdf.b.rename()).cummax().sort_index(),
         )
 
         # multi-index columns
@@ -1069,26 +1093,34 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         self.assert_eq(
             kdf.groupby(["b"])["a"].cumsum().sort_index(),
             pdf.groupby(["b"])["a"].cumsum().sort_index(),
-            almost=True,
         )
         self.assert_eq(
             kdf.groupby(["b"])[["a", "c"]].cumsum().sort_index(),
             pdf.groupby(["b"])[["a", "c"]].cumsum().sort_index(),
-            almost=True,
         )
         self.assert_eq(
             kdf.groupby(kdf.b // 5).cumsum().sort_index(),
             pdf.groupby(pdf.b // 5).cumsum().sort_index(),
-            almost=True,
         )
         self.assert_eq(
             kdf.groupby(kdf.b // 5)["a"].cumsum().sort_index(),
             pdf.groupby(pdf.b // 5)["a"].cumsum().sort_index(),
-            almost=True,
         )
         self.assert_eq(
             kdf.groupby("b").cumsum().sum().sort_index(),
             pdf.groupby("b").cumsum().sum().sort_index(),
+        )
+        self.assert_eq(
+            kdf.a.rename().groupby(kdf.b).cumsum().sort_index(),
+            pdf.a.rename().groupby(pdf.b).cumsum().sort_index(),
+        )
+        self.assert_eq(
+            kdf.a.groupby(kdf.b.rename()).cumsum().sort_index(),
+            pdf.a.groupby(pdf.b.rename()).cumsum().sort_index(),
+        )
+        self.assert_eq(
+            kdf.a.rename().groupby(kdf.b.rename()).cumsum().sort_index(),
+            pdf.a.rename().groupby(pdf.b.rename()).cumsum().sort_index(),
         )
 
         # multi-index columns
@@ -1149,6 +1181,21 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         self.assert_eq(
             kdf.groupby("b").cumprod().sum().sort_index(),
             pdf.groupby("b").cumprod().sum().sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            kdf.a.rename().groupby(kdf.b).cumprod().sort_index(),
+            pdf.a.rename().groupby(pdf.b).cumprod().sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            kdf.a.groupby(kdf.b.rename()).cumprod().sort_index(),
+            pdf.a.groupby(pdf.b.rename()).cumprod().sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            kdf.a.rename().groupby(kdf.b.rename()).cumprod().sort_index(),
+            pdf.a.rename().groupby(pdf.b.rename()).cumprod().sort_index(),
             almost=True,
         )
 
@@ -1293,6 +1340,18 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             kdf.groupby(kdf.A // 5)[["C"]].fillna(method="ffill").sort_index(),
             pdf.groupby(pdf.A // 5)[["C"]].fillna(method="ffill").sort_index(),
             almost=True,
+        )
+        self.assert_eq(
+            kdf.C.rename().groupby(kdf.A).fillna(0).sort_index(),
+            pdf.C.rename().groupby(pdf.A).fillna(0).sort_index(),
+        )
+        self.assert_eq(
+            kdf.C.groupby(kdf.A.rename()).fillna(0).sort_index(),
+            pdf.C.groupby(pdf.A.rename()).fillna(0).sort_index(),
+        )
+        self.assert_eq(
+            kdf.C.rename().groupby(kdf.A.rename()).fillna(0).sort_index(),
+            pdf.C.rename().groupby(pdf.A.rename()).fillna(0).sort_index(),
         )
 
         # multi-index columns
@@ -1461,6 +1520,21 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
                 pdf.groupby(["b"])[["a", "c"]].shift(periods=-1, fill_value=0).sort_index(),
                 almost=True,
             )
+        self.assert_eq(
+            kdf.a.rename().groupby(kdf.b).shift().sort_index(),
+            pdf.a.rename().groupby(pdf.b).shift().sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            kdf.a.groupby(kdf.b.rename()).shift().sort_index(),
+            pdf.a.groupby(pdf.b.rename()).shift().sort_index(),
+            almost=True,
+        )
+        self.assert_eq(
+            kdf.a.rename().groupby(kdf.b.rename()).shift().sort_index(),
+            pdf.a.rename().groupby(pdf.b.rename()).shift().sort_index(),
+            almost=True,
+        )
 
         # multi-index columns
         columns = pd.MultiIndex.from_tuples([("x", "a"), ("x", "b"), ("y", "c")])
@@ -1525,6 +1599,18 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         self.assert_eq(
             kdf.groupby(kdf.b // 5)[["a"]].apply(len).sort_index(),
             pdf.groupby(pdf.b // 5)[["a"]].apply(len).sort_index(),
+        )
+        self.assert_eq(
+            kdf.a.rename().groupby(kdf.b).apply(lambda x: x + x.min()).sort_index(),
+            pdf.a.rename().groupby(pdf.b).apply(lambda x: x + x.min()).sort_index(),
+        )
+        self.assert_eq(
+            kdf.a.groupby(kdf.b.rename()).apply(lambda x: x + x.min()).sort_index(),
+            pdf.a.groupby(pdf.b.rename()).apply(lambda x: x + x.min()).sort_index(),
+        )
+        self.assert_eq(
+            kdf.a.rename().groupby(kdf.b.rename()).apply(lambda x: x + x.min()).sort_index(),
+            pdf.a.rename().groupby(pdf.b.rename()).apply(lambda x: x + x.min()).sort_index(),
         )
 
         with self.assertRaisesRegex(TypeError, "<class 'int'> object is not callable"):
@@ -1692,6 +1778,18 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             kdf.groupby(kdf.b // 5)[["a"]].transform(lambda x: x + x.min()).sort_index(),
             pdf.groupby(pdf.b // 5)[["a"]].transform(lambda x: x + x.min()).sort_index(),
         )
+        self.assert_eq(
+            kdf.a.rename().groupby(kdf.b).transform(lambda x: x + x.min()).sort_index(),
+            pdf.a.rename().groupby(pdf.b).transform(lambda x: x + x.min()).sort_index(),
+        )
+        self.assert_eq(
+            kdf.a.groupby(kdf.b.rename()).transform(lambda x: x + x.min()).sort_index(),
+            pdf.a.groupby(pdf.b.rename()).transform(lambda x: x + x.min()).sort_index(),
+        )
+        self.assert_eq(
+            kdf.a.rename().groupby(kdf.b.rename()).transform(lambda x: x + x.min()).sort_index(),
+            pdf.a.rename().groupby(pdf.b.rename()).transform(lambda x: x + x.min()).sort_index(),
+        )
 
         # multi-index columns
         columns = pd.MultiIndex.from_tuples([("x", "a"), ("x", "b"), ("y", "c")])
@@ -1746,6 +1844,18 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             kdf.groupby(kdf["b"] // 5)[["a"]].filter(lambda x: any(x.a == 2)).sort_index(),
             pdf.groupby(pdf["b"] // 5)[["a"]].filter(lambda x: any(x.a == 2)).sort_index(),
         )
+        self.assert_eq(
+            kdf.a.rename().groupby(kdf.b).filter(lambda x: any(x == 2)).sort_index(),
+            pdf.a.rename().groupby(pdf.b).filter(lambda x: any(x == 2)).sort_index(),
+        )
+        self.assert_eq(
+            kdf.a.groupby(kdf.b.rename()).filter(lambda x: any(x == 2)).sort_index(),
+            pdf.a.groupby(pdf.b.rename()).filter(lambda x: any(x == 2)).sort_index(),
+        )
+        self.assert_eq(
+            kdf.a.rename().groupby(kdf.b.rename()).filter(lambda x: any(x == 2)).sort_index(),
+            pdf.a.rename().groupby(pdf.b.rename()).filter(lambda x: any(x == 2)).sort_index(),
+        )
 
         with self.assertRaisesRegex(TypeError, "<class 'int'> object is not callable"):
             kdf.groupby("b").filter(1)
@@ -1781,6 +1891,22 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             pdf.groupby(["a"]).idxmax(skipna=False).sort_index(),
             kdf.groupby(["a"]).idxmax(skipna=False).sort_index(),
         )
+        self.assert_eq(
+            pdf.groupby(["a"])["b"].idxmax().sort_index(),
+            kdf.groupby(["a"])["b"].idxmax().sort_index(),
+        )
+        self.assert_eq(
+            pdf.b.rename().groupby(pdf.a).idxmax().sort_index(),
+            kdf.b.rename().groupby(kdf.a).idxmax().sort_index(),
+        )
+        self.assert_eq(
+            pdf.b.groupby(pdf.a.rename()).idxmax().sort_index(),
+            kdf.b.groupby(kdf.a.rename()).idxmax().sort_index(),
+        )
+        self.assert_eq(
+            pdf.b.rename().groupby(pdf.a.rename()).idxmax().sort_index(),
+            kdf.b.rename().groupby(kdf.a.rename()).idxmax().sort_index(),
+        )
 
         with self.assertRaisesRegex(ValueError, "idxmax only support one-level index now"):
             kdf.set_index(["a", "b"]).groupby(["c"]).idxmax()
@@ -1811,6 +1937,22 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         self.assert_eq(
             pdf.groupby(["a"]).idxmin(skipna=False).sort_index(),
             kdf.groupby(["a"]).idxmin(skipna=False).sort_index(),
+        )
+        self.assert_eq(
+            pdf.groupby(["a"])["b"].idxmin().sort_index(),
+            kdf.groupby(["a"])["b"].idxmin().sort_index(),
+        )
+        self.assert_eq(
+            pdf.b.rename().groupby(pdf.a).idxmin().sort_index(),
+            kdf.b.rename().groupby(kdf.a).idxmin().sort_index(),
+        )
+        self.assert_eq(
+            pdf.b.groupby(pdf.a.rename()).idxmin().sort_index(),
+            kdf.b.groupby(kdf.a.rename()).idxmin().sort_index(),
+        )
+        self.assert_eq(
+            pdf.b.rename().groupby(pdf.a.rename()).idxmin().sort_index(),
+            kdf.b.rename().groupby(kdf.a.rename()).idxmin().sort_index(),
         )
 
         with self.assertRaisesRegex(ValueError, "idxmin only support one-level index now"):
@@ -1884,6 +2026,19 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         self.assert_eq(
             pdf.groupby(pdf.a // 2)[["b"]].head(2).sort_index(),
             kdf.groupby(kdf.a // 2)[["b"]].head(2).sort_index(),
+        )
+
+        self.assert_eq(
+            pdf.b.rename().groupby(pdf.a).head(2).sort_index(),
+            kdf.b.rename().groupby(kdf.a).head(2).sort_index(),
+        )
+        self.assert_eq(
+            pdf.b.groupby(pdf.a.rename()).head(2).sort_index(),
+            kdf.b.groupby(kdf.a.rename()).head(2).sort_index(),
+        )
+        self.assert_eq(
+            pdf.b.rename().groupby(pdf.a.rename()).head(2).sort_index(),
+            kdf.b.rename().groupby(kdf.a.rename()).head(2).sort_index(),
         )
 
         # multi-index

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -1240,16 +1240,16 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             (pdf.b * 10).groupby(pdf.a).nsmallest(2).sort_index(),
         )
         self.assert_eq(
-            kdf.b.rename("x").groupby(kdf.a).nsmallest(2).sort_index(),
-            pdf.b.rename("x").groupby(pdf.a).nsmallest(2).sort_index(),
+            kdf.b.rename().groupby(kdf.a).nsmallest(2).sort_index(),
+            pdf.b.rename().groupby(pdf.a).nsmallest(2).sort_index(),
         )
         self.assert_eq(
-            kdf.b.groupby(kdf.a.rename("x")).nsmallest(2).sort_index(),
-            pdf.b.groupby(pdf.a.rename("x")).nsmallest(2).sort_index(),
+            kdf.b.groupby(kdf.a.rename()).nsmallest(2).sort_index(),
+            pdf.b.groupby(pdf.a.rename()).nsmallest(2).sort_index(),
         )
         self.assert_eq(
-            kdf.b.rename("x").groupby(kdf.a.rename("x")).nsmallest(2).sort_index(),
-            pdf.b.rename("x").groupby(pdf.a.rename("x")).nsmallest(2).sort_index(),
+            kdf.b.rename().groupby(kdf.a.rename()).nsmallest(2).sort_index(),
+            pdf.b.rename().groupby(pdf.a.rename()).nsmallest(2).sort_index(),
         )
         with self.assertRaisesRegex(ValueError, "nsmallest do not support multi-index now"):
             kdf.set_index(["a", "b"]).groupby(["c"])["d"].nsmallest(1)
@@ -1279,16 +1279,16 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             (pdf.b * 10).groupby(pdf.a).nlargest(2).sort_index(),
         )
         self.assert_eq(
-            kdf.b.rename("x").groupby(kdf.a).nlargest(2).sort_index(),
-            pdf.b.rename("x").groupby(pdf.a).nlargest(2).sort_index(),
+            kdf.b.rename().groupby(kdf.a).nlargest(2).sort_index(),
+            pdf.b.rename().groupby(pdf.a).nlargest(2).sort_index(),
         )
         self.assert_eq(
-            kdf.b.groupby(kdf.a.rename("x")).nlargest(2).sort_index(),
-            pdf.b.groupby(pdf.a.rename("x")).nlargest(2).sort_index(),
+            kdf.b.groupby(kdf.a.rename()).nlargest(2).sort_index(),
+            pdf.b.groupby(pdf.a.rename()).nlargest(2).sort_index(),
         )
         self.assert_eq(
-            kdf.b.rename("x").groupby(kdf.a.rename("x")).nlargest(2).sort_index(),
-            pdf.b.rename("x").groupby(pdf.a.rename("x")).nlargest(2).sort_index(),
+            kdf.b.rename().groupby(kdf.a.rename()).nlargest(2).sort_index(),
+            pdf.b.rename().groupby(pdf.a.rename()).nlargest(2).sort_index(),
         )
         with self.assertRaisesRegex(ValueError, "nlargest do not support multi-index now"):
             kdf.set_index(["a", "b"]).groupby(["c"])["d"].nlargest(1)

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -273,6 +273,7 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
                 (kdf.b, pdf.b),
                 (kdf.b + 1, pdf.b + 1),
                 (kdf.copy().b, pdf.copy().b),
+                (kdf.b.rename(), pdf.b.rename()),
             ]:
                 with self.subTest(func=func, key=pkey):
                     self.assert_eq(
@@ -288,6 +289,11 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
                     self.assert_eq(
                         getattr((kdf.b + 1).groupby(kkey), func)().sort_index(),
                         getattr((pdf.b + 1).groupby(pkey), func)().sort_index(),
+                        almost=almost,
+                    )
+                    self.assert_eq(
+                        getattr(kdf.a.rename().groupby(kkey), func)().sort_index(),
+                        getattr(pdf.a.rename().groupby(pkey), func)().sort_index(),
                         almost=almost,
                     )
 
@@ -720,16 +726,28 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         pdf = pd.DataFrame({"A": [1, 2, 2, 3, 3, 3], "B": [1, 1, 2, 3, 3, 3]}, columns=["A", "B"])
         kdf = ks.from_pandas(pdf)
         self.assert_eq(
-            repr(kdf.groupby("A")["B"].value_counts().sort_index()),
-            repr(pdf.groupby("A")["B"].value_counts().sort_index()),
+            kdf.groupby("A")["B"].value_counts().sort_index(),
+            pdf.groupby("A")["B"].value_counts().sort_index(),
         )
         self.assert_eq(
-            repr(kdf.groupby("A")["B"].value_counts(sort=True, ascending=False).sort_index()),
-            repr(pdf.groupby("A")["B"].value_counts(sort=True, ascending=False).sort_index()),
+            kdf.groupby("A")["B"].value_counts(sort=True, ascending=False).sort_index(),
+            pdf.groupby("A")["B"].value_counts(sort=True, ascending=False).sort_index(),
         )
         self.assert_eq(
-            repr(kdf.groupby("A")["B"].value_counts(sort=True, ascending=True).sort_index()),
-            repr(pdf.groupby("A")["B"].value_counts(sort=True, ascending=True).sort_index()),
+            kdf.groupby("A")["B"].value_counts(sort=True, ascending=True).sort_index(),
+            pdf.groupby("A")["B"].value_counts(sort=True, ascending=True).sort_index(),
+        )
+        self.assert_eq(
+            kdf.B.rename().groupby(kdf.A).value_counts().sort_index(),
+            pdf.B.rename().groupby(pdf.A).value_counts().sort_index(),
+        )
+        self.assert_eq(
+            kdf.B.groupby(kdf.A.rename()).value_counts().sort_index(),
+            pdf.B.groupby(pdf.A.rename()).value_counts().sort_index(),
+        )
+        self.assert_eq(
+            kdf.B.rename().groupby(kdf.A.rename()).value_counts().sort_index(),
+            pdf.B.rename().groupby(pdf.A.rename()).value_counts().sort_index(),
         )
 
     def test_size(self):

--- a/databricks/koalas/tests/test_numpy_compat.py
+++ b/databricks/koalas/tests/test_numpy_compat.py
@@ -59,7 +59,9 @@ class NumPyCompatTest(ReusedSQLTestCase, SQLTestUtils):
     def test_np_add_series(self):
         kdf = self.kdf
         pdf = self.pdf
-        self.assert_eq(np.add(kdf.a, kdf.b), np.add(pdf.a, pdf.b))
+        self.assert_eq(
+            np.add(kdf.a, kdf.b), np.add(pdf.a, pdf.b).rename("a")  # TODO: Fix the Series name
+        )
 
         kdf = self.kdf
         pdf = self.pdf
@@ -105,7 +107,11 @@ class NumPyCompatTest(ReusedSQLTestCase, SQLTestUtils):
             if np_name not in self.blacklist:
                 try:
                     # binary ufunc
-                    self.assert_eq(np_func(pdf.a, pdf.b), np_func(kdf.a, kdf.b), almost=True)
+                    self.assert_eq(
+                        np_func(pdf.a, pdf.b).rename("a"),  # TODO: Fix the Series name
+                        np_func(kdf.a, kdf.b),
+                        almost=True,
+                    )
                     self.assert_eq(np_func(pdf.a, 1), np_func(kdf.a, 1), almost=True)
                 except Exception as e:
                     raise AssertionError("Test in '%s' function was failed." % np_name) from e
@@ -119,7 +125,9 @@ class NumPyCompatTest(ReusedSQLTestCase, SQLTestUtils):
                     try:
                         # binary ufunc
                         self.assert_eq(
-                            np_func(pdf.a, pdf2.b).sort_index(),
+                            np_func(pdf.a, pdf2.b)
+                            .rename("a")
+                            .sort_index(),  # TODO: Fix the Series name
                             np_func(kdf.a, kdf2.b).sort_index(),
                             almost=True,
                         )

--- a/databricks/koalas/tests/test_ops_on_diff_frames_groupby.py
+++ b/databricks/koalas/tests/test_ops_on_diff_frames_groupby.py
@@ -139,6 +139,19 @@ class OpsOnDiffFramesGroupByTest(ReusedSQLTestCase, SQLTestUtils):
             (pdf1.B + 1).groupby(pdf2.A).sum().sort_index(),
         )
 
+        self.assert_eq(
+            kdf1.B.groupby(kdf2.A.rename()).sum().sort_index(),
+            pdf1.B.groupby(pdf2.A.rename()).sum().sort_index(),
+        )
+        self.assert_eq(
+            kdf1.B.rename().groupby(kdf2.A).sum().sort_index(),
+            pdf1.B.rename().groupby(pdf2.A).sum().sort_index(),
+        )
+        self.assert_eq(
+            kdf1.B.rename().groupby(kdf2.A.rename()).sum().sort_index(),
+            pdf1.B.rename().groupby(pdf2.A.rename()).sum().sort_index(),
+        )
+
     def test_aggregate(self):
         pdf1 = pd.DataFrame({"C": [0.362, 0.227, 1.267, -0.562], "B": [1, 2, 3, 4]})
         pdf2 = pd.DataFrame({"A": [1, 1, 2, 2]})

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -965,7 +965,7 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(plot_to_base64(ax1), plot_to_base64(ax2))
 
     def test_cummin(self):
-        pser = pd.Series([1.0, None, 0.0, 4.0, 9.0]).rename("a")
+        pser = pd.Series([1.0, None, 0.0, 4.0, 9.0])
         kser = ks.from_pandas(pser)
         self.assert_eq(pser.cummin(), kser.cummin(), almost=True)
         self.assert_eq(pser.cummin(skipna=False), kser.cummin(skipna=False), almost=True)
@@ -978,7 +978,7 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(pser.cummin(skipna=False), kser.cummin(skipna=False), almost=True)
 
     def test_cummax(self):
-        pser = pd.Series([1.0, None, 0.0, 4.0, 9.0]).rename("a")
+        pser = pd.Series([1.0, None, 0.0, 4.0, 9.0])
         kser = ks.from_pandas(pser)
         self.assert_eq(pser.cummax(), kser.cummax(), almost=True)
         self.assert_eq(pser.cummax(skipna=False), kser.cummax(skipna=False), almost=True)
@@ -991,7 +991,7 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(pser.cummax(skipna=False), kser.cummax(skipna=False), almost=True)
 
     def test_cumsum(self):
-        pser = pd.Series([1.0, None, 0.0, 4.0, 9.0]).rename("a")
+        pser = pd.Series([1.0, None, 0.0, 4.0, 9.0])
         kser = ks.from_pandas(pser)
         self.assert_eq(pser.cumsum(), kser.cumsum(), almost=True)
         self.assert_eq(pser.cumsum(skipna=False), kser.cumsum(skipna=False), almost=True)
@@ -1004,7 +1004,7 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(pser.cumsum(skipna=False), kser.cumsum(skipna=False), almost=True)
 
     def test_cumprod(self):
-        pser = pd.Series([1.0, None, 1.0, 4.0, 9.0]).rename("a")
+        pser = pd.Series([1.0, None, 1.0, 4.0, 9.0])
         kser = ks.from_pandas(pser)
         self.assert_eq(pser.cumprod(), kser.cumprod(), almost=True)
         self.assert_eq(pser.cumprod(skipna=False), kser.cumprod(skipna=False), almost=True)

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -176,7 +176,10 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         )
         kdf = ks.from_pandas(pdf)
 
-        self.assert_eq(pdf["left"] | pdf["right"], kdf["left"] | kdf["right"])
+        self.assert_eq(
+            (pdf["left"] | pdf["right"]).rename("left"),  # TODO: Fix the Series name
+            kdf["left"] | kdf["right"],
+        )
 
     def test_and(self):
         pdf = pd.DataFrame(
@@ -187,7 +190,10 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         )
         kdf = ks.from_pandas(pdf)
 
-        self.assert_eq(pdf["left"] & pdf["right"], kdf["left"] & kdf["right"])
+        self.assert_eq(
+            (pdf["left"] & pdf["right"]).rename("left"),  # TODO: Fix the Series name
+            kdf["left"] & kdf["right"],
+        )
 
     def test_to_numpy(self):
         pser = pd.Series([1, 2, 3, 4, 5, 6, 7], name="x")

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -897,20 +897,18 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         pser = pd.Series(["cat", "dog", None, "rabbit"])
         kser = ks.from_pandas(pser)
         # Currently Koalas doesn't return NaN as pandas does.
-        self.assertEqual(
-            repr(kser.map({})), repr(pser.map({}).replace({pd.np.nan: None}).rename(0))
-        )
+        self.assertEqual(repr(kser.map({})), repr(pser.map({}).replace({pd.np.nan: None})))
 
         d = defaultdict(lambda: "abc")
         self.assertTrue("abc" in repr(kser.map(d)))
-        self.assertEqual(repr(kser.map(d)), repr(pser.map(d).rename(0)))
+        self.assertEqual(repr(kser.map(d)), repr(pser.map(d)))
 
         def tomorrow(date) -> datetime:
             return date + timedelta(days=1)
 
         pser = pd.Series([datetime(2019, 10, 24)])
         kser = ks.from_pandas(pser)
-        self.assertEqual(repr(kser.map(tomorrow)), repr(pser.map(tomorrow).rename(0)))
+        self.assertEqual(repr(kser.map(tomorrow)), repr(pser.map(tomorrow)))
 
     def test_add_prefix(self):
         pser = pd.Series([1, 2, 3, 4], name="0")

--- a/databricks/koalas/tests/test_series_datetime.py
+++ b/databricks/koalas/tests/test_series_datetime.py
@@ -52,7 +52,9 @@ class SeriesDateTimeTest(ReusedSQLTestCase, SQLTestUtils):
         # timezone behaviours inherited from C library.
 
         actual = (kdf["end_date"] - kdf["start_date"] - 1).to_pandas()
-        expected = (pdf["end_date"] - pdf["start_date"]) // np.timedelta64(1, "s") - 1
+        expected = ((pdf["end_date"] - pdf["start_date"]) // np.timedelta64(1, "s") - 1).rename(
+            "end_date"
+        )
         # self.assert_eq(actual, expected)
 
         actual = (kdf["end_date"] - pd.Timestamp("2012-1-1 12:45:31") - 1).to_pandas()
@@ -82,9 +84,10 @@ class SeriesDateTimeTest(ReusedSQLTestCase, SQLTestUtils):
         pdf = self.pdf1
         kdf = ks.from_pandas(pdf)
 
+        # TODO: Fix the Series name
         self.assert_eq(
             kdf["end_date"].dt.date - kdf["start_date"].dt.date,
-            (pdf["end_date"].dt.date - pdf["start_date"].dt.date).dt.days,
+            (pdf["end_date"].dt.date - pdf["start_date"].dt.date).dt.days.rename("end_date"),
         )
 
         self.assert_eq(

--- a/databricks/koalas/tests/test_series_plot.py
+++ b/databricks/koalas/tests/test_series_plot.py
@@ -251,7 +251,7 @@ class SeriesPlotTest(ReusedSQLTestCase, TestUtils):
         expected_histogram = np.array([5, 4, 1, 0, 0, 0, 0, 0, 0, 1])
         histogram = KoalasHistPlot._compute_hist(kdf[["a"]].to_spark(), bins)
         self.assert_eq(pd.Series(expected_bins), pd.Series(bins))
-        self.assert_eq(pd.Series(expected_histogram), histogram)
+        self.assert_eq(pd.Series(expected_histogram, name="__a_bucket"), histogram)
 
     def test_area_plot(self):
         pdf = pd.DataFrame(

--- a/databricks/koalas/tests/test_series_string.py
+++ b/databricks/koalas/tests/test_series_string.py
@@ -70,8 +70,10 @@ class SeriesStringTest(ReusedSQLTestCase, SQLTestUtils):
     def test_string_add_str_str(self):
         pdf = pd.DataFrame(dict(col1=["a", "b", "c"], col2=["1", "2", "3"]))
         kdf = ks.from_pandas(pdf)
-        self.assert_eq(kdf["col1"] + kdf["col2"], pdf["col1"] + pdf["col2"])
-        self.assert_eq(kdf["col2"] + kdf["col1"], pdf["col2"] + pdf["col1"])
+
+        # TODO: Fix the Series names
+        self.assert_eq(kdf["col1"] + kdf["col2"], (pdf["col1"] + pdf["col2"]).rename("col1"))
+        self.assert_eq(kdf["col2"] + kdf["col1"], (pdf["col2"] + pdf["col1"]).rename("col2"))
 
     def test_string_add_str_lit(self):
         pdf = pd.DataFrame(dict(col1=["a", "b", "c"]))

--- a/databricks/koalas/utils.py
+++ b/databricks/koalas/utils.py
@@ -520,7 +520,9 @@ def name_like_string(name: Optional[Union[str, Tuple]]) -> str:
     >>> name_like_string(name)
     '(a, b, c)'
     """
-    if name is not None and is_list_like(name):
+    if name is None:
+        name = ("__none__",)
+    elif is_list_like(name):
         name = tuple([str(n) for n in name])
     else:
         name = (str(name),)

--- a/databricks/koalas/utils.py
+++ b/databricks/koalas/utils.py
@@ -20,7 +20,7 @@ Commonly used utils in Koalas.
 import functools
 from collections import OrderedDict
 from distutils.version import LooseVersion
-from typing import Callable, Dict, List, Tuple, Union, TYPE_CHECKING
+from typing import Callable, Dict, List, Optional, Tuple, Union, TYPE_CHECKING
 
 import pyarrow
 import pyspark
@@ -93,13 +93,13 @@ def combine_frames(this, *args, how="full", preserve_order_column=False):
         assert all(
             same_anchor(arg, args[0]) for arg in args
         ), "Currently only one different DataFrame (from given Series) is supported"
-        if same_anchor(this, args[0]):
-            return  # We don't need to combine. All series is in this.
+        assert not same_anchor(this, args[0]), "We don't need to combine. All series is in this."
         that = args[0]._kdf[list(args)]
     elif len(args) == 1 and isinstance(args[0], DataFrame):
         assert isinstance(args[0], DataFrame)
-        if same_anchor(this, args[0]):
-            return  # We don't need to combine. `this` and `that` are same.
+        assert not same_anchor(
+            this, args[0]
+        ), "We don't need to combine. `this` and `that` are same."
         that = args[0]
     else:
         raise AssertionError("args should be single DataFrame or " "single/multiple Series")
@@ -173,13 +173,16 @@ def combine_frames(this, *args, how="full", preserve_order_column=False):
             if col not in index_columns and col != NATURAL_ORDER_COLUMN_NAME
         ]
         level = max(this._internal.column_labels_level, that._internal.column_labels_level)
+
+        def fill_label(label):
+            if label is None:
+                return ([""] * (level - 1)) + [None]
+            else:
+                return ([""] * (level - len(label))) + list(label)
+
         column_labels = [
-            tuple(["this"] + ([""] * (level - len(label))) + list(label))
-            for label in this._internal.column_labels
-        ] + [
-            tuple(["that"] + ([""] * (level - len(label))) + list(label))
-            for label in that._internal.column_labels
-        ]
+            tuple(["this"] + fill_label(label)) for label in this._internal.column_labels
+        ] + [tuple(["that"] + fill_label(label)) for label in that._internal.column_labels]
         column_label_names = (
             (
                 ([None] * (1 + level - len(this._internal.column_labels_level)))
@@ -499,7 +502,7 @@ def column_labels_level(column_labels: List[Tuple[str, ...]]) -> int:
         return list(levels)[0]
 
 
-def name_like_string(name: Union[str, Tuple]) -> str:
+def name_like_string(name: Optional[Union[str, Tuple]]) -> str:
     """
     Return the name-like strings from str or tuple of str
 
@@ -517,7 +520,7 @@ def name_like_string(name: Union[str, Tuple]) -> str:
     >>> name_like_string(name)
     '(a, b, c)'
     """
-    if is_list_like(name):
+    if name is not None and is_list_like(name):
         name = tuple([str(n) for n in name])
     else:
         name = (str(name),)

--- a/databricks/koalas/window.py
+++ b/databricks/koalas/window.py
@@ -177,14 +177,14 @@ class Rolling(RollingAndExpanding):
         1    1.0
         2    0.0
         3    1.0
-        Name: 0, dtype: float64
+        dtype: float64
 
         >>> s.rolling(3).count()
         0    1.0
         1    2.0
         2    2.0
         3    2.0
-        Name: 0, dtype: float64
+        dtype: float64
 
         >>> s.to_frame().rolling(1).count()
              0
@@ -233,7 +233,7 @@ class Rolling(RollingAndExpanding):
         2    5
         3    2
         4    6
-        Name: 0, dtype: int64
+        dtype: int64
 
         >>> s.rolling(2).sum()
         0    NaN
@@ -241,7 +241,7 @@ class Rolling(RollingAndExpanding):
         2    8.0
         3    7.0
         4    8.0
-        Name: 0, dtype: float64
+        dtype: float64
 
         >>> s.rolling(3).sum()
         0     NaN
@@ -249,7 +249,7 @@ class Rolling(RollingAndExpanding):
         2    12.0
         3    10.0
         4    13.0
-        Name: 0, dtype: float64
+        dtype: float64
 
         For DataFrame, each rolling summation is computed column-wise.
 
@@ -311,7 +311,7 @@ class Rolling(RollingAndExpanding):
         2    5
         3    2
         4    6
-        Name: 0, dtype: int64
+        dtype: int64
 
         >>> s.rolling(2).min()
         0    NaN
@@ -319,7 +319,7 @@ class Rolling(RollingAndExpanding):
         2    3.0
         3    2.0
         4    2.0
-        Name: 0, dtype: float64
+        dtype: float64
 
         >>> s.rolling(3).min()
         0    NaN
@@ -327,7 +327,7 @@ class Rolling(RollingAndExpanding):
         2    3.0
         3    2.0
         4    2.0
-        Name: 0, dtype: float64
+        dtype: float64
 
         For DataFrame, each rolling minimum is computed column-wise.
 
@@ -388,7 +388,7 @@ class Rolling(RollingAndExpanding):
         2    5
         3    2
         4    6
-        Name: 0, dtype: int64
+        dtype: int64
 
         >>> s.rolling(2).max()
         0    NaN
@@ -396,7 +396,7 @@ class Rolling(RollingAndExpanding):
         2    5.0
         3    5.0
         4    6.0
-        Name: 0, dtype: float64
+        dtype: float64
 
         >>> s.rolling(3).max()
         0    NaN
@@ -404,7 +404,7 @@ class Rolling(RollingAndExpanding):
         2    5.0
         3    5.0
         4    6.0
-        Name: 0, dtype: float64
+        dtype: float64
 
         For DataFrame, each rolling maximum is computed column-wise.
 
@@ -466,7 +466,7 @@ class Rolling(RollingAndExpanding):
         2    5
         3    2
         4    6
-        Name: 0, dtype: int64
+        dtype: int64
 
         >>> s.rolling(2).mean()
         0    NaN
@@ -474,7 +474,7 @@ class Rolling(RollingAndExpanding):
         2    4.0
         3    3.5
         4    4.0
-        Name: 0, dtype: float64
+        dtype: float64
 
         >>> s.rolling(3).mean()
         0         NaN
@@ -482,7 +482,7 @@ class Rolling(RollingAndExpanding):
         2    4.000000
         3    3.333333
         4    4.333333
-        Name: 0, dtype: float64
+        dtype: float64
 
         For DataFrame, each rolling mean is computed column-wise.
 
@@ -546,7 +546,7 @@ class Rolling(RollingAndExpanding):
         4    1.000000
         5    1.154701
         6    0.000000
-        Name: 0, dtype: float64
+        dtype: float64
 
         For DataFrame, each rolling standard deviation is computed column-wise.
 
@@ -596,7 +596,7 @@ class Rolling(RollingAndExpanding):
         4    1.000000
         5    1.333333
         6    0.000000
-        Name: 0, dtype: float64
+        dtype: float64
 
         For DataFrame, each unbiased rolling variance is computed column-wise.
 
@@ -732,8 +732,7 @@ class RollingGroupby(Rolling):
         Examples
         --------
         >>> s = ks.Series([2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5])
-        >>> s.groupby(s).rolling(3).count().sort_index()  # doctest: +NORMALIZE_WHITESPACE
-        0
+        >>> s.groupby(s).rolling(3).count().sort_index()
         2  0     1.0
            1     2.0
         3  2     1.0
@@ -745,7 +744,7 @@ class RollingGroupby(Rolling):
            8     3.0
         5  9     1.0
            10    2.0
-        Name: 0, dtype: float64
+        dtype: float64
 
         For DataFrame, each rolling count is computed column-wise.
 
@@ -787,8 +786,7 @@ class RollingGroupby(Rolling):
         Examples
         --------
         >>> s = ks.Series([2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5])
-        >>> s.groupby(s).rolling(3).sum().sort_index()  # doctest: +NORMALIZE_WHITESPACE
-        0
+        >>> s.groupby(s).rolling(3).sum().sort_index()
         2  0      NaN
            1      NaN
         3  2      NaN
@@ -800,7 +798,7 @@ class RollingGroupby(Rolling):
            8     12.0
         5  9      NaN
            10     NaN
-        Name: 0, dtype: float64
+        dtype: float64
 
         For DataFrame, each rolling summation is computed column-wise.
 
@@ -842,8 +840,7 @@ class RollingGroupby(Rolling):
         Examples
         --------
         >>> s = ks.Series([2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5])
-        >>> s.groupby(s).rolling(3).min().sort_index()  # doctest: +NORMALIZE_WHITESPACE
-        0
+        >>> s.groupby(s).rolling(3).min().sort_index()
         2  0     NaN
            1     NaN
         3  2     NaN
@@ -855,7 +852,7 @@ class RollingGroupby(Rolling):
            8     4.0
         5  9     NaN
            10    NaN
-        Name: 0, dtype: float64
+        dtype: float64
 
         For DataFrame, each rolling minimum is computed column-wise.
 
@@ -897,8 +894,7 @@ class RollingGroupby(Rolling):
         Examples
         --------
         >>> s = ks.Series([2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5])
-        >>> s.groupby(s).rolling(3).max().sort_index()  # doctest: +NORMALIZE_WHITESPACE
-        0
+        >>> s.groupby(s).rolling(3).max().sort_index()
         2  0     NaN
            1     NaN
         3  2     NaN
@@ -910,7 +906,7 @@ class RollingGroupby(Rolling):
            8     4.0
         5  9     NaN
            10    NaN
-        Name: 0, dtype: float64
+        dtype: float64
 
         For DataFrame, each rolling maximum is computed column-wise.
 
@@ -952,8 +948,7 @@ class RollingGroupby(Rolling):
         Examples
         --------
         >>> s = ks.Series([2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5])
-        >>> s.groupby(s).rolling(3).mean().sort_index()  # doctest: +NORMALIZE_WHITESPACE
-        0
+        >>> s.groupby(s).rolling(3).mean().sort_index()
         2  0     NaN
            1     NaN
         3  2     NaN
@@ -965,7 +960,7 @@ class RollingGroupby(Rolling):
            8     4.0
         5  9     NaN
            10    NaN
-        Name: 0, dtype: float64
+        dtype: float64
 
         For DataFrame, each rolling mean is computed column-wise.
 
@@ -1089,7 +1084,7 @@ class Expanding(RollingAndExpanding):
         1    2.0
         2    2.0
         3    3.0
-        Name: 0, dtype: float64
+        dtype: float64
 
         >>> s.to_frame().expanding().count()
              0
@@ -1138,7 +1133,7 @@ class Expanding(RollingAndExpanding):
         2    3
         3    4
         4    5
-        Name: 0, dtype: int64
+        dtype: int64
 
         >>> s.expanding(3).sum()
         0     NaN
@@ -1146,7 +1141,7 @@ class Expanding(RollingAndExpanding):
         2     6.0
         3    10.0
         4    15.0
-        Name: 0, dtype: float64
+        dtype: float64
 
         For DataFrame, each expanding summation is computed column-wise.
 
@@ -1202,7 +1197,7 @@ class Expanding(RollingAndExpanding):
         2    3.0
         3    2.0
         4    2.0
-        Name: 0, dtype: float64
+        dtype: float64
         """
         return super(Expanding, self).min()
 
@@ -1238,7 +1233,7 @@ class Expanding(RollingAndExpanding):
         2    5.0
         3    5.0
         4    6.0
-        Name: 0, dtype: float64
+        dtype: float64
         """
         return super(Expanding, self).max()
 
@@ -1275,14 +1270,14 @@ class Expanding(RollingAndExpanding):
         1    1.5
         2    2.0
         3    2.5
-        Name: 0, dtype: float64
+        dtype: float64
 
         >>> s.expanding(3).mean()
         0    NaN
         1    NaN
         2    2.0
         3    2.5
-        Name: 0, dtype: float64
+        dtype: float64
         """
         return super(Expanding, self).mean()
 
@@ -1319,7 +1314,7 @@ class Expanding(RollingAndExpanding):
         4    0.894427
         5    0.836660
         6    0.786796
-        Name: 0, dtype: float64
+        dtype: float64
 
         For DataFrame, each expanding standard deviation variance is computed column-wise.
 
@@ -1369,7 +1364,7 @@ class Expanding(RollingAndExpanding):
         4    0.800000
         5    0.700000
         6    0.619048
-        Name: 0, dtype: float64
+        dtype: float64
 
         For DataFrame, each unbiased expanding variance is computed column-wise.
 
@@ -1441,8 +1436,7 @@ class ExpandingGroupby(Expanding):
         Examples
         --------
         >>> s = ks.Series([2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5])
-        >>> s.groupby(s).expanding(3).count().sort_index()  # doctest: +NORMALIZE_WHITESPACE
-        0
+        >>> s.groupby(s).expanding(3).count().sort_index()
         2  0     NaN
            1     NaN
         3  2     NaN
@@ -1454,7 +1448,7 @@ class ExpandingGroupby(Expanding):
            8     4.0
         5  9     NaN
            10    NaN
-        Name: 0, dtype: float64
+        dtype: float64
 
         For DataFrame, each expanding count is computed column-wise.
 
@@ -1496,8 +1490,7 @@ class ExpandingGroupby(Expanding):
         Examples
         --------
         >>> s = ks.Series([2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5])
-        >>> s.groupby(s).expanding(3).sum().sort_index()  # doctest: +NORMALIZE_WHITESPACE
-        0
+        >>> s.groupby(s).expanding(3).sum().sort_index()
         2  0      NaN
            1      NaN
         3  2      NaN
@@ -1509,7 +1502,7 @@ class ExpandingGroupby(Expanding):
            8     16.0
         5  9      NaN
            10     NaN
-        Name: 0, dtype: float64
+        dtype: float64
 
         For DataFrame, each expanding summation is computed column-wise.
 
@@ -1551,8 +1544,7 @@ class ExpandingGroupby(Expanding):
         Examples
         --------
         >>> s = ks.Series([2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5])
-        >>> s.groupby(s).expanding(3).min().sort_index()  # doctest: +NORMALIZE_WHITESPACE
-        0
+        >>> s.groupby(s).expanding(3).min().sort_index()
         2  0     NaN
            1     NaN
         3  2     NaN
@@ -1564,7 +1556,7 @@ class ExpandingGroupby(Expanding):
            8     4.0
         5  9     NaN
            10    NaN
-        Name: 0, dtype: float64
+        dtype: float64
 
         For DataFrame, each expanding minimum is computed column-wise.
 
@@ -1605,8 +1597,7 @@ class ExpandingGroupby(Expanding):
         Examples
         --------
         >>> s = ks.Series([2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5])
-        >>> s.groupby(s).expanding(3).max().sort_index()  # doctest: +NORMALIZE_WHITESPACE
-        0
+        >>> s.groupby(s).expanding(3).max().sort_index()
         2  0     NaN
            1     NaN
         3  2     NaN
@@ -1618,7 +1609,7 @@ class ExpandingGroupby(Expanding):
            8     4.0
         5  9     NaN
            10    NaN
-        Name: 0, dtype: float64
+        dtype: float64
 
         For DataFrame, each expanding maximum is computed column-wise.
 
@@ -1660,8 +1651,7 @@ class ExpandingGroupby(Expanding):
         Examples
         --------
         >>> s = ks.Series([2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5])
-        >>> s.groupby(s).expanding(3).mean().sort_index()  # doctest: +NORMALIZE_WHITESPACE
-        0
+        >>> s.groupby(s).expanding(3).mean().sort_index()
         2  0     NaN
            1     NaN
         3  2     NaN
@@ -1673,7 +1663,7 @@ class ExpandingGroupby(Expanding):
            8     4.0
         5  9     NaN
            10    NaN
-        Name: 0, dtype: float64
+        dtype: float64
 
         For DataFrame, each expanding mean is computed column-wise.
 

--- a/docs/source/getting_started/10min.ipynb
+++ b/docs/source/getting_started/10min.ipynb
@@ -61,7 +61,7 @@
        "3    NaN\n",
        "4    6.0\n",
        "5    8.0\n",
-       "Name: 0, dtype: float64"
+       "dtype: float64"
       ]
      },
      "execution_count": 3,

--- a/docs/source/user_guide/best_practices.rst
+++ b/docs/source/user_guide/best_practices.rst
@@ -272,4 +272,4 @@ The example above can be also changed to directly using Koalas APIs as below:
    London      400.0
    New York    441.0
    Helsinki    144.0
-   Name: 0, dtype: float64
+   dtype: float64


### PR DESCRIPTION
Adding support non-named Series.
Currently Koalas Series must have its name, but this PR allows it.

```py
>>> ks.Series([1, 2, 3])
0    1
1    2
2    3
dtype: int64

>>> ks.Series([1, 2, 3], name='x')
0    1
1    2
2    3
Name: x, dtype: int64
```