### PR TITLE
Upgrade PySpark version to 3.0.1 for CI.

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -110,11 +110,11 @@ jobs:
             pyarrow-version: 0.15.1
             default-index-type: 'distributed-sequence'
           - python-version: 3.7
-            spark-version: 3.0.0
+            spark-version: 3.0.1
             pandas-version: 0.25.3
             pyarrow-version: 0.15.1
           - python-version: 3.8
-            spark-version: 3.0.0
+            spark-version: 3.0.1
             pandas-version: 1.0.5
             pyarrow-version: 1.0.1
             default-index-type: 'distributed-sequence'

--- a/databricks/koalas/internal.py
+++ b/databricks/koalas/internal.py
@@ -21,7 +21,6 @@ import re
 from typing import Dict, List, Optional, Tuple, Union, TYPE_CHECKING
 from itertools import accumulate
 from collections import OrderedDict
-import os
 import py4j
 
 import numpy as np
@@ -49,6 +48,7 @@ from databricks.koalas.typedef import infer_pd_series_spark_type, spark_type_to_
 from databricks.koalas.utils import (
     column_labels_level,
     default_session,
+    is_testing,
     lazy_property,
     name_like_string,
     scol_for,
@@ -616,7 +616,7 @@ class InternalFrame(object):
                     "`{}` as `{}`".format(columns[1], column_name), "`{}`.*".format(columns[0])
                 )
             except py4j.protocol.Py4JError:
-                if "KOALAS_TESTING" in os.environ:
+                if is_testing():
                     raise
                 return InternalFrame._attach_distributed_sequence_column(sdf, column_name)
         else:


### PR DESCRIPTION
As PySpark 3.0.1 was released, this upgrades PySpark version to 3.0.1 for CI.
Also set a config `spark.executor.allowSparkContext` to `"false"` to check Koalas don't create `SparkContext` in executors unexpectedly.