### PR TITLE
Set a flake8 rule for unused imports.

### DIFF
--- a/databricks/koalas/__init__.py
+++ b/databricks/koalas/__init__.py
@@ -17,7 +17,7 @@ import os
 import sys
 from distutils.version import LooseVersion
 
-from databricks.koalas.version import __version__
+from databricks.koalas.version import __version__  # noqa: F401
 
 
 def assert_pyspark_version():

--- a/databricks/koalas/accessors.py
+++ b/databricks/koalas/accessors.py
@@ -22,7 +22,7 @@ from distutils.version import LooseVersion
 from typing import Tuple, Union, TYPE_CHECKING
 import types
 
-import numpy as np
+import numpy as np  # noqa: F401
 import pandas as pd
 import pyspark
 from pyspark.sql import functions as F

--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -25,7 +25,7 @@ from typing import Union, Callable, Any
 import warnings
 
 import numpy as np
-import pandas as pd
+import pandas as pd  # noqa: F401
 from pandas.api.types import is_list_like
 from pandas.core.accessor import CachedAccessor
 from pyspark import sql as spark

--- a/databricks/koalas/datetimes.py
+++ b/databricks/koalas/datetimes.py
@@ -20,7 +20,7 @@ Date/Time related functions on Koalas Series
 from typing import TYPE_CHECKING
 
 import numpy as np
-import pandas as pd
+import pandas as pd  # noqa: F401
 import pyspark.sql.functions as F
 from pyspark.sql.types import DateType, TimestampType, LongType
 

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -9925,7 +9925,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         3     NaN
         dtype: float64
         """
-        from databricks.koalas.series import Series, first_series
+        from databricks.koalas.series import first_series
 
         axis = validate_axis(axis)
 

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -25,7 +25,7 @@ from functools import reduce
 from typing import Optional, Union, List
 import warnings
 
-import numpy as np
+import numpy as np  # noqa: F401
 import pandas as pd
 
 from pyspark import sql as spark

--- a/databricks/koalas/internal.py
+++ b/databricks/koalas/internal.py
@@ -34,9 +34,10 @@ from pyspark.sql.types import BooleanType, DataType, StructField, StructType, Lo
 try:
     from pyspark.sql.types import to_arrow_type
 except ImportError:
-    from pyspark.sql.pandas.types import to_arrow_type
+    from pyspark.sql.pandas.types import to_arrow_type  # noqa: F401
 
-from databricks import koalas as ks  # For running doctests and reference resolution in PyCharm.
+# For running doctests and reference resolution in PyCharm.
+from databricks import koalas as ks  # noqa: F401
 
 if TYPE_CHECKING:
     # This is required in old Python 3.5 to prevent circular reference.

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -73,7 +73,6 @@ from databricks.koalas.utils import (
     validate_axis,
     validate_bool_kwarg,
     verify_temp_column_name,
-    default_session,
 )
 from databricks.koalas.datetimes import DatetimeMethods
 from databricks.koalas.spark import functions as SF

--- a/databricks/koalas/tests/test_extension.py
+++ b/databricks/koalas/tests/test_extension.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 import contextlib
-import unittest
-import warnings
 
 import numpy as np
 import pandas as pd

--- a/databricks/koalas/tests/test_indexing.py
+++ b/databricks/koalas/tests/test_indexing.py
@@ -22,7 +22,7 @@ import numpy as np
 import pandas as pd
 
 from databricks import koalas as ks
-from databricks.koalas.exceptions import SparkPandasIndexingError, SparkPandasNotImplementedError
+from databricks.koalas.exceptions import SparkPandasIndexingError
 from databricks.koalas.testing.utils import ComparisonTestBase, ReusedSQLTestCase, compare_both
 
 

--- a/databricks/koalas/typedef/string_typehints.py
+++ b/databricks/koalas/typedef/string_typehints.py
@@ -13,12 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import numpy as np
-import pandas
-import pandas as pd
-from numpy import *
-from pandas import *
-from inspect import getfullargspec
+import numpy as np  # noqa: F401
+import pandas  # noqa: F401
+import pandas as pd  # noqa: F401
+from numpy import *  # noqa: F401
+from pandas import *  # noqa: F401
+from inspect import getfullargspec  # noqa: F401
 
 
 def resolve_string_type_hint(tpe):

--- a/databricks/koalas/utils.py
+++ b/databricks/koalas/utils.py
@@ -30,7 +30,8 @@ from pyspark.sql.types import FloatType
 import pandas as pd
 from pandas.api.types import is_list_like
 
-from databricks import koalas as ks  # For running doctests and reference resolution in PyCharm.
+# For running doctests and reference resolution in PyCharm.
+from databricks import koalas as ks  # noqa: F401
 
 if TYPE_CHECKING:
     # This is required in old Python 3.5 to prevent circular reference.

--- a/databricks/koalas/window.py
+++ b/databricks/koalas/window.py
@@ -17,8 +17,6 @@ from collections import OrderedDict
 from functools import partial
 from typing import Any
 
-from databricks.koalas.internal import SPARK_INDEX_NAME_FORMAT
-from databricks.koalas.utils import name_like_string
 from pyspark.sql import Window
 from pyspark.sql import functions as F
 from databricks.koalas.missing.window import (
@@ -28,8 +26,10 @@ from databricks.koalas.missing.window import (
     MissingPandasLikeExpandingGroupby,
 )
 
-from databricks import koalas as ks  # For running doctests and reference resolution in PyCharm.
-from databricks.koalas.internal import NATURAL_ORDER_COLUMN_NAME
+# For running doctests and reference resolution in PyCharm.
+from databricks import koalas as ks  # noqa: F401
+
+from databricks.koalas.internal import NATURAL_ORDER_COLUMN_NAME, SPARK_INDEX_NAME_FORMAT
 from databricks.koalas.utils import scol_for
 
 

--- a/dev/lint-python
+++ b/dev/lint-python
@@ -158,7 +158,7 @@ flake8 checks failed."
     fi
 
     echo "starting $FLAKE8_BUILD test..."
-    FLAKE8_REPORT=$( ($FLAKE8_BUILD . --count --select=E901,E999,F821,F822,F823 \
+    FLAKE8_REPORT=$( ($FLAKE8_BUILD . --count --select=E901,E999,F821,F822,F823,F401 \
                      --exclude="docs/build/html/reference/api/*.py" \
                      --max-line-length=100 --show-source --statistics) 2>&1)
     FLAKE8_STATUS=$?


### PR DESCRIPTION
Let us take advantage of a flake8 rule `F401` to detect unused imports.