### PR TITLE
Excluded build directory from flake8

### DIFF
--- a/dev/lint-python
+++ b/dev/lint-python
@@ -159,7 +159,7 @@ flake8 checks failed."
 
     echo "starting $FLAKE8_BUILD test..."
     FLAKE8_REPORT=$( ($FLAKE8_BUILD . --count --select=E901,E999,F821,F822,F823,F401 \
-                     --exclude="docs/build/html/reference/api/*.py" \
+                     --exclude="docs/build/html/reference/api/*.py","build" \
                      --max-line-length=100 --show-source --statistics) 2>&1)
     FLAKE8_STATUS=$?
 


### PR DESCRIPTION
Since we use F401 rule for flake8 from #1736 ,

The local linter is failed in build directory as shown below.

![스크린샷 2020-09-02 오후 8 14 07](https://user-images.githubusercontent.com/44108233/91974731-25300e00-ed59-11ea-80c2-a5c882731720.png)


I think we can just exclude `build` directory from flake8 rule.