### PR TITLE
Fix DataFrame.size to consider its number of columns.

### DIFF
--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -1406,9 +1406,17 @@ class Frame(object, metaclass=ABCMeta):
 
         >>> df = ks.DataFrame({'col1': [1, 2, None], 'col2': [3, 4, None]})
         >>> df.size
-        3
+        6
+
+        >>> df = ks.DataFrame(index=[1, 2, None])
+        >>> df.size
+        0
         """
-        return len(self)  # type: ignore
+        num_columns = len(self._internal.data_spark_columns)
+        if num_columns == 0:
+            return 0
+        else:
+            return len(self) * num_columns  # type: ignore
 
     def abs(self):
         """

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -207,7 +207,6 @@ class Index(IndexOpsMixin):
                     ('b', 'y'),
                     ('c', 'z')],
                    )
-
         >>> midx.shape
         (3,)
         """


### PR DESCRIPTION
`DataFrame.size` should consider its number of columns:

```py
>>> ks.Series({'a': 1, 'b': 2, 'c': None}).size
3
>>> ks.DataFrame({'col1': [1, 2, None], 'col2': [3, 4, None]}).size
3
>>> ks.DataFrame(index=[1, 2, None]).size
3
```

This should be:

```py
>>> pd.Series({'a': 1, 'b': 2, 'c': None}).size
3
>>> pd.DataFrame({'col1': [1, 2, None], 'col2': [3, 4, None]}).size
6
>>> pd.DataFrame(index=[1, 2, None]).size
0
```