### PR TITLE
Remove most of repr comparison.

### DIFF
--- a/databricks/koalas/tests/test_csv.py
+++ b/databricks/koalas/tests/test_csv.py
@@ -129,7 +129,7 @@ class CsvTest(ReusedSQLTestCase, TestUtils):
             def check(header="infer", names=None, usecols=None):
                 expected = pd.read_csv(fn, header=header, names=names, usecols=usecols)
                 actual = ks.read_csv(fn, header=header, names=names, usecols=usecols)
-                self.assertPandasAlmostEqual(expected, actual.to_pandas())
+                self.assert_eq(expected, actual, almost=True)
 
             check()
             check(header=None)
@@ -185,19 +185,19 @@ class CsvTest(ReusedSQLTestCase, TestUtils):
             # check with index_col
             expected = pd.read_csv(fn).set_index("name")
             actual = ks.read_csv(fn, index_col="name")
-            self.assertPandasAlmostEqual(expected, actual.to_pandas())
+            self.assert_eq(expected, actual, almost=True)
 
     def test_read_with_spark_schema(self):
         with self.csv_file(self.csv_text_2) as fn:
             actual = ks.read_csv(fn, names="A string, B string, C long, D long, E long")
             expected = pd.read_csv(fn, names=["A", "B", "C", "D", "E"])
-            self.assertEqual(repr(expected), repr(actual))
+            self.assert_eq(expected, actual)
 
     def test_read_csv_with_comment(self):
         with self.csv_file(self.csv_text_with_comments) as fn:
             expected = pd.read_csv(fn, comment="#")
             actual = ks.read_csv(fn, comment="#")
-            self.assertPandasAlmostEqual(expected, actual.to_pandas())
+            self.assert_eq(expected, actual, almost=True)
 
             self.assertRaisesRegex(
                 ValueError,
@@ -224,23 +224,23 @@ class CsvTest(ReusedSQLTestCase, TestUtils):
         with self.csv_file(self.csv_text_with_comments) as fn:
             expected = pd.read_csv(fn, comment="#", nrows=2)
             actual = ks.read_csv(fn, comment="#", nrows=2)
-            self.assertPandasAlmostEqual(expected, actual.to_pandas())
+            self.assert_eq(expected, actual, almost=True)
 
     def test_read_csv_with_sep(self):
         with self.csv_file(self.tab_delimited_csv_text) as fn:
             expected = pd.read_csv(fn, sep="\t")
             actual = ks.read_csv(fn, sep="\t")
-            self.assertPandasAlmostEqual(expected, actual.to_pandas())
+            self.assert_eq(expected, actual, almost=True)
 
     def test_read_csv_with_squeeze(self):
         with self.csv_file(self.csv_text) as fn:
             expected = pd.read_csv(fn, squeeze=True, usecols=["name"])
             actual = ks.read_csv(fn, squeeze=True, usecols=["name"])
-            self.assertPandasAlmostEqual(expected, actual.to_pandas())
+            self.assert_eq(expected, actual, almost=True)
 
             expected = pd.read_csv(fn, squeeze=True, usecols=["name", "amount"])
             actual = ks.read_csv(fn, squeeze=True, usecols=["name", "amount"])
-            self.assertPandasAlmostEqual(expected, actual.to_pandas())
+            self.assert_eq(expected, actual, almost=True)
 
     def test_read_csv_with_mangle_dupe_cols(self):
         self.assertRaisesRegex(

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -2162,16 +2162,21 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         )
         kdf2 = ks.from_pandas(pdf2)
 
-        self.assertEqual(repr(pdf1.transpose().sort_index()), repr(kdf1.transpose().sort_index()))
-
-        self.assert_eq(repr(pdf2.transpose().sort_index()), repr(kdf2.transpose().sort_index()))
+        self.assert_eq(
+            pdf1.transpose().sort_index().rename(columns=str), kdf1.transpose().sort_index()
+        )
+        self.assert_eq(
+            pdf2.transpose().sort_index().rename(columns=str), kdf2.transpose().sort_index()
+        )
 
         with option_context("compute.max_rows", None):
-            self.assertEqual(
-                repr(pdf1.transpose().sort_index()), repr(kdf1.transpose().sort_index())
+            self.assert_eq(
+                pdf1.transpose().sort_index().rename(columns=str), kdf1.transpose().sort_index()
             )
 
-            self.assert_eq(repr(pdf2.transpose().sort_index()), repr(kdf2.transpose().sort_index()))
+            self.assert_eq(
+                pdf2.transpose().sort_index().rename(columns=str), kdf2.transpose().sort_index()
+            )
 
         pdf3 = pd.DataFrame(
             {
@@ -2184,12 +2189,10 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         )
         kdf3 = ks.from_pandas(pdf3)
 
-        self.assertEqual(repr(pdf3.transpose().sort_index()), repr(kdf3.transpose().sort_index()))
+        self.assert_eq(pdf3.transpose().sort_index(), kdf3.transpose().sort_index())
 
         with option_context("compute.max_rows", None):
-            self.assertEqual(
-                repr(pdf3.transpose().sort_index()), repr(kdf3.transpose().sort_index())
-            )
+            self.assert_eq(pdf3.transpose().sort_index(), kdf3.transpose().sort_index())
 
     def _test_cummin(self, pdf, kdf):
         self.assert_eq(pdf.cummin(), kdf.cummin())
@@ -3274,7 +3277,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         pdf.columns = pd.MultiIndex.from_tuples([("a", "x"), ("b", "y"), ("c", "z")])
         kdf = ks.from_pandas(pdf)
 
-        self.assert_eq(repr(kdf.pct_change(2)), repr(pdf.pct_change(2)))
+        self.assert_eq(kdf.pct_change(2), pdf.pct_change(2), check_exact=False)
 
     def test_where(self):
         kdf = ks.from_pandas(self.pdf)
@@ -3849,8 +3852,9 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         )
         kdf = ks.from_pandas(pdf)
 
-        for p_items, k_items in zip(pdf.iteritems(), kdf.iteritems()):
-            self.assert_eq(repr(p_items), repr(k_items))
+        for (p_name, p_items), (k_name, k_items) in zip(pdf.iteritems(), kdf.iteritems()):
+            self.assert_eq(p_name, k_name)
+            self.assert_eq(p_items, k_items)
 
     def test_tail(self):
         if LooseVersion(pyspark.__version__) >= LooseVersion("3.0"):

--- a/databricks/koalas/tests/test_dataframe_conversion.py
+++ b/databricks/koalas/tests/test_dataframe_conversion.py
@@ -221,17 +221,18 @@ class DataFrameConversionTest(ReusedSQLTestCase, SQLTestUtils, TestUtils):
         )
         # Assert using a list of tuples as input
         self.assert_eq(
-            repr(ks.DataFrame.from_records([(1, 2), (3, 4)])),
-            repr(pd.DataFrame.from_records([(1, 2), (3, 4)])),
+            ks.DataFrame.from_records([(1, 2), (3, 4)]),
+            pd.DataFrame.from_records([(1, 2), (3, 4)]).rename(columns=str),
         )
         # Assert using a NumPy array as input
         self.assert_eq(
-            repr(ks.DataFrame.from_records(np.eye(3))), repr(pd.DataFrame.from_records(np.eye(3)))
+            ks.DataFrame.from_records(np.eye(3)),
+            pd.DataFrame.from_records(np.eye(3)).rename(columns=str),
         )
         # Asserting using a custom index
         self.assert_eq(
-            repr(ks.DataFrame.from_records([(1, 2), (3, 4)], index=[2, 3])),
-            repr(pd.DataFrame.from_records([(1, 2), (3, 4)], index=[2, 3])),
+            ks.DataFrame.from_records([(1, 2), (3, 4)], index=[2, 3]),
+            pd.DataFrame.from_records([(1, 2), (3, 4)], index=[2, 3]).rename(columns=str),
         )
         # Assert excluding excluding column(s)
         self.assert_eq(
@@ -245,6 +246,6 @@ class DataFrameConversionTest(ReusedSQLTestCase, SQLTestUtils, TestUtils):
         )
         # Assert limiting to a number of rows
         self.assert_eq(
-            repr(ks.DataFrame.from_records([(1, 2), (3, 4)], nrows=1)),
-            repr(pd.DataFrame.from_records([(1, 2), (3, 4)], nrows=1)),
+            ks.DataFrame.from_records([(1, 2), (3, 4)], nrows=1),
+            pd.DataFrame.from_records([(1, 2), (3, 4)], nrows=1).rename(columns=str),
         )

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -75,19 +75,19 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         kidx = self.kdf.index
 
         self.assert_eq(kidx.to_series(), pidx.to_series())
-        self.assert_eq(repr(kidx.to_series(name="a")), repr(pidx.to_series(name="a")))
+        self.assert_eq(kidx.to_series(name="a"), pidx.to_series(name="a"))
 
         # With name
         pidx.name = "Koalas"
         kidx.name = "Koalas"
-        self.assert_eq(repr(kidx.to_series()), repr(pidx.to_series()))
-        self.assert_eq(repr(kidx.to_series(name=("x", "a"))), repr(pidx.to_series(name=("x", "a"))))
+        self.assert_eq(kidx.to_series(), pidx.to_series())
+        self.assert_eq(kidx.to_series(name=("x", "a")), pidx.to_series(name=("x", "a")))
 
         # With tupled name
         pidx.name = ("x", "a")
         kidx.name = ("x", "a")
-        self.assert_eq(repr(kidx.to_series()), repr(pidx.to_series()))
-        self.assert_eq(repr(kidx.to_series(name="a")), repr(pidx.to_series(name="a")))
+        self.assert_eq(kidx.to_series(), pidx.to_series())
+        self.assert_eq(kidx.to_series(name="a"), pidx.to_series(name="a"))
 
         self.assert_eq((kidx + 1).to_series(), (pidx + 1).to_series())
 
@@ -106,37 +106,34 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         pidx = self.pdf.index
         kidx = self.kdf.index
 
-        self.assert_eq(repr(kidx.to_frame()), repr(pidx.to_frame()))
-        self.assert_eq(repr(kidx.to_frame(index=False)), repr(pidx.to_frame(index=False)))
+        self.assert_eq(kidx.to_frame(), pidx.to_frame().rename(columns=str))
+        self.assert_eq(kidx.to_frame(index=False), pidx.to_frame(index=False).rename(columns=str))
 
         pidx.name = "a"
         kidx.name = "a"
 
-        self.assert_eq(repr(kidx.to_frame()), repr(pidx.to_frame()))
-        self.assert_eq(repr(kidx.to_frame(index=False)), repr(pidx.to_frame(index=False)))
+        self.assert_eq(kidx.to_frame(), pidx.to_frame())
+        self.assert_eq(kidx.to_frame(index=False), pidx.to_frame(index=False))
 
         if LooseVersion(pd.__version__) >= LooseVersion("0.24"):
             # The `name` argument is added in pandas 0.24.
-            self.assert_eq(repr(kidx.to_frame(name="x")), repr(pidx.to_frame(name="x")))
+            self.assert_eq(kidx.to_frame(name="x"), pidx.to_frame(name="x"))
             self.assert_eq(
-                repr(kidx.to_frame(index=False, name="x")),
-                repr(pidx.to_frame(index=False, name="x")),
+                kidx.to_frame(index=False, name="x"), pidx.to_frame(index=False, name="x"),
             )
 
         pidx = self.pdf.set_index("b", append=True).index
         kidx = self.kdf.set_index("b", append=True).index
 
-        self.assert_eq(repr(kidx.to_frame()), repr(pidx.to_frame()))
-        self.assert_eq(repr(kidx.to_frame(index=False)), repr(pidx.to_frame(index=False)))
+        self.assert_eq(kidx.to_frame(), pidx.to_frame().rename(columns=str))
+        self.assert_eq(kidx.to_frame(index=False), pidx.to_frame(index=False).rename(columns=str))
 
         if LooseVersion(pd.__version__) >= LooseVersion("0.24"):
             # The `name` argument is added in pandas 0.24.
+            self.assert_eq(kidx.to_frame(name=["x", "y"]), pidx.to_frame(name=["x", "y"]))
             self.assert_eq(
-                repr(kidx.to_frame(name=["x", "y"])), repr(pidx.to_frame(name=["x", "y"]))
-            )
-            self.assert_eq(
-                repr(kidx.to_frame(index=False, name=["x", "y"])),
-                repr(pidx.to_frame(index=False, name=["x", "y"])),
+                kidx.to_frame(index=False, name=["x", "y"]),
+                pidx.to_frame(index=False, name=["x", "y"]),
             )
 
     def test_index_names(self):

--- a/databricks/koalas/tests/test_ops_on_diff_frames.py
+++ b/databricks/koalas/tests/test_ops_on_diff_frames.py
@@ -789,14 +789,14 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
         kdf1 = ks.from_pandas(pdf1)
         kdf2 = ks.from_pandas(pdf2)
 
-        self.assert_eq(repr(pdf1.where(pdf2 > 100)), repr(kdf1.where(kdf2 > 100).sort_index()))
+        self.assert_eq(pdf1.where(pdf2 > 100), kdf1.where(kdf2 > 100).sort_index())
 
         pdf1 = pd.DataFrame({"A": [-1, -2, -3, -4, -5], "B": [-100, -200, -300, -400, -500]})
         pdf2 = pd.DataFrame({"A": [-10, -20, -30, -40, -50], "B": [-5, -4, -3, -2, -1]})
         kdf1 = ks.from_pandas(pdf1)
         kdf2 = ks.from_pandas(pdf2)
 
-        self.assert_eq(repr(pdf1.where(pdf2 < -250)), repr(kdf1.where(kdf2 < -250).sort_index()))
+        self.assert_eq(pdf1.where(pdf2 < -250), kdf1.where(kdf2 < -250).sort_index())
 
         # multi-index columns
         pdf1 = pd.DataFrame({("X", "A"): [0, 1, 2, 3, 4], ("X", "B"): [100, 200, 300, 400, 500]})
@@ -806,7 +806,7 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
         kdf1 = ks.from_pandas(pdf1)
         kdf2 = ks.from_pandas(pdf2)
 
-        self.assert_eq(repr(pdf1.where(pdf2 > 100)), repr(kdf1.where(kdf2 > 100).sort_index()))
+        self.assert_eq(pdf1.where(pdf2 > 100), kdf1.where(kdf2 > 100).sort_index())
 
     def test_mask(self):
         pdf1 = pd.DataFrame({"A": [0, 1, 2, 3, 4], "B": [100, 200, 300, 400, 500]})
@@ -814,14 +814,14 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
         kdf1 = ks.from_pandas(pdf1)
         kdf2 = ks.from_pandas(pdf2)
 
-        self.assert_eq(repr(pdf1.mask(pdf2 < 100)), repr(kdf1.mask(kdf2 < 100).sort_index()))
+        self.assert_eq(pdf1.mask(pdf2 < 100), kdf1.mask(kdf2 < 100).sort_index())
 
         pdf1 = pd.DataFrame({"A": [-1, -2, -3, -4, -5], "B": [-100, -200, -300, -400, -500]})
         pdf2 = pd.DataFrame({"A": [-10, -20, -30, -40, -50], "B": [-5, -4, -3, -2, -1]})
         kdf1 = ks.from_pandas(pdf1)
         kdf2 = ks.from_pandas(pdf2)
 
-        self.assert_eq(repr(pdf1.mask(pdf2 > -250)), repr(kdf1.mask(kdf2 > -250).sort_index()))
+        self.assert_eq(pdf1.mask(pdf2 > -250), kdf1.mask(kdf2 > -250).sort_index())
 
         # multi-index columns
         pdf1 = pd.DataFrame({("X", "A"): [0, 1, 2, 3, 4], ("X", "B"): [100, 200, 300, 400, 500]})
@@ -831,7 +831,7 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
         kdf1 = ks.from_pandas(pdf1)
         kdf2 = ks.from_pandas(pdf2)
 
-        self.assert_eq(repr(pdf1.mask(pdf2 < 100)), repr(kdf1.mask(kdf2 < 100).sort_index()))
+        self.assert_eq(pdf1.mask(pdf2 < 100), kdf1.mask(kdf2 < 100).sort_index())
 
     def test_multi_index_column_assignment_frame(self):
         pdf = pd.DataFrame({"a": [1, 2, 3, 2], "b": [4.0, 2.0, 3.0, 1.0]})
@@ -1036,7 +1036,7 @@ class OpsOnDiffFramesDisabledTest(ReusedSQLTestCase, SQLTestUtils):
         kdf2 = ks.from_pandas(pdf2)
 
         with self.assertRaisesRegex(ValueError, "Cannot combine the series or dataframe"):
-            self.assert_eq(repr(pdf1.where(pdf2 > 100)), repr(kdf1.where(kdf2 > 100).sort_index()))
+            kdf1.where(kdf2 > 100)
 
         pdf1 = pd.DataFrame({"A": [-1, -2, -3, -4, -5], "B": [-100, -200, -300, -400, -500]})
         pdf2 = pd.DataFrame({"A": [-10, -20, -30, -40, -50], "B": [-5, -4, -3, -2, -1]})
@@ -1044,9 +1044,7 @@ class OpsOnDiffFramesDisabledTest(ReusedSQLTestCase, SQLTestUtils):
         kdf2 = ks.from_pandas(pdf2)
 
         with self.assertRaisesRegex(ValueError, "Cannot combine the series or dataframe"):
-            self.assert_eq(
-                repr(pdf1.where(pdf2 < -250)), repr(kdf1.where(kdf2 < -250).sort_index())
-            )
+            kdf1.where(kdf2 < -250)
 
     def test_mask(self):
         pdf1 = pd.DataFrame({"A": [0, 1, 2, 3, 4], "B": [100, 200, 300, 400, 500]})
@@ -1055,7 +1053,7 @@ class OpsOnDiffFramesDisabledTest(ReusedSQLTestCase, SQLTestUtils):
         kdf2 = ks.from_pandas(pdf2)
 
         with self.assertRaisesRegex(ValueError, "Cannot combine the series or dataframe"):
-            self.assert_eq(repr(pdf1.mask(pdf2 < 100)), repr(kdf1.mask(kdf2 < 100).sort_index()))
+            kdf1.mask(kdf2 < 100)
 
         pdf1 = pd.DataFrame({"A": [-1, -2, -3, -4, -5], "B": [-100, -200, -300, -400, -500]})
         pdf2 = pd.DataFrame({"A": [-10, -20, -30, -40, -50], "B": [-5, -4, -3, -2, -1]})
@@ -1063,4 +1061,4 @@ class OpsOnDiffFramesDisabledTest(ReusedSQLTestCase, SQLTestUtils):
         kdf2 = ks.from_pandas(pdf2)
 
         with self.assertRaisesRegex(ValueError, "Cannot combine the series or dataframe"):
-            self.assert_eq(repr(pdf1.mask(pdf2 > -250)), repr(kdf1.mask(kdf2 > -250).sort_index()))
+            kdf1.mask(kdf2 > -250)

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -963,7 +963,7 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(pser.cumprod(skipna=False), kser.cumprod(skipna=False))
 
         with self.assertRaisesRegex(Exception, "values should be bigger than 0"):
-            ks.Series([0, 1]).cumprod()
+            ks.Series([0, 1]).cumprod().to_pandas()
 
     def test_median(self):
         with self.assertRaisesRegex(ValueError, "accuracy must be an integer; however"):

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -849,18 +849,18 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         pser = pd.Series(["cat", "dog", None, "rabbit"])
         kser = ks.from_pandas(pser)
         # Currently Koalas doesn't return NaN as pandas does.
-        self.assertEqual(repr(kser.map({})), repr(pser.map({}).replace({pd.np.nan: None})))
+        self.assert_eq(kser.map({}), pser.map({}).replace({pd.np.nan: None}))
 
         d = defaultdict(lambda: "abc")
         self.assertTrue("abc" in repr(kser.map(d)))
-        self.assertEqual(repr(kser.map(d)), repr(pser.map(d)))
+        self.assert_eq(kser.map(d), pser.map(d))
 
         def tomorrow(date) -> datetime:
             return date + timedelta(days=1)
 
         pser = pd.Series([datetime(2019, 10, 24)])
         kser = ks.from_pandas(pser)
-        self.assertEqual(repr(kser.map(tomorrow)), repr(pser.map(tomorrow)))
+        self.assert_eq(kser.map(tomorrow), pser.map(tomorrow))
 
     def test_add_prefix(self):
         pser = pd.Series([1, 2, 3, 4], name="0")
@@ -963,7 +963,7 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(pser.cumprod(skipna=False), kser.cumprod(skipna=False))
 
         with self.assertRaisesRegex(Exception, "values should be bigger than 0"):
-            repr(ks.Series([0, 1]).cumprod())
+            ks.Series([0, 1]).cumprod()
 
     def test_median(self):
         with self.assertRaisesRegex(ValueError, "accuracy must be an integer; however"):
@@ -972,19 +972,12 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
     def test_rank(self):
         pser = pd.Series([1, 2, 3, 1], name="x")
         kser = ks.from_pandas(pser)
-        self.assertEqual(repr(pser.rank()), repr(kser.rank().sort_index()))
-        self.assertEqual(repr(pser.rank()), repr(kser.rank().sort_index()))
-        self.assertEqual(
-            repr(pser.rank(ascending=False)), repr(kser.rank(ascending=False).sort_index())
-        )
-        self.assertEqual(repr(pser.rank(method="min")), repr(kser.rank(method="min").sort_index()))
-        self.assertEqual(repr(pser.rank(method="max")), repr(kser.rank(method="max").sort_index()))
-        self.assertEqual(
-            repr(pser.rank(method="first")), repr(kser.rank(method="first").sort_index())
-        )
-        self.assertEqual(
-            repr(pser.rank(method="dense")), repr(kser.rank(method="dense").sort_index())
-        )
+        self.assert_eq(pser.rank(), kser.rank().sort_index())
+        self.assert_eq(pser.rank(ascending=False), kser.rank(ascending=False).sort_index())
+        self.assert_eq(pser.rank(method="min"), kser.rank(method="min").sort_index())
+        self.assert_eq(pser.rank(method="max"), kser.rank(method="max").sort_index())
+        self.assert_eq(pser.rank(method="first"), kser.rank(method="first").sort_index())
+        self.assert_eq(pser.rank(method="dense"), kser.rank(method="dense").sort_index())
 
         msg = "method must be one of 'average', 'min', 'max', 'first', 'dense'"
         with self.assertRaisesRegex(ValueError, msg):
@@ -993,7 +986,7 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
     def test_round(self):
         pser = pd.Series([0.028208, 0.038683, 0.877076], name="x")
         kser = ks.from_pandas(pser)
-        self.assertEqual(repr(pser.round(2)), repr(kser.round(2)))
+        self.assert_eq(pser.round(2), kser.round(2))
         msg = "decimals must be an integer"
         with self.assertRaisesRegex(ValueError, msg):
             kser.round(1.5)
@@ -1062,11 +1055,9 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         pser = pd.Series([10, 20, 15, 30, 45], name="x")
         kser = ks.Series(pser)
         if LooseVersion(pd.__version__) < LooseVersion("0.24.2"):
-            self.assertEqual(repr(kser.shift(periods=2)), repr(pser.shift(periods=2)))
+            self.assert_eq(kser.shift(periods=2), pser.shift(periods=2))
         else:
-            self.assertEqual(
-                repr(kser.shift(periods=2, fill_value=0)), repr(pser.shift(periods=2, fill_value=0))
-            )
+            self.assert_eq(kser.shift(periods=2, fill_value=0), pser.shift(periods=2, fill_value=0))
         with self.assertRaisesRegex(ValueError, "periods should be an int; however"):
             kser.shift(periods=1.5)
 
@@ -1467,63 +1458,84 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         kser = ks.from_pandas(pser)
 
         if LooseVersion(pd.__version__) >= LooseVersion("1.0.0"):
-            self.assert_eq(repr(kser.divmod(-100)), repr(pser.divmod(-100)))
-            self.assert_eq(repr(kser.divmod(100)), repr(pser.divmod(100)))
+            kdiv, kmod = kser.divmod(-100)
+            pdiv, pmod = pser.divmod(-100)
+            self.assert_eq(kdiv, pdiv)
+            self.assert_eq(kmod, pmod)
+
+            kdiv, kmod = kser.divmod(100)
+            pdiv, pmod = pser.divmod(100)
+            self.assert_eq(kdiv, pdiv)
+            self.assert_eq(kmod, pmod)
         elif LooseVersion(pd.__version__) < LooseVersion("1.0.0"):
-            expected_result = repr((pser.floordiv(-100), pser.mod(-100)))
-            self.assert_eq(repr(kser.divmod(-100)), expected_result)
-            expected_result = repr((pser.floordiv(100), pser.mod(100)))
-            self.assert_eq(repr(kser.divmod(100)), expected_result)
+            kdiv, kmod = kser.divmod(-100)
+            pdiv, pmod = pser.floordiv(-100), pser.mod(-100)
+            self.assert_eq(kdiv, pdiv)
+            self.assert_eq(kmod, pmod)
+
+            kdiv, kmod = kser.divmod(100)
+            pdiv, pmod = pser.floordiv(100), pser.mod(100)
+            self.assert_eq(kdiv, pdiv)
+            self.assert_eq(kmod, pmod)
 
     def test_rdivmod(self):
         pser = pd.Series([100, None, 300, None, 500], name="Koalas")
         kser = ks.from_pandas(pser)
 
         if LooseVersion(pd.__version__) >= LooseVersion("1.0.0"):
-            self.assert_eq(repr(kser.rdivmod(-100)), repr(pser.rdivmod(-100)))
-            self.assert_eq(repr(kser.rdivmod(100)), repr(pser.rdivmod(100)))
+            krdiv, krmod = kser.rdivmod(-100)
+            prdiv, prmod = pser.rdivmod(-100)
+            self.assert_eq(krdiv, prdiv)
+            self.assert_eq(krmod, prmod)
+
+            krdiv, krmod = kser.rdivmod(100)
+            prdiv, prmod = pser.rdivmod(100)
+            self.assert_eq(krdiv, prdiv)
+            self.assert_eq(krmod, prmod)
         elif LooseVersion(pd.__version__) < LooseVersion("1.0.0"):
-            expected_result = repr((pser.rfloordiv(-100), pser.rmod(-100)))
-            self.assert_eq(repr(kser.rdivmod(-100)), expected_result)
-            expected_result = repr((pser.rfloordiv(100), pser.rmod(100)))
-            self.assert_eq(repr(kser.rdivmod(100)), expected_result)
+            krdiv, krmod = kser.rdivmod(-100)
+            prdiv, prmod = pser.rfloordiv(-100), pser.rmod(-100)
+            self.assert_eq(krdiv, prdiv)
+            self.assert_eq(krmod, prmod)
+
+            krdiv, krmod = kser.rdivmod(100)
+            prdiv, prmod = pser.rfloordiv(100), pser.rmod(100)
+            self.assert_eq(krdiv, prdiv)
+            self.assert_eq(krmod, prmod)
 
     def test_mod(self):
         pser = pd.Series([100, None, -300, None, 500, -700], name="Koalas")
         kser = ks.from_pandas(pser)
 
-        self.assert_eq(repr(kser.mod(-150)), repr(pser.mod(-150)))
-        self.assert_eq(repr(kser.mod(0)), repr(pser.mod(0)))
-        self.assert_eq(repr(kser.mod(150)), repr(pser.mod(150)))
+        self.assert_eq(kser.mod(-150), pser.mod(-150))
+        self.assert_eq(kser.mod(0), pser.mod(0))
+        self.assert_eq(kser.mod(150), pser.mod(150))
 
         pdf = pd.DataFrame({"a": [100, None, -300, None, 500, -700], "b": [150] * 6})
         kdf = ks.from_pandas(pdf)
-        self.assert_eq(repr(kdf.a.mod(kdf.b)), repr(pdf.a.mod(pdf.b).rename("a")))
+        self.assert_eq(kdf.a.mod(kdf.b), pdf.a.mod(pdf.b).rename("a"))
 
     def test_rmod(self):
         pser = pd.Series([100, None, -300, None, 500, -700], name="Koalas")
         kser = ks.from_pandas(pser)
 
-        self.assert_eq(repr(kser.rmod(-150)), repr(pser.rmod(-150)))
-        self.assert_eq(repr(kser.rmod(0)), repr(pser.rmod(0)))
-        self.assert_eq(repr(kser.rmod(150)), repr(pser.rmod(150)))
+        self.assert_eq(kser.rmod(-150), pser.rmod(-150))
+        self.assert_eq(kser.rmod(0), pser.rmod(0))
+        self.assert_eq(kser.rmod(150), pser.rmod(150))
 
         pdf = pd.DataFrame({"a": [100, None, -300, None, 500, -700], "b": [150] * 6})
         kdf = ks.from_pandas(pdf)
-        self.assert_eq(repr(kdf.a.rmod(kdf.b)), repr(pdf.a.rmod(pdf.b).rename("a")))
+        self.assert_eq(kdf.a.rmod(kdf.b), pdf.a.rmod(pdf.b).rename("a"))
 
     def test_asof(self):
         pser = pd.Series([1, 2, np.nan, 4], index=[10, 20, 30, 40], name="Koalas")
         kser = ks.from_pandas(pser)
 
-        self.assert_eq(repr(kser.asof(20)), repr(pser.asof(20)))
-        self.assert_eq(repr(kser.asof([5, 20]).sort_index()), repr(pser.asof([5, 20]).sort_index()))
-        self.assert_eq(repr(kser.asof(100)), repr(pser.asof(100)))
+        self.assert_eq(kser.asof(20), pser.asof(20))
+        self.assert_eq(kser.asof([5, 20]).sort_index(), pser.asof([5, 20]).sort_index())
+        self.assert_eq(kser.asof(100), pser.asof(100))
         self.assert_eq(repr(kser.asof(-100)), repr(pser.asof(-100)))
-        self.assert_eq(repr(kser.asof(-100)), repr(pser.asof(-100)))
-        self.assert_eq(
-            repr(kser.asof([-100, 100]).sort_index()), repr(pser.asof([-100, 100]).sort_index())
-        )
+        self.assert_eq(kser.asof([-100, 100]).sort_index(), pser.asof([-100, 100]).sort_index())
 
         # where cannot be an Index, Series or a DataFrame
         self.assertRaises(ValueError, lambda: kser.asof(ks.Index([-100, 100])))
@@ -1566,24 +1578,24 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         pser = pd.Series([100, None, -300, None, 500, -700, np.inf, -np.inf], name="Koalas")
         kser = ks.from_pandas(pser)
 
-        self.assert_eq(repr(pser.div(0)), repr(kser.div(0)))
-        self.assert_eq(repr(pser.truediv(0)), repr(kser.truediv(0)))
-        self.assert_eq(repr(pser / 0), repr(kser / 0))
-        self.assert_eq(repr(pser.div(np.nan)), repr(kser.div(np.nan)))
-        self.assert_eq(repr(pser.truediv(np.nan)), repr(kser.truediv(np.nan)))
-        self.assert_eq(repr(pser / np.nan), repr(kser / np.nan))
+        self.assert_eq(pser.div(0), kser.div(0))
+        self.assert_eq(pser.truediv(0), kser.truediv(0))
+        self.assert_eq(pser / 0, kser / 0)
+        self.assert_eq(pser.div(np.nan), kser.div(np.nan))
+        self.assert_eq(pser.truediv(np.nan), kser.truediv(np.nan))
+        self.assert_eq(pser / np.nan, kser / np.nan)
 
         # floordiv has different behavior in pandas > 1.0.0 when divide by 0
         if LooseVersion(pd.__version__) >= LooseVersion("1.0.0"):
-            self.assert_eq(repr(pser.floordiv(0)), repr(kser.floordiv(0)))
-            self.assert_eq(repr(pser // 0), repr(kser // 0))
+            self.assert_eq(pser.floordiv(0), kser.floordiv(0))
+            self.assert_eq(pser // 0, kser // 0)
         else:
             result = pd.Series(
                 [np.inf, np.nan, -np.inf, np.nan, np.inf, -np.inf, np.inf, -np.inf], name="Koalas"
             )
-            self.assert_eq(repr(kser.floordiv(0)), repr(result))
-            self.assert_eq(repr(kser // 0), repr(result))
-        self.assert_eq(repr(pser.floordiv(np.nan)), repr(kser.floordiv(np.nan)))
+            self.assert_eq(kser.floordiv(0), result)
+            self.assert_eq(kser // 0, result)
+        self.assert_eq(pser.floordiv(np.nan), kser.floordiv(np.nan))
 
     def test_mad(self):
         pser = pd.Series([1, 2, 3, 4], name="Koalas")
@@ -1763,8 +1775,9 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         pser = pd.Series(["A", "B", "C"])
         kser = ks.from_pandas(pser)
 
-        for p_items, k_items in zip(pser.iteritems(), kser.iteritems()):
-            self.assert_eq(repr(p_items), repr(k_items))
+        for (p_name, p_items), (k_name, k_items) in zip(pser.iteritems(), kser.iteritems()):
+            self.assert_eq(p_name, k_name)
+            self.assert_eq(p_items, k_items)
 
     def test_droplevel(self):
         # droplevel is new in pandas 0.24.0


### PR DESCRIPTION
Removes most of `repr` comparison as now that we don't need to use it for most cases.