### PR TITLE
Fix plotting backend to refer the option.

### DIFF
--- a/databricks/koalas/plot.py
+++ b/databricks/koalas/plot.py
@@ -1318,7 +1318,7 @@ class KoalasPlotAccessor(PandasObject):
 
         return data, kwargs
 
-    def __call__(self, kind="line", backend="matplotlib", **kwargs):
+    def __call__(self, kind="line", backend=None, **kwargs):
 
         positional_args = locals()
         plot_backend = _get_plot_backend(backend)


### PR DESCRIPTION
The plot functions don't refer the option `plotting.backend` when the backend is not specified as a parameter but always shows `"matplotlib"` plots.

```py
>>> import databricks.koalas as ks
>>> ks.options.plotting.backend = "plotly"
>>> kdf = ks.DataFrame([[1, 2, 3, 4], [5, 6, 7, 8]], columns=["A", "B", "C", "D"])
>>> kdf.plot(kind="line")
<matplotlib.axes._subplots.AxesSubplot object at 0x121be2bb0>
```

After the fix:

```py
>>> kdf.plot(kind="line")
Figure({
...
})
```
