### PR TITLE
Rename GitHub Actions workflow build to prevent confusion with branch name

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,4 +1,4 @@
-name: master
+name: Build and test
 
 on:
   push:


### PR DESCRIPTION
To make it less confused. This is actually matched with Apache Spark side.