### PR TITLE
Fix typo: `Dataframe.notnull` -> `DataFrame.notnull`

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -3491,7 +3491,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         See Also
         --------
-        Dataframe.notnull
+        DataFrame.notnull
 
         Examples
         --------
@@ -3523,7 +3523,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         See Also
         --------
-        Dataframe.isnull
+        DataFrame.isnull
 
         Examples
         --------


### PR DESCRIPTION
Fix typo: `Dataframe.notnull` -> `DataFrame.notnull`.

It's currently unclickable due to a typo:

![unclickable](https://user-images.githubusercontent.com/17039389/92080806-11d67e80-edfd-11ea-89bd-3a5d5a8deb95.gif)

https://koalas.readthedocs.io/en/latest/reference/api/databricks.koalas.DataFrame.isnull.html#databricks.koalas.DataFrame.isnull


