### PR TITLE
Fix SeriesGroupBy.nsmallest/nlargest.

### DIFF
--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -2540,26 +2540,45 @@ class SeriesGroupBy(GroupBy):
         3  6    3
         Name: b, dtype: int64
         """
-        if len(self._kdf._internal.index_names) > 1:
+        if len(self._kser._internal.index_names) > 1:
             raise ValueError("nsmallest do not support multi-index now")
 
-        sdf = self._kdf._internal.spark_frame
-        name = self._agg_columns[0]._internal.data_spark_column_names[0]
-        window = Window.partitionBy(self._groupkeys_scols).orderBy(
-            self._agg_columns[0].spark.column, NATURAL_ORDER_COLUMN_NAME
+        groupkey_col_names = [SPARK_INDEX_NAME_FORMAT(i) for i in range(len(self._groupkeys))]
+        sdf = self._kser._internal.spark_frame.select(
+            [scol.alias(name) for scol, name in zip(self._groupkeys_scols, groupkey_col_names)]
+            + [
+                scol.alias(SPARK_INDEX_NAME_FORMAT(i + len(self._groupkeys)))
+                for i, scol in enumerate(self._kser._internal.index_spark_columns)
+            ]
+            + [self._kser.spark.column]
+            + [NATURAL_ORDER_COLUMN_NAME]
         )
-        sdf = sdf.withColumn("rank", F.row_number().over(window)).filter(F.col("rank") <= n)
+
+        window = Window.partitionBy(groupkey_col_names).orderBy(
+            F.col(self._kser._internal.data_spark_column_names[0]).asc(), NATURAL_ORDER_COLUMN_NAME
+        )
+
+        temp_rank_column = verify_temp_column_name(sdf, "__rank__")
+        sdf = (
+            sdf.withColumn(temp_rank_column, F.row_number().over(window))
+            .filter(F.col(temp_rank_column) <= n)
+            .drop(temp_rank_column)
+        )
 
         internal = InternalFrame(
             spark_frame=sdf.drop(NATURAL_ORDER_COLUMN_NAME),
             index_map=OrderedDict(
                 [
-                    (s._internal.data_spark_column_names[0], s._internal.column_labels[0])
-                    for s in self._groupkeys
+                    (col, s._internal.column_labels[0])
+                    for s, col in zip(self._groupkeys, groupkey_col_names)
                 ]
-                + list(self._kdf._internal.index_map.items())
+                + [
+                    (SPARK_INDEX_NAME_FORMAT(i + len(self._groupkeys)), name)
+                    for i, name in enumerate(self._kdf._internal.index_names)
+                ]
             ),
-            data_spark_columns=[scol_for(sdf, name)],
+            column_labels=[self._kser._column_label],
+            data_spark_columns=[scol_for(sdf, self._kser._internal.data_spark_column_names[0])],
         )
         return first_series(DataFrame(internal))
 
@@ -2593,26 +2612,45 @@ class SeriesGroupBy(GroupBy):
         3  7    4
         Name: b, dtype: int64
         """
-        if len(self._kdf._internal.index_names) > 1:
+        if len(self._kser._internal.index_names) > 1:
             raise ValueError("nlargest do not support multi-index now")
 
-        sdf = self._kdf._internal.spark_frame
-        name = self._agg_columns[0]._internal.data_spark_column_names[0]
-        window = Window.partitionBy(self._groupkeys_scols).orderBy(
-            self._agg_columns[0].spark.column.desc(), NATURAL_ORDER_COLUMN_NAME
+        groupkey_col_names = [SPARK_INDEX_NAME_FORMAT(i) for i in range(len(self._groupkeys))]
+        sdf = self._kser._internal.spark_frame.select(
+            [scol.alias(name) for scol, name in zip(self._groupkeys_scols, groupkey_col_names)]
+            + [
+                scol.alias(SPARK_INDEX_NAME_FORMAT(i + len(self._groupkeys)))
+                for i, scol in enumerate(self._kser._internal.index_spark_columns)
+            ]
+            + [self._kser.spark.column]
+            + [NATURAL_ORDER_COLUMN_NAME]
         )
-        sdf = sdf.withColumn("rank", F.row_number().over(window)).filter(F.col("rank") <= n)
+
+        window = Window.partitionBy(groupkey_col_names).orderBy(
+            F.col(self._kser._internal.data_spark_column_names[0]).desc(), NATURAL_ORDER_COLUMN_NAME
+        )
+
+        temp_rank_column = verify_temp_column_name(sdf, "__rank__")
+        sdf = (
+            sdf.withColumn(temp_rank_column, F.row_number().over(window))
+            .filter(F.col(temp_rank_column) <= n)
+            .drop(temp_rank_column)
+        )
 
         internal = InternalFrame(
             spark_frame=sdf.drop(NATURAL_ORDER_COLUMN_NAME),
             index_map=OrderedDict(
                 [
-                    (s._internal.data_spark_column_names[0], s._internal.column_labels[0])
-                    for s in self._groupkeys
+                    (col, s._internal.column_labels[0])
+                    for s, col in zip(self._groupkeys, groupkey_col_names)
                 ]
-                + list(self._kdf._internal.index_map.items())
+                + [
+                    (SPARK_INDEX_NAME_FORMAT(i + len(self._groupkeys)), name)
+                    for i, name in enumerate(self._kdf._internal.index_names)
+                ]
             ),
-            data_spark_columns=[scol_for(sdf, name)],
+            column_labels=[self._kser._column_label],
+            data_spark_columns=[scol_for(sdf, self._kser._internal.data_spark_column_names[0])],
         )
         return first_series(DataFrame(internal))
 

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -2555,7 +2555,8 @@ class SeriesGroupBy(GroupBy):
         )
 
         window = Window.partitionBy(groupkey_col_names).orderBy(
-            F.col(self._kser._internal.data_spark_column_names[0]).asc(), NATURAL_ORDER_COLUMN_NAME
+            scol_for(sdf, self._kser._internal.data_spark_column_names[0]).asc(),
+            NATURAL_ORDER_COLUMN_NAME,
         )
 
         temp_rank_column = verify_temp_column_name(sdf, "__rank__")
@@ -2627,7 +2628,8 @@ class SeriesGroupBy(GroupBy):
         )
 
         window = Window.partitionBy(groupkey_col_names).orderBy(
-            F.col(self._kser._internal.data_spark_column_names[0]).desc(), NATURAL_ORDER_COLUMN_NAME
+            scol_for(sdf, self._kser._internal.data_spark_column_names[0]).desc(),
+            NATURAL_ORDER_COLUMN_NAME,
         )
 
         temp_rank_column = verify_temp_column_name(sdf, "__rank__")

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -1103,12 +1103,28 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         kdf = ks.from_pandas(pdf)
 
         self.assert_eq(
-            repr(kdf.groupby(["a"])["b"].nsmallest(1).sort_values()),
-            repr(pdf.groupby(["a"])["b"].nsmallest(1).sort_values()),
+            kdf.groupby(["a"])["b"].nsmallest(1).sort_values(),
+            pdf.groupby(["a"])["b"].nsmallest(1).sort_values(),
         )
         self.assert_eq(
-            repr(kdf.groupby(["a"])["b"].nsmallest(2).sort_index()),
-            repr(pdf.groupby(["a"])["b"].nsmallest(2).sort_index()),
+            kdf.groupby(["a"])["b"].nsmallest(2).sort_index(),
+            pdf.groupby(["a"])["b"].nsmallest(2).sort_index(),
+        )
+        self.assert_eq(
+            (kdf.b * 10).groupby(kdf.a).nsmallest(2).sort_index(),
+            (pdf.b * 10).groupby(pdf.a).nsmallest(2).sort_index(),
+        )
+        self.assert_eq(
+            kdf.b.rename("x").groupby(kdf.a).nsmallest(2).sort_index(),
+            pdf.b.rename("x").groupby(pdf.a).nsmallest(2).sort_index(),
+        )
+        self.assert_eq(
+            kdf.b.groupby(kdf.a.rename("x")).nsmallest(2).sort_index(),
+            pdf.b.groupby(pdf.a.rename("x")).nsmallest(2).sort_index(),
+        )
+        self.assert_eq(
+            kdf.b.rename("x").groupby(kdf.a.rename("x")).nsmallest(2).sort_index(),
+            pdf.b.rename("x").groupby(pdf.a.rename("x")).nsmallest(2).sort_index(),
         )
         with self.assertRaisesRegex(ValueError, "nsmallest do not support multi-index now"):
             kdf.set_index(["a", "b"]).groupby(["c"])["d"].nsmallest(1)
@@ -1126,12 +1142,28 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         kdf = ks.from_pandas(pdf)
 
         self.assert_eq(
-            repr(kdf.groupby(["a"])["b"].nlargest(1).sort_values()),
-            repr(pdf.groupby(["a"])["b"].nlargest(1).sort_values()),
+            kdf.groupby(["a"])["b"].nlargest(1).sort_values(),
+            pdf.groupby(["a"])["b"].nlargest(1).sort_values(),
         )
         self.assert_eq(
-            repr(kdf.groupby(["a"])["b"].nlargest(2).sort_index()),
-            repr(pdf.groupby(["a"])["b"].nlargest(2).sort_index()),
+            kdf.groupby(["a"])["b"].nlargest(2).sort_index(),
+            pdf.groupby(["a"])["b"].nlargest(2).sort_index(),
+        )
+        self.assert_eq(
+            (kdf.b * 10).groupby(kdf.a).nlargest(2).sort_index(),
+            (pdf.b * 10).groupby(pdf.a).nlargest(2).sort_index(),
+        )
+        self.assert_eq(
+            kdf.b.rename("x").groupby(kdf.a).nlargest(2).sort_index(),
+            pdf.b.rename("x").groupby(pdf.a).nlargest(2).sort_index(),
+        )
+        self.assert_eq(
+            kdf.b.groupby(kdf.a.rename("x")).nlargest(2).sort_index(),
+            pdf.b.groupby(pdf.a.rename("x")).nlargest(2).sort_index(),
+        )
+        self.assert_eq(
+            kdf.b.rename("x").groupby(kdf.a.rename("x")).nlargest(2).sort_index(),
+            pdf.b.rename("x").groupby(pdf.a.rename("x")).nlargest(2).sort_index(),
         )
         with self.assertRaisesRegex(ValueError, "nlargest do not support multi-index now"):
             kdf.set_index(["a", "b"]).groupby(["c"])["d"].nlargest(1)


### PR DESCRIPTION
When `SeriesGroupBy.nsmallest`/`nlargest` doesn't follow the Series changes:

```py
>>> kdf = ks.DataFrame({'a': [1, 1, 1, 2, 2, 2, 3, 3, 3], 'b': [1, 2, 2, 2, 3, 3, 3, 4, 4]})
>>> (kdf.b * 10).groupby(kdf.a).nsmallest()
a
1  0    1
   1    2
   2    2
3  6    3
   7    4
   8    4
2  3    2
   4    3
   5    3
Name: b, dtype: int64
```

Also, for the renamed Series raises an `AnalysisException`:

```py
>>> kdf.b.rename('x').groupby(kdf.a).nsmallest()
Traceback (most recent call last):
...
pyspark.sql.utils.AnalysisException: Cannot resolve column name "`x`" among (__index_level_0__, a, b, __natural_order__, rank);
```