### PR TITLE
Set some upper bounds in setup.py file.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,8 +50,8 @@ setup(
     install_requires=[
         'pandas>=0.23.2,<1.1.0',
         'pyarrow>=0.10',
-        'numpy>=1.14',
-        'matplotlib>=3.0.0',
+        'numpy>=1.14,<1.19.0',
+        'matplotlib>=3.0.0,<3.3.0',
     ],
     author="Databricks",
     author_email="koalas@databricks.com",


### PR DESCRIPTION
We set upper bounds for `numpy` and `matplotlib` in `requirements-dev.txt`, so we should set them in `setup.py` as well.