### PR TITLE
Rename parameter: is_cum_func -> numeric_only

### DIFF
--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -91,7 +91,7 @@ class GroupBy(object, metaclass=ABCMeta):
         return [s.spark.column for s in self._agg_columns]
 
     @abstractmethod
-    def _apply_series_op(self, op, should_resolve: bool = False, is_cum_func: bool = False):
+    def _apply_series_op(self, op, should_resolve: bool = False, numeric_only: bool = False):
         pass
 
     # TODO: Series support is not implemented yet.
@@ -744,7 +744,7 @@ class GroupBy(object, metaclass=ABCMeta):
         return self._apply_series_op(
             lambda sg: sg._kser._cum(F.max, True, part_cols=sg._groupkeys_scols),
             should_resolve=True,
-            is_cum_func=True,
+            numeric_only=True,
         )
 
     def cummin(self):
@@ -793,7 +793,7 @@ class GroupBy(object, metaclass=ABCMeta):
         return self._apply_series_op(
             lambda sg: sg._kser._cum(F.min, True, part_cols=sg._groupkeys_scols),
             should_resolve=True,
-            is_cum_func=True,
+            numeric_only=True,
         )
 
     def cumprod(self):
@@ -842,7 +842,7 @@ class GroupBy(object, metaclass=ABCMeta):
         return self._apply_series_op(
             lambda sg: sg._kser._cumprod(True, part_cols=sg._groupkeys_scols),
             should_resolve=True,
-            is_cum_func=True,
+            numeric_only=True,
         )
 
     def cumsum(self):
@@ -891,7 +891,7 @@ class GroupBy(object, metaclass=ABCMeta):
         return self._apply_series_op(
             lambda sg: sg._kser._cum(F.sum, True, part_cols=sg._groupkeys_scols),
             should_resolve=True,
-            is_cum_func=True,
+            numeric_only=True,
         )
 
     def apply(self, func, *args, **kwargs):
@@ -2386,11 +2386,11 @@ class DataFrameGroupBy(GroupBy):
                 agg_columns=item,
             )
 
-    def _apply_series_op(self, op, should_resolve: bool = False, is_cum_func: bool = False):
+    def _apply_series_op(self, op, should_resolve: bool = False, numeric_only: bool = False):
         applied = []
         for column in self._agg_columns:
             applied.append(op(column.groupby(self._groupkeys)))
-        if is_cum_func:
+        if numeric_only:
             applied = [col for col in applied if isinstance(col.spark.data_type, NumericType)]
             if not applied:
                 raise DataError("No numeric types to aggregate")
@@ -2523,8 +2523,8 @@ class SeriesGroupBy(GroupBy):
                 return partial(property_or_func, self)
         raise AttributeError(item)
 
-    def _apply_series_op(self, op, should_resolve: bool = False, is_cum_func: bool = False):
-        if is_cum_func and not isinstance(self._agg_columns[0].spark.data_type, NumericType):
+    def _apply_series_op(self, op, should_resolve: bool = False, numeric_only: bool = False):
+        if numeric_only and not isinstance(self._agg_columns[0].spark.data_type, NumericType):
             raise DataError("No numeric types to aggregate")
         kser = op(self)
         if should_resolve:


### PR DESCRIPTION
For using more general name for the argument.

It's suggested by @ueshin at https://github.com/databricks/koalas/pull/1708#discussion_r488108888

