### PR TITLE
Add property inferred_type for Index & MultiIndex

### DIFF
--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -1967,9 +1967,6 @@ class Index(IndexOpsMixin):
         """
         Return a string of the type inferred from the values.
 
-        .. note:: Unlike pandas, inferred_type for Koalas never return "mixed" type
-                  since Spark can have only single type of columns internally
-
         Examples
         --------
         >>> from datetime import datetime

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -1988,7 +1988,6 @@ class Index(IndexOpsMixin):
         return lib.infer_dtype([self.to_series().head(1).item()])
 
     def __getattr__(self, item: str) -> Any:
-        print(f"item: {item}")
         if hasattr(MissingPandasLikeIndex, item):
             property_or_func = getattr(MissingPandasLikeIndex, item)
             if isinstance(property_or_func, property):

--- a/databricks/koalas/missing/indexes.py
+++ b/databricks/koalas/missing/indexes.py
@@ -53,7 +53,6 @@ class MissingPandasLikeIndex(object):
     intersection = _unsupported_function("intersection")
     is_ = _unsupported_function("is_")
     is_lexsorted_for_tuple = _unsupported_function("is_lexsorted_for_tuple")
-    is_mixed = _unsupported_function("is_mixed")
     is_type_compatible = _unsupported_function("is_type_compatible")
     join = _unsupported_function("join")
     map = _unsupported_function("map")
@@ -70,6 +69,7 @@ class MissingPandasLikeIndex(object):
     where = _unsupported_function("where")
 
     # Deprecated functions
+    is_mixed = _unsupported_function("is_mixed")
     get_values = _unsupported_function("get_values", deprecated=True)
     item = _unsupported_function("item", deprecated=True)
     set_value = _unsupported_function("set_value")
@@ -125,7 +125,6 @@ class MissingPandasLikeMultiIndex(object):
     is_ = _unsupported_function("is_")
     is_lexsorted = _unsupported_function("is_lexsorted")
     is_lexsorted_for_tuple = _unsupported_function("is_lexsorted_for_tuple")
-    is_mixed = _unsupported_function("is_mixed")
     is_type_compatible = _unsupported_function("is_type_compatible")
     join = _unsupported_function("join")
     map = _unsupported_function("map")
@@ -147,6 +146,7 @@ class MissingPandasLikeMultiIndex(object):
     where = _unsupported_function("where")
 
     # Deprecated functions
+    is_mixed = _unsupported_function("is_mixed")
     get_duplicates = _unsupported_function("get_duplicates", deprecated=True)
     get_values = _unsupported_function("get_values", deprecated=True)
     item = _unsupported_function("item", deprecated=True)

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -15,6 +15,7 @@
 #
 
 from distutils.version import LooseVersion
+from datetime import datetime
 import inspect
 
 import numpy as np
@@ -1391,3 +1392,29 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         pser = pd.Series([pd.Timestamp("2020-07-30"), np.nan, pd.Timestamp("2020-07-30")])
         kser = ks.from_pandas(pser)
         self.assert_eq(pser.hasnans, kser.hasnans)
+
+    def test_inferred_type(self):
+        # Integer
+        pidx = pd.Index([1, 2, 3])
+        kidx = ks.from_pandas(pidx)
+        self.assert_eq(pidx.inferred_type, kidx.inferred_type)
+
+        # Floating
+        pidx = pd.Index([1.0, 2.0, 3.0])
+        kidx = ks.from_pandas(pidx)
+        self.assert_eq(pidx.inferred_type, kidx.inferred_type)
+
+        # String
+        pidx = pd.Index(["a", "b", "c"])
+        kidx = ks.from_pandas(pidx)
+        self.assert_eq(pidx.inferred_type, kidx.inferred_type)
+
+        # Boolean
+        pidx = pd.Index([True, False, True, False])
+        kidx = ks.from_pandas(pidx)
+        self.assert_eq(pidx.inferred_type, kidx.inferred_type)
+
+        # MultiIndex
+        pmidx = pd.MultiIndex.from_tuples([("a", "x")])
+        kmidx = ks.from_pandas(pmidx)
+        self.assert_eq(pmidx.inferred_type, kmidx.inferred_type)

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -15,7 +15,6 @@
 #
 
 from distutils.version import LooseVersion
-from datetime import datetime
 import inspect
 
 import numpy as np

--- a/docs/source/reference/indexing.rst
+++ b/docs/source/reference/indexing.rst
@@ -24,6 +24,7 @@ Properties
    Index.has_duplicates
    Index.hasnans
    Index.dtype
+   Index.inferred_type
    Index.is_all_dates
    Index.shape
    Index.name
@@ -171,6 +172,7 @@ MultiIndex Properties
 
    MultiIndex.has_duplicates
    MultiIndex.hasnans
+   MultiIndex.inferred_type
    MultiIndex.is_all_dates
    MultiIndex.shape
    MultiIndex.names


### PR DESCRIPTION
Since Index.mixed is deprecated in pandas, and they recommend use `inferred_type`.
- Anyway in Koalas, `is_mixed()` is not that useful because we don't support the mixed type though.

```python
>>> pd.Index([1, 2, 3]).is_mixed()
<stdin>:1: FutureWarning: Index.is_mixed is deprecated and will be removed in a future version. Check index.inferred_type directly instead.
```

```python
>>> ks.Index([1, 2, 3]).inferred_type
'integer'

>>> ks.Index([1.0, 2.0, 3.0]).inferred_type
'floating'

>>> ks.Index(['a', 'b', 'c']).inferred_type
'string'

>>> ks.Index([True, False, True, False]).inferred_type
'boolean'
```