### PR TITLE
Implemented DataFrame.product

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -10109,7 +10109,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             dtype = self._kser_for(column_label).spark.data_type
             if isinstance(dtype, NumericType):
                 column_labels.append(column_label)
-                if isinstance(dtype, DoubleType):
+                if isinstance(dtype, (DoubleType, FloatType)):
                     has_float_col = True
 
         # Getting spark columns from column names.
@@ -10142,7 +10142,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             if not has_float_col:
                 # Since the rows of the `result` is the same as the number of columns,
                 # it's assumed that it's small enough to use apply.
-                return result.apply(lambda row: int(round(row)))
+                return spark.apply(lambda col: F.round(col).cast(IntegerType()))
             else:
                 return result
 

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -53,6 +53,7 @@ from pyspark.sql.types import (
     StructType,
     StructField,
     ArrayType,
+    IntegerType,
 )
 from pyspark.sql.window import Window
 

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -10090,7 +10090,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         3  4  40  d
         4  5  50  e
 
-        >>> kdf.prod()
+        >>> kdf.prod().sort_index()
         A         120
         B    12000000
         dtype: int64

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -53,7 +53,7 @@ from pyspark.sql.types import (
     StructType,
     StructField,
     ArrayType,
-    IntegerType,
+    LongType,
 )
 from pyspark.sql.window import Window
 
@@ -10139,11 +10139,11 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         )
 
         with ks.option_context("compute.max_rows", None):
-            result = first_series(DataFrame(internal).transpose())
+            result = first_series(DataFrame(internal).T)
             if not has_float_col:
                 # Since the rows of the `result` is the same as the number of columns,
                 # it's assumed that it's small enough to use apply.
-                return spark.apply(lambda col: F.round(col).cast(IntegerType()))
+                return result.spark.transform(lambda col: F.round(col).cast(LongType()))
             else:
                 return result
 

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -10142,7 +10142,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             result = first_series(DataFrame(internal).T)
             if not has_float_col:
                 # Since the rows of the `result` is the same as the number of columns,
-                # it's assumed that it's small enough to use apply.
+                # it's assumed that it's small enough to use transform.
                 return result.spark.transform(lambda col: F.round(col).cast(LongType()))
             else:
                 return result

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -54,6 +54,7 @@ from pyspark.sql.types import (
     StructField,
     ArrayType,
     LongType,
+    FractionalType,
 )
 from pyspark.sql.window import Window
 
@@ -10110,7 +10111,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             dtype = self._kser_for(column_label).spark.data_type
             if isinstance(dtype, NumericType):
                 column_labels.append(column_label)
-                if isinstance(dtype, (DoubleType, FloatType)):
+                if isinstance(dtype, FractionalType):
                     has_float_col = True
 
         # Getting spark columns from column names.
@@ -10141,8 +10142,6 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         with ks.option_context("compute.max_rows", None):
             result = first_series(DataFrame(internal).T)
             if not has_float_col:
-                # Since the rows of the `result` is the same as the number of columns,
-                # it's assumed that it's small enough to use transform.
                 return result.spark.transform(lambda col: F.round(col).cast(LongType()))
             else:
                 return result

--- a/databricks/koalas/missing/frame.py
+++ b/databricks/koalas/missing/frame.py
@@ -55,8 +55,6 @@ class _MissingPandasLikeDataFrame(object):
     last = _unsupported_function("last")
     lookup = _unsupported_function("lookup")
     mode = _unsupported_function("mode")
-    prod = _unsupported_function("prod")
-    product = _unsupported_function("product")
     reindex_like = _unsupported_function("reindex_like")
     rename_axis = _unsupported_function("rename_axis")
     reorder_levels = _unsupported_function("reorder_levels")

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -3918,3 +3918,71 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         pdf = pd.Series([], name=0).to_frame()
         kdf = ks.Series([]).to_frame()
         self.assert_eq(pdf.first_valid_index(), kdf.first_valid_index())
+
+    def test_product(self):
+        pdf = pd.DataFrame(
+            {"A": [1, 2, 3, 4, 5], "B": [10, 20, 30, 40, 50], "C": ["a", "b", "c", "d", "e"]}
+        )
+        kdf = ks.from_pandas(pdf)
+        self.assert_eq(pdf.prod(), kdf.prod())
+
+        # Named columns
+        pdf.columns.name = "Koalas"
+        kdf = ks.from_pandas(pdf)
+        self.assert_eq(pdf.prod(), kdf.prod())
+
+        # MultiIndex columns
+        pdf.columns = pd.MultiIndex.from_tuples([("a", "x"), ("b", "y"), ("c", "z")])
+        kdf = ks.from_pandas(pdf)
+        self.assert_eq(pdf.prod(), kdf.prod())
+
+        # Named MultiIndex columns
+        pdf.columns.names = ["Hello", "Koalas"]
+        kdf = ks.from_pandas(pdf)
+        self.assert_eq(pdf.prod(), kdf.prod())
+
+        # No numeric columns
+        pdf = pd.DataFrame({"key": ["a", "b", "c"], "val": ["x", "y", "z"]})
+        kdf = ks.from_pandas(pdf)
+        self.assert_eq(pdf.prod(), kdf.prod())
+
+        # No numeric named columns
+        pdf.columns.name = "Koalas"
+        kdf = ks.from_pandas(pdf)
+        self.assert_eq(pdf.prod(), kdf.prod())
+
+        # No numeric MultiIndex columns
+        pdf.columns = pd.MultiIndex.from_tuples([("a", "x"), ("b", "y")])
+        kdf = ks.from_pandas(pdf)
+        self.assert_eq(pdf.prod(), kdf.prod())
+
+        # No numeric names MultiIndex columns
+        pdf.columns.names = ["Hello", "Koalas"]
+        kdf = ks.from_pandas(pdf)
+        self.assert_eq(pdf.prod(), kdf.prod())
+
+        # All NaN columns
+        pdf = pd.DataFrame(
+            {
+                "A": [np.nan, np.nan, np.nan, np.nan, np.nan],
+                "B": [10, 20, 30, 40, 50],
+                "C": ["a", "b", "c", "d", "e"],
+            }
+        )
+        kdf = ks.from_pandas(pdf)
+        self.assert_eq(pdf.prod(), kdf.prod(), almost=True)
+
+        # All NaN named columns
+        pdf.columns.name = "Koalas"
+        kdf = ks.from_pandas(pdf)
+        self.assert_eq(pdf.prod(), kdf.prod(), almost=True)
+
+        # All NaN MultiIndex columns
+        pdf.columns = pd.MultiIndex.from_tuples([("a", "x"), ("b", "y"), ("c", "z")])
+        kdf = ks.from_pandas(pdf)
+        self.assert_eq(pdf.prod(), kdf.prod(), almost=True)
+
+        # All NaN named MultiIndex columns
+        pdf.columns.names = ["Hello", "Koalas"]
+        kdf = ks.from_pandas(pdf)
+        self.assert_eq(pdf.prod(), kdf.prod(), almost=True)

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -3949,17 +3949,17 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         # No numeric named columns
         pdf.columns.name = "Koalas"
         kdf = ks.from_pandas(pdf)
-        self.assert_eq(pdf.prod(), kdf.prod().sort_index())
+        self.assert_eq(pdf.prod(), kdf.prod().sort_index(), almost=True)
 
         # No numeric MultiIndex columns
         pdf.columns = pd.MultiIndex.from_tuples([("a", "x"), ("b", "y")])
         kdf = ks.from_pandas(pdf)
-        self.assert_eq(pdf.prod(), kdf.prod().sort_index())
+        self.assert_eq(pdf.prod(), kdf.prod().sort_index(), almost=True)
 
         # No numeric named MultiIndex columns
         pdf.columns.names = ["Hello", "Koalas"]
         kdf = ks.from_pandas(pdf)
-        self.assert_eq(pdf.prod(), kdf.prod().sort_index())
+        self.assert_eq(pdf.prod(), kdf.prod().sort_index(), almost=True)
 
         # All NaN columns
         pdf = pd.DataFrame(

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -3924,42 +3924,42 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             {"A": [1, 2, 3, 4, 5], "B": [10, 20, 30, 40, 50], "C": ["a", "b", "c", "d", "e"]}
         )
         kdf = ks.from_pandas(pdf)
-        self.assert_eq(pdf.prod(), kdf.prod())
+        self.assert_eq(pdf.prod(), kdf.prod().sort_index())
 
         # Named columns
         pdf.columns.name = "Koalas"
         kdf = ks.from_pandas(pdf)
-        self.assert_eq(pdf.prod(), kdf.prod())
+        self.assert_eq(pdf.prod(), kdf.prod().sort_index())
 
         # MultiIndex columns
         pdf.columns = pd.MultiIndex.from_tuples([("a", "x"), ("b", "y"), ("c", "z")])
         kdf = ks.from_pandas(pdf)
-        self.assert_eq(pdf.prod(), kdf.prod())
+        self.assert_eq(pdf.prod(), kdf.prod().sort_index())
 
         # Named MultiIndex columns
         pdf.columns.names = ["Hello", "Koalas"]
         kdf = ks.from_pandas(pdf)
-        self.assert_eq(pdf.prod(), kdf.prod())
+        self.assert_eq(pdf.prod(), kdf.prod().sort_index())
 
         # No numeric columns
         pdf = pd.DataFrame({"key": ["a", "b", "c"], "val": ["x", "y", "z"]})
         kdf = ks.from_pandas(pdf)
-        self.assert_eq(pdf.prod(), kdf.prod())
+        self.assert_eq(pdf.prod(), kdf.prod().sort_index())
 
         # No numeric named columns
         pdf.columns.name = "Koalas"
         kdf = ks.from_pandas(pdf)
-        self.assert_eq(pdf.prod(), kdf.prod(), almost=True)
+        self.assert_eq(pdf.prod(), kdf.prod().sort_index(), almost=True)
 
         # No numeric MultiIndex columns
         pdf.columns = pd.MultiIndex.from_tuples([("a", "x"), ("b", "y")])
         kdf = ks.from_pandas(pdf)
-        self.assert_eq(pdf.prod(), kdf.prod(), almost=True)
+        self.assert_eq(pdf.prod(), kdf.prod().sort_index(), almost=True)
 
         # No numeric named MultiIndex columns
         pdf.columns.names = ["Hello", "Koalas"]
         kdf = ks.from_pandas(pdf)
-        self.assert_eq(pdf.prod(), kdf.prod(), almost=True)
+        self.assert_eq(pdf.prod(), kdf.prod().sort_index(), almost=True)
 
         # All NaN columns
         pdf = pd.DataFrame(
@@ -3970,19 +3970,19 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             }
         )
         kdf = ks.from_pandas(pdf)
-        self.assert_eq(pdf.prod(), kdf.prod(), almost=True)
+        self.assert_eq(pdf.prod(), kdf.prod().sort_index(), almost=True)
 
         # All NaN named columns
         pdf.columns.name = "Koalas"
         kdf = ks.from_pandas(pdf)
-        self.assert_eq(pdf.prod(), kdf.prod(), almost=True)
+        self.assert_eq(pdf.prod(), kdf.prod().sort_index(), almost=True)
 
         # All NaN MultiIndex columns
         pdf.columns = pd.MultiIndex.from_tuples([("a", "x"), ("b", "y"), ("c", "z")])
         kdf = ks.from_pandas(pdf)
-        self.assert_eq(pdf.prod(), kdf.prod(), almost=True)
+        self.assert_eq(pdf.prod(), kdf.prod().sort_index(), almost=True)
 
         # All NaN named MultiIndex columns
         pdf.columns.names = ["Hello", "Koalas"]
         kdf = ks.from_pandas(pdf)
-        self.assert_eq(pdf.prod(), kdf.prod(), almost=True)
+        self.assert_eq(pdf.prod(), kdf.prod().sort_index(), almost=True)

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -3932,7 +3932,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         # No numeric named columns
         pdf.columns.name = "Koalas"
         kdf = ks.from_pandas(pdf)
-        self.assert_eq(pdf.prod(), kdf.prod().sort_index())
+        self.assert_eq(pdf.prod(), kdf.prod().sort_index(), almost=True)
 
         # No numeric MultiIndex columns
         pdf.columns = pd.MultiIndex.from_tuples([("a", "x"), ("b", "y")])

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -3926,7 +3926,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         # No numeric named columns
         pdf.columns.name = "Koalas"
         kdf = ks.from_pandas(pdf)
-        self.assert_eq(pdf.prod(), kdf.prod().sort_index(), almost=True)
+        self.assert_eq(pdf.prod(), kdf.prod().sort_index())
 
         # No numeric MultiIndex columns
         pdf.columns = pd.MultiIndex.from_tuples([("a", "x"), ("b", "y")])
@@ -3947,19 +3947,19 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             }
         )
         kdf = ks.from_pandas(pdf)
-        self.assert_eq(pdf.prod(), kdf.prod().sort_index(), almost=True)
+        self.assert_eq(pdf.prod(), kdf.prod().sort_index(), check_exact=False)
 
         # All NaN named columns
         pdf.columns.name = "Koalas"
         kdf = ks.from_pandas(pdf)
-        self.assert_eq(pdf.prod(), kdf.prod().sort_index(), almost=True)
+        self.assert_eq(pdf.prod(), kdf.prod().sort_index(), check_exact=False)
 
         # All NaN MultiIndex columns
         pdf.columns = pd.MultiIndex.from_tuples([("a", "x"), ("b", "y"), ("c", "z")])
         kdf = ks.from_pandas(pdf)
-        self.assert_eq(pdf.prod(), kdf.prod().sort_index(), almost=True)
+        self.assert_eq(pdf.prod(), kdf.prod().sort_index(), check_exact=False)
 
         # All NaN named MultiIndex columns
         pdf.columns.names = ["Hello", "Koalas"]
         kdf = ks.from_pandas(pdf)
-        self.assert_eq(pdf.prod(), kdf.prod().sort_index(), almost=True)
+        self.assert_eq(pdf.prod(), kdf.prod().sort_index(), check_exact=False)

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -3949,7 +3949,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         # No numeric named columns
         pdf.columns.name = "Koalas"
         kdf = ks.from_pandas(pdf)
-        self.assert_eq(pdf.prod(), kdf.prod())
+        self.assert_eq(pdf.prod(), kdf.prod(), almost=True)
 
         # No numeric MultiIndex columns
         pdf.columns = pd.MultiIndex.from_tuples([("a", "x"), ("b", "y")])

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -3954,12 +3954,12 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         # No numeric MultiIndex columns
         pdf.columns = pd.MultiIndex.from_tuples([("a", "x"), ("b", "y")])
         kdf = ks.from_pandas(pdf)
-        self.assert_eq(pdf.prod(), kdf.prod())
+        self.assert_eq(pdf.prod(), kdf.prod(), almost=True)
 
-        # No numeric names MultiIndex columns
+        # No numeric named MultiIndex columns
         pdf.columns.names = ["Hello", "Koalas"]
         kdf = ks.from_pandas(pdf)
-        self.assert_eq(pdf.prod(), kdf.prod())
+        self.assert_eq(pdf.prod(), kdf.prod(), almost=True)
 
         # All NaN columns
         pdf = pd.DataFrame(

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -3949,17 +3949,17 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         # No numeric named columns
         pdf.columns.name = "Koalas"
         kdf = ks.from_pandas(pdf)
-        self.assert_eq(pdf.prod(), kdf.prod().sort_index(), almost=True)
+        self.assert_eq(pdf.prod(), kdf.prod().sort_index())
 
         # No numeric MultiIndex columns
         pdf.columns = pd.MultiIndex.from_tuples([("a", "x"), ("b", "y")])
         kdf = ks.from_pandas(pdf)
-        self.assert_eq(pdf.prod(), kdf.prod().sort_index(), almost=True)
+        self.assert_eq(pdf.prod(), kdf.prod().sort_index())
 
         # No numeric named MultiIndex columns
         pdf.columns.names = ["Hello", "Koalas"]
         kdf = ks.from_pandas(pdf)
-        self.assert_eq(pdf.prod(), kdf.prod().sort_index(), almost=True)
+        self.assert_eq(pdf.prod(), kdf.prod().sort_index())
 
         # All NaN columns
         pdf = pd.DataFrame(

--- a/docs/source/reference/frame.rst
+++ b/docs/source/reference/frame.rst
@@ -136,6 +136,8 @@ Computations / Descriptive Stats
    DataFrame.min
    DataFrame.median
    DataFrame.pct_change
+   DataFrame.prod
+   DataFrame.product
    DataFrame.quantile
    DataFrame.nunique
    DataFrame.skew


### PR DESCRIPTION
This PR introduces `DataFrame.product` for Koalas.

```python
# Non-numeric type column is not included to the result.

>>> kdf = ks.DataFrame({'A': [1, 2, 3, 4, 5],
...                     'B': [10, 20, 30, 40, 50],
...                     'C': ['a', 'b', 'c', 'd', 'e']})
>>> kdf
   A   B  C
0  1  10  a
1  2  20  b
2  3  30  c
3  4  40  d
4  5  50  e

>>> kdf.prod()
A         120
B    12000000
dtype: int64

# If there is no numeric type columns, returns empty Series.

>>> ks.DataFrame({"key": ['a', 'b', 'c'], "val": ['x', 'y', 'z']}).prod()
Series([], dtype: float64)
```