### PR TITLE
Add ks.DataFrame.from_dict

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -10224,7 +10224,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         keys as rows:
 
         >>> data = {'row_1': [3, 2, 1, 0], 'row_2': [10, 20, 30, 40]}
-        >>> ks.DataFrame.from_dict(data, orient='index')
+        >>> ks.DataFrame.from_dict(data, orient='index').sort_index()
                 0   1   2   3
         row_1   3   2   1   0
         row_2  10  20  30  40
@@ -10233,7 +10233,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         specified manually:
 
         >>> ks.DataFrame.from_dict(data, orient='index',
-        ...                        columns=['A', 'B', 'C', 'D'])
+        ...                        columns=['A', 'B', 'C', 'D']).sort_index()
                 A   B   C   D
         row_1   3   2   1   0
         row_2  10  20  30  40

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -10177,18 +10177,26 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
     prod = product
 
     @staticmethod
-    def from_dict(data, dtype=None) -> "DataFrame":
+    def from_dict(data, orient="columns", dtype=None, columns=None) -> "DataFrame":
         """
         Construct DataFrame from dict of array-like or dicts.
-        Creates DataFrame object from dictionary by columns
-        fallowing dtype specification.
+
+        Creates DataFrame object from dictionary by columns or by index
+        allowing dtype specification.
 
         Parameters
         ----------
         data : dict
             Of the form {field : array-like} or {field : dict}.
+        orient : {'columns', 'index'}, default 'columns'
+            The "orientation" of the data. If the keys of the passed dict
+            should be the columns of the resulting DataFrame, pass 'columns'
+            (default). Otherwise if the keys should be rows, pass 'index'.
         dtype : dtype, default None
             Data type to force, otherwise infer.
+        columns : list, default None
+            Column labels to use when ``orient='index'``. Raises a ValueError
+            if used with ``orient='columns'``.
 
         Returns
         -------
@@ -10202,15 +10210,35 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> data = {'col_1': [3, 2, 1, 0], 'col_2': ['a', 'b', 'c', 'd']}
+        By default the keys of the dict become the DataFrame columns:
+
+        >>> data = {'col_1': [3, 2, 1, 0], 'col_2': [10, 20, 30, 40]}
         >>> ks.DataFrame.from_dict(data)
-           col_1 col_2
-        0      3     a
-        1      2     b
-        2      1     c
-        3      0     d
+           col_1  col_2
+        0      3     10
+        1      2     20
+        2      1     30
+        3      0     40
+
+        Specify ``orient='index'`` to create the DataFrame using dictionary
+        keys as rows:
+
+        >>> data = {'row_1': [3, 2, 1, 0], 'row_2': [10, 20, 30, 40]}
+        >>> ks.DataFrame.from_dict(data, orient='index')
+                0   1   2   3
+        row_1   3   2   1   0
+        row_2  10  20  30  40
+
+        When using the 'index' orientation, the column names can be
+        specified manually:
+
+        >>> ks.DataFrame.from_dict(data, orient='index',
+        ...                        columns=['A', 'B', 'C', 'D'])
+                A   B   C   D
+        row_1   3   2   1   0
+        row_2  10  20  30  40
         """
-        return DataFrame(data, dtype=dtype)
+        return DataFrame(pd.DataFrame.from_dict(data, orient=orient, dtype=dtype, columns=columns))
 
     def _to_internal_pandas(self):
         """

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -10203,7 +10203,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         Examples
         --------
         >>> data = {'col_1': [3, 2, 1, 0], 'col_2': ['a', 'b', 'c', 'd']}
-        >>> pd.DataFrame.from_dict(data)
+        >>> ks.DataFrame.from_dict(data)
            col_1 col_2
         0      3     a
         1      2     b

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -10176,6 +10176,42 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
     prod = product
 
+    @staticmethod
+    def from_dict(data, dtype=None) -> "DataFrame":
+        """
+        Construct DataFrame from dict of array-like or dicts.
+        Creates DataFrame object from dictionary by columns
+        fallowing dtype specification.
+
+        Parameters
+        ----------
+        data : dict
+            Of the form {field : array-like} or {field : dict}.
+        dtype : dtype, default None
+            Data type to force, otherwise infer.
+
+        Returns
+        -------
+        DataFrame
+
+        See Also
+        --------
+        DataFrame.from_records : DataFrame from structured ndarray, sequence
+            of tuples or dicts, or DataFrame.
+        DataFrame : DataFrame object creation using constructor.
+
+        Examples
+        --------
+        >>> data = {'col_1': [3, 2, 1, 0], 'col_2': ['a', 'b', 'c', 'd']}
+        >>> pd.DataFrame.from_dict(data)
+           col_1 col_2
+        0      3     a
+        1      2     b
+        2      1     c
+        3      0     d
+        """
+        return DataFrame(data, dtype=dtype)
+
     def _to_internal_pandas(self):
         """
         Return a pandas DataFrame directly from _internal to avoid overhead of copy.

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -3976,3 +3976,13 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         pdf.columns.names = ["Hello", "Koalas"]
         kdf = ks.from_pandas(pdf)
         self.assert_eq(pdf.prod(), kdf.prod().sort_index(), check_exact=False)
+
+    def test_from_dict(self):
+        data = {"row_1": [3, 2, 1, 0], "row_2": ["a", "b", "c", "d"]}
+        pdf = pd.DataFrame.from_dict(data)
+        kdf = ks.DataFrame.from_dict(data)
+        self.assert_eq(pdf, kdf)
+
+        pdf = pd.DataFrame.from_dict(data, dtype="int8")
+        kdf = ks.DataFrame.from_dict(data, dtype="int8")
+        self.assert_eq(pdf, kdf)

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -3978,11 +3978,15 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(pdf.prod(), kdf.prod().sort_index(), check_exact=False)
 
     def test_from_dict(self):
-        data = {"row_1": [3, 2, 1, 0], "row_2": ["a", "b", "c", "d"]}
+        data = {"row_1": [3, 2, 1, 0], "row_2": [10, 20, 30, 40]}
         pdf = pd.DataFrame.from_dict(data)
         kdf = ks.DataFrame.from_dict(data)
         self.assert_eq(pdf, kdf)
 
         pdf = pd.DataFrame.from_dict(data, dtype="int8")
         kdf = ks.DataFrame.from_dict(data, dtype="int8")
+        self.assert_eq(pdf, kdf)
+
+        pdf = pd.DataFrame.from_dict(data, orient="index", columns=["A", "B", "C", "D"])
+        kdf = ks.DataFrame.from_dict(data, orient="index", columns=["A", "B", "C", "D"])
         self.assert_eq(pdf, kdf)


### PR DESCRIPTION
This PR proposes `ks.DataFrame.from_dict`.

Basically it just reuse the `DataFrame` constructor.

```python
>>> data = {'col_1': [3, 2, 1, 0], 'col_2': ['a', 'b', 'c', 'd']}
>>> ks.DataFrame.from_dict(data)
   col_1 col_2
0      3     a
1      2     b
2      1     c
3      0     d
```