### PR TITLE
Modify test_cumcount to address comments.

### DIFF
--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -867,50 +867,54 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         )
         kdf = ks.from_pandas(pdf)
 
-        self.assert_eq(
-            kdf.groupby("b").cumcount().sort_index(), pdf.groupby("b").cumcount().sort_index()
-        )
-        self.assert_eq(
-            kdf.groupby(["a", "b"]).cumcount().sort_index(),
-            pdf.groupby(["a", "b"]).cumcount().sort_index(),
-        )
-        self.assert_eq(
-            kdf.groupby(["b"])["a"].cumcount().sort_index(),
-            pdf.groupby(["b"])["a"].cumcount().sort_index(),
-            almost=True,
-        )
-        self.assert_eq(
-            kdf.groupby(["b"])[["a", "c"]].cumcount().sort_index(),
-            pdf.groupby(["b"])[["a", "c"]].cumcount().sort_index(),
-            almost=True,
-        )
-        self.assert_eq(
-            kdf.groupby(kdf.b // 5).cumcount().sort_index(),
-            pdf.groupby(pdf.b // 5).cumcount().sort_index(),
-            almost=True,
-        )
-        self.assert_eq(
-            kdf.groupby(kdf.b // 5)["a"].cumcount().sort_index(),
-            pdf.groupby(pdf.b // 5)["a"].cumcount().sort_index(),
-            almost=True,
-        )
-        self.assert_eq(
-            kdf.groupby("b").cumcount().sum(), pdf.groupby("b").cumcount().sum(),
-        )
+        for ascending in [True, False]:
+            self.assert_eq(
+                kdf.groupby("b").cumcount(ascending=ascending).sort_index(),
+                pdf.groupby("b").cumcount(ascending=ascending).sort_index(),
+            )
+            self.assert_eq(
+                kdf.groupby(["a", "b"]).cumcount(ascending=ascending).sort_index(),
+                pdf.groupby(["a", "b"]).cumcount(ascending=ascending).sort_index(),
+            )
+            self.assert_eq(
+                kdf.groupby(["b"])["a"].cumcount(ascending=ascending).sort_index(),
+                pdf.groupby(["b"])["a"].cumcount(ascending=ascending).sort_index(),
+                almost=True,
+            )
+            self.assert_eq(
+                kdf.groupby(["b"])[["a", "c"]].cumcount(ascending=ascending).sort_index(),
+                pdf.groupby(["b"])[["a", "c"]].cumcount(ascending=ascending).sort_index(),
+                almost=True,
+            )
+            self.assert_eq(
+                kdf.groupby(kdf.b // 5).cumcount(ascending=ascending).sort_index(),
+                pdf.groupby(pdf.b // 5).cumcount(ascending=ascending).sort_index(),
+                almost=True,
+            )
+            self.assert_eq(
+                kdf.groupby(kdf.b // 5)["a"].cumcount(ascending=ascending).sort_index(),
+                pdf.groupby(pdf.b // 5)["a"].cumcount(ascending=ascending).sort_index(),
+                almost=True,
+            )
+            self.assert_eq(
+                kdf.groupby("b").cumcount(ascending=ascending).sum(),
+                pdf.groupby("b").cumcount(ascending=ascending).sum(),
+            )
 
         # multi-index columns
         columns = pd.MultiIndex.from_tuples([("x", "a"), ("x", "b"), ("y", "c")])
         pdf.columns = columns
         kdf.columns = columns
 
-        self.assert_eq(
-            kdf.groupby(("x", "b")).cumcount().sort_index(),
-            pdf.groupby(("x", "b")).cumcount().sort_index(),
-        )
-        self.assert_eq(
-            kdf.groupby([("x", "a"), ("x", "b")]).cumcount().sort_index(),
-            pdf.groupby([("x", "a"), ("x", "b")]).cumcount().sort_index(),
-        )
+        for ascending in [True, False]:
+            self.assert_eq(
+                kdf.groupby(("x", "b")).cumcount(ascending=ascending).sort_index(),
+                pdf.groupby(("x", "b")).cumcount(ascending=ascending).sort_index(),
+            )
+            self.assert_eq(
+                kdf.groupby([("x", "a"), ("x", "b")]).cumcount(ascending=ascending).sort_index(),
+                pdf.groupby([("x", "a"), ("x", "b")]).cumcount(ascending=ascending).sort_index(),
+            )
 
     def test_cummin(self):
         pdf = pd.DataFrame(

--- a/databricks/koalas/tests/test_ops_on_diff_frames_groupby.py
+++ b/databricks/koalas/tests/test_ops_on_diff_frames_groupby.py
@@ -344,6 +344,35 @@ class OpsOnDiffFramesGroupByTest(ReusedSQLTestCase, SQLTestUtils):
             kdf.groupby([kkey, "b"]).head(2).sort_index(),
         )
 
+    def test_cumcount(self):
+        pdf = pd.DataFrame(
+            {
+                "a": [1, 2, 3, 4, 5, 6] * 3,
+                "b": [1, 1, 2, 3, 5, 8] * 3,
+                "c": [1, 4, 9, 16, 25, 36] * 3,
+            },
+        )
+        pkey = pd.Series([1, 1, 2, 3, 5, 8] * 3)
+        kdf = ks.from_pandas(pdf)
+        kkey = ks.from_pandas(pkey)
+
+        for ascending in [True, False]:
+            self.assert_eq(
+                kdf.groupby(kkey).cumcount(ascending=ascending).sort_index(),
+                pdf.groupby(pkey).cumcount(ascending=ascending).sort_index(),
+                almost=True,
+            )
+            self.assert_eq(
+                kdf.groupby(kkey)["a"].cumcount(ascending=ascending).sort_index(),
+                pdf.groupby(pkey)["a"].cumcount(ascending=ascending).sort_index(),
+                almost=True,
+            )
+            self.assert_eq(
+                kdf.groupby(kkey)[["a"]].cumcount(ascending=ascending).sort_index(),
+                pdf.groupby(pkey)[["a"]].cumcount(ascending=ascending).sort_index(),
+                almost=True,
+            )
+
     def test_cummin(self):
         pdf = pd.DataFrame(
             {


### PR DESCRIPTION
Modifies `test_cumcount` to address comments https://github.com/databricks/koalas/pull/1702#discussion_r471079743, and also added some more tests in `OpsOnDiffFramesGroupByTest`.