### PR TITLE
Support subtraction of date/timestamp with literals.

### DIFF
--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -198,7 +198,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
                 if not isinstance(other.spark.data_type, DateType):
                     raise TypeError("date subtraction can only be applied to date series.")
                 return column_op(F.datediff)(self, other)
-            elif isinstance(other, datetime.date):
+            elif isinstance(other, datetime.date) and not isinstance(other, datetime.datetime):
                 return column_op(F.datediff)(self, F.lit(other))
         return column_op(Column.__sub__)(self, other)
 
@@ -251,7 +251,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
             if isinstance(other, datetime.datetime):
                 return -(self.astype("bigint") - F.lit(other).cast(as_spark_type("bigint")))
         elif isinstance(self.spark.data_type, DateType):
-            if isinstance(other, datetime.date):
+            if isinstance(other, datetime.date) and not isinstance(other, datetime.datetime):
                 return -column_op(F.datediff)(self, F.lit(other))
         return column_op(Column.__rsub__)(self, other)
 

--- a/databricks/koalas/tests/test_series_datetime.py
+++ b/databricks/koalas/tests/test_series_datetime.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+import datetime
 import unittest
 
 import numpy as np
@@ -44,16 +44,28 @@ class SeriesDateTimeTest(ReusedSQLTestCase, SQLTestUtils):
             func(self.ks_start_date).to_pandas(), func(self.pd_start_date), check_names=False
         )
 
-    @unittest.skip(
-        "It fails in certain OSs presumably due to different "
-        "timezone behaviours inherited from C library."
-    )
     def test_timestamp_subtraction(self):
         pdf = self.pdf1
         kdf = ks.from_pandas(pdf)
-        kdf["diff_seconds"] = kdf["end_date"] - kdf["start_date"] - 1
 
-        self.assertEqual(list(kdf["diff_seconds"].toPandas()), [35545499, 33644699, 31571099])
+        # Those fail in certain OSs presumably due to different
+        # timezone behaviours inherited from C library.
+
+        actual = (kdf["end_date"] - kdf["start_date"] - 1).to_list()
+        expected = ((pdf["end_date"] - pdf["start_date"]) // np.timedelta64(1, "s") - 1).to_list()
+        # self.assertEqual(actual, expected)
+
+        actual = (kdf["end_date"] - pd.Timestamp("2012-1-1 12:45:31") - 1).to_list()
+        expected = (
+            (pdf["end_date"] - pd.Timestamp("2012-1-1 12:45:31")) // np.timedelta64(1, "s") - 1
+        ).to_list()
+        # self.assertEqual(actual, expected)
+
+        actual = (pd.Timestamp("2013-3-11 21:45:00") - kdf["start_date"] - 1).to_list()
+        expected = (
+            (pd.Timestamp("2013-3-11 21:45:00") - pdf["start_date"]) // np.timedelta64(1, "s") - 1
+        ).to_list()
+        # self.assertEqual(actual, expected)
 
         kdf = ks.DataFrame(
             {"a": pd.date_range("2016-12-31", "2017-01-08", freq="D"), "b": pd.Series(range(9))}
@@ -65,9 +77,21 @@ class SeriesDateTimeTest(ReusedSQLTestCase, SQLTestUtils):
     def test_date_subtraction(self):
         pdf = self.pdf1
         kdf = ks.from_pandas(pdf)
-        kdf["diff_days"] = kdf["end_date"].dt.date - kdf["start_date"].dt.date
 
-        self.assert_eq(list(kdf["diff_days"].toPandas()), [411, 389, 365])
+        self.assert_eq(
+            kdf["end_date"].dt.date - kdf["start_date"].dt.date,
+            (pdf["end_date"].dt.date - pdf["start_date"].dt.date).dt.days,
+        )
+
+        self.assert_eq(
+            kdf["end_date"].dt.date - datetime.date(2012, 1, 1),
+            (pdf["end_date"].dt.date - datetime.date(2012, 1, 1)).dt.days,
+        )
+
+        self.assert_eq(
+            datetime.date(2013, 3, 11) - kdf["start_date"].dt.date,
+            (datetime.date(2013, 3, 11) - pdf["start_date"].dt.date).dt.days,
+        )
 
         kdf = ks.DataFrame(
             {"a": pd.date_range("2016-12-31", "2017-01-08", freq="D"), "b": pd.Series(range(9))}

--- a/databricks/koalas/tests/test_series_datetime.py
+++ b/databricks/koalas/tests/test_series_datetime.py
@@ -51,21 +51,21 @@ class SeriesDateTimeTest(ReusedSQLTestCase, SQLTestUtils):
         # Those fail in certain OSs presumably due to different
         # timezone behaviours inherited from C library.
 
-        actual = (kdf["end_date"] - kdf["start_date"] - 1).to_list()
-        expected = ((pdf["end_date"] - pdf["start_date"]) // np.timedelta64(1, "s") - 1).to_list()
-        # self.assertEqual(actual, expected)
+        actual = (kdf["end_date"] - kdf["start_date"] - 1).to_pandas()
+        expected = (pdf["end_date"] - pdf["start_date"]) // np.timedelta64(1, "s") - 1
+        # self.assert_eq(actual, expected)
 
-        actual = (kdf["end_date"] - pd.Timestamp("2012-1-1 12:45:31") - 1).to_list()
-        expected = (
-            (pdf["end_date"] - pd.Timestamp("2012-1-1 12:45:31")) // np.timedelta64(1, "s") - 1
-        ).to_list()
-        # self.assertEqual(actual, expected)
+        actual = (kdf["end_date"] - pd.Timestamp("2012-1-1 12:45:31") - 1).to_pandas()
+        expected = (pdf["end_date"] - pd.Timestamp("2012-1-1 12:45:31")) // np.timedelta64(
+            1, "s"
+        ) - 1
+        # self.assert_eq(actual, expected)
 
-        actual = (pd.Timestamp("2013-3-11 21:45:00") - kdf["start_date"] - 1).to_list()
-        expected = (
-            (pd.Timestamp("2013-3-11 21:45:00") - pdf["start_date"]) // np.timedelta64(1, "s") - 1
-        ).to_list()
-        # self.assertEqual(actual, expected)
+        actual = (pd.Timestamp("2013-3-11 21:45:00") - kdf["start_date"] - 1).to_pandas()
+        expected = (pd.Timestamp("2013-3-11 21:45:00") - pdf["start_date"]) // np.timedelta64(
+            1, "s"
+        ) - 1
+        # self.assert_eq(actual, expected)
 
         kdf = ks.DataFrame(
             {"a": pd.date_range("2016-12-31", "2017-01-08", freq="D"), "b": pd.Series(range(9))}

--- a/databricks/koalas/tests/test_series_datetime.py
+++ b/databricks/koalas/tests/test_series_datetime.py
@@ -73,6 +73,10 @@ class SeriesDateTimeTest(ReusedSQLTestCase, SQLTestUtils):
         expected_error_message = "datetime subtraction can only be applied to datetime series."
         with self.assertRaisesRegex(TypeError, expected_error_message):
             kdf["a"] - kdf["b"]
+        with self.assertRaisesRegex(TypeError, expected_error_message):
+            kdf["a"] - 1
+        with self.assertRaisesRegex(TypeError, expected_error_message):
+            1 - kdf["a"]
 
     def test_date_subtraction(self):
         pdf = self.pdf1
@@ -99,6 +103,10 @@ class SeriesDateTimeTest(ReusedSQLTestCase, SQLTestUtils):
         expected_error_message = "date subtraction can only be applied to date series."
         with self.assertRaisesRegex(TypeError, expected_error_message):
             kdf["a"].dt.date - kdf["b"]
+        with self.assertRaisesRegex(TypeError, expected_error_message):
+            kdf["a"].dt.date - 1
+        with self.assertRaisesRegex(TypeError, expected_error_message):
+            1 - kdf["a"].dt.date
 
     @unittest.skip(
         "It fails in certain OSs presumably due to different "


### PR DESCRIPTION
This PR allows subtraction of date/timestamp with literals.

```py
>>> date1 = pd.Series(pd.date_range("2012-1-1 12:45:31", periods=3, freq="M"))
>>> date2 = pd.Series(pd.date_range("2013-3-11 21:45:00", periods=3, freq="W"))
>>> kdf = ks.DataFrame(dict(start_date=date1, end_date=date2))
>>> kdf
           start_date            end_date
0 2012-01-31 12:45:31 2013-03-17 21:45:00
1 2012-02-29 12:45:31 2013-03-24 21:45:00
2 2012-03-31 12:45:31 2013-03-31 21:45:00

>>> kdf['end_date'] - kdf['start_date']
0    35539169
1    33638369
2    31568369
Name: end_date, dtype: int64
>>> kdf['end_date'] - datetime(2012, 1, 31, 12, 45, 31)
0    35539169
1    36143969
2    36748769
Name: end_date, dtype: int64
>>> datetime(2013, 3, 17, 21, 45, 0) - kdf['start_date']
0    35539169
1    33033569
2    30358769
Name: start_date, dtype: int64

>>> kdf['end_date'].dt.date - kdf['start_date'].dt.date
0    411
1    389
2    365
Name: end_date, dtype: int32
>>> kdf['end_date'].dt.date - date(2012, 1, 31)
0    411
1    418
2    425
Name: end_date, dtype: int32
>>> date(2013, 3, 17) - kdf['start_date'].dt.date
0    411
1    382
2    351
Name: start_date, dtype: int32
```

Note: pandas returns `timedelta64` type but Koalas doesn't support the type yet.