### PR TITLE
Upgrade PyArrow for CI.

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -115,7 +115,7 @@ jobs:
           - python-version: 3.8
             spark-version: 3.0.0
             pandas-version: 1.0.5
-            pyarrow-version: 1.0.0
+            pyarrow-version: 1.0.1
             default-index-type: 'distributed-sequence'
     env:
       PYTHON_VERSION: ${{ matrix.python-version }}


### PR DESCRIPTION
Upgrades PyArrow for CI to `1.0.1`.