### PR TITLE
Introduce `check_exact` parameter for assertions.

### DIFF
--- a/databricks/koalas/testing/utils.py
+++ b/databricks/koalas/testing/utils.py
@@ -131,7 +131,7 @@ class ReusedSQLTestCase(unittest.TestCase, SQLTestUtils):
         # Please see databricks/koalas/conftest.py.
         pass
 
-    def assertPandasEqual(self, left, right, less_precise=False):
+    def assertPandasEqual(self, left, right, check_exact=True):
         if isinstance(left, pd.DataFrame) and isinstance(right, pd.DataFrame):
             try:
                 pd.util.testing.assert_frame_equal(
@@ -139,7 +139,7 @@ class ReusedSQLTestCase(unittest.TestCase, SQLTestUtils):
                     right,
                     check_index_type=("equiv" if len(left.index) > 0 else False),
                     check_column_type=("equiv" if len(left.columns) > 0 else False),
-                    check_exact=(not less_precise),
+                    check_exact=check_exact,
                 )
             except AssertionError as e:
                 msg = (
@@ -154,7 +154,7 @@ class ReusedSQLTestCase(unittest.TestCase, SQLTestUtils):
                     left,
                     right,
                     check_index_type=("equiv" if len(left.index) > 0 else False),
-                    check_exact=(not less_precise),
+                    check_exact=check_exact,
                 )
             except AssertionError as e:
                 msg = (
@@ -165,9 +165,7 @@ class ReusedSQLTestCase(unittest.TestCase, SQLTestUtils):
                 raise AssertionError(msg) from e
         elif isinstance(left, pd.Index) and isinstance(right, pd.Index):
             try:
-                pd.util.testing.assert_index_equal(
-                    left, right, check_exact=(not less_precise),
-                )
+                pd.util.testing.assert_index_equal(left, right, check_exact=check_exact)
             except AssertionError as e:
                 msg = (
                     str(e)
@@ -234,14 +232,14 @@ class ReusedSQLTestCase(unittest.TestCase, SQLTestUtils):
         else:
             raise ValueError("Unexpected values: (%s, %s)" % (left, right))
 
-    def assert_eq(self, left, right, less_precise=False, almost=False):
+    def assert_eq(self, left, right, check_exact=True, almost=False):
         """
         Asserts if two arbitrary objects are equal or not. If given objects are Koalas DataFrame
         or Series, they are converted into pandas' and compared.
 
         :param left: object to compare
         :param right: object to compare
-        :param less_precise: if this is enabled, the comparison is done less precisely.
+        :param check_exact: if this is False, the comparison is done less precisely.
         :param almost: if this is enabled, the comparison is delegated to `unittest`'s
                        `assertAlmostEqual`. See its documentation for more details.
         """
@@ -251,7 +249,7 @@ class ReusedSQLTestCase(unittest.TestCase, SQLTestUtils):
             if almost:
                 self.assertPandasAlmostEqual(lpdf, rpdf)
             else:
-                self.assertPandasEqual(lpdf, rpdf, less_precise)
+                self.assertPandasEqual(lpdf, rpdf, check_exact=check_exact)
         else:
             if almost:
                 self.assertAlmostEqual(lpdf, rpdf)

--- a/databricks/koalas/testing/utils.py
+++ b/databricks/koalas/testing/utils.py
@@ -131,7 +131,7 @@ class ReusedSQLTestCase(unittest.TestCase, SQLTestUtils):
         # Please see databricks/koalas/conftest.py.
         pass
 
-    def assertPandasEqual(self, left, right):
+    def assertPandasEqual(self, left, right, less_precise=False):
         if isinstance(left, pd.DataFrame) and isinstance(right, pd.DataFrame):
             try:
                 pd.util.testing.assert_frame_equal(
@@ -139,7 +139,7 @@ class ReusedSQLTestCase(unittest.TestCase, SQLTestUtils):
                     right,
                     check_index_type=("equiv" if len(left.index) > 0 else False),
                     check_column_type=("equiv" if len(left.columns) > 0 else False),
-                    check_exact=True,
+                    check_exact=(not less_precise),
                 )
             except AssertionError as e:
                 msg = (
@@ -154,7 +154,7 @@ class ReusedSQLTestCase(unittest.TestCase, SQLTestUtils):
                     left,
                     right,
                     check_index_type=("equiv" if len(left.index) > 0 else False),
-                    check_exact=True,
+                    check_exact=(not less_precise),
                 )
             except AssertionError as e:
                 msg = (
@@ -165,7 +165,9 @@ class ReusedSQLTestCase(unittest.TestCase, SQLTestUtils):
                 raise AssertionError(msg) from e
         elif isinstance(left, pd.Index) and isinstance(right, pd.Index):
             try:
-                pd.util.testing.assert_index_equal(left, right, check_exact=True)
+                pd.util.testing.assert_index_equal(
+                    left, right, check_exact=(not less_precise),
+                )
             except AssertionError as e:
                 msg = (
                     str(e)
@@ -232,13 +234,14 @@ class ReusedSQLTestCase(unittest.TestCase, SQLTestUtils):
         else:
             raise ValueError("Unexpected values: (%s, %s)" % (left, right))
 
-    def assert_eq(self, left, right, almost=False):
+    def assert_eq(self, left, right, less_precise=False, almost=False):
         """
         Asserts if two arbitrary objects are equal or not. If given objects are Koalas DataFrame
         or Series, they are converted into pandas' and compared.
 
         :param left: object to compare
         :param right: object to compare
+        :param less_precise: if this is enabled, the comparison is done less precisely.
         :param almost: if this is enabled, the comparison is delegated to `unittest`'s
                        `assertAlmostEqual`. See its documentation for more details.
         """
@@ -248,7 +251,7 @@ class ReusedSQLTestCase(unittest.TestCase, SQLTestUtils):
             if almost:
                 self.assertPandasAlmostEqual(lpdf, rpdf)
             else:
-                self.assertPandasEqual(lpdf, rpdf)
+                self.assertPandasEqual(lpdf, rpdf, less_precise)
         else:
             if almost:
                 self.assertAlmostEqual(lpdf, rpdf)

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -1316,9 +1316,9 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         kser = ks.Series([90, 91, 85], index=[2, 4, 1])
         pser = kser.to_pandas()
 
-        self.assert_eq(kser.pct_change(), pser.pct_change(), almost=True)
-        self.assert_eq(kser.pct_change(periods=2), pser.pct_change(periods=2), almost=True)
-        self.assert_eq(kser.pct_change(periods=-1), pser.pct_change(periods=-1), almost=True)
+        self.assert_eq(kser.pct_change(), pser.pct_change(), less_precise=True)
+        self.assert_eq(kser.pct_change(periods=2), pser.pct_change(periods=2), less_precise=True)
+        self.assert_eq(kser.pct_change(periods=-1), pser.pct_change(periods=-1), less_precise=True)
         self.assert_eq(kser.pct_change(periods=-100000000), pser.pct_change(periods=-100000000))
         self.assert_eq(kser.pct_change(periods=100000000), pser.pct_change(periods=100000000))
 
@@ -1330,9 +1330,9 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         kser = ks.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3], index=midx)
         pser = kser.to_pandas()
 
-        self.assert_eq(kser.pct_change(), pser.pct_change(), almost=True)
-        self.assert_eq(kser.pct_change(periods=2), pser.pct_change(periods=2), almost=True)
-        self.assert_eq(kser.pct_change(periods=-1), pser.pct_change(periods=-1), almost=True)
+        self.assert_eq(kser.pct_change(), pser.pct_change(), less_precise=True)
+        self.assert_eq(kser.pct_change(periods=2), pser.pct_change(periods=2), less_precise=True)
+        self.assert_eq(kser.pct_change(periods=-1), pser.pct_change(periods=-1), less_precise=True)
         self.assert_eq(kser.pct_change(periods=-100000000), pser.pct_change(periods=-100000000))
         self.assert_eq(kser.pct_change(periods=100000000), pser.pct_change(periods=100000000))
 

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -1316,9 +1316,9 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         kser = ks.Series([90, 91, 85], index=[2, 4, 1])
         pser = kser.to_pandas()
 
-        self.assert_eq(kser.pct_change(), pser.pct_change(), less_precise=True)
-        self.assert_eq(kser.pct_change(periods=2), pser.pct_change(periods=2), less_precise=True)
-        self.assert_eq(kser.pct_change(periods=-1), pser.pct_change(periods=-1), less_precise=True)
+        self.assert_eq(kser.pct_change(), pser.pct_change(), check_exact=False)
+        self.assert_eq(kser.pct_change(periods=2), pser.pct_change(periods=2), check_exact=False)
+        self.assert_eq(kser.pct_change(periods=-1), pser.pct_change(periods=-1), check_exact=False)
         self.assert_eq(kser.pct_change(periods=-100000000), pser.pct_change(periods=-100000000))
         self.assert_eq(kser.pct_change(periods=100000000), pser.pct_change(periods=100000000))
 
@@ -1330,9 +1330,9 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         kser = ks.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3], index=midx)
         pser = kser.to_pandas()
 
-        self.assert_eq(kser.pct_change(), pser.pct_change(), less_precise=True)
-        self.assert_eq(kser.pct_change(periods=2), pser.pct_change(periods=2), less_precise=True)
-        self.assert_eq(kser.pct_change(periods=-1), pser.pct_change(periods=-1), less_precise=True)
+        self.assert_eq(kser.pct_change(), pser.pct_change(), check_exact=False)
+        self.assert_eq(kser.pct_change(periods=2), pser.pct_change(periods=2), check_exact=False)
+        self.assert_eq(kser.pct_change(periods=-1), pser.pct_change(periods=-1), check_exact=False)
         self.assert_eq(kser.pct_change(periods=-100000000), pser.pct_change(periods=-100000000))
         self.assert_eq(kser.pct_change(periods=100000000), pser.pct_change(periods=100000000))
 

--- a/databricks/koalas/tests/test_stats.py
+++ b/databricks/koalas/tests/test_stats.py
@@ -26,13 +26,15 @@ class StatsTest(ReusedSQLTestCase, SQLTestUtils):
     def _test_stat_functions(self, pdf, kdf):
         functions = ["max", "min", "mean", "sum"]
         for funcname in functions:
-            self.assert_eq(getattr(kdf.A, funcname)(), getattr(pdf.A, funcname)(), almost=True)
-            self.assert_eq(getattr(kdf, funcname)(), getattr(pdf, funcname)(), almost=True)
+            self.assert_eq(getattr(kdf.A, funcname)(), getattr(pdf.A, funcname)())
+            self.assert_eq(getattr(kdf, funcname)(), getattr(pdf, funcname)())
 
         functions = ["std", "var"]
         for funcname in functions:
-            self.assert_eq(getattr(kdf.A, funcname)(), getattr(pdf.A, funcname)(), almost=True)
-            self.assert_eq(getattr(kdf, funcname)(), getattr(pdf, funcname)(), almost=True)
+            self.assert_eq(
+                getattr(kdf.A, funcname)(), getattr(pdf.A, funcname)(), less_precise=True
+            )
+            self.assert_eq(getattr(kdf, funcname)(), getattr(pdf, funcname)(), less_precise=True)
 
         # NOTE: To test skew, kurt, and median, just make sure they run.
         #       The numbers are different in spark and pandas.
@@ -100,7 +102,7 @@ class StatsTest(ReusedSQLTestCase, SQLTestUtils):
             pdf = pd.util.testing.makeMissingDataframe(0.3, 42).fillna(0)
             kdf = ks.from_pandas(pdf)
 
-            self.assert_eq(kdf.corr(), pdf.corr(), almost=True)
+            self.assert_eq(kdf.corr(), pdf.corr(), less_precise=True)
 
             # Series
             pser_a = pdf.A
@@ -116,7 +118,7 @@ class StatsTest(ReusedSQLTestCase, SQLTestUtils):
             pdf.columns = columns
             kdf.columns = columns
 
-            self.assert_eq(kdf.corr(), pdf.corr(), almost=True)
+            self.assert_eq(kdf.corr(), pdf.corr(), less_precise=True)
 
             # Series
             pser_xa = pdf[("X", "A")]
@@ -124,7 +126,7 @@ class StatsTest(ReusedSQLTestCase, SQLTestUtils):
             kser_xa = kdf[("X", "A")]
             kser_xb = kdf[("X", "B")]
 
-            self.assertAlmostEqual(kser_xa.corr(kser_xb), pser_xa.corr(pser_xb))
+            self.assert_eq(kser_xa.corr(kser_xb), pser_xa.corr(pser_xb), almost=True)
 
     def test_cov_corr_meta(self):
         # Disable arrow execution since corr() is using UDT internally which is not supported.
@@ -155,8 +157,8 @@ class StatsTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(kdf.sum(), pdf.sum())
         self.assert_eq(kdf.mean(), pdf.mean())
 
-        self.assert_eq(kdf.var(), pdf.var(), almost=True)
-        self.assert_eq(kdf.std(), pdf.std(), almost=True)
+        self.assert_eq(kdf.var(), pdf.var(), less_precise=True)
+        self.assert_eq(kdf.std(), pdf.std(), less_precise=True)
 
     def test_stats_on_boolean_series(self):
         pser = pd.Series([True, False, True])

--- a/databricks/koalas/tests/test_stats.py
+++ b/databricks/koalas/tests/test_stats.py
@@ -32,9 +32,9 @@ class StatsTest(ReusedSQLTestCase, SQLTestUtils):
         functions = ["std", "var"]
         for funcname in functions:
             self.assert_eq(
-                getattr(kdf.A, funcname)(), getattr(pdf.A, funcname)(), less_precise=True
+                getattr(kdf.A, funcname)(), getattr(pdf.A, funcname)(), check_exact=False
             )
-            self.assert_eq(getattr(kdf, funcname)(), getattr(pdf, funcname)(), less_precise=True)
+            self.assert_eq(getattr(kdf, funcname)(), getattr(pdf, funcname)(), check_exact=False)
 
         # NOTE: To test skew, kurt, and median, just make sure they run.
         #       The numbers are different in spark and pandas.
@@ -102,7 +102,7 @@ class StatsTest(ReusedSQLTestCase, SQLTestUtils):
             pdf = pd.util.testing.makeMissingDataframe(0.3, 42).fillna(0)
             kdf = ks.from_pandas(pdf)
 
-            self.assert_eq(kdf.corr(), pdf.corr(), less_precise=True)
+            self.assert_eq(kdf.corr(), pdf.corr(), check_exact=False)
 
             # Series
             pser_a = pdf.A
@@ -118,7 +118,7 @@ class StatsTest(ReusedSQLTestCase, SQLTestUtils):
             pdf.columns = columns
             kdf.columns = columns
 
-            self.assert_eq(kdf.corr(), pdf.corr(), less_precise=True)
+            self.assert_eq(kdf.corr(), pdf.corr(), check_exact=False)
 
             # Series
             pser_xa = pdf[("X", "A")]
@@ -157,8 +157,8 @@ class StatsTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(kdf.sum(), pdf.sum())
         self.assert_eq(kdf.mean(), pdf.mean())
 
-        self.assert_eq(kdf.var(), pdf.var(), less_precise=True)
-        self.assert_eq(kdf.std(), pdf.std(), less_precise=True)
+        self.assert_eq(kdf.var(), pdf.var(), check_exact=False)
+        self.assert_eq(kdf.std(), pdf.std(), check_exact=False)
 
     def test_stats_on_boolean_series(self):
         pser = pd.Series([True, False, True])


### PR DESCRIPTION
Introduces `check_exact` parameter for assertions to use pandas testing utils for more cases instead of `almost=True`.