### PR TITLE
Manage column_label_names properly.

### DIFF
--- a/databricks/koalas/indexing.py
+++ b/databricks/koalas/indexing.py
@@ -471,11 +471,7 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
             if i == 0 and none_column == 1:
                 column_labels = [None]
 
-            if self._internal.column_label_names is None:
-                column_label_names = None
-            else:
-                # Manage column index names
-                column_label_names = self._internal.column_label_names[-column_labels_level:]
+            column_label_names = self._internal.column_label_names[-column_labels_level:]
         else:
             column_label_names = None
 

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -390,6 +390,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         internal = self._kdf._internal.copy(
             column_labels=[self._column_label],
             data_spark_columns=[scol.alias(name_like_string(self._column_label))],
+            column_label_names=None,
         )
         return first_series(DataFrame(internal))
 
@@ -1088,7 +1089,9 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             index = (index,)
         scol = self.spark.column.alias(name_like_string(index))
 
-        internal = self._kdf._internal.copy(column_labels=[index], data_spark_columns=[scol])
+        internal = self._kdf._internal.copy(
+            column_labels=[index], data_spark_columns=[scol], column_label_names=None
+        )
         kdf = DataFrame(internal)  # type: DataFrame
 
         if kwargs.get("inplace", False):
@@ -4573,13 +4576,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         sdf = combined._internal.spark_frame.select(
             *index_scols, cond.alias(self._internal.data_spark_column_names[0])
         ).distinct()
-        internal = InternalFrame(
-            spark_frame=sdf,
-            index_map=self._internal.index_map,
-            column_labels=self._internal.column_labels,
-            data_spark_columns=[scol_for(sdf, self._internal.data_spark_column_names[0])],
-            column_label_names=self._internal.column_label_names,
-        )
+        internal = self._internal.with_new_sdf(sdf)
         return first_series(ks.DataFrame(internal))
 
     def dot(self, other):
@@ -4913,9 +4910,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             (index_scol_name, self._internal.index_map[index_scol_name])
             for index_scol_name in index_scol_names
         )
-        column_label_names = self._internal.index_map[pivot_col]
-        if column_label_names is not None:
-            column_label_names = [name_like_string(column_label_names)]
+        column_label_names = [self._internal.index_map[pivot_col]]
 
         sdf = sdf.groupby(index_scol_names).pivot(pivot_col).agg(F.first(scol))
         internal = InternalFrame(

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -165,10 +165,9 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         kdf1 = ks.from_pandas(pdf)
         self.assert_eq(kdf1.columns.names, pdf.columns.names)
 
-        with self.assertRaisesRegex(
-            ValueError, "Column_index_names should " "be list-like or None for a MultiIndex"
-        ):
-            ks.DataFrame(kdf1._internal.copy(column_label_names="level"))
+        self.assertRaises(
+            AssertionError, lambda: ks.DataFrame(kdf1._internal.copy(column_label_names=("level",)))
+        )
 
         self.assert_eq(kdf["X"], pdf["X"])
         self.assert_eq(kdf["X"].columns.names, pdf["X"].columns.names)


### PR DESCRIPTION
`InternalFrame.column_label_names` is equivalent to `index_names`. We should manage it properly.
Now it will never be `None` but a list of tuples, the same as `index_names`.