### PR TITLE
Cleanup to_pandas() from tests and deprecate toPandas()

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -4230,7 +4230,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         warnings.warn(
             "DataFrame.toPandas is deprecated as of DataFrame.to_pandas. "
             "Please use the API instead.",
-            DeprecationWarning,
+            FutureWarning,
         )
         return self.to_pandas()
 

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -4226,7 +4226,13 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         return self._internal.to_pandas_frame.copy()
 
     # Alias to maintain backward compatibility with Spark
-    toPandas = to_pandas
+    def toPandas(self):
+        warnings.warn(
+            "DataFrame.toPandas is deprecated as of DataFrame.to_pandas. "
+            "Please use the API instead.",
+            FutureWarning,
+        )
+        return self.to_pandas()
 
     def assign(self, **kwargs):
         """

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -4230,9 +4230,11 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         warnings.warn(
             "DataFrame.toPandas is deprecated as of DataFrame.to_pandas. "
             "Please use the API instead.",
-            FutureWarning,
+            DeprecationWarning,
         )
         return self.to_pandas()
+
+    toPandas.__doc__ = to_pandas.__doc__
 
     def assign(self, **kwargs):
         """

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -374,8 +374,7 @@ class Index(IndexOpsMixin):
 
     def toPandas(self):
         warnings.warn(
-            "Index.toPandas is deprecated as of Index.to_pandas. "
-            "Please use the API instead.",
+            "Index.toPandas is deprecated as of Index.to_pandas. Please use the API instead.",
             FutureWarning,
         )
         return self.to_pandas()

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -375,7 +375,7 @@ class Index(IndexOpsMixin):
     def toPandas(self):
         warnings.warn(
             "Index.toPandas is deprecated as of Index.to_pandas. Please use the API instead.",
-            DeprecationWarning,
+            FutureWarning,
         )
         return self.to_pandas()
 
@@ -2442,7 +2442,7 @@ class MultiIndex(Index):
         warnings.warn(
             "MultiIndex.toPandas is deprecated as of MultiIndex.to_pandas. "
             "Please use the API instead.",
-            DeprecationWarning,
+            FutureWarning,
         )
         return self.to_pandas()
 

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -375,9 +375,11 @@ class Index(IndexOpsMixin):
     def toPandas(self):
         warnings.warn(
             "Index.toPandas is deprecated as of Index.to_pandas. Please use the API instead.",
-            FutureWarning,
+            DeprecationWarning,
         )
         return self.to_pandas()
+
+    toPandas.__doc__ = to_pandas.__doc__
 
     def to_numpy(self, dtype=None, copy=False):
         """
@@ -2440,9 +2442,11 @@ class MultiIndex(Index):
         warnings.warn(
             "MultiIndex.toPandas is deprecated as of MultiIndex.to_pandas. "
             "Please use the API instead.",
-            FutureWarning,
+            DeprecationWarning,
         )
         return self.to_pandas()
+
+    toPandas.__doc__ = to_pandas.__doc__
 
     def nunique(self, dropna=True):
         raise NotImplementedError("isna is not defined for MultiIndex")

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -372,7 +372,13 @@ class Index(IndexOpsMixin):
         """
         return self._internal.to_pandas_frame.index  # type: ignore
 
-    toPandas = to_pandas
+    def toPandas(self):
+        warnings.warn(
+            "Index.toPandas is deprecated as of Index.to_pandas. "
+            "Please use the API instead.",
+            FutureWarning,
+        )
+        return self.to_pandas()
 
     def to_numpy(self, dtype=None, copy=False):
         """
@@ -2431,7 +2437,13 @@ class MultiIndex(Index):
         # series-like operations. In that case, it creates new Index object instead of MultiIndex.
         return self._kdf[[]]._to_internal_pandas().index
 
-    toPandas = to_pandas
+    def toPandas(self):
+        warnings.warn(
+            "MultiIndex.toPandas is deprecated as of MultiIndex.to_pandas. "
+            "Please use the API instead.",
+            FutureWarning,
+        )
+        return self.to_pandas()
 
     def nunique(self, dropna=True):
         raise NotImplementedError("isna is not defined for MultiIndex")

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -1444,9 +1444,11 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
     def toPandas(self):
         warnings.warn(
             "Series.toPandas is deprecated as of Series.to_pandas. Please use the API instead.",
-            FutureWarning,
+            DeprecationWarning,
         )
         return self.to_pandas()
+
+    toPandas.__doc__ = to_pandas.__doc__
 
     def to_list(self):
         """

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -1443,8 +1443,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
     # Alias to maintain backward compatibility with Spark
     def toPandas(self):
         warnings.warn(
-            "Series.toPandas is deprecated as of Series.to_pandas. "
-            "Please use the API instead.",
+            "Series.toPandas is deprecated as of Series.to_pandas. Please use the API instead.",
             FutureWarning,
         )
         return self.to_pandas()

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -1441,7 +1441,13 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         return first_series(self._internal.to_pandas_frame.copy())
 
     # Alias to maintain backward compatibility with Spark
-    toPandas = to_pandas
+    def toPandas(self):
+        warnings.warn(
+            "Series.toPandas is deprecated as of Series.to_pandas. "
+            "Please use the API instead.",
+            FutureWarning,
+        )
+        return self.to_pandas()
 
     def to_list(self):
         """

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -1444,7 +1444,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
     def toPandas(self):
         warnings.warn(
             "Series.toPandas is deprecated as of Series.to_pandas. Please use the API instead.",
-            DeprecationWarning,
+            FutureWarning,
         )
         return self.to_pandas()
 

--- a/databricks/koalas/tests/test_csv.py
+++ b/databricks/koalas/tests/test_csv.py
@@ -129,7 +129,7 @@ class CsvTest(ReusedSQLTestCase, TestUtils):
             def check(header="infer", names=None, usecols=None):
                 expected = pd.read_csv(fn, header=header, names=names, usecols=usecols)
                 actual = ks.read_csv(fn, header=header, names=names, usecols=usecols)
-                self.assertPandasAlmostEqual(expected, actual.toPandas())
+                self.assertPandasAlmostEqual(expected, actual.to_pandas())
 
             check()
             check(header=None)
@@ -148,7 +148,7 @@ class CsvTest(ReusedSQLTestCase, TestUtils):
             # check with pyspark patch.
             expected = pd.read_csv(fn)
             actual = ks.read_csv(fn)
-            self.assertPandasAlmostEqual(expected, actual.toPandas())
+            self.assertPandasAlmostEqual(expected, actual.to_pandas())
 
             self.assertRaisesRegex(
                 ValueError, "non-unique", lambda: ks.read_csv(fn, names=["n", "n"])
@@ -185,7 +185,7 @@ class CsvTest(ReusedSQLTestCase, TestUtils):
             # check with index_col
             expected = pd.read_csv(fn).set_index("name")
             actual = ks.read_csv(fn, index_col="name")
-            self.assertPandasAlmostEqual(expected, actual.toPandas())
+            self.assertPandasAlmostEqual(expected, actual.to_pandas())
 
     def test_read_with_spark_schema(self):
         with self.csv_file(self.csv_text_2) as fn:
@@ -197,7 +197,7 @@ class CsvTest(ReusedSQLTestCase, TestUtils):
         with self.csv_file(self.csv_text_with_comments) as fn:
             expected = pd.read_csv(fn, comment="#")
             actual = ks.read_csv(fn, comment="#")
-            self.assertPandasAlmostEqual(expected, actual.toPandas())
+            self.assertPandasAlmostEqual(expected, actual.to_pandas())
 
             self.assertRaisesRegex(
                 ValueError,
@@ -224,23 +224,23 @@ class CsvTest(ReusedSQLTestCase, TestUtils):
         with self.csv_file(self.csv_text_with_comments) as fn:
             expected = pd.read_csv(fn, comment="#", nrows=2)
             actual = ks.read_csv(fn, comment="#", nrows=2)
-            self.assertPandasAlmostEqual(expected, actual.toPandas())
+            self.assertPandasAlmostEqual(expected, actual.to_pandas())
 
     def test_read_csv_with_sep(self):
         with self.csv_file(self.tab_delimited_csv_text) as fn:
             expected = pd.read_csv(fn, sep="\t")
             actual = ks.read_csv(fn, sep="\t")
-            self.assertPandasAlmostEqual(expected, actual.toPandas())
+            self.assertPandasAlmostEqual(expected, actual.to_pandas())
 
     def test_read_csv_with_squeeze(self):
         with self.csv_file(self.csv_text) as fn:
             expected = pd.read_csv(fn, squeeze=True, usecols=["name"])
             actual = ks.read_csv(fn, squeeze=True, usecols=["name"])
-            self.assertPandasAlmostEqual(expected, actual.toPandas())
+            self.assertPandasAlmostEqual(expected, actual.to_pandas())
 
             expected = pd.read_csv(fn, squeeze=True, usecols=["name", "amount"])
             actual = ks.read_csv(fn, squeeze=True, usecols=["name", "amount"])
-            self.assertPandasAlmostEqual(expected, actual.toPandas())
+            self.assertPandasAlmostEqual(expected, actual.to_pandas())
 
     def test_read_csv_with_mangle_dupe_cols(self):
         self.assertRaisesRegex(

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -1017,9 +1017,9 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             "animal": ["cat", "dog", "bat", "penguin"],
             "locomotion": ["walks", "walks", "flies", "walks"],
         }
-        kdf = ks.DataFrame(data=d)
-        kdf = kdf.set_index(["class", "animal", "locomotion"])
-        pdf = kdf.to_pandas()
+        pdf = pd.DataFrame(data=d)
+        pdf = pdf.set_index(["class", "animal", "locomotion"])
+        kdf = ks.from_pandas(pdf)
 
         self.assert_eq(kdf.xs(("mammal", "dog", "walks")), pdf.xs(("mammal", "dog", "walks")))
 
@@ -3271,12 +3271,12 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             kdf.to_spark(index_col=["x", "y", "z"])
 
     def test_keys(self):
-        kdf = ks.DataFrame(
+        pdf = pd.DataFrame(
             [[1, 2], [4, 5], [7, 8]],
             index=["cobra", "viper", "sidewinder"],
             columns=["max_speed", "shield"],
         )
-        pdf = kdf.to_pandas()
+        kdf = ks.from_pandas(pdf)
 
         self.assert_eq(kdf.keys(), pdf.keys())
 
@@ -3294,12 +3294,12 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             kdf.quantile(0.5, numeric_only=False)
 
     def test_pct_change(self):
-        kdf = ks.DataFrame(
+        pdf = pd.DataFrame(
             {"a": [1, 2, 3, 2], "b": [4.0, 2.0, 3.0, 1.0], "c": [300, 200, 400, 200]},
             index=np.random.rand(4),
         )
-        kdf.columns = pd.MultiIndex.from_tuples([("a", "x"), ("b", "y"), ("c", "z")])
-        pdf = kdf.to_pandas()
+        pdf.columns = pd.MultiIndex.from_tuples([("a", "x"), ("b", "y"), ("c", "z")])
+        kdf = ks.from_pandas(pdf)
 
         self.assert_eq(repr(kdf.pct_change(2)), repr(pdf.pct_change(2)))
 
@@ -3316,8 +3316,8 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             kdf.mask(1)
 
     def test_query(self):
-        kdf = ks.DataFrame({"A": range(1, 6), "B": range(10, 0, -2), "C": range(10, 5, -1)})
-        pdf = kdf.to_pandas()
+        pdf = pd.DataFrame({"A": range(1, 6), "B": range(10, 0, -2), "C": range(10, 5, -1)})
+        kdf = ks.from_pandas(pdf)
 
         exprs = ("A > B", "A < C", "C == B")
         for expr in exprs:
@@ -3362,10 +3362,10 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             kdf.query("('A', 'Z') > ('B', 'X')")
 
     def test_take(self):
-        kdf = ks.DataFrame(
+        pdf = pd.DataFrame(
             {"A": range(0, 50000), "B": range(100000, 0, -2), "C": range(100000, 50000, -1)}
         )
-        pdf = kdf.to_pandas()
+        kdf = ks.from_pandas(pdf)
 
         # axis=0 (default)
         self.assert_eq(kdf.take([1, 2]).sort_index(), pdf.take([1, 2]).sort_index())

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -1103,7 +1103,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
     def test_to_pandas(self):
         pdf, kdf = self.df_pair
-        self.assert_eq(kdf.to_pandas(), pdf)
+        self.assert_eq(kdf.toPandas(), pdf)
         self.assert_eq(kdf.to_pandas(), pdf)
 
     def test_isin(self):

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -1103,7 +1103,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
     def test_to_pandas(self):
         pdf, kdf = self.df_pair
-        self.assert_eq(kdf.toPandas(), pdf)
+        self.assert_eq(kdf.to_pandas(), pdf)
         self.assert_eq(kdf.to_pandas(), pdf)
 
     def test_isin(self):

--- a/databricks/koalas/tests/test_dataframe_spark_io.py
+++ b/databricks/koalas/tests/test_dataframe_spark_io.py
@@ -133,8 +133,8 @@ class DataFrameSparkIOTest(ReusedSQLTestCase, TestUtils):
             self.assertFalse((actual.columns == self.test_column_order).all())
             actual = actual[self.test_column_order]
             self.assert_eq(
-                actual.sort_values(by="f").to_spark().to_pandas(),
-                expected.sort_values(by="f").to_spark().to_pandas(),
+                actual.sort_values(by="f").to_spark().toPandas(),
+                expected.sort_values(by="f").to_spark().toPandas(),
             )
 
             # Write out partitioned by two columns
@@ -145,8 +145,8 @@ class DataFrameSparkIOTest(ReusedSQLTestCase, TestUtils):
             self.assertFalse((actual.columns == self.test_column_order).all())
             actual = actual[self.test_column_order]
             self.assert_eq(
-                actual.sort_values(by="f").to_spark().to_pandas(),
-                expected.sort_values(by="f").to_spark().to_pandas(),
+                actual.sort_values(by="f").to_spark().toPandas(),
+                expected.sort_values(by="f").to_spark().toPandas(),
             )
 
     def test_table(self):

--- a/databricks/koalas/tests/test_dataframe_spark_io.py
+++ b/databricks/koalas/tests/test_dataframe_spark_io.py
@@ -89,8 +89,8 @@ class DataFrameSparkIOTest(ReusedSQLTestCase, TestUtils):
             expected_idx = expected.set_index("bhello")[["f", "i32", "i64"]]
             actual_idx = ks.read_parquet(tmp, index_col="bhello")[["f", "i32", "i64"]]
             self.assert_eq(
-                actual_idx.sort_values(by="f").to_spark().to_pandas(),
-                expected_idx.sort_values(by="f").to_spark().to_pandas(),
+                actual_idx.sort_values(by="f").to_spark().toPandas(),
+                expected_idx.sort_values(by="f").to_spark().toPandas(),
             )
 
     @unittest.skipIf(

--- a/databricks/koalas/tests/test_dataframe_spark_io.py
+++ b/databricks/koalas/tests/test_dataframe_spark_io.py
@@ -162,8 +162,8 @@ class DataFrameSparkIOTest(ReusedSQLTestCase, TestUtils):
             self.assertFalse((actual.columns == self.test_column_order).all())
             actual = actual[self.test_column_order]
             self.assert_eq(
-                actual.sort_values(by="f").to_spark().to_pandas(),
-                expected.sort_values(by="f").to_spark().to_pandas(),
+                actual.sort_values(by="f").to_spark().toPandas(),
+                expected.sort_values(by="f").to_spark().toPandas(),
             )
 
             # Write out partitioned by two columns
@@ -174,30 +174,30 @@ class DataFrameSparkIOTest(ReusedSQLTestCase, TestUtils):
             self.assertFalse((actual.columns == self.test_column_order).all())
             actual = actual[self.test_column_order]
             self.assert_eq(
-                actual.sort_values(by="f").to_spark().to_pandas(),
-                expected.sort_values(by="f").to_spark().to_pandas(),
+                actual.sort_values(by="f").to_spark().toPandas(),
+                expected.sort_values(by="f").to_spark().toPandas(),
             )
 
             # When index columns are known
             expected_idx = expected.set_index("bhello")[["f", "i32", "i64"]]
             actual_idx = ks.read_table("test_table", index_col="bhello")[["f", "i32", "i64"]]
             self.assert_eq(
-                actual_idx.sort_values(by="f").to_spark().to_pandas(),
-                expected_idx.sort_values(by="f").to_spark().to_pandas(),
+                actual_idx.sort_values(by="f").to_spark().toPandas(),
+                expected_idx.sort_values(by="f").to_spark().toPandas(),
             )
 
             expected_idx = expected.set_index(["bhello"])[["f", "i32", "i64"]]
             actual_idx = ks.read_table("test_table", index_col=["bhello"])[["f", "i32", "i64"]]
             self.assert_eq(
-                actual_idx.sort_values(by="f").to_spark().to_pandas(),
-                expected_idx.sort_values(by="f").to_spark().to_pandas(),
+                actual_idx.sort_values(by="f").to_spark().toPandas(),
+                expected_idx.sort_values(by="f").to_spark().toPandas(),
             )
 
             expected_idx = expected.set_index(["i32", "bhello"])[["f", "i64"]]
             actual_idx = ks.read_table("test_table", index_col=["i32", "bhello"])[["f", "i64"]]
             self.assert_eq(
-                actual_idx.sort_values(by="f").to_spark().to_pandas(),
-                expected_idx.sort_values(by="f").to_spark().to_pandas(),
+                actual_idx.sort_values(by="f").to_spark().toPandas(),
+                expected_idx.sort_values(by="f").to_spark().toPandas(),
             )
 
     def test_spark_io(self):
@@ -213,8 +213,8 @@ class DataFrameSparkIOTest(ReusedSQLTestCase, TestUtils):
             self.assertFalse((actual.columns == self.test_column_order).all())
             actual = actual[self.test_column_order]
             self.assert_eq(
-                actual.sort_values(by="f").to_spark().to_pandas(),
-                expected.sort_values(by="f").to_spark().to_pandas(),
+                actual.sort_values(by="f").to_spark().toPandas(),
+                expected.sort_values(by="f").to_spark().toPandas(),
             )
 
             # Write out partitioned by two columns
@@ -227,8 +227,8 @@ class DataFrameSparkIOTest(ReusedSQLTestCase, TestUtils):
             self.assertFalse((actual.columns == self.test_column_order).all())
             actual = actual[self.test_column_order]
             self.assert_eq(
-                actual.sort_values(by="f").to_spark().to_pandas(),
-                expected.sort_values(by="f").to_spark().to_pandas(),
+                actual.sort_values(by="f").to_spark().toPandas(),
+                expected.sort_values(by="f").to_spark().toPandas(),
             )
 
             # When index columns are known
@@ -239,8 +239,8 @@ class DataFrameSparkIOTest(ReusedSQLTestCase, TestUtils):
             expected_idx = expected.set_index("bhello")[col_order]
             actual_idx = ks.read_spark_io(tmp, format="json", index_col="bhello")[col_order]
             self.assert_eq(
-                actual_idx.sort_values(by="f").to_spark().to_pandas(),
-                expected_idx.sort_values(by="f").to_spark().to_pandas(),
+                actual_idx.sort_values(by="f").to_spark().toPandas(),
+                expected_idx.sort_values(by="f").to_spark().toPandas(),
             )
 
     def test_read_excel(self):

--- a/databricks/koalas/tests/test_dataframe_spark_io.py
+++ b/databricks/koalas/tests/test_dataframe_spark_io.py
@@ -58,7 +58,7 @@ class DataFrameSparkIOTest(ReusedSQLTestCase, TestUtils):
                 if LooseVersion("0.21.1") <= LooseVersion(pd.__version__):
                     expected = pd.read_parquet(tmp, columns=columns)
                 actual = ks.read_parquet(tmp, columns=columns)
-                self.assertPandasEqual(expected, actual.toPandas())
+                self.assertPandasEqual(expected, actual.to_pandas())
 
             check(None, data)
             check(["i32", "i64"], data[["i32", "i64"]])
@@ -80,7 +80,7 @@ class DataFrameSparkIOTest(ReusedSQLTestCase, TestUtils):
             else:
                 expected = data
             actual = ks.read_parquet(tmp)
-            self.assertPandasEqual(expected, actual.toPandas())
+            self.assertPandasEqual(expected, actual.to_pandas())
 
             # When index columns are known
             pdf = self.test_pdf
@@ -89,8 +89,8 @@ class DataFrameSparkIOTest(ReusedSQLTestCase, TestUtils):
             expected_idx = expected.set_index("bhello")[["f", "i32", "i64"]]
             actual_idx = ks.read_parquet(tmp, index_col="bhello")[["f", "i32", "i64"]]
             self.assert_eq(
-                actual_idx.sort_values(by="f").to_spark().toPandas(),
-                expected_idx.sort_values(by="f").to_spark().toPandas(),
+                actual_idx.sort_values(by="f").to_spark().to_pandas(),
+                expected_idx.sort_values(by="f").to_spark().to_pandas(),
             )
 
     @unittest.skipIf(
@@ -133,8 +133,8 @@ class DataFrameSparkIOTest(ReusedSQLTestCase, TestUtils):
             self.assertFalse((actual.columns == self.test_column_order).all())
             actual = actual[self.test_column_order]
             self.assert_eq(
-                actual.sort_values(by="f").to_spark().toPandas(),
-                expected.sort_values(by="f").to_spark().toPandas(),
+                actual.sort_values(by="f").to_spark().to_pandas(),
+                expected.sort_values(by="f").to_spark().to_pandas(),
             )
 
             # Write out partitioned by two columns
@@ -145,8 +145,8 @@ class DataFrameSparkIOTest(ReusedSQLTestCase, TestUtils):
             self.assertFalse((actual.columns == self.test_column_order).all())
             actual = actual[self.test_column_order]
             self.assert_eq(
-                actual.sort_values(by="f").to_spark().toPandas(),
-                expected.sort_values(by="f").to_spark().toPandas(),
+                actual.sort_values(by="f").to_spark().to_pandas(),
+                expected.sort_values(by="f").to_spark().to_pandas(),
             )
 
     def test_table(self):
@@ -162,8 +162,8 @@ class DataFrameSparkIOTest(ReusedSQLTestCase, TestUtils):
             self.assertFalse((actual.columns == self.test_column_order).all())
             actual = actual[self.test_column_order]
             self.assert_eq(
-                actual.sort_values(by="f").to_spark().toPandas(),
-                expected.sort_values(by="f").to_spark().toPandas(),
+                actual.sort_values(by="f").to_spark().to_pandas(),
+                expected.sort_values(by="f").to_spark().to_pandas(),
             )
 
             # Write out partitioned by two columns
@@ -174,30 +174,30 @@ class DataFrameSparkIOTest(ReusedSQLTestCase, TestUtils):
             self.assertFalse((actual.columns == self.test_column_order).all())
             actual = actual[self.test_column_order]
             self.assert_eq(
-                actual.sort_values(by="f").to_spark().toPandas(),
-                expected.sort_values(by="f").to_spark().toPandas(),
+                actual.sort_values(by="f").to_spark().to_pandas(),
+                expected.sort_values(by="f").to_spark().to_pandas(),
             )
 
             # When index columns are known
             expected_idx = expected.set_index("bhello")[["f", "i32", "i64"]]
             actual_idx = ks.read_table("test_table", index_col="bhello")[["f", "i32", "i64"]]
             self.assert_eq(
-                actual_idx.sort_values(by="f").to_spark().toPandas(),
-                expected_idx.sort_values(by="f").to_spark().toPandas(),
+                actual_idx.sort_values(by="f").to_spark().to_pandas(),
+                expected_idx.sort_values(by="f").to_spark().to_pandas(),
             )
 
             expected_idx = expected.set_index(["bhello"])[["f", "i32", "i64"]]
             actual_idx = ks.read_table("test_table", index_col=["bhello"])[["f", "i32", "i64"]]
             self.assert_eq(
-                actual_idx.sort_values(by="f").to_spark().toPandas(),
-                expected_idx.sort_values(by="f").to_spark().toPandas(),
+                actual_idx.sort_values(by="f").to_spark().to_pandas(),
+                expected_idx.sort_values(by="f").to_spark().to_pandas(),
             )
 
             expected_idx = expected.set_index(["i32", "bhello"])[["f", "i64"]]
             actual_idx = ks.read_table("test_table", index_col=["i32", "bhello"])[["f", "i64"]]
             self.assert_eq(
-                actual_idx.sort_values(by="f").to_spark().toPandas(),
-                expected_idx.sort_values(by="f").to_spark().toPandas(),
+                actual_idx.sort_values(by="f").to_spark().to_pandas(),
+                expected_idx.sort_values(by="f").to_spark().to_pandas(),
             )
 
     def test_spark_io(self):
@@ -213,8 +213,8 @@ class DataFrameSparkIOTest(ReusedSQLTestCase, TestUtils):
             self.assertFalse((actual.columns == self.test_column_order).all())
             actual = actual[self.test_column_order]
             self.assert_eq(
-                actual.sort_values(by="f").to_spark().toPandas(),
-                expected.sort_values(by="f").to_spark().toPandas(),
+                actual.sort_values(by="f").to_spark().to_pandas(),
+                expected.sort_values(by="f").to_spark().to_pandas(),
             )
 
             # Write out partitioned by two columns
@@ -227,8 +227,8 @@ class DataFrameSparkIOTest(ReusedSQLTestCase, TestUtils):
             self.assertFalse((actual.columns == self.test_column_order).all())
             actual = actual[self.test_column_order]
             self.assert_eq(
-                actual.sort_values(by="f").to_spark().toPandas(),
-                expected.sort_values(by="f").to_spark().toPandas(),
+                actual.sort_values(by="f").to_spark().to_pandas(),
+                expected.sort_values(by="f").to_spark().to_pandas(),
             )
 
             # When index columns are known
@@ -239,8 +239,8 @@ class DataFrameSparkIOTest(ReusedSQLTestCase, TestUtils):
             expected_idx = expected.set_index("bhello")[col_order]
             actual_idx = ks.read_spark_io(tmp, format="json", index_col="bhello")[col_order]
             self.assert_eq(
-                actual_idx.sort_values(by="f").to_spark().toPandas(),
-                expected_idx.sort_values(by="f").to_spark().toPandas(),
+                actual_idx.sort_values(by="f").to_spark().to_pandas(),
+                expected_idx.sort_values(by="f").to_spark().to_pandas(),
             )
 
     def test_read_excel(self):

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -535,9 +535,9 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             self.assertRaises(NotImplementedError, lambda: kdf.groupby("a").describe().sort_index())
 
     def test_aggregate_relabel_multiindex(self):
-        kdf = ks.DataFrame({"A": [0, 1, 2, 3], "B": [5, 6, 7, 8], "group": ["a", "a", "b", "b"]})
-        kdf.columns = pd.MultiIndex.from_tuples([("y", "A"), ("y", "B"), ("x", "group")])
-        pdf = kdf.to_pandas()
+        pdf = pd.DataFrame({"A": [0, 1, 2, 3], "B": [5, 6, 7, 8], "group": ["a", "a", "b", "b"]})
+        pdf.columns = pd.MultiIndex.from_tuples([("y", "A"), ("y", "B"), ("x", "group")])
+        kdf = ks.from_pandas(pdf)
 
         if LooseVersion(pd.__version__) < LooseVersion("1.0.0"):
             agg_pdf = pd.DataFrame(

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -971,10 +971,10 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
 
     def test_difference(self):
         # Index
-        kidx1 = ks.Index([1, 2, 3, 4], name="koalas")
-        kidx2 = ks.Index([3, 4, 5, 6], name="koalas")
-        pidx1 = kidx1.to_pandas()
-        pidx2 = kidx2.to_pandas()
+        pidx1 = pd.Index([1, 2, 3, 4], name="koalas")
+        pidx2 = pd.Index([3, 4, 5, 6], name="koalas")
+        kidx1 = ks.from_pandas(pidx1)
+        kidx2 = ks.from_pandas(pidx2)
 
         self.assert_eq(kidx1.difference(kidx2).sort_values(), pidx1.difference(pidx2).sort_values())
         self.assert_eq(
@@ -1011,14 +1011,14 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
             kidx1.difference(kidx2, sort=1)
 
         # MultiIndex
-        kidx1 = ks.MultiIndex.from_tuples(
+        pidx1 = pd.MultiIndex.from_tuples(
             [("a", "x", 1), ("b", "y", 2), ("c", "z", 3)], names=["hello", "koalas", "world"]
         )
-        kidx2 = ks.MultiIndex.from_tuples(
+        pidx2 = pd.MultiIndex.from_tuples(
             [("a", "x", 1), ("b", "z", 2), ("k", "z", 3)], names=["hello", "koalas", "world"]
         )
-        pidx1 = kidx1.to_pandas()
-        pidx2 = kidx2.to_pandas()
+        kidx1 = ks.from_pandas(pidx1)
+        kidx2 = ks.from_pandas(pidx2)
 
         self.assert_eq(kidx1.difference(kidx2).sort_values(), pidx1.difference(pidx2).sort_values())
         self.assert_eq(

--- a/databricks/koalas/tests/test_indexing.py
+++ b/databricks/koalas/tests/test_indexing.py
@@ -106,10 +106,10 @@ class BasicIndexingTest(ComparisonTestBase):
         pdf = self.pdf
 
         df1 = ks.from_pandas(pdf.set_index("month"))
-        self.assertPandasEqual(df1.toPandas(), pdf.set_index("month"))
+        self.assertPandasEqual(df1.to_pandas(), pdf.set_index("month"))
 
         df2 = ks.from_pandas(pdf.set_index(["year", "month"]))
-        self.assertPandasEqual(df2.toPandas(), pdf.set_index(["year", "month"]))
+        self.assertPandasEqual(df2.to_pandas(), pdf.set_index(["year", "month"]))
 
     def test_limitations(self):
         df = self.kdf.set_index("month")

--- a/databricks/koalas/tests/test_ops_on_diff_frames.py
+++ b/databricks/koalas/tests/test_ops_on_diff_frames.py
@@ -901,10 +901,10 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
             kdf[("1", "2", "3")] = ks.Series([100, 200, 300, 200])
 
     def test_dot(self):
-        kser = ks.Series([90, 91, 85], index=[2, 4, 1])
-        pser = kser.to_pandas()
-        kser_other = ks.Series([90, 91, 85], index=[2, 4, 1])
-        pser_other = kser_other.to_pandas()
+        pser = pd.Series([90, 91, 85], index=[2, 4, 1])
+        kser = ks.from_pandas(pser)
+        pser_other = pd.Series([90, 91, 85], index=[2, 4, 1])
+        kser_other = ks.from_pandas(pser_other)
 
         self.assert_eq(kser.dot(kser_other), pser.dot(pser_other))
 
@@ -930,10 +930,10 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
             [["lama", "cow", "falcon"], ["speed", "weight", "length"]],
             [[0, 0, 0, 1, 1, 1, 2, 2, 2], [0, 1, 2, 0, 1, 2, 0, 1, 2]],
         )
-        kser = ks.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3], index=midx)
-        pser = kser.to_pandas()
-        kser_other = ks.Series([-450, 20, 12, -30, -250, 15, -320, 100, 3], index=midx)
-        pser_other = kser_other.to_pandas()
+        pser = pd.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3], index=midx)
+        kser = ks.from_pandas(pser)
+        pser_other = pd.Series([-450, 20, 12, -30, -250, 15, -320, 100, 3], index=midx)
+        kser_other = ks.from_pandas(pser_other)
 
         self.assert_eq(kser.dot(kser_other), pser.dot(pser_other))
 

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -92,12 +92,12 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         b = pd.Series([None, None, None], dtype="str")
 
         self.assert_eq(ks.from_pandas(a).dtype, a.dtype)
-        self.assertTrue(ks.from_pandas(a).toPandas().isnull().all())
+        self.assertTrue(ks.from_pandas(a).to_pandas().isnull().all())
         self.assertRaises(ValueError, lambda: ks.from_pandas(b))
 
         with self.sql_conf({"spark.sql.execution.arrow.enabled": False}):
             self.assert_eq(ks.from_pandas(a).dtype, a.dtype)
-            self.assertTrue(ks.from_pandas(a).toPandas().isnull().all())
+            self.assertTrue(ks.from_pandas(a).to_pandas().isnull().all())
             self.assertRaises(ValueError, lambda: ks.from_pandas(b))
 
     def test_head_tail(self):

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -1247,8 +1247,8 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
             [["a", "b", "c"], ["lama", "cow", "falcon"], ["speed", "weight", "length"]],
             [[0, 0, 0, 1, 1, 1, 2, 2, 2], [0, 0, 0, 1, 1, 1, 2, 2, 2], [0, 1, 2, 0, 1, 2, 0, 1, 2]],
         )
-        kser = ks.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3], index=midx)
-        pser = kser.to_pandas()
+        pser = pd.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3], index=midx)
+        kser = ks.from_pandas(pser)
 
         self.assert_eq(kser.xs(("a", "lama", "speed")), pser.xs(("a", "lama", "speed")))
 
@@ -1343,16 +1343,16 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
             [["lama", "cow", "falcon"], ["speed", "weight", "length"]],
             [[0, 0, 0, 1, 1, 1, 2, 2, 2], [0, 1, 2, 0, 1, 2, 0, 1, 2]],
         )
-        kser = ks.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3], index=midx)
-        pser = kser.to_pandas()
+        pser = pd.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3], index=midx)
+        kser = ks.from_pandas(pser)
 
         self.assert_eq(kser.keys(), pser.keys())
 
     def test_index(self):
         # to check setting name of Index properly.
         idx = pd.Index([1, 2, 3, 4, 5, 6, 7, 8, 9])
-        kser = ks.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3], index=idx)
-        pser = kser.to_pandas()
+        pser = pd.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3], index=idx)
+        kser = ks.from_pandas(pser)
 
         kser.name = "koalas"
         pser.name = "koalas"
@@ -1364,8 +1364,8 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(kser.index.names, pser.index.names)
 
     def test_pct_change(self):
-        kser = ks.Series([90, 91, 85], index=[2, 4, 1])
-        pser = kser.to_pandas()
+        pser = pd.Series([90, 91, 85], index=[2, 4, 1])
+        kser = ks.from_pandas(pser)
 
         self.assert_eq(kser.pct_change(periods=-1), pser.pct_change(periods=-1), almost=True)
         self.assert_eq(
@@ -1380,8 +1380,8 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
             [["lama", "cow", "falcon"], ["speed", "weight", "length"]],
             [[0, 0, 0, 1, 1, 1, 2, 2, 2], [0, 1, 2, 0, 1, 2, 0, 1, 2]],
         )
-        kser = ks.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3], index=midx)
-        pser = kser.to_pandas()
+        pser = pd.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3], index=midx)
+        kser = ks.from_pandas(pser)
 
         self.assert_eq(kser.pct_change(), pser.pct_change(), almost=True)
         self.assert_eq(kser.pct_change(periods=2), pser.pct_change(periods=2), almost=True)
@@ -1394,8 +1394,8 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         )
 
     def test_axes(self):
-        kser = ks.Series([90, 91, 85], index=[2, 4, 1])
-        pser = kser.to_pandas()
+        pser = pd.Series([90, 91, 85], index=[2, 4, 1])
+        kser = ks.from_pandas(pser)
         self.assert_list_eq(kser.axes, pser.axes)
 
         # for MultiIndex
@@ -1403,15 +1403,15 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
             [["lama", "cow", "falcon"], ["speed", "weight", "length"]],
             [[0, 0, 0, 1, 1, 1, 2, 2, 2], [0, 1, 2, 0, 1, 2, 0, 1, 2]],
         )
-        kser = ks.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3], index=midx)
-        pser = kser.to_pandas()
+        pser = pd.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3], index=midx)
+        kser = ks.from_pandas(pser)
         self.assert_list_eq(kser.axes, pser.axes)
 
     def test_combine_first(self):
-        kser1 = ks.Series({"falcon": 330.0, "eagle": 160.0})
-        kser2 = ks.Series({"falcon": 345.0, "eagle": 200.0, "duck": 30.0})
-        pser1 = kser1.to_pandas()
-        pser2 = kser2.to_pandas()
+        pser1 = pd.Series({"falcon": 330.0, "eagle": 160.0})
+        pser2 = pd.Series({"falcon": 345.0, "eagle": 200.0, "duck": 30.0})
+        kser1 = ks.from_pandas(pser1)
+        kser2 = ks.from_pandas(pser2)
 
         self.assert_eq(
             kser1.combine_first(kser2).sort_index(), pser1.combine_first(pser2).sort_index()
@@ -1438,26 +1438,26 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
             [["lama", "cow", "falcon"], ["speed", "weight", "length"]],
             [[0, 0, 0, 1, 1, 1, 2, 2, 2], [0, 1, 2, 0, 1, 2, 0, 1, 2]],
         )
-        kser1 = ks.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1], index=midx1)
-        kser2 = ks.Series([-45, 200, -1.2, 30, -250, 1.5, 320, 1, -0.3], index=midx2)
-        pser1 = kser1.to_pandas()
-        pser2 = kser2.to_pandas()
+        pser1 = pd.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1], index=midx1)
+        pser2 = pd.Series([-45, 200, -1.2, 30, -250, 1.5, 320, 1, -0.3], index=midx2)
+        kser1 = ks.from_pandas(pser1)
+        kser2 = ks.from_pandas(pser2)
 
         self.assert_eq(
             kser1.combine_first(kser2).sort_index(), pser1.combine_first(pser2).sort_index()
         )
 
         # Series come from same DataFrame
-        kdf = ks.DataFrame(
+        pdf = pd.DataFrame(
             {
                 "A": {"falcon": 330.0, "eagle": 160.0},
                 "B": {"falcon": 345.0, "eagle": 200.0, "duck": 30.0},
             }
         )
-        kser1 = kdf.A
-        kser2 = kdf.B
-        pser1 = kser1.to_pandas()
-        pser2 = kser2.to_pandas()
+        pser1 = pdf.A
+        pser2 = pdf.B
+        kser1 = ks.from_pandas(pser1)
+        kser2 = ks.from_pandas(pser2)
 
         self.assert_eq(
             kser1.combine_first(kser2).sort_index(), pser1.combine_first(pser2).sort_index()
@@ -1601,25 +1601,25 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
 
     def test_squeeze(self):
         # Single value
-        kser = ks.Series([90])
-        pser = kser.to_pandas()
+        pser = pd.Series([90])
+        kser = ks.from_pandas(pser)
         self.assert_eq(kser.squeeze(), pser.squeeze())
 
         # Single value with MultiIndex
         midx = pd.MultiIndex.from_tuples([("a", "b", "c")])
-        kser = ks.Series([90], index=midx)
-        pser = kser.to_pandas()
+        pser = pd.Series([90], index=midx)
+        kser = ks.from_pandas(pser)
         self.assert_eq(kser.squeeze(), pser.squeeze())
 
         # Multiple values
-        kser = ks.Series([90, 91, 85])
-        pser = kser.to_pandas()
+        pser = pd.Series([90, 91, 85])
+        kser = ks.from_pandas(pser)
         self.assert_eq(kser.squeeze(), pser.squeeze())
 
         # Multiple values with MultiIndex
         midx = pd.MultiIndex.from_tuples([("a", "x"), ("b", "y"), ("c", "z")])
-        kser = ks.Series([90, 91, 85], index=midx)
-        pser = kser.to_pandas()
+        pser = pd.Series([90, 91, 85], index=midx)
+        kser = ks.from_pandas(pser)
         self.assert_eq(kser.squeeze(), pser.squeeze())
 
     def test_div_zero_and_nan(self):
@@ -1675,28 +1675,28 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(pser.mad(), kser.mad())
 
     def test_to_frame(self):
-        kser = ks.Series(["a", "b", "c"])
-        pser = kser.to_pandas()
+        pser = pd.Series(["a", "b", "c"])
+        kser = ks.from_pandas(pser)
 
         self.assert_eq(pser.to_frame(name="a"), kser.to_frame(name="a"))
 
         # for MultiIndex
         midx = pd.MultiIndex.from_tuples([("a", "x"), ("b", "y"), ("c", "z")])
-        kser = ks.Series(["a", "b", "c"], index=midx)
-        pser = kser.to_pandas()
+        pser = pd.Series(["a", "b", "c"], index=midx)
+        kser = ks.from_pandas(pser)
 
         self.assert_eq(pser.to_frame(name="a"), kser.to_frame(name="a"))
 
     def test_shape(self):
-        kser = ks.Series(["a", "b", "c"])
-        pser = kser.to_pandas()
+        pser = pd.Series(["a", "b", "c"])
+        kser = ks.from_pandas(pser)
 
         self.assert_eq(pser.shape, kser.shape)
 
         # for MultiIndex
         midx = pd.MultiIndex.from_tuples([("a", "x"), ("b", "y"), ("c", "z")])
-        kser = ks.Series(["a", "b", "c"], index=midx)
-        pser = kser.to_pandas()
+        pser = pd.Series(["a", "b", "c"], index=midx)
+        kser = ks.from_pandas(pser)
 
         self.assert_eq(pser.shape, kser.shape)
 


### PR DESCRIPTION
1. Use `ks.from_pandas` instead of `to_pandas()` to avoid unnecessary copy internally.
2. Use `to_pandas()` instead of `toPandas()` since we've explicitly exposed the former in our official document.
3. Deprecate `toPandas()`