### PR TITLE
Fix DataFrame.mad to work properly

### DIFF
--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -3811,7 +3811,13 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             sys.stdout = prev
 
     def test_mad(self):
-        pdf = pd.DataFrame({"A": [1, 2, None, 4, np.nan], "B": [-0.1, 0.2, -0.3, np.nan, 0.5]})
+        pdf = pd.DataFrame(
+            {
+                "A": [1, 2, None, 4, np.nan],
+                "B": [-0.1, 0.2, -0.3, np.nan, 0.5],
+                "C": ["a", "b", "c", "d", "e"],
+            }
+        )
         kdf = ks.from_pandas(pdf)
 
         self.assert_eq(kdf.mad(), pdf.mad())
@@ -3821,7 +3827,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             kdf.mad(axis=2)
 
         # MultiIndex columns
-        columns = pd.MultiIndex.from_tuples([("A", "X"), ("A", "Y")])
+        columns = pd.MultiIndex.from_tuples([("A", "X"), ("A", "Y"), ("A", "Z")])
         pdf.columns = columns
         kdf.columns = columns
 


### PR DESCRIPTION
`DataFrame.mad()` has not been working properly as shown below.

```python
>>> pdf
   A  B  C
0  3  3  a
1  4  4  b
2  5  5  c
3  6  6  d
4  7  7  e

>>> pdf.mad()
A    1.2
B    1.2
dtype: float64

>>> ks.from_pandas(pdf).mad()
A    1.2
B    1.2
C    NaN  # It should've not been here
dtype: float64
```

This PR fixed it and also fixed related tests.

```python
>>> pdf.mad()
A    1.2
B    1.2
dtype: float64

>>> ks.from_pandas(pdf).mad()
A    1.2
B    1.2
dtype: float64
```