### PR TITLE
Fix iloc for slice(None, 0)

### DIFF
--- a/databricks/koalas/indexing.py
+++ b/databricks/koalas/indexing.py
@@ -1420,9 +1420,7 @@ class iLocIndexer(LocIndexerLike):
         stop = rows_sel.stop
         if stop is not None:
             verify_type(stop)
-            if stop == 0:
-                stop = None
-            elif stop < 0:
+            if stop < 0:
                 has_negative = True
 
         step = rows_sel.step

--- a/databricks/koalas/tests/test_indexing.py
+++ b/databricks/koalas/tests/test_indexing.py
@@ -808,6 +808,7 @@ class IndexingTest(ReusedSQLTestCase):
             slice(1, 2),
             slice(-3, None),
             slice(None, -3),
+            slice(None, 0),
             slice(None, None, 3),
             slice(3, 8, 2),
             slice(None, None, -2),


### PR DESCRIPTION
Current behavior of `iloc` seems not work properly in the case below.


```python
>>> pdf = pd.DataFrame({'A': [3, 4, 5, 6, 7],
...                     'B': [10.0, 20.0, 30.0, 40.0, 50.0],
...                     'C': ['a', 'b', 'c', 'd', 'e'],
...                     'D': [np.nan, np.nan, np.nan, np.nan, np.nan]})
>>> pdf.columns.name = "Koalas"
>>> kdf = ks.from_pandas(pdf)

>>> pdf.iloc[:0]  # same as `pdf[:0]`
Empty DataFrame
Columns: [A, B, C, D]
Index: []

>>> kdf.iloc[:0]  # should've returned `Empty DataFrame` 
Koalas  A     B  C   D
0       3  10.0  a NaN
1       4  20.0  b NaN
2       5  30.0  c NaN
3       6  40.0  d NaN
4       7  50.0  e NaN
```

This PR fixed it.

```python
>>> pdf.iloc[:0]
Empty DataFrame
Columns: [A, B, C, D]
Index: []

>>> kdf.iloc[:0]
Empty DataFrame
Columns: [A, B, C, D]
Index: []

>>> pdf[:0]
Empty DataFrame
Columns: [A, B, C, D]
Index: []

>>> kdf[:0]
Empty DataFrame
Columns: [A, B, C, D]
Index: []
```