### PR TITLE
Upgrade PySpark version to 2.4.7 for CI.

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -91,21 +91,21 @@ jobs:
       matrix:
         include:
           - python-version: 3.6
-            spark-version: 2.4.6
+            spark-version: 2.4.7
             pandas-version: 0.24.2
             pyarrow-version: 0.14.1
             logger: databricks.koalas.usage_logging.usage_logger
           - python-version: 3.6
-            spark-version: 2.4.6
+            spark-version: 2.4.7
             pandas-version: 0.25.3
             pyarrow-version: 0.15.1
             default-index-type: 'distributed-sequence'
           - python-version: 3.7
-            spark-version: 2.4.6
+            spark-version: 2.4.7
             pandas-version: 0.25.3
             pyarrow-version: 0.14.1
           - python-version: 3.7
-            spark-version: 2.4.6
+            spark-version: 2.4.7
             pandas-version: 1.0.5
             pyarrow-version: 0.15.1
             default-index-type: 'distributed-sequence'

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -150,7 +150,12 @@ jobs:
         conda config --env --add pinned_packages pandas==$PANDAS_VERSION
         conda config --env --add pinned_packages pyarrow==$PYARROW_VERSION
         conda config --env --add pinned_packages pyspark==$SPARK_VERSION
-        conda install -c conda-forge --yes pandas==$PANDAS_VERSION pyarrow==$PYARROW_VERSION pyspark==$SPARK_VERSION
+        if [[ "$SPARK_VERSION" < "3.0" ]]; then
+          pip install pyspark==$SPARK_VERSION
+        else
+          conda install -c conda-forge --yes pyspark==$SPARK_VERSION
+        fi
+        conda install -c conda-forge --yes pandas==$PANDAS_VERSION pyarrow==$PYARROW_VERSION
         sed -i -e "/pandas/d" -e "/pyarrow/d" requirements-dev.txt
         conda install -c conda-forge --yes --file requirements-dev.txt
         conda list


### PR DESCRIPTION
As PySpark 2.4.7 was released, this upgrades PySpark version to 2.4.7 for CI.