### PR TITLE
Add asi8 for Index & MultiIndex

### DIFF
--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -467,8 +467,10 @@ class Index(IndexOpsMixin):
         warnings.warn("We recommend using `{}.to_numpy()` instead.".format(type(self).__name__))
         if self.dtype == "int64":
             return self.to_numpy()
+        elif self.dtype == "<M8[ns]":
+            return np.array(list(map(lambda x: x.astype(np.int64), self.to_numpy())))
         else:
-            return
+            return None
 
     @property
     def spark_type(self):
@@ -2863,8 +2865,16 @@ class MultiIndex(Index):
         """
         Return a string of the type inferred from the values.
         """
-        # It's always 'mixed' for MultiIndex
+        # Always returns "mixed" for MultiIndex
         return "mixed"
+
+    @property
+    def asi8(self):
+        """
+        Integer representation of the values.
+        """
+        # Always returns None for MultiIndex
+        return None
 
     def __iter__(self):
         return MissingPandasLikeMultiIndex.__iter__(self)

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -456,6 +456,13 @@ class Index(IndexOpsMixin):
 
         Examples
         --------
+        >>> ks.Index([1, 2, 3]).asi8
+        array([1, 2, 3])
+
+        Returns None for non-int64 dtype
+
+        >>> ks.Index(['a', 'b', 'c']).asi8 is None
+        True
         """
         warnings.warn("We recommend using `{}.to_numpy()` instead.".format(type(self).__name__))
         if self.dtype == "int64":

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -465,9 +465,9 @@ class Index(IndexOpsMixin):
         True
         """
         warnings.warn("We recommend using `{}.to_numpy()` instead.".format(type(self).__name__))
-        if self.dtype == "int64":
+        if isinstance(self.spark.data_type, IntegralType):
             return self.to_numpy()
-        elif self.dtype == "<M8[ns]":
+        elif isinstance(self.spark.data_type, TimestampType):
             return np.array(list(map(lambda x: x.astype(np.int64), self.to_numpy())))
         else:
             return None

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -440,6 +440,30 @@ class Index(IndexOpsMixin):
         return self.to_numpy()
 
     @property
+    def asi8(self):
+        """
+        Integer representation of the values.
+
+        .. warning:: We recommend using `Index.to_numpy()` instead.
+
+        .. note:: This method should only be used if the resulting NumPy ndarray is expected
+            to be small, as all the data is loaded into the driver's memory.
+
+        Returns
+        -------
+        numpy.ndarray
+            An ndarray with int64 dtype.
+
+        Examples
+        --------
+        """
+        warnings.warn("We recommend using `{}.to_numpy()` instead.".format(type(self).__name__))
+        if self.dtype == "int64":
+            return self.to_numpy()
+        else:
+            return
+
+    @property
     def spark_type(self):
         """ Returns the data type as defined by Spark, as a Spark DataType object."""
         warnings.warn(

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -1445,3 +1445,29 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         pmidx = pd.MultiIndex.from_tuples([("a", "x")])
         kmidx = ks.from_pandas(pmidx)
         self.assert_eq(pmidx.inferred_type, kmidx.inferred_type)
+
+    def test_asi8(self):
+        # Integer
+        pidx = pd.Index([1, 2, 3])
+        kidx = ks.from_pandas(pidx)
+        self.assertTrue(all(pidx.asi8 == kidx.asi8))
+
+        # Floating
+        pidx = pd.Index([1.0, 2.0, 3.0])
+        kidx = ks.from_pandas(pidx)
+        self.assert_eq(pidx.asi8, kidx.asi8)
+
+        # String
+        pidx = pd.Index(["a", "b", "c"])
+        kidx = ks.from_pandas(pidx)
+        self.assert_eq(pidx.asi8, kidx.asi8)
+
+        # Boolean
+        pidx = pd.Index([True, False, True, False])
+        kidx = ks.from_pandas(pidx)
+        self.assert_eq(pidx.asi8, kidx.asi8)
+
+        # MultiIndex
+        pmidx = pd.MultiIndex.from_tuples([("a", "x")])
+        kmidx = ks.from_pandas(pmidx)
+        self.assert_eq(pidx.asi8, kidx.asi8)

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -1450,7 +1450,12 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         # Integer
         pidx = pd.Index([1, 2, 3])
         kidx = ks.from_pandas(pidx)
-        self.assertTrue(all(pidx.asi8 == kidx.asi8))
+        self.assert_array_eq(pidx.asi8, kidx.asi8)
+
+        # Datetime
+        pidx = pd.date_range(end="1/1/2018", periods=3)
+        kidx = ks.from_pandas(pidx)
+        self.assert_array_eq(pidx.asi8, kidx.asi8)
 
         # Floating
         pidx = pd.Index([1.0, 2.0, 3.0])
@@ -1468,6 +1473,6 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         self.assert_eq(pidx.asi8, kidx.asi8)
 
         # MultiIndex
-        pmidx = pd.MultiIndex.from_tuples([("a", "x")])
+        pmidx = pd.MultiIndex.from_tuples([(1, 2)])
         kmidx = ks.from_pandas(pmidx)
-        self.assert_eq(pidx.asi8, kidx.asi8)
+        self.assert_eq(pmidx.asi8, kmidx.asi8)

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -1451,6 +1451,14 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         pidx = pd.Index([1, 2, 3])
         kidx = ks.from_pandas(pidx)
         self.assert_array_eq(pidx.asi8, kidx.asi8)
+        self.assert_array_eq(pidx.astype("int").asi8, kidx.astype("int").asi8)
+        self.assert_array_eq(pidx.astype("int16").asi8, kidx.astype("int16").asi8)
+        self.assert_array_eq(pidx.astype("int8").asi8, kidx.astype("int8").asi8)
+
+        # Integer with missing value
+        pidx = pd.Index([1, 2, None, 4, 5])
+        kidx = ks.from_pandas(pidx)
+        self.assert_eq(pidx.asi8, kidx.asi8)
 
         # Datetime
         pidx = pd.date_range(end="1/1/2018", periods=3)


### PR DESCRIPTION
The PR proposes asi8 for Index & MultiIndex

```python
>>> ks.Index([1, 2, 3]).asi8
array([1, 2, 3])

>>> ks.Index(['a', 'b', 'c']).asi8 is None
True
```