### PR TITLE
Implemented item for Index & MultiIndex

### DIFF
--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -2825,9 +2825,8 @@ class MultiIndex(Index):
         >>> kmidx.item()
         ('a', 'x')
         """
-        result = self._internal.spark_frame.head(2)
-        if len(result) == 1:
-            return tuple(result[0][nlevel] for nlevel in range(self.nlevels))
+        if len(self._kdf.head(2)) == 1:
+            return self.to_pandas().item()
         raise ValueError("can only convert an array of size 1 to a Python scalar")
 
     @property

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -1980,15 +1980,10 @@ class Index(IndexOpsMixin):
         >>> kidx = ks.Index([10])
         >>> kidx.item()
         10
-
-        Support MultiIndex
-
-        >>> kmidx = ks.MultiIndex.from_tuples([('a', 'x')])
-        >>> kmidx.item()
-        ('a', 'x')
         """
-        if len(self._kdf.head(2)) == 1:
-            return self.to_pandas().item()
+        result = self._internal.spark_frame.head(2)
+        if len(result) == 1:
+            return result[0][0]
         raise ValueError("can only convert an array of size 1 to a Python scalar")
 
     def __getattr__(self, item: str) -> Any:
@@ -2789,6 +2784,31 @@ class MultiIndex(Index):
             spark_frame=sdf.select(scol), index_map=OrderedDict({index_scol_name: index_name})
         )
         return ks.DataFrame(internal).index
+
+    def item(self):
+        """
+        Return the first element of the underlying data as a python tuple.
+
+        Returns
+        -------
+        tuple
+            The first element of MultiIndex.
+
+        Raises
+        ------
+        ValueError
+            If the data is not length-1.
+
+        Examples
+        --------
+        >>> kmidx = ks.MultiIndex.from_tuples([('a', 'x')])
+        >>> kmidx.item()
+        ('a', 'x')
+        """
+        result = self._internal.spark_frame.head(2)
+        if len(result) == 1:
+            return tuple(result[0][nlevel] for nlevel in range(self.nlevels))
+        raise ValueError("can only convert an array of size 1 to a Python scalar")
 
     def __iter__(self):
         return MissingPandasLikeMultiIndex.__iter__(self)

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -2825,7 +2825,7 @@ class MultiIndex(Index):
         >>> kmidx.item()
         ('a', 'x')
         """
-        self._kdf.head(2).to_pandas().index.item()
+        return self._kdf.head(2).to_pandas().index.item()
 
     @property
     def inferred_type(self):

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -2825,9 +2825,7 @@ class MultiIndex(Index):
         >>> kmidx.item()
         ('a', 'x')
         """
-        if len(self._kdf.head(2)) == 1:
-            return self.to_pandas().item()
-        raise ValueError("can only convert an array of size 1 to a Python scalar")
+        self._kdf.head(2).to_pandas().index.item()
 
     @property
     def inferred_type(self):

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -1961,6 +1961,36 @@ class Index(IndexOpsMixin):
         """
         return isinstance(self.spark.data_type, IntegralType)
 
+    def item(self):
+        """
+        Return the first element of the underlying data as a python scalar.
+
+        Returns
+        -------
+        scalar
+            The first element of Index.
+
+        Raises
+        ------
+        ValueError
+            If the data is not length-1.
+
+        Examples
+        --------
+        >>> kidx = ks.Index([10])
+        >>> kidx.item()
+        10
+
+        Support MultiIndex
+
+        >>> kmidx = ks.MultiIndex.from_tuples([('a', 'x')])
+        >>> kmidx.item()
+        ('a', 'x')
+        """
+        if len(self._kdf.head(2)) == 1:
+            return self.to_pandas().item()
+        raise ValueError("can only convert an array of size 1 to a Python scalar")
+
     def __getattr__(self, item: str) -> Any:
         if hasattr(MissingPandasLikeIndex, item):
             property_or_func = getattr(MissingPandasLikeIndex, item)

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -1981,10 +1981,7 @@ class Index(IndexOpsMixin):
         >>> kidx.item()
         10
         """
-        result = self._internal.spark_frame.head(2)
-        if len(result) == 1:
-            return result[0][0]
-        raise ValueError("can only convert an array of size 1 to a Python scalar")
+        return self.to_series().item()
 
     def __getattr__(self, item: str) -> Any:
         if hasattr(MissingPandasLikeIndex, item):

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -2825,7 +2825,7 @@ class MultiIndex(Index):
         >>> kmidx.item()
         ('a', 'x')
         """
-        return self._kdf.head(2).to_pandas().index.item()
+        return self._kdf.head(2)._to_internal_pandas().index.item()
 
     @property
     def inferred_type(self):

--- a/databricks/koalas/missing/indexes.py
+++ b/databricks/koalas/missing/indexes.py
@@ -148,7 +148,6 @@ class MissingPandasLikeMultiIndex(object):
     # Deprecated functions
     get_duplicates = _unsupported_function("get_duplicates", deprecated=True)
     get_values = _unsupported_function("get_values", deprecated=True)
-    item = _unsupported_function("item", deprecated=True)
     set_value = _unsupported_function("set_value", deprecated=True)
 
     # Functions we won't support.

--- a/databricks/koalas/missing/indexes.py
+++ b/databricks/koalas/missing/indexes.py
@@ -71,7 +71,6 @@ class MissingPandasLikeIndex(object):
 
     # Deprecated functions
     get_values = _unsupported_function("get_values", deprecated=True)
-    item = _unsupported_function("item", deprecated=True)
     set_value = _unsupported_function("set_value")
 
     # Properties we won't support.

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -14,8 +14,9 @@
 # limitations under the License.
 #
 
-from distutils.version import LooseVersion
 import inspect
+from distutils.version import LooseVersion
+from datetime import datetime
 
 import numpy as np
 import pandas as pd
@@ -1395,11 +1396,23 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
 
         self.assert_eq(pidx.item(), kidx.item())
 
+        # with timestamp
+        pidx = pd.Index([datetime(1990, 3, 9)])
+        kidx = ks.from_pandas(pidx)
+
+        self.assert_eq(pidx.item(), kidx.item())
+
         # MultiIndex
         pmidx = pd.MultiIndex.from_tuples([("a", "x")])
         kmidx = ks.from_pandas(pmidx)
 
         self.assert_eq(pmidx.item(), kmidx.item())
+
+        # MultiIndex with timestamp
+        pmidx = pd.MultiIndex.from_tuples([(datetime(1990, 3, 9), datetime(2019, 8, 15))])
+        kmidx = ks.from_pandas(pmidx)
+
+        self.assert_eq(pidx.item(), kidx.item())
 
         err_msg = "can only convert an array of size 1 to a Python scalar"
         with self.assertRaisesRegex(ValueError, err_msg):

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -1391,3 +1391,21 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         pser = pd.Series([pd.Timestamp("2020-07-30"), np.nan, pd.Timestamp("2020-07-30")])
         kser = ks.from_pandas(pser)
         self.assert_eq(pser.hasnans, kser.hasnans)
+
+    def test_item(self):
+        pidx = pd.Index([10])
+        kidx = ks.from_pandas(pidx)
+
+        self.assert_eq(pidx.item(), kidx.item())
+
+        # MultiIndex
+        pmidx = pd.MultiIndex.from_tuples([("a", "x")])
+        kmidx = ks.from_pandas(pmidx)
+
+        self.assert_eq(pmidx.item(), kmidx.item())
+
+        err_msg = "can only convert an array of size 1 to a Python scalar"
+        with self.assertRaisesRegex(ValueError, err_msg):
+            ks.Index([10, 20]).item()
+        with self.assertRaisesRegex(ValueError, err_msg):
+            ks.MultiIndex.from_tuples([("a", "x"), ("b", "y")]).item()

--- a/docs/source/reference/indexing.rst
+++ b/docs/source/reference/indexing.rst
@@ -98,6 +98,7 @@ Conversion
    :toctree: api/
 
    Index.astype
+   Index.item
    Index.to_series
    Index.to_frame
    Index.to_numpy
@@ -238,6 +239,7 @@ MultiIndex Conversion
    :toctree: api/
 
    MultiIndex.astype
+   MultiIndex.item
    MultiIndex.to_series
    MultiIndex.to_frame
    MultiIndex.to_numpy


### PR DESCRIPTION
Since `Index.item()` is un-deprecated from pandas 1.0.0 (https://github.com/pandas-dev/pandas/issues/29250), this PR proposes `Index.item()` and `MultiIndex.item()`.

```python
>>> kidx = ks.Index([10])
>>> kidx.item()
10

>>> kmidx = ks.MultiIndex.from_tuples([('a', 'x')])
>>> kmidx.item()
('a', 'x')
```