### PR TITLE
Refactor DataFrame.aggregate

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -1241,7 +1241,12 @@ class DataFrame(Frame, Generic[T]):
             #
             # Aggregated output is usually pretty much small.
 
-            return kdf.stack().droplevel(0)[list(func.keys())]
+            if LooseVersion(pyspark.__version__) >= LooseVersion("2.4"):
+                return kdf.stack().droplevel(0)[list(func.keys())]
+            else:
+                pdf = kdf._to_internal_pandas().stack()
+                pdf.index = pdf.index.droplevel()
+                return ks.from_pandas(pdf[list(func.keys())])
 
     agg = aggregate
 

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -2895,7 +2895,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         >>> s.agg('min')
         1
 
-        >>> s.agg(['min', 'max'])
+        >>> s.agg(['min', 'max']).sort_index()
         max    4
         min    1
         dtype: int64


### PR DESCRIPTION
Refactor `DataFrame.aggregate` to:

- support multi-index columns
- avoid attaching possibly heavy default index
- avoid falling back to pandas