### PR TITLE
[MINOR][DOC] Rename Indexing to Index objects in the doc

### DIFF
--- a/docs/source/reference/indexing.rst
+++ b/docs/source/reference/indexing.rst
@@ -1,8 +1,8 @@
 .. _api.indexing:
 
-========
-Indexing
-========
+=============
+Index objects
+=============
 
 Index
 -----


### PR DESCRIPTION
In pandas' doc, they uses `Index objects` for `Index` whereas Koalas uses `Indexing` and I'm not sure If it is intended.

<img width="806" alt="스크린샷 2020-09-14 오후 6 09 09" src="https://user-images.githubusercontent.com/44108233/93067241-edf52180-f6b5-11ea-83e3-4c8246c631fe.png">

<img width="695" alt="스크린샷 2020-09-14 오후 6 13 14" src="https://user-images.githubusercontent.com/44108233/93067279-f9484d00-f6b5-11ea-8676-7d4e6f6c441c.png">


If it's not intended, this PR suggests just match the name same as pandas'.