### PR TITLE
Deprecate Series.alias.

### DIFF
--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -1022,6 +1022,10 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
     def alias(self, name):
         """An alias for :meth:`Series.rename`."""
+        warnings.warn(
+            "Series.alias is deprecated as of Series.rename. Please use the API instead.",
+            FutureWarning,
+        )
         return self.rename(name)
 
     @property

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -69,7 +69,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         pdf, kdf = self.df_pair
         self.assert_eq(kdf[["a", "b"]], pdf[["a", "b"]])
 
-        self.assertEqual(kdf.a.notnull().alias("x").name, "x")
+        self.assertEqual(kdf.a.notnull().rename("x").name, "x")
 
         # check ks.DataFrame(ks.Series)
         pser = pd.Series([1, 2, 3], name="x", index=np.random.rand(3))


### PR DESCRIPTION
`Series.alias` doesn't exist in pandas but was added by a historical reason. We should deprecate it now.