### PR TITLE
Remove arguments from super()

### DIFF
--- a/databricks/koalas/exceptions.py
+++ b/databricks/koalas/exceptions.py
@@ -48,7 +48,7 @@ class SparkPandasNotImplementedError(NotImplementedError):
             description += " " + hint
         else:
             description = hint
-        super(SparkPandasNotImplementedError, self).__init__(description)
+        super().__init__(description)
 
 
 class PandasNotImplementedError(NotImplementedError):
@@ -98,4 +98,4 @@ class PandasNotImplementedError(NotImplementedError):
                 msg = "The property `{0}.{1}()` is not implemented{2}".format(
                     class_name, property_name, reason
                 )
-        super(NotImplementedError, self).__init__(msg)
+        super().__init__(msg)

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -10352,7 +10352,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         fields = [
             f for f in self._internal.resolved_copy.spark_frame.schema.fieldNames() if " " not in f
         ]
-        return super(DataFrame, self).__dir__() + fields
+        return super().__dir__() + fields
 
     def __iter__(self):
         return iter(self.columns)
@@ -10441,7 +10441,7 @@ class CachedDataFrame(DataFrame):
             raise TypeError(
                 "Only a valid pyspark.StorageLevel type is acceptable for the `storage_level`"
             )
-        super(CachedDataFrame, self).__init__(internal)
+        super().__init__(internal)
 
     def __enter__(self):
         return self

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -2532,9 +2532,7 @@ class SeriesGroupBy(GroupBy):
     def _reduce_for_stat_function(self, sfun, only_numeric, should_include_groupkeys=False):
         assert not should_include_groupkeys, should_include_groupkeys
         return first_series(
-            super(SeriesGroupBy, self)._reduce_for_stat_function(
-                sfun, only_numeric, should_include_groupkeys
-            )
+            super()._reduce_for_stat_function(sfun, only_numeric, should_include_groupkeys)
         )
 
     def agg(self, *args, **kwargs):
@@ -2544,29 +2542,27 @@ class SeriesGroupBy(GroupBy):
         return MissingPandasLikeSeriesGroupBy.aggregate(self, *args, **kwargs)
 
     def transform(self, func, *args, **kwargs):
-        return first_series(super(SeriesGroupBy, self).transform(func, *args, **kwargs)).rename(
-            self._kser.name
-        )
+        return first_series(super().transform(func, *args, **kwargs)).rename(self._kser.name)
 
     transform.__doc__ = GroupBy.transform.__doc__
 
     def idxmin(self, skipna=True):
-        return first_series(super(SeriesGroupBy, self).idxmin(skipna))
+        return first_series(super().idxmin(skipna))
 
     idxmin.__doc__ = GroupBy.idxmin.__doc__
 
     def idxmax(self, skipna=True):
-        return first_series(super(SeriesGroupBy, self).idxmax(skipna))
+        return first_series(super().idxmax(skipna))
 
     idxmax.__doc__ = GroupBy.idxmax.__doc__
 
     def head(self, n=5):
-        return first_series(super(SeriesGroupBy, self).head(n)).rename(self._kser.name)
+        return first_series(super().head(n)).rename(self._kser.name)
 
     head.__doc__ = GroupBy.head.__doc__
 
     def size(self):
-        return super(SeriesGroupBy, self).size().rename(self._kser.name)
+        return super().size().rename(self._kser.name)
 
     size.__doc__ = GroupBy.size.__doc__
 

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -115,7 +115,7 @@ class Index(IndexOpsMixin):
         else:
             data = DataFrame(index=pd.Index(data=data, dtype=dtype, name=name))
 
-        super(Index, self).__init__(data)
+        super().__init__(data)
 
     @property
     def _internal(self) -> InternalFrame:
@@ -2078,7 +2078,7 @@ class MultiIndex(Index):
     def __init__(self, kdf: DataFrame):
         assert len(kdf._internal._index_map) > 1
 
-        super(MultiIndex, self).__init__(kdf)
+        super().__init__(kdf)
 
     @property
     def _internal(self):
@@ -2527,7 +2527,7 @@ class MultiIndex(Index):
                     ('d', 'h')],
                    )
         """
-        return super(MultiIndex, self).copy(deep=deep)
+        return super().copy(deep=deep)
 
     def symmetric_difference(self, other, result_name=None, sort=None):
         """
@@ -2686,7 +2686,7 @@ class MultiIndex(Index):
                 "'spark.sql.execution.arrow.enabled' to 'false' "
                 "for using this function with MultiIndex"
             )
-        return super(MultiIndex, self).value_counts(
+        return super().value_counts(
             normalize=normalize, sort=sort, ascending=ascending, bins=bins, dropna=dropna
         )
 

--- a/databricks/koalas/indexing.py
+++ b/databricks/koalas/indexing.py
@@ -1370,7 +1370,7 @@ class iLocIndexer(LocIndexerLike):
     @lazy_property
     def _internal(self):
         # Use resolved_copy to fix the natural order.
-        internal = super(iLocIndexer, self)._internal.resolved_copy
+        internal = super()._internal.resolved_copy
         sdf = InternalFrame.attach_distributed_sequence_column(
             internal.spark_frame, column_name=self._sequence_col
         )
@@ -1379,7 +1379,7 @@ class iLocIndexer(LocIndexerLike):
     @lazy_property
     def _sequence_col(self):
         # Use resolved_copy to fix the natural order.
-        internal = super(iLocIndexer, self)._internal.resolved_copy
+        internal = super()._internal.resolved_copy
         return verify_temp_column_name(internal.spark_frame, "__distributed_sequence_column__")
 
     def _select_rows_by_series(
@@ -1595,7 +1595,7 @@ class iLocIndexer(LocIndexerLike):
             )
 
     def __setitem__(self, key, value):
-        super(iLocIndexer, self).__setitem__(key, value)
+        super().__setitem__(key, value)
         # Update again with resolved_copy to drop extra columns.
         self._kdf._update_internal_frame(
             self._kdf._internal.resolved_copy, requires_same_anchor=False

--- a/databricks/koalas/plot.py
+++ b/databricks/koalas/plot.py
@@ -133,7 +133,7 @@ class SampledPlot:
 
 class KoalasBarPlot(BarPlot, TopNPlot):
     def __init__(self, data, **kwargs):
-        super(KoalasBarPlot, self).__init__(self.get_top_n(data), **kwargs)
+        super().__init__(self.get_top_n(data), **kwargs)
 
     def _plot(self, ax, x, y, w, start=0, log=False, **kwds):
         self.set_result_text(ax)
@@ -619,38 +619,38 @@ class KoalasHistPlot(HistPlot):
 
 class KoalasPiePlot(PiePlot, TopNPlot):
     def __init__(self, data, **kwargs):
-        super(KoalasPiePlot, self).__init__(self.get_top_n(data), **kwargs)
+        super().__init__(self.get_top_n(data), **kwargs)
 
     def _make_plot(self):
         self.set_result_text(self._get_ax(0))
-        super(KoalasPiePlot, self)._make_plot()
+        super()._make_plot()
 
 
 class KoalasAreaPlot(AreaPlot, SampledPlot):
     def __init__(self, data, **kwargs):
-        super(KoalasAreaPlot, self).__init__(self.get_sampled(data), **kwargs)
+        super().__init__(self.get_sampled(data), **kwargs)
 
     def _make_plot(self):
         self.set_result_text(self._get_ax(0))
-        super(KoalasAreaPlot, self)._make_plot()
+        super()._make_plot()
 
 
 class KoalasLinePlot(LinePlot, SampledPlot):
     def __init__(self, data, **kwargs):
-        super(KoalasLinePlot, self).__init__(self.get_sampled(data), **kwargs)
+        super().__init__(self.get_sampled(data), **kwargs)
 
     def _make_plot(self):
         self.set_result_text(self._get_ax(0))
-        super(KoalasLinePlot, self)._make_plot()
+        super()._make_plot()
 
 
 class KoalasBarhPlot(BarhPlot, TopNPlot):
     def __init__(self, data, **kwargs):
-        super(KoalasBarhPlot, self).__init__(self.get_top_n(data), **kwargs)
+        super().__init__(self.get_top_n(data), **kwargs)
 
     def _make_plot(self):
         self.set_result_text(self._get_ax(0))
-        super(KoalasBarhPlot, self)._make_plot()
+        super()._make_plot()
 
 
 class KoalasScatterPlot(ScatterPlot, TopNPlot):
@@ -659,7 +659,7 @@ class KoalasScatterPlot(ScatterPlot, TopNPlot):
 
     def _make_plot(self):
         self.set_result_text(self._get_ax(0))
-        super(KoalasScatterPlot, self)._make_plot()
+        super()._make_plot()
 
 
 class KoalasKdePlot(KdePlot):

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -345,7 +345,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             assert not copy
             assert not fastpath
 
-            super(Series, self).__init__(data)
+            super().__init__(data)
             self._column_label = index
         else:
             if isinstance(data, pd.Series):
@@ -364,7 +364,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
                 internal = internal.copy(column_labels=[None])
             anchor = DataFrame(internal)
 
-            super(Series, self).__init__(anchor)
+            super().__init__(anchor)
             self._column_label = anchor._internal.column_labels[0]
             anchor._kseries = {self._column_label: self}
 
@@ -5363,7 +5363,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             fields = []
         else:
             fields = [f for f in self.spark.data_type.fieldNames() if " " not in f]
-        return super(Series, self).__dir__() + fields
+        return super().__dir__() + fields
 
     def __iter__(self):
         return MissingPandasLikeSeries.__iter__(self)

--- a/databricks/koalas/tests/test_default_index.py
+++ b/databricks/koalas/tests/test_default_index.py
@@ -23,13 +23,13 @@ from databricks.koalas.testing.utils import ReusedSQLTestCase
 class OneByOneDefaultIndexTest(ReusedSQLTestCase):
     @classmethod
     def setUpClass(cls):
-        super(OneByOneDefaultIndexTest, cls).setUpClass()
+        super().setUpClass()
         set_option("compute.default_index_type", "sequence")
 
     @classmethod
     def tearDownClass(cls):
         reset_option("compute.default_index_type")
-        super(OneByOneDefaultIndexTest, cls).tearDownClass()
+        super().tearDownClass()
 
     def test_default_index(self):
         sdf = self.spark.range(1000)
@@ -39,13 +39,13 @@ class OneByOneDefaultIndexTest(ReusedSQLTestCase):
 class DistributedOneByOneDefaultIndexTest(ReusedSQLTestCase):
     @classmethod
     def setUpClass(cls):
-        super(DistributedOneByOneDefaultIndexTest, cls).setUpClass()
+        super().setUpClass()
         set_option("compute.default_index_type", "distributed-sequence")
 
     @classmethod
     def tearDownClass(cls):
         reset_option("compute.default_index_type")
-        super(DistributedOneByOneDefaultIndexTest, cls).tearDownClass()
+        super().tearDownClass()
 
     def test_default_index(self):
         sdf = self.spark.range(1000)
@@ -55,13 +55,13 @@ class DistributedOneByOneDefaultIndexTest(ReusedSQLTestCase):
 class DistributedDefaultIndexTest(ReusedSQLTestCase):
     @classmethod
     def setUpClass(cls):
-        super(DistributedDefaultIndexTest, cls).setUpClass()
+        super().setUpClass()
         set_option("compute.default_index_type", "distributed")
 
     @classmethod
     def tearDownClass(cls):
         reset_option("compute.default_index_type")
-        super(DistributedDefaultIndexTest, cls).tearDownClass()
+        super().tearDownClass()
 
     def test_default_index(self):
         sdf = self.spark.range(1000)

--- a/databricks/koalas/tests/test_frame_plot.py
+++ b/databricks/koalas/tests/test_frame_plot.py
@@ -21,7 +21,7 @@ class DataFramePlotTest(ReusedSQLTestCase, TestUtils):
 
     @classmethod
     def setUpClass(cls):
-        super(DataFramePlotTest, cls).setUpClass()
+        super().setUpClass()
         set_option("plotting.max_rows", 2000)
         set_option("plotting.sample_ratio", None)
 
@@ -29,7 +29,7 @@ class DataFramePlotTest(ReusedSQLTestCase, TestUtils):
     def tearDownClass(cls):
         reset_option("plotting.max_rows")
         reset_option("plotting.sample_ratio")
-        super(DataFramePlotTest, cls).tearDownClass()
+        super().tearDownClass()
 
     @property
     def pdf1(self):

--- a/databricks/koalas/tests/test_ops_on_diff_frames.py
+++ b/databricks/koalas/tests/test_ops_on_diff_frames.py
@@ -28,13 +28,13 @@ from databricks.koalas.testing.utils import ReusedSQLTestCase, SQLTestUtils
 class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
     @classmethod
     def setUpClass(cls):
-        super(OpsOnDiffFramesEnabledTest, cls).setUpClass()
+        super().setUpClass()
         set_option("compute.ops_on_diff_frames", True)
 
     @classmethod
     def tearDownClass(cls):
         reset_option("compute.ops_on_diff_frames")
-        super(OpsOnDiffFramesEnabledTest, cls).tearDownClass()
+        super().tearDownClass()
 
     @property
     def pdf1(self):
@@ -915,13 +915,13 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
 class OpsOnDiffFramesDisabledTest(ReusedSQLTestCase, SQLTestUtils):
     @classmethod
     def setUpClass(cls):
-        super(OpsOnDiffFramesDisabledTest, cls).setUpClass()
+        super().setUpClass()
         set_option("compute.ops_on_diff_frames", False)
 
     @classmethod
     def tearDownClass(cls):
         reset_option("compute.ops_on_diff_frames")
-        super(OpsOnDiffFramesDisabledTest, cls).tearDownClass()
+        super().tearDownClass()
 
     @property
     def pdf1(self):

--- a/databricks/koalas/tests/test_ops_on_diff_frames_groupby.py
+++ b/databricks/koalas/tests/test_ops_on_diff_frames_groupby.py
@@ -25,13 +25,13 @@ from databricks.koalas.testing.utils import ReusedSQLTestCase, SQLTestUtils
 class OpsOnDiffFramesGroupByTest(ReusedSQLTestCase, SQLTestUtils):
     @classmethod
     def setUpClass(cls):
-        super(OpsOnDiffFramesGroupByTest, cls).setUpClass()
+        super().setUpClass()
         set_option("compute.ops_on_diff_frames", True)
 
     @classmethod
     def tearDownClass(cls):
         reset_option("compute.ops_on_diff_frames")
-        super(OpsOnDiffFramesGroupByTest, cls).tearDownClass()
+        super().tearDownClass()
 
     def test_groupby_different_lengths(self):
         pdfs1 = [

--- a/databricks/koalas/tests/test_ops_on_diff_frames_groupby_expanding.py
+++ b/databricks/koalas/tests/test_ops_on_diff_frames_groupby_expanding.py
@@ -27,13 +27,13 @@ from databricks.koalas.testing.utils import ReusedSQLTestCase, TestUtils
 class OpsOnDiffFramesGroupByExpandingTest(ReusedSQLTestCase, TestUtils):
     @classmethod
     def setUpClass(cls):
-        super(OpsOnDiffFramesGroupByExpandingTest, cls).setUpClass()
+        super().setUpClass()
         set_option("compute.ops_on_diff_frames", True)
 
     @classmethod
     def tearDownClass(cls):
         reset_option("compute.ops_on_diff_frames")
-        super(OpsOnDiffFramesGroupByExpandingTest, cls).tearDownClass()
+        super().tearDownClass()
 
     def _test_groupby_expanding_func(self, f):
         pser = pd.Series([1, 2, 3])

--- a/databricks/koalas/tests/test_ops_on_diff_frames_groupby_rolling.py
+++ b/databricks/koalas/tests/test_ops_on_diff_frames_groupby_rolling.py
@@ -24,13 +24,13 @@ from databricks.koalas.testing.utils import ReusedSQLTestCase, TestUtils
 class OpsOnDiffFramesGroupByRollingTest(ReusedSQLTestCase, TestUtils):
     @classmethod
     def setUpClass(cls):
-        super(OpsOnDiffFramesGroupByRollingTest, cls).setUpClass()
+        super().setUpClass()
         set_option("compute.ops_on_diff_frames", True)
 
     @classmethod
     def tearDownClass(cls):
         reset_option("compute.ops_on_diff_frames")
-        super(OpsOnDiffFramesGroupByRollingTest, cls).tearDownClass()
+        super().tearDownClass()
 
     def _test_groupby_rolling_func(self, f):
         pser = pd.Series([1, 2, 3], name="a")

--- a/databricks/koalas/tests/test_repr.py
+++ b/databricks/koalas/tests/test_repr.py
@@ -25,13 +25,13 @@ class ReprTest(ReusedSQLTestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(ReprTest, cls).setUpClass()
+        super().setUpClass()
         set_option("display.max_rows", ReprTest.max_display_count)
 
     @classmethod
     def tearDownClass(cls):
         reset_option("display.max_rows")
-        super(ReprTest, cls).tearDownClass()
+        super().tearDownClass()
 
     def test_repr_dataframe(self):
         kdf = ks.range(ReprTest.max_display_count)

--- a/databricks/koalas/tests/test_series_plot.py
+++ b/databricks/koalas/tests/test_series_plot.py
@@ -33,13 +33,13 @@ matplotlib.use("agg")
 class SeriesPlotTest(ReusedSQLTestCase, TestUtils):
     @classmethod
     def setUpClass(cls):
-        super(SeriesPlotTest, cls).setUpClass()
+        super().setUpClass()
         set_option("plotting.max_rows", 1000)
 
     @classmethod
     def tearDownClass(cls):
         reset_option("plotting.max_rows")
-        super(SeriesPlotTest, cls).tearDownClass()
+        super().tearDownClass()
 
     @property
     def pdf1(self):

--- a/databricks/koalas/window.py
+++ b/databricks/koalas/window.py
@@ -137,7 +137,7 @@ class Rolling(RollingAndExpanding):
             Window.currentRow - (window - 1), Window.currentRow
         )
 
-        super(Rolling, self).__init__(kdf_or_kser, window, min_periods)
+        super().__init__(kdf_or_kser, window, min_periods)
 
     def __getattr__(self, item: str) -> Any:
         if hasattr(MissingPandasLikeRolling, item):
@@ -200,7 +200,7 @@ class Rolling(RollingAndExpanding):
         2  2.0
         3  2.0
         """
-        return super(Rolling, self).count()
+        return super().count()
 
     def sum(self):
         """
@@ -278,7 +278,7 @@ class Rolling(RollingAndExpanding):
         3  10.0  38.0
         4  13.0  65.0
         """
-        return super(Rolling, self).sum()
+        return super().sum()
 
     def min(self):
         """
@@ -356,7 +356,7 @@ class Rolling(RollingAndExpanding):
         3  2.0  4.0
         4  2.0  4.0
         """
-        return super(Rolling, self).min()
+        return super().min()
 
     def max(self):
         """
@@ -433,7 +433,7 @@ class Rolling(RollingAndExpanding):
         3  5.0  25.0
         4  6.0  36.0
         """
-        return super(Rolling, self).max()
+        return super().max()
 
     def mean(self):
         """
@@ -511,7 +511,7 @@ class Rolling(RollingAndExpanding):
         3  3.333333  12.666667
         4  4.333333  21.666667
         """
-        return super(Rolling, self).mean()
+        return super().mean()
 
     def std(self):
         """
@@ -561,7 +561,7 @@ class Rolling(RollingAndExpanding):
         5  0.000000   0.000000
         6  0.000000   0.000000
         """
-        return super(Rolling, self).std()
+        return super().std()
 
     def var(self):
         """
@@ -611,7 +611,7 @@ class Rolling(RollingAndExpanding):
         5  0.0    0.0
         6  0.0    0.0
         """
-        return super(Rolling, self).var()
+        return super().var()
 
 
 class RollingGroupby(Rolling):
@@ -629,7 +629,7 @@ class RollingGroupby(Rolling):
                 "however, got: %s" % type(groupby)
             )
 
-        super(RollingGroupby, self).__init__(kdf_or_kser, window, min_periods)
+        super().__init__(kdf_or_kser, window, min_periods)
 
         self._groupby = groupby
         self._window = self._window.partitionBy(*[ser.spark.column for ser in groupby._groupkeys])
@@ -764,7 +764,7 @@ class RollingGroupby(Rolling):
         5 9   1.0  1.0
           10  2.0  2.0
         """
-        return super(RollingGroupby, self).count()
+        return super().count()
 
     def sum(self):
         """
@@ -818,7 +818,7 @@ class RollingGroupby(Rolling):
         5 9    NaN   NaN
           10  10.0  50.0
         """
-        return super(RollingGroupby, self).sum()
+        return super().sum()
 
     def min(self):
         """
@@ -872,7 +872,7 @@ class RollingGroupby(Rolling):
         5 9   NaN   NaN
           10  5.0  25.0
         """
-        return super(RollingGroupby, self).min()
+        return super().min()
 
     def max(self):
         """
@@ -926,7 +926,7 @@ class RollingGroupby(Rolling):
         5 9   NaN   NaN
           10  5.0  25.0
         """
-        return super(RollingGroupby, self).max()
+        return super().max()
 
     def mean(self):
         """
@@ -980,7 +980,7 @@ class RollingGroupby(Rolling):
         5 9   NaN   NaN
           10  5.0  25.0
         """
-        return super(RollingGroupby, self).mean()
+        return super().mean()
 
     def std(self):
         """
@@ -999,7 +999,7 @@ class RollingGroupby(Rolling):
         DataFrame.std : Equivalent method for DataFrame.
         numpy.std : Equivalent method for Numpy array.
         """
-        return super(RollingGroupby, self).std()
+        return super().std()
 
     def var(self):
         """
@@ -1018,7 +1018,7 @@ class RollingGroupby(Rolling):
         DataFrame.var : Equivalent method for DataFrame.
         numpy.var : Equivalent method for Numpy array.
         """
-        return super(RollingGroupby, self).var()
+        return super().var()
 
 
 class Expanding(RollingAndExpanding):
@@ -1037,7 +1037,7 @@ class Expanding(RollingAndExpanding):
             Window.unboundedPreceding, Window.currentRow
         )
 
-        super(Expanding, self).__init__(kdf_or_kser, window, min_periods)
+        super().__init__(kdf_or_kser, window, min_periods)
 
     def __getattr__(self, item: str) -> Any:
         if hasattr(MissingPandasLikeExpanding, item):
@@ -1162,7 +1162,7 @@ class Expanding(RollingAndExpanding):
         3  10.0  30.0
         4  15.0  55.0
         """
-        return super(Expanding, self).sum()
+        return super().sum()
 
     def min(self):
         """
@@ -1199,7 +1199,7 @@ class Expanding(RollingAndExpanding):
         4    2.0
         dtype: float64
         """
-        return super(Expanding, self).min()
+        return super().min()
 
     def max(self):
         """
@@ -1235,7 +1235,7 @@ class Expanding(RollingAndExpanding):
         4    6.0
         dtype: float64
         """
-        return super(Expanding, self).max()
+        return super().max()
 
     def mean(self):
         """
@@ -1279,7 +1279,7 @@ class Expanding(RollingAndExpanding):
         3    2.5
         dtype: float64
         """
-        return super(Expanding, self).mean()
+        return super().mean()
 
     def std(self):
         """
@@ -1329,7 +1329,7 @@ class Expanding(RollingAndExpanding):
         5  0.836660   9.928075
         6  0.786796   9.327379
         """
-        return super(Expanding, self).std()
+        return super().std()
 
     def var(self):
         """
@@ -1379,7 +1379,7 @@ class Expanding(RollingAndExpanding):
         5  0.700000   98.566667
         6  0.619048   87.000000
         """
-        return super(Expanding, self).var()
+        return super().var()
 
 
 class ExpandingGroupby(Expanding):
@@ -1397,7 +1397,7 @@ class ExpandingGroupby(Expanding):
                 "however, got: %s" % type(groupby)
             )
 
-        super(ExpandingGroupby, self).__init__(kdf_or_kser, min_periods)
+        super().__init__(kdf_or_kser, min_periods)
 
         self._groupby = groupby
         self._window = self._window.partitionBy(*[ser.spark.column for ser in groupby._groupkeys])
@@ -1468,7 +1468,7 @@ class ExpandingGroupby(Expanding):
         5 9   NaN  NaN
           10  2.0  2.0
         """
-        return super(ExpandingGroupby, self).count()
+        return super().count()
 
     def sum(self):
         """
@@ -1522,7 +1522,7 @@ class ExpandingGroupby(Expanding):
         5 9    NaN   NaN
           10  10.0  50.0
         """
-        return super(ExpandingGroupby, self).sum()
+        return super().sum()
 
     def min(self):
         """
@@ -1576,7 +1576,7 @@ class ExpandingGroupby(Expanding):
         5 9   NaN   NaN
           10  5.0  25.0
         """
-        return super(ExpandingGroupby, self).min()
+        return super().min()
 
     def max(self):
         """
@@ -1629,7 +1629,7 @@ class ExpandingGroupby(Expanding):
         5 9   NaN   NaN
           10  5.0  25.0
         """
-        return super(ExpandingGroupby, self).max()
+        return super().max()
 
     def mean(self):
         """
@@ -1683,7 +1683,7 @@ class ExpandingGroupby(Expanding):
         5 9   NaN   NaN
           10  5.0  25.0
         """
-        return super(ExpandingGroupby, self).mean()
+        return super().mean()
 
     def std(self):
         """
@@ -1703,7 +1703,7 @@ class ExpandingGroupby(Expanding):
         DataFrame.std : Equivalent method for DataFrame.
         numpy.std : Equivalent method for Numpy array.
         """
-        return super(ExpandingGroupby, self).std()
+        return super().std()
 
     def var(self):
         """
@@ -1722,4 +1722,4 @@ class ExpandingGroupby(Expanding):
         DataFrame.var : Equivalent method for DataFrame.
         numpy.var : Equivalent method for Numpy array.
         """
-        return super(ExpandingGroupby, self).var()
+        return super().var()


### PR DESCRIPTION
Since the syntax for `super()` changed in [Python 3.0](https://docs.python.org/3/library/functions.html#super),

I think we can make the code more simpler and get more readability.

```diff
class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
    @classmethod
    def setUpClass(cls):
-       super(OpsOnDiffFramesEnabledTest, cls).setUpClass()
+       super().setUpClass()
```