### PR TITLE
Fix Series name after binary operations.

### DIFF
--- a/databricks/koalas/datetimes.py
+++ b/databricks/koalas/datetimes.py
@@ -24,8 +24,6 @@ import pandas as pd  # noqa: F401
 import pyspark.sql.functions as F
 from pyspark.sql.types import DateType, TimestampType, LongType
 
-from databricks.koalas.base import column_op
-
 if TYPE_CHECKING:
     import databricks.koalas as ks
 
@@ -49,7 +47,7 @@ class DatetimeMethods(object):
         """
         # TODO: Hit a weird exception
         # syntax error in attribute name: `to_date(`start_date`)` with alias
-        return column_op(F.to_date)(self._data).alias(self._data.name)
+        return self._data.spark.transform(F.to_date)
 
     @property
     def time(self) -> "ks.Series":
@@ -64,44 +62,42 @@ class DatetimeMethods(object):
         """
         The year of the datetime.
         """
-        return column_op(lambda c: F.year(c).cast(LongType()))(self._data).alias(self._data.name)
+        return self._data.spark.transform(lambda c: F.year(c).cast(LongType()))
 
     @property
     def month(self) -> "ks.Series":
         """
         The month of the timestamp as January = 1 December = 12.
         """
-        return column_op(lambda c: F.month(c).cast(LongType()))(self._data).alias(self._data.name)
+        return self._data.spark.transform(lambda c: F.month(c).cast(LongType()))
 
     @property
     def day(self) -> "ks.Series":
         """
         The days of the datetime.
         """
-        return column_op(lambda c: F.dayofmonth(c).cast(LongType()))(self._data).alias(
-            self._data.name
-        )
+        return self._data.spark.transform(lambda c: F.dayofmonth(c).cast(LongType()))
 
     @property
     def hour(self) -> "ks.Series":
         """
         The hours of the datetime.
         """
-        return column_op(lambda c: F.hour(c).cast(LongType()))(self._data).alias(self._data.name)
+        return self._data.spark.transform(lambda c: F.hour(c).cast(LongType()))
 
     @property
     def minute(self) -> "ks.Series":
         """
         The minutes of the datetime.
         """
-        return column_op(lambda c: F.minute(c).cast(LongType()))(self._data).alias(self._data.name)
+        return self._data.spark.transform(lambda c: F.minute(c).cast(LongType()))
 
     @property
     def second(self) -> "ks.Series":
         """
         The seconds of the datetime.
         """
-        return column_op(lambda c: F.second(c).cast(LongType()))(self._data).alias(self._data.name)
+        return self._data.spark.transform(lambda c: F.second(c).cast(LongType()))
 
     @property
     def microsecond(self) -> "ks.Series":
@@ -123,9 +119,7 @@ class DatetimeMethods(object):
         """
         The week ordinal of the year.
         """
-        return column_op(lambda c: F.weekofyear(c).cast(LongType()))(self._data).alias(
-            self._data.name
-        )
+        return self._data.spark.transform(lambda c: F.weekofyear(c).cast(LongType()))
 
     @property
     def weekofyear(self) -> "ks.Series":

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -717,7 +717,9 @@ class DataFrame(Frame, Generic[T]):
                 def apply_op(kdf, this_column_labels, that_column_labels):
                     for this_label, that_label in zip(this_column_labels, that_column_labels):
                         yield (
-                            getattr(kdf._kser_for(this_label), op)(kdf._kser_for(that_label)),
+                            getattr(kdf._kser_for(this_label), op)(
+                                kdf._kser_for(that_label)
+                            ).rename(this_label),
                             this_label,
                         )
 
@@ -10293,7 +10295,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             def apply_op(kdf, this_column_labels, that_column_labels):
                 for this_label, that_label in zip(this_column_labels, that_column_labels):
                     yield (
-                        ufunc(kdf._kser_for(this_label), kdf._kser_for(that_label), **kwargs),
+                        ufunc(
+                            kdf._kser_for(this_label), kdf._kser_for(that_label), **kwargs
+                        ).rename(this_label),
                         this_label,
                     )
 
@@ -10309,7 +10313,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 for inp in inputs:
                     arguments.append(inp[label] if isinstance(inp, DataFrame) else inp)
                 # both binary and unary.
-                applied.append(ufunc(*arguments, **kwargs))
+                applied.append(ufunc(*arguments, **kwargs).rename(label))
 
             internal = this._internal.with_new_columns(applied)
             return DataFrame(internal)

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -125,14 +125,14 @@ a    4.0
 b    NaN
 c    6.0
 d    NaN
-Name: a, dtype: float64
+dtype: float64
 
 >>> df.a.radd(df.b)
 a    4.0
 b    NaN
 c    6.0
 d    NaN
-Name: a, dtype: float64
+dtype: float64
 """
 
 _sub_example_SERIES = """
@@ -153,14 +153,14 @@ a    0.0
 b    NaN
 c    2.0
 d    NaN
-Name: a, dtype: float64
+dtype: float64
 
 >>> df.a.rsub(df.b)
 a    0.0
 b    NaN
 c   -2.0
 d    NaN
-Name: a, dtype: float64
+dtype: float64
 """
 
 _mul_example_SERIES = """
@@ -181,14 +181,14 @@ a    4.0
 b    NaN
 c    8.0
 d    NaN
-Name: a, dtype: float64
+dtype: float64
 
 >>> df.a.rmul(df.b)
 a    4.0
 b    NaN
 c    8.0
 d    NaN
-Name: a, dtype: float64
+dtype: float64
 """
 
 _div_example_SERIES = """
@@ -209,14 +209,14 @@ a    1.0
 b    NaN
 c    2.0
 d    NaN
-Name: a, dtype: float64
+dtype: float64
 
 >>> df.a.rdiv(df.b)
 a    1.0
 b    NaN
 c    0.5
 d    NaN
-Name: a, dtype: float64
+dtype: float64
 """
 
 _pow_example_SERIES = """
@@ -237,14 +237,14 @@ a     4.0
 b     NaN
 c    16.0
 d     NaN
-Name: a, dtype: float64
+dtype: float64
 
 >>> df.a.rpow(df.b)
 a     4.0
 b     NaN
 c    16.0
 d     NaN
-Name: a, dtype: float64
+dtype: float64
 """
 
 _mod_example_SERIES = """
@@ -265,14 +265,14 @@ a    0.0
 b    NaN
 c    0.0
 d    NaN
-Name: a, dtype: float64
+dtype: float64
 
 >>> df.a.rmod(df.b)
 a    0.0
 b    NaN
 c    2.0
 d    NaN
-Name: a, dtype: float64
+dtype: float64
 """
 
 _floordiv_example_SERIES = """
@@ -293,14 +293,14 @@ a    1.0
 b    NaN
 c    2.0
 d    NaN
-Name: a, dtype: float64
+dtype: float64
 
 >>> df.a.rfloordiv(df.b)
 a    1.0
 b    NaN
 c    0.0
 d    NaN
-Name: a, dtype: float64
+dtype: float64
 """
 
 T = TypeVar("T")
@@ -441,7 +441,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
     )
 
     def radd(self, other):
-        return (other + self).rename(self.name)
+        return other + self
 
     radd.__doc__ = _flex_doc_SERIES.format(
         desc="Reverse Addition",
@@ -465,7 +465,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
     divide = div
 
     def rdiv(self, other):
-        return (other / self).rename(self.name)
+        return other / self
 
     rdiv.__doc__ = _flex_doc_SERIES.format(
         desc="Reverse Floating division",
@@ -487,7 +487,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
     )
 
     def rtruediv(self, other):
-        return (other / self).rename(self.name)
+        return other / self
 
     rtruediv.__doc__ = _flex_doc_SERIES.format(
         desc="Reverse Floating division",
@@ -511,7 +511,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
     multiply = mul
 
     def rmul(self, other):
-        return (other * self).rename(self.name)
+        return other * self
 
     rmul.__doc__ = _flex_doc_SERIES.format(
         desc="Reverse Multiplication",
@@ -535,7 +535,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
     subtract = sub
 
     def rsub(self, other):
-        return (other - self).rename(self.name)
+        return other - self
 
     rsub.__doc__ = _flex_doc_SERIES.format(
         desc="Reverse Subtraction",
@@ -557,7 +557,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
     )
 
     def rmod(self, other):
-        return (other % self).rename(self.name)
+        return other % self
 
     rmod.__doc__ = _flex_doc_SERIES.format(
         desc="Reverse Modulo",
@@ -579,7 +579,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
     )
 
     def rpow(self, other):
-        return (other ** self).rename(self.name)
+        return other ** self
 
     rpow.__doc__ = _flex_doc_SERIES.format(
         desc="Reverse Exponential power",
@@ -601,7 +601,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
     )
 
     def rfloordiv(self, other):
-        return (other // self).rename(self.name)
+        return other // self
 
     rfloordiv.__doc__ = _flex_doc_SERIES.format(
         desc="Reverse Integer division",

--- a/databricks/koalas/strings.py
+++ b/databricks/koalas/strings.py
@@ -25,8 +25,6 @@ from pyspark.sql.types import StringType, BinaryType, ArrayType, LongType, MapTy
 from pyspark.sql import functions as F
 from pyspark.sql.functions import pandas_udf, PandasUDFType
 
-from databricks.koalas.base import column_op
-
 if TYPE_CHECKING:
     import databricks.koalas as ks
 
@@ -115,7 +113,7 @@ class StringMethods(object):
         3              swapcase
         dtype: object
         """
-        return column_op(lambda c: F.lower(c))(self._data).alias(self._data.name)
+        return self._data.spark.transform(F.lower)
 
     def upper(self) -> "ks.Series":
         """
@@ -138,7 +136,7 @@ class StringMethods(object):
         3              SWAPCASE
         dtype: object
         """
-        return column_op(lambda c: F.upper(c))(self._data).alias(self._data.name)
+        return self._data.spark.transform(F.upper)
 
     def swapcase(self) -> "ks.Series":
         """
@@ -1271,13 +1269,9 @@ class StringMethods(object):
         dtype: int64
         """
         if isinstance(self._data.spark.data_type, (ArrayType, MapType)):
-            return column_op(lambda c: F.size(c).cast(LongType()))(self._data).alias(
-                self._data.name
-            )
+            return self._data.spark.transform(lambda c: F.size(c).cast(LongType()))
         else:
-            return column_op(lambda c: F.length(c).cast(LongType()))(self._data).alias(
-                self._data.name
-            )
+            return self._data.spark.transform(lambda c: F.length(c).cast(LongType()))
 
     def ljust(self, width, fillchar=" ") -> "ks.Series":
         """

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -431,13 +431,20 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assertNotIn(5, dir(kdf))
 
     def test_column_names(self):
-        kdf = self.kdf
+        pdf, kdf = self.df_pair
 
-        self.assert_eq(kdf.columns, pd.Index(["a", "b"]))
-        self.assert_eq(kdf[["b", "a"]].columns, pd.Index(["b", "a"]))
-        self.assertEqual(kdf["a"].name, "a")
-        self.assertEqual((kdf["a"] + 1).name, "a")
-        self.assertEqual((kdf["a"] + kdf["b"]).name, "a")  # TODO: None
+        self.assert_eq(kdf.columns, pdf.columns)
+        self.assert_eq(kdf[["b", "a"]].columns, pdf[["b", "a"]].columns)
+        self.assert_eq(kdf["a"].name, pdf["a"].name)
+        self.assert_eq((kdf["a"] + 1).name, (pdf["a"] + 1).name)
+
+        self.assert_eq((kdf.a + kdf.b).name, (pdf.a + pdf.b).name)
+        self.assert_eq((kdf.a + kdf.b.rename("a")).name, (pdf.a + pdf.b.rename("a")).name)
+        self.assert_eq((kdf.a + kdf.b.rename()).name, (pdf.a + pdf.b.rename()).name)
+        self.assert_eq((kdf.a.rename() + kdf.b).name, (pdf.a.rename() + pdf.b).name)
+        self.assert_eq(
+            (kdf.a.rename() + kdf.b.rename()).name, (pdf.a.rename() + pdf.b.rename()).name
+        )
 
     def test_rename_columns(self):
         pdf = pd.DataFrame(

--- a/databricks/koalas/tests/test_numpy_compat.py
+++ b/databricks/koalas/tests/test_numpy_compat.py
@@ -48,7 +48,7 @@ class NumPyCompatTest(ReusedSQLTestCase, SQLTestUtils):
     @property
     def pdf(self):
         return pd.DataFrame(
-            {"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": [4, 5, 6, 3, 2, 1, 0, 0, 0],},
+            {"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": [4, 5, 6, 3, 2, 1, 0, 0, 0]},
             index=[0, 1, 3, 5, 6, 8, 9, 9, 9],
         )
 
@@ -59,9 +59,7 @@ class NumPyCompatTest(ReusedSQLTestCase, SQLTestUtils):
     def test_np_add_series(self):
         kdf = self.kdf
         pdf = self.pdf
-        self.assert_eq(
-            np.add(kdf.a, kdf.b), np.add(pdf.a, pdf.b).rename("a")  # TODO: Fix the Series name
-        )
+        self.assert_eq(np.add(kdf.a, kdf.b), np.add(pdf.a, pdf.b))
 
         kdf = self.kdf
         pdf = self.pdf
@@ -107,11 +105,7 @@ class NumPyCompatTest(ReusedSQLTestCase, SQLTestUtils):
             if np_name not in self.blacklist:
                 try:
                     # binary ufunc
-                    self.assert_eq(
-                        np_func(pdf.a, pdf.b).rename("a"),  # TODO: Fix the Series name
-                        np_func(kdf.a, kdf.b),
-                        almost=True,
-                    )
+                    self.assert_eq(np_func(pdf.a, pdf.b), np_func(kdf.a, kdf.b), almost=True)
                     self.assert_eq(np_func(pdf.a, 1), np_func(kdf.a, 1), almost=True)
                 except Exception as e:
                     raise AssertionError("Test in '%s' function was failed." % np_name) from e
@@ -125,9 +119,7 @@ class NumPyCompatTest(ReusedSQLTestCase, SQLTestUtils):
                     try:
                         # binary ufunc
                         self.assert_eq(
-                            np_func(pdf.a, pdf2.b)
-                            .rename("a")
-                            .sort_index(),  # TODO: Fix the Series name
+                            np_func(pdf.a, pdf2.b).sort_index(),
                             np_func(kdf.a, kdf2.b).sort_index(),
                             almost=True,
                         )

--- a/databricks/koalas/tests/test_ops_on_diff_frames.py
+++ b/databricks/koalas/tests/test_ops_on_diff_frames.py
@@ -172,13 +172,11 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
         pser2 = self.pser2
 
         # Series
-        self.assert_eq((kdf1.a - kdf2.b).sort_index(), (pdf1.a - pdf2.b).rename("a").sort_index())
+        self.assert_eq((kdf1.a - kdf2.b).sort_index(), (pdf1.a - pdf2.b).sort_index())
 
-        self.assert_eq((kdf1.a * kdf2.a).sort_index(), (pdf1.a * pdf2.a).rename("a").sort_index())
+        self.assert_eq((kdf1.a * kdf2.a).sort_index(), (pdf1.a * pdf2.a).sort_index())
 
-        self.assert_eq(
-            (kdf1["a"] / kdf2["a"]).sort_index(), (pdf1["a"] / pdf2["a"]).rename("a").sort_index()
-        )
+        self.assert_eq((kdf1["a"] / kdf2["a"]).sort_index(), (pdf1["a"] / pdf2["a"]).sort_index())
 
         # DataFrame
         self.assert_eq((kdf1 + kdf2).sort_index(), (pdf1 + pdf2).sort_index())
@@ -193,17 +191,17 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
         # Series
         self.assert_eq(
             (kdf1[("x", "a")] - kdf2[("x", "b")]).sort_index(),
-            (pdf1[("x", "a")] - pdf2[("x", "b")]).rename(("x", "a")).sort_index(),
+            (pdf1[("x", "a")] - pdf2[("x", "b")]).sort_index(),
         )
 
         self.assert_eq(
             (kdf1[("x", "a")] - kdf2["x"]["b"]).sort_index(),
-            (pdf1[("x", "a")] - pdf2["x"]["b"]).rename(("x", "a")).sort_index(),
+            (pdf1[("x", "a")] - pdf2["x"]["b"]).sort_index(),
         )
 
         self.assert_eq(
             (kdf1["x"]["a"] - kdf2[("x", "b")]).sort_index(),
-            (pdf1["x"]["a"] - pdf2[("x", "b")]).rename("a").sort_index(),
+            (pdf1["x"]["a"] - pdf2[("x", "b")]).sort_index(),
         )
 
         # DataFrame
@@ -234,18 +232,16 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
 
         # Series
         self.assert_eq(
-            (kdf1.a - kdf2.b - kdf3.c).sort_index(),
-            (pdf1.a - pdf2.b - pdf3.c).rename("a").sort_index(),
+            (kdf1.a - kdf2.b - kdf3.c).sort_index(), (pdf1.a - pdf2.b - pdf3.c).sort_index()
         )
 
         self.assert_eq(
-            (kdf1.a * (kdf2.a * kdf3.c)).sort_index(),
-            (pdf1.a * (pdf2.a * pdf3.c)).rename("a").sort_index(),
+            (kdf1.a * (kdf2.a * kdf3.c)).sort_index(), (pdf1.a * (pdf2.a * pdf3.c)).sort_index()
         )
 
         self.assert_eq(
             (kdf1["a"] / kdf2["a"] / kdf3["c"]).sort_index(),
-            (pdf1["a"] / pdf2["a"] / pdf3["c"]).rename("a").sort_index(),
+            (pdf1["a"] / pdf2["a"] / pdf3["c"]).sort_index(),
         )
 
         # DataFrame
@@ -266,16 +262,12 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
         # Series
         self.assert_eq(
             (kdf1[("x", "a")] - kdf2[("x", "b")] - kdf3[("y", "c")]).sort_index(),
-            (pdf1[("x", "a")] - pdf2[("x", "b")] - pdf3[("y", "c")])
-            .rename(("x", "a"))
-            .sort_index(),
+            (pdf1[("x", "a")] - pdf2[("x", "b")] - pdf3[("y", "c")]).sort_index(),
         )
 
         self.assert_eq(
             (kdf1[("x", "a")] * (kdf2[("x", "b")] * kdf3[("y", "c")])).sort_index(),
-            (pdf1[("x", "a")] * (pdf2[("x", "b")] * pdf3[("y", "c")]))
-            .rename(("x", "a"))
-            .sort_index(),
+            (pdf1[("x", "a")] * (pdf2[("x", "b")] * pdf3[("y", "c")])).sort_index(),
         )
 
         # DataFrame
@@ -522,11 +514,9 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
         pdf6 = self.pdf6
 
         # Series
-        self.assert_eq((kdf5.c - kdf6.e).sort_index(), (pdf5.c - pdf6.e).rename("c").sort_index())
+        self.assert_eq((kdf5.c - kdf6.e).sort_index(), (pdf5.c - pdf6.e).sort_index())
 
-        self.assert_eq(
-            (kdf5["c"] / kdf6["e"]).sort_index(), (pdf5["c"] / pdf6["e"]).rename("c").sort_index()
-        )
+        self.assert_eq((kdf5["c"] / kdf6["e"]).sort_index(), (pdf5["c"] / pdf6["e"]).sort_index())
 
         # DataFrame
         self.assert_eq((kdf5 + kdf6).sort_index(), (pdf5 + pdf6).sort_index(), almost=True)

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -176,10 +176,7 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         )
         kdf = ks.from_pandas(pdf)
 
-        self.assert_eq(
-            (pdf["left"] | pdf["right"]).rename("left"),  # TODO: Fix the Series name
-            kdf["left"] | kdf["right"],
-        )
+        self.assert_eq(pdf["left"] | pdf["right"], kdf["left"] | kdf["right"])
 
     def test_and(self):
         pdf = pd.DataFrame(
@@ -191,8 +188,7 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         kdf = ks.from_pandas(pdf)
 
         self.assert_eq(
-            (pdf["left"] & pdf["right"]).rename("left"),  # TODO: Fix the Series name
-            kdf["left"] & kdf["right"],
+            pdf["left"] & pdf["right"], kdf["left"] & kdf["right"],
         )
 
     def test_to_numpy(self):
@@ -1502,7 +1498,7 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
             self.assert_eq(kmod, pmod)
 
     def test_rdivmod(self):
-        pser = pd.Series([100, None, 300, None, 500], name="Koalas")
+        pser = pd.Series([100, None, 300, None, 500])
         kser = ks.from_pandas(pser)
 
         if LooseVersion(pd.__version__) >= LooseVersion("1.0.0"):
@@ -1536,7 +1532,7 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
 
         pdf = pd.DataFrame({"a": [100, None, -300, None, 500, -700], "b": [150] * 6})
         kdf = ks.from_pandas(pdf)
-        self.assert_eq(kdf.a.mod(kdf.b), pdf.a.mod(pdf.b).rename("a"))
+        self.assert_eq(kdf.a.mod(kdf.b), pdf.a.mod(pdf.b))
 
     def test_rmod(self):
         pser = pd.Series([100, None, -300, None, 500, -700], name="Koalas")
@@ -1548,7 +1544,7 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
 
         pdf = pd.DataFrame({"a": [100, None, -300, None, 500, -700], "b": [150] * 6})
         kdf = ks.from_pandas(pdf)
-        self.assert_eq(kdf.a.rmod(kdf.b), pdf.a.rmod(pdf.b).rename("a"))
+        self.assert_eq(kdf.a.rmod(kdf.b), pdf.a.rmod(pdf.b))
 
     def test_asof(self):
         pser = pd.Series([1, 2, np.nan, 4], index=[10, 20, 30, 40], name="Koalas")

--- a/databricks/koalas/tests/test_series_datetime.py
+++ b/databricks/koalas/tests/test_series_datetime.py
@@ -49,9 +49,7 @@ class SeriesDateTimeTest(ReusedSQLTestCase, SQLTestUtils):
         # timezone behaviours inherited from C library.
 
         actual = (kdf["end_date"] - kdf["start_date"] - 1).to_pandas()
-        expected = ((pdf["end_date"] - pdf["start_date"]) // np.timedelta64(1, "s") - 1).rename(
-            "end_date"
-        )
+        expected = (pdf["end_date"] - pdf["start_date"]) // np.timedelta64(1, "s") - 1
         # self.assert_eq(actual, expected)
 
         actual = (kdf["end_date"] - pd.Timestamp("2012-1-1 12:45:31") - 1).to_pandas()
@@ -81,10 +79,9 @@ class SeriesDateTimeTest(ReusedSQLTestCase, SQLTestUtils):
         pdf = self.pdf1
         kdf = ks.from_pandas(pdf)
 
-        # TODO: Fix the Series name
         self.assert_eq(
             kdf["end_date"].dt.date - kdf["start_date"].dt.date,
-            (pdf["end_date"].dt.date - pdf["start_date"].dt.date).dt.days.rename("end_date"),
+            (pdf["end_date"].dt.date - pdf["start_date"].dt.date).dt.days,
         )
 
         self.assert_eq(

--- a/databricks/koalas/tests/test_series_string.py
+++ b/databricks/koalas/tests/test_series_string.py
@@ -65,8 +65,8 @@ class SeriesStringTest(ReusedSQLTestCase, SQLTestUtils):
         kdf = ks.from_pandas(pdf)
 
         # TODO: Fix the Series names
-        self.assert_eq(kdf["col1"] + kdf["col2"], (pdf["col1"] + pdf["col2"]).rename("col1"))
-        self.assert_eq(kdf["col2"] + kdf["col1"], (pdf["col2"] + pdf["col1"]).rename("col2"))
+        self.assert_eq(kdf["col1"] + kdf["col2"], pdf["col1"] + pdf["col2"])
+        self.assert_eq(kdf["col2"] + kdf["col1"], pdf["col2"] + pdf["col1"])
 
     def test_string_add_str_lit(self):
         pdf = pd.DataFrame(dict(col1=["a", "b", "c"]))


### PR DESCRIPTION
Fix `Series` name after binary operations.

When binary operations, if the name of the second operand is different from the first one, the name of the result Series becomes `None`.

```py
>>> pd.Series([1, 2, 3], name="x") + pd.Series([1, 2, 3], name="x")
0    2
1    4
2    6
Name: x, dtype: int64
>>> pd.Series([1, 2, 3], name="x") + pd.Series([1, 2, 3])
0    2
1    4
2    6
dtype: int64
>>> pd.Series([1, 2, 3], name="x") + pd.Series([1, 2, 3], name="y")
0    2
1    4
2    6
dtype: int64
>>> pd.Series([1, 2, 3]) + pd.Series([1, 2, 3])
0    2
1    4
2    6
dtype: int64
>>> pd.Series([1, 2, 3]) + pd.Series([1, 2, 3], name="x")
0    2
1    4
2    6
dtype: int64
```