### PR TITLE
Exclude nbconvert 6.0 temporarily to recover Read the Docs build

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,6 +10,9 @@ mlflow>=1.0
 # Documentation build.
 sphinx>=2.0.0,<3.1.0
 nbsphinx
+# Temporarily exclude nbconvert 6.0 that is a dependency from nbsphinx.
+# It causes Read the Docs build fails
+nbconvert!=6.0
 numpydoc==0.8
 pypandoc
 ipython

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,7 +12,7 @@ sphinx>=2.0.0,<3.1.0
 nbsphinx
 # Temporarily exclude nbconvert 6.0 that is a dependency from nbsphinx.
 # It causes Read the Docs build fails
-nbconvert!=6.0
+nbconvert!=6.0.*
 numpydoc==0.8
 pypandoc
 ipython


### PR DESCRIPTION
Read the Docs build is being failed after `nbconvert` 6.0.1 release https://github.com/jupyter/nbconvert/releases.
This PR temporarily exclude 6.0 in the dependency to recover Read the Docs build.

```
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/koalas/envs/latest/lib/python3.6/site-packages/sphinx/cmd/build.py", line 279, in build_main
    args.tags, args.verbosity, args.jobs, args.keep_going)
  File "/home/docs/checkouts/readthedocs.org/user_builds/koalas/envs/latest/lib/python3.6/site-packages/sphinx/application.py", line 244, in __init__
    self.setup_extension(extension)
  File "/home/docs/checkouts/readthedocs.org/user_builds/koalas/envs/latest/lib/python3.6/site-packages/sphinx/application.py", line 398, in setup_extension
    self.registry.load_extension(self, extname)
  File "/home/docs/checkouts/readthedocs.org/user_builds/koalas/envs/latest/lib/python3.6/site-packages/sphinx/registry.py", line 402, in load_extension
    mod = import_module(extname)
  File "/home/docs/checkouts/readthedocs.org/user_builds/koalas/envs/latest/lib/python3.6/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 994, in _gcd_import
  File "<frozen importlib._bootstrap>", line 971, in _find_and_load
  File "<frozen importlib._bootstrap>", line 955, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 665, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 678, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/home/docs/checkouts/readthedocs.org/user_builds/koalas/envs/latest/lib/python3.6/site-packages/nbsphinx.py", line 41, in <module>
    import nbconvert
  File "/home/docs/checkouts/readthedocs.org/user_builds/koalas/envs/latest/lib/python3.6/site-packages/nbconvert/__init__.py", line 4, in <module>
    from .exporters import *
  File "/home/docs/checkouts/readthedocs.org/user_builds/koalas/envs/latest/lib/python3.6/site-packages/nbconvert/exporters/__init__.py", line 4, in <module>
    from .slides import SlidesExporter
  File "/home/docs/checkouts/readthedocs.org/user_builds/koalas/envs/latest/lib/python3.6/site-packages/nbconvert/exporters/slides.py", line 12, in <module>
    from ..preprocessors.base import Preprocessor
  File "/home/docs/checkouts/readthedocs.org/user_builds/koalas/envs/latest/lib/python3.6/site-packages/nbconvert/preprocessors/__init__.py", line 7, in <module>
    from .csshtmlheader import CSSHTMLHeaderPreprocessor
  File "/home/docs/checkouts/readthedocs.org/user_builds/koalas/envs/latest/lib/python3.6/site-packages/nbconvert/preprocessors/csshtmlheader.py", line 14, in <module>
    from jupyterlab_pygments import JupyterStyle
  File "/home/docs/checkouts/readthedocs.org/user_builds/koalas/envs/latest/lib/python3.6/site-packages/jupyterlab_pygments/__init__.py", line 4, in <module>
    from .style import JupyterStyle
  File "/home/docs/checkouts/readthedocs.org/user_builds/koalas/envs/latest/lib/python3.6/site-packages/jupyterlab_pygments/style.py", line 10, in <module>
    class JupyterStyle(Style):
  File "/home/docs/checkouts/readthedocs.org/user_builds/koalas/envs/latest/lib/python3.6/site-packages/pygments/style.py", line 101, in __new__
    ndef[0] = colorformat(styledef)
  File "/home/docs/checkouts/readthedocs.org/user_builds/koalas/envs/latest/lib/python3.6/site-packages/pygments/style.py", line 58, in colorformat
    assert False, "wrong color format %r" % text
AssertionError: wrong color format 'var(--jp-mirror-editor-variable-color)'

Exception occurred:
  File "/home/docs/checkouts/readthedocs.org/user_builds/koalas/envs/latest/lib/python3.6/site-packages/pygments/style.py", line 58, in colorformat
    assert False, "wrong color format %r" % text
AssertionError: wrong color format 'var(--jp-mirror-editor-variable-color)'
The full traceback has been saved in /tmp/sphinx-err-uuamc6ui.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at <https://github.com/sphinx-doc/sphinx/issues>. Thanks!
```