### PR TITLE
Set a flake8 rule for missing imports.

### DIFF
--- a/databricks/koalas/__init__.py
+++ b/databricks/koalas/__init__.py
@@ -74,10 +74,9 @@ elif "ARROW_PRE_0_15_IPC_FORMAT" in os.environ:
 from databricks.koalas.frame import DataFrame
 from databricks.koalas.indexes import Index, MultiIndex
 from databricks.koalas.series import Series
-from databricks.koalas.config import get_option, set_option, reset_option, options
 from databricks.koalas.groupby import NamedAgg
 
-__all__ = [
+__all__ = [  # noqa: F405
     "read_csv",
     "read_parquet",
     "to_datetime",
@@ -159,6 +158,6 @@ _auto_patch_spark()
 _auto_patch_pandas()
 
 # Import after the usage logger is attached.
-from databricks.koalas.config import *
-from databricks.koalas.namespace import *
+from databricks.koalas.config import get_option, options, option_context, reset_option, set_option
+from databricks.koalas.namespace import *  # F405
 from databricks.koalas.sql import sql

--- a/databricks/koalas/tests/test_typedef.py
+++ b/databricks/koalas/tests/test_typedef.py
@@ -19,7 +19,7 @@ import unittest
 import pandas
 import pandas as pd
 import numpy as np
-from pyspark.sql.types import *
+from pyspark.sql.types import FloatType, IntegerType, LongType, StringType, StructField, StructType
 
 from databricks.koalas.typedef import infer_return_type
 from databricks import koalas as ks
@@ -90,13 +90,13 @@ class TypeHintTests(unittest.TestCase):
         "Type inference from pandas instances is supported with Python 3.7+",
     )
     def test_infer_schema_with_names_pandas_instances(self):
-        def func() -> 'pd.DataFrame["a" : np.float, "b":str]':
+        def func() -> 'pd.DataFrame["a" : np.float, "b":str]':  # noqa: F821
             pass
 
         expected = StructType([StructField("a", FloatType()), StructField("b", StringType())])
         self.assertEqual(infer_return_type(func).tpe, expected)
 
-        def func() -> "pd.DataFrame['a': np.float, 'b': int]":
+        def func() -> "pd.DataFrame['a': np.float, 'b': int]":  # noqa: F821
             pass
 
         expected = StructType([StructField("a", FloatType()), StructField("b", IntegerType())])
@@ -116,7 +116,7 @@ class TypeHintTests(unittest.TestCase):
     )
     def test_infer_schema_with_names_pandas_instances_negative(self):
         def try_infer_return_type():
-            def f() -> 'pd.DataFrame["a" : np.float : 1, "b":str:2]':
+            def f() -> 'pd.DataFrame["a" : np.float : 1, "b":str:2]':  # noqa: F821
                 pass
 
             infer_return_type(f)
@@ -135,7 +135,7 @@ class TypeHintTests(unittest.TestCase):
         self.assertRaisesRegex(TypeError, "not understood", try_infer_return_type)
 
         def try_infer_return_type():
-            def f() -> 'pd.DataFrame["a" : np.float : 1, "b":str:2]':
+            def f() -> 'pd.DataFrame["a" : np.float : 1, "b":str:2]':  # noqa: F821
                 pass
 
             infer_return_type(f)
@@ -155,7 +155,7 @@ class TypeHintTests(unittest.TestCase):
 
     def test_infer_schema_with_names_negative(self):
         def try_infer_return_type():
-            def f() -> 'ks.DataFrame["a" : np.float : 1, "b":str:2]':
+            def f() -> 'ks.DataFrame["a" : np.float : 1, "b":str:2]':  # noqa: F821
                 pass
 
             infer_return_type(f)
@@ -174,7 +174,7 @@ class TypeHintTests(unittest.TestCase):
         self.assertRaisesRegex(TypeError, "not understood", try_infer_return_type)
 
         def try_infer_return_type():
-            def f() -> 'ks.DataFrame["a" : np.float : 1, "b":str:2]':
+            def f() -> 'ks.DataFrame["a" : np.float : 1, "b":str:2]':  # noqa: F821
                 pass
 
             infer_return_type(f)

--- a/databricks/koalas/typedef/__init__.py
+++ b/databricks/koalas/typedef/__init__.py
@@ -14,6 +14,4 @@
 # limitations under the License.
 #
 
-from databricks.koalas.typedef.typehints import *
-
-__all__ = ["as_spark_type", "infer_pd_series_spark_type"]
+from databricks.koalas.typedef.typehints import *  # noqa: F401,F405

--- a/dev/lint-python
+++ b/dev/lint-python
@@ -158,7 +158,7 @@ flake8 checks failed."
     fi
 
     echo "starting $FLAKE8_BUILD test..."
-    FLAKE8_REPORT=$( ($FLAKE8_BUILD . --count --select=E901,E999,F821,F822,F823,F401 \
+    FLAKE8_REPORT=$( ($FLAKE8_BUILD . --count --select=E901,E999,F821,F822,F823,F401,F405 \
                      --exclude="docs/build/html/reference/api/*.py","build" \
                      --max-line-length=100 --show-source --statistics) 2>&1)
     FLAKE8_STATUS=$?


### PR DESCRIPTION
Let us take advantage of a flake8 rule `F405` to detect missing imports.