### PR TITLE
Fixed doctest for last_valid_index

### DIFF
--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -1749,7 +1749,7 @@ class Frame(object, metaclass=ABCMeta):
         300    3.0
         400    NaN
         500    NaN
-        Name: 0, dtype: float64
+        dtype: float64
 
         >>> s.last_valid_index()  # doctest: +SKIP
         300
@@ -1771,7 +1771,7 @@ class Frame(object, metaclass=ABCMeta):
         falcon  speed       NaN
                 weight      NaN
                 length      NaN
-        Name: 0, dtype: float64
+        dtype: float64
 
         >>> s.last_valid_index()  # doctest: +SKIP
         ('cow', 'weight')


### PR DESCRIPTION
Quick fix for build failure. The PR #1705 have failed since It made conflicts with #1712 .

`Series` has no more default name `0`,  we should not include it to the result.

- previous behaviour
```python
>>> s = ks.Series([1, 2, 3, None, None], index=[100, 200, 300, 400, 500])
>>> s
100    1.0
200    2.0
300    3.0
400    NaN
500    NaN
name: 0, dtype: float64
```

- current behaviour
```python
>>> s = ks.Series([1, 2, 3, None, None], index=[100, 200, 300, 400, 500])
>>> s
100    1.0
200    2.0
300    3.0
400    NaN
500    NaN
dtype: float64
```