### PR TITLE
Fix tests to avoid resetting "compute.default_index_type" and related test failures.

### DIFF
--- a/databricks/conftest.py
+++ b/databricks/conftest.py
@@ -96,7 +96,7 @@ def add_db(doctest_namespace):
     doctest_namespace["db"] = db_name
 
 
-@pytest.fixture(autouse=os.getenv("KOALAS_USAGE_LOGGER", None) is not None)
+@pytest.fixture(autouse=os.getenv("KOALAS_USAGE_LOGGER", "") != "")
 def add_caplog(caplog):
     with caplog.at_level(logging.INFO, logger="databricks.koalas.usage_logger"):
         yield
@@ -106,3 +106,10 @@ def add_caplog(caplog):
 def close_figs():
     yield
     plt.close("all")
+
+
+@pytest.fixture(autouse=True)
+def check_options():
+    orig_default_index_type = ks.options.compute.default_index_type
+    yield
+    assert ks.options.compute.default_index_type == orig_default_index_type

--- a/databricks/koalas/__init__.py
+++ b/databricks/koalas/__init__.py
@@ -107,8 +107,8 @@ def _auto_patch_spark():
     import logging
 
     # Attach a usage logger.
-    logger_module = os.getenv("KOALAS_USAGE_LOGGER", None)
-    if logger_module is not None:
+    logger_module = os.getenv("KOALAS_USAGE_LOGGER", "")
+    if logger_module != "":
         try:
             from databricks.koalas import usage_logging
 

--- a/databricks/koalas/internal.py
+++ b/databricks/koalas/internal.py
@@ -620,7 +620,13 @@ class InternalFrame(object):
                     raise
                 return InternalFrame._attach_distributed_sequence_column(sdf, column_name)
         else:
-            return default_session().range(sdf.count()).toDF(column_name)
+            cnt = sdf.count()
+            if cnt > 0:
+                return default_session().range(cnt).toDF(column_name)
+            else:
+                return default_session().createDataFrame(
+                    [], schema=StructType().add(column_name, data_type=LongType(), nullable=False)
+                )
 
     @staticmethod
     def _attach_distributed_sequence_column(sdf, column_name):

--- a/databricks/koalas/internal.py
+++ b/databricks/koalas/internal.py
@@ -606,7 +606,7 @@ class InternalFrame(object):
                 encoders = sql_ctx._jvm.org.apache.spark.sql.Encoders
                 encoder = encoders.tuple(jdf.exprEnc(), encoders.scalaLong())
 
-                jrdd = jdf.rdd().zipWithIndex()
+                jrdd = jdf.localCheckpoint(False).rdd().zipWithIndex()
 
                 df = spark.DataFrame(
                     sql_ctx.sparkSession._jsparkSession.createDataset(jrdd, encoder).toDF(), sql_ctx
@@ -620,9 +620,7 @@ class InternalFrame(object):
                     raise
                 return InternalFrame._attach_distributed_sequence_column(sdf, column_name)
         else:
-            return default_session().createDataFrame(
-                [], schema=StructType().add(column_name, data_type=LongType(), nullable=False)
-            )
+            return default_session().range(sdf.count()).toDF(column_name)
 
     @staticmethod
     def _attach_distributed_sequence_column(sdf, column_name):

--- a/databricks/koalas/tests/test_default_index.py
+++ b/databricks/koalas/tests/test_default_index.py
@@ -16,54 +16,22 @@
 import pandas as pd
 
 from databricks import koalas as ks
-from databricks.koalas.config import set_option, reset_option
 from databricks.koalas.testing.utils import ReusedSQLTestCase
 
 
-class OneByOneDefaultIndexTest(ReusedSQLTestCase):
-    @classmethod
-    def setUpClass(cls):
-        super(OneByOneDefaultIndexTest, cls).setUpClass()
-        set_option("compute.default_index_type", "sequence")
+class DefaultIndexTest(ReusedSQLTestCase):
+    def test_default_index_sequence(self):
+        with ks.option_context("compute.default_index_type", "sequence"):
+            sdf = self.spark.range(1000)
+            self.assert_eq(ks.DataFrame(sdf), pd.DataFrame({"id": list(range(1000))}))
 
-    @classmethod
-    def tearDownClass(cls):
-        reset_option("compute.default_index_type")
-        super(OneByOneDefaultIndexTest, cls).tearDownClass()
+    def test_default_index_distributed_sequence(self):
+        with ks.option_context("compute.default_index_type", "distributed-sequence"):
+            sdf = self.spark.range(1000)
+            self.assert_eq(ks.DataFrame(sdf), pd.DataFrame({"id": list(range(1000))}))
 
-    def test_default_index(self):
-        sdf = self.spark.range(1000)
-        self.assert_eq(ks.DataFrame(sdf), pd.DataFrame({"id": list(range(1000))}))
-
-
-class DistributedOneByOneDefaultIndexTest(ReusedSQLTestCase):
-    @classmethod
-    def setUpClass(cls):
-        super(DistributedOneByOneDefaultIndexTest, cls).setUpClass()
-        set_option("compute.default_index_type", "distributed-sequence")
-
-    @classmethod
-    def tearDownClass(cls):
-        reset_option("compute.default_index_type")
-        super(DistributedOneByOneDefaultIndexTest, cls).tearDownClass()
-
-    def test_default_index(self):
-        sdf = self.spark.range(1000)
-        self.assert_eq(ks.DataFrame(sdf), pd.DataFrame({"id": list(range(1000))}))
-
-
-class DistributedDefaultIndexTest(ReusedSQLTestCase):
-    @classmethod
-    def setUpClass(cls):
-        super(DistributedDefaultIndexTest, cls).setUpClass()
-        set_option("compute.default_index_type", "distributed")
-
-    @classmethod
-    def tearDownClass(cls):
-        reset_option("compute.default_index_type")
-        super(DistributedDefaultIndexTest, cls).tearDownClass()
-
-    def test_default_index(self):
-        sdf = self.spark.range(1000)
-        pdf = ks.DataFrame(sdf).to_pandas()
-        self.assertEqual(len(set(pdf.index)), len(pdf))
+    def test_default_index_distributed(self):
+        with ks.option_context("compute.default_index_type", "distributed"):
+            sdf = self.spark.range(1000)
+            pdf = ks.DataFrame(sdf).to_pandas()
+            self.assertEqual(len(set(pdf.index)), len(pdf))

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -1728,6 +1728,12 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         )
         kdf = ks.from_pandas(pdf)
 
+        import os
+
+        self.assertEqual(
+            ks.get_option("compute.default_index_type"), os.getenv("DEFAULT_INDEX_TYPE", "sequence")
+        )
+
         acc = ks.utils.default_session().sparkContext.accumulator(0)
 
         def sum_with_acc_frame(x) -> ks.DataFrame[np.float64, np.float64]:

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -1731,7 +1731,8 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         import os
 
         self.assertEqual(
-            ks.get_option("compute.default_index_type"), os.getenv("DEFAULT_INDEX_TYPE", "sequence")
+            ks.get_option("compute.default_index_type"),
+            os.getenv("DEFAULT_INDEX_TYPE", "") or "sequence",
         )
 
         acc = ks.utils.default_session().sparkContext.accumulator(0)

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -1728,13 +1728,6 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         )
         kdf = ks.from_pandas(pdf)
 
-        import os
-
-        self.assertEqual(
-            ks.get_option("compute.default_index_type"),
-            os.getenv("DEFAULT_INDEX_TYPE", "") or "sequence",
-        )
-
         acc = ks.utils.default_session().sparkContext.accumulator(0)
 
         def sum_with_acc_frame(x) -> ks.DataFrame[np.float64, np.float64]:


### PR DESCRIPTION
`DefaultIndexTest`s reset the config `compute.default_index_type`, so the following tests are not working under the default index type given by the test environment.

Then found out some tests failed and fixed them (https://github.com/databricks/koalas/runs/1093753632):

- `GroupByTest.test_apply_with_side_effect`
- `NamespaceTest.test_concat_index_axis`