### PR TITLE
Implemented get_group for DataFrameGroupBy & SeriesGroupBy.

### DIFF
--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -2217,6 +2217,7 @@ class GroupBy(object, metaclass=ABCMeta):
                 spark_frame=spark_frame,
                 index_map=internal.index_map,
                 column_labels=[s._column_label for s in self._agg_columns],
+                column_label_names=internal.column_label_names,
             )
 
         return DataFrame(internal)

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -2196,8 +2196,13 @@ class GroupBy(object, metaclass=ABCMeta):
         groupkeys = self._groupkeys
         if not is_hashable(name):
             raise TypeError("unhashable type: '{}'".format(type(name).__name__))
-        elif len(groupkeys) > 1 and not isinstance(name, tuple):
-            raise ValueError("must supply a tuple to get_group with multiple grouping keys")
+        elif len(groupkeys) > 1:
+            if not isinstance(name, tuple):
+                raise ValueError("must supply a tuple to get_group with multiple grouping keys")
+            if len(groupkeys) != len(name):
+                raise ValueError(
+                    "must supply a same-length tuple to get_group with multiple grouping keys"
+                )
         if not is_list_like(name):
             name = [name]
         cond = F.lit(True)

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -2208,11 +2208,19 @@ class GroupBy(object, metaclass=ABCMeta):
         if internal.spark_frame.head() is None:
             raise KeyError(name)
         if self._agg_columns_selected:
+            spark_frame = internal.spark_frame.select(
+                internal.index_spark_columns + self._agg_columns_scols
+            )
+            column_labels = list()
+            for agg_column in self._agg_columns:
+                agg_column_name = agg_column.name
+                if isinstance(agg_column_name, tuple):
+                    column_labels.append(agg_column_name)
+                else:
+                    column_labels.append((agg_column_name,))
+
             internal = InternalFrame(
-                spark_frame=internal.spark_frame.select(
-                    internal.index_spark_columns + self._agg_columns_scols
-                ),
-                index_map=internal.index_map,
+                spark_frame=spark_frame, index_map=internal.index_map, column_labels=column_labels,
             )
 
         return DataFrame(internal)

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -2621,7 +2621,7 @@ class SeriesGroupBy(GroupBy):
     def get_group(self, name):
         return first_series(super().get_group(name))
 
-    size.__doc__ = GroupBy.size.__doc__
+    get_group.__doc__ = GroupBy.get_group.__doc__
 
     # TODO: add keep parameter
     def nsmallest(self, n=5):

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -2208,19 +2208,15 @@ class GroupBy(object, metaclass=ABCMeta):
         if internal.spark_frame.head() is None:
             raise KeyError(name)
         if self._agg_columns_selected:
+            internal = self._kdf._internal
             spark_frame = internal.spark_frame.select(
                 internal.index_spark_columns + self._agg_columns_scols
-            )
-            column_labels = list()
-            for agg_column in self._agg_columns:
-                agg_column_name = agg_column.name
-                if isinstance(agg_column_name, tuple):
-                    column_labels.append(agg_column_name)
-                else:
-                    column_labels.append((agg_column_name,))
+            ).filter(cond)
 
             internal = InternalFrame(
-                spark_frame=spark_frame, index_map=internal.index_map, column_labels=column_labels,
+                spark_frame=spark_frame,
+                index_map=internal.index_map,
+                column_labels=[s._column_label for s in self._agg_columns],
             )
 
         return DataFrame(internal)

--- a/databricks/koalas/missing/groupby.py
+++ b/databricks/koalas/missing/groupby.py
@@ -57,7 +57,6 @@ class MissingPandasLikeDataFrameGroupBy(object):
 
     # Functions
     boxplot = _unsupported_function("boxplot")
-    get_group = _unsupported_function("get_group")
     median = _unsupported_function("median")
     ngroup = _unsupported_function("ngroup")
     nth = _unsupported_function("nth")
@@ -95,7 +94,6 @@ class MissingPandasLikeSeriesGroupBy(object):
     agg = _unsupported_function("agg")
     aggregate = _unsupported_function("aggregate")
     describe = _unsupported_function("describe")
-    get_group = _unsupported_function("get_group")
     median = _unsupported_function("median")
     ngroup = _unsupported_function("ngroup")
     nth = _unsupported_function("nth")

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -2293,3 +2293,46 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             KeyError, lambda: kdf.groupby(["class", "name"]).get_group(("lion", "mammal"))
         )
         self.assertRaises(ValueError, lambda: kdf.groupby(["class", "name"]).get_group("lion"))
+
+        # MultiIndex columns
+        pdf.columns = pd.MultiIndex.from_tuples([("A", "name"), ("B", "class"), ("C", "max_speed")])
+        kdf = ks.from_pandas(pdf)
+        self.assert_eq(
+            kdf.groupby(("B", "class")).get_group("bird"),
+            pdf.groupby(("B", "class")).get_group("bird"),
+        )
+        self.assert_eq(
+            kdf.groupby(("B", "class"))[[("A", "name")]].get_group("mammal"),
+            pdf.groupby(("B", "class"))[[("A", "name")]].get_group("mammal"),
+        )
+        self.assert_eq(
+            kdf.groupby([("B", "class"), ("A", "name")]).get_group(("mammal", "lion")),
+            pdf.groupby([("B", "class"), ("A", "name")]).get_group(("mammal", "lion")),
+        )
+        self.assert_eq(
+            kdf.groupby([("B", "class"), ("A", "name")])[[("C", "max_speed")]].get_group(
+                ("mammal", "lion")
+            ),
+            pdf.groupby([("B", "class"), ("A", "name")])[[("C", "max_speed")]].get_group(
+                ("mammal", "lion")
+            ),
+        )
+
+        self.assertRaises(KeyError, lambda: kdf.groupby(("B", "class")).get_group("fish"))
+        self.assertRaises(
+            TypeError, lambda: kdf.groupby(("B", "class")).get_group(["bird", "mammal"])
+        )
+        self.assertRaises(
+            KeyError, lambda: kdf.groupby(("B", "class"))[("A", "name")].get_group("fish")
+        )
+        self.assertRaises(
+            KeyError,
+            lambda: kdf.groupby(("B", "class"))[("A", "name")].get_group(["bird", "mammal"]),
+        )
+        self.assertRaises(
+            KeyError,
+            lambda: kdf.groupby([("B", "class"), ("A", "name")]).get_group(("lion", "mammal")),
+        )
+        self.assertRaises(
+            ValueError, lambda: kdf.groupby([("B", "class"), ("A", "name")]).get_group("lion")
+        )

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -2287,6 +2287,9 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             (kdf.max_speed + 1).groupby(kdf["class"]).get_group("mammal"),
             (pdf.max_speed + 1).groupby(pdf["class"]).get_group("mammal"),
         )
+        self.assert_eq(
+            kdf.groupby("max_speed").get_group(80.5), pdf.groupby("max_speed").get_group(80.5),
+        )
 
         self.assertRaises(KeyError, lambda: kdf.groupby("class").get_group("fish"))
         self.assertRaises(TypeError, lambda: kdf.groupby("class").get_group(["bird", "mammal"]))
@@ -2326,6 +2329,10 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         self.assert_eq(
             (kdf[("C", "max_speed")] + 1).groupby(kdf[("B", "class")]).get_group("mammal"),
             (pdf[("C", "max_speed")] + 1).groupby(pdf[("B", "class")]).get_group("mammal"),
+        )
+        self.assert_eq(
+            kdf.groupby(("C", "max_speed")).get_group(80.5),
+            pdf.groupby(("C", "max_speed")).get_group(80.5),
         )
 
         self.assertRaises(KeyError, lambda: kdf.groupby(("B", "class")).get_group("fish"))

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -2301,6 +2301,7 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             KeyError, lambda: kdf.groupby(["class", "name"]).get_group(("lion", "mammal"))
         )
         self.assertRaises(ValueError, lambda: kdf.groupby(["class", "name"]).get_group("lion"))
+        self.assertRaises(ValueError, lambda: kdf.groupby(["class", "name"]).get_group("mammal"))
 
         # MultiIndex columns
         pdf.columns = pd.MultiIndex.from_tuples([("A", "name"), ("B", "class"), ("C", "max_speed")])
@@ -2352,4 +2353,7 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         )
         self.assertRaises(
             ValueError, lambda: kdf.groupby([("B", "class"), ("A", "name")]).get_group("lion")
+        )
+        self.assertRaises(
+            ValueError, lambda: kdf.groupby([("B", "class"), ("A", "name")]).get_group("mammal")
         )

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -2282,6 +2282,10 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             kdf.groupby(["class", "name"])[["max_speed"]].get_group(("mammal", "lion")),
             pdf.groupby(["class", "name"])[["max_speed"]].get_group(("mammal", "lion")),
         )
+        self.assert_eq(
+            (kdf.max_speed + 1).groupby(kdf["class"]).get_group("mammal"),
+            (pdf.max_speed + 1).groupby(pdf["class"]).get_group("mammal"),
+        )
 
         self.assertRaises(KeyError, lambda: kdf.groupby("class").get_group("fish"))
         self.assertRaises(TypeError, lambda: kdf.groupby("class").get_group(["bird", "mammal"]))
@@ -2316,6 +2320,10 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             pdf.groupby([("B", "class"), ("A", "name")])[[("C", "max_speed")]].get_group(
                 ("mammal", "lion")
             ),
+        )
+        self.assert_eq(
+            (kdf[("C", "max_speed")] + 1).groupby(kdf[("B", "class")]).get_group("mammal"),
+            (pdf[("C", "max_speed")] + 1).groupby(pdf[("B", "class")]).get_group("mammal"),
         )
 
         self.assertRaises(KeyError, lambda: kdf.groupby(("B", "class")).get_group("fish"))

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -2300,8 +2300,8 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         self.assertRaises(
             KeyError, lambda: kdf.groupby(["class", "name"]).get_group(("lion", "mammal"))
         )
-        self.assertRaises(KeyError, lambda: kdf.groupby(["class", "name"]).get_group(("lion",)))
-        self.assertRaises(ValueError, lambda: kdf.groupby(["class", "name"]).get_group("lion"))
+        self.assertRaises(ValueError, lambda: kdf.groupby(["class", "name"]).get_group(("lion",)))
+        self.assertRaises(ValueError, lambda: kdf.groupby(["class", "name"]).get_group(("mammal",)))
         self.assertRaises(ValueError, lambda: kdf.groupby(["class", "name"]).get_group("mammal"))
 
         # MultiIndex columns
@@ -2353,10 +2353,10 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             lambda: kdf.groupby([("B", "class"), ("A", "name")]).get_group(("lion", "mammal")),
         )
         self.assertRaises(
-            KeyError, lambda: kdf.groupby([("B", "class"), ("A", "name")]).get_group(("lion",)),
+            ValueError, lambda: kdf.groupby([("B", "class"), ("A", "name")]).get_group(("lion",)),
         )
         self.assertRaises(
-            ValueError, lambda: kdf.groupby([("B", "class"), ("A", "name")]).get_group("lion")
+            ValueError, lambda: kdf.groupby([("B", "class"), ("A", "name")]).get_group(("mammal",))
         )
         self.assertRaises(
             ValueError, lambda: kdf.groupby([("B", "class"), ("A", "name")]).get_group("mammal")

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -2260,8 +2260,7 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         kdf = ks.from_pandas(pdf)
 
         self.assert_eq(
-            kdf.groupby("class").get_group("bird"),
-            pdf.groupby("class").get_group("bird"),
+            kdf.groupby("class").get_group("bird"), pdf.groupby("class").get_group("bird"),
         )
         self.assert_eq(
             kdf.groupby("class")["name"].get_group("mammal"),

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -2300,6 +2300,7 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         self.assertRaises(
             KeyError, lambda: kdf.groupby(["class", "name"]).get_group(("lion", "mammal"))
         )
+        self.assertRaises(KeyError, lambda: kdf.groupby(["class", "name"]).get_group(("lion",)))
         self.assertRaises(ValueError, lambda: kdf.groupby(["class", "name"]).get_group("lion"))
         self.assertRaises(ValueError, lambda: kdf.groupby(["class", "name"]).get_group("mammal"))
 
@@ -2350,6 +2351,9 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         self.assertRaises(
             KeyError,
             lambda: kdf.groupby([("B", "class"), ("A", "name")]).get_group(("lion", "mammal")),
+        )
+        self.assertRaises(
+            KeyError, lambda: kdf.groupby([("B", "class"), ("A", "name")]).get_group(("lion",)),
         )
         self.assertRaises(
             ValueError, lambda: kdf.groupby([("B", "class"), ("A", "name")]).get_group("lion")

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -2269,6 +2269,26 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             pdf.groupby("class")["name"].get_group("mammal"),
             check_exact=False,
         )
+        self.assert_eq(
+            kdf.groupby("class")[["name"]].get_group("mammal"),
+            pdf.groupby("class")[["name"]].get_group("mammal"),
+            check_exact=False,
+        )
+        self.assert_eq(
+            kdf.groupby(["class", "name"]).get_group(("mammal", "lion")),
+            pdf.groupby(["class", "name"]).get_group(("mammal", "lion")),
+            check_exact=False,
+        )
+        self.assert_eq(
+            kdf.groupby(["class", "name"])["max_speed"].get_group(("mammal", "lion")),
+            pdf.groupby(["class", "name"])["max_speed"].get_group(("mammal", "lion")),
+            check_exact=False,
+        )
+        self.assert_eq(
+            kdf.groupby(["class", "name"])[["max_speed"]].get_group(("mammal", "lion")),
+            pdf.groupby(["class", "name"])[["max_speed"]].get_group(("mammal", "lion")),
+            check_exact=False,
+        )
 
         self.assertRaises(KeyError, lambda: kdf.groupby("class").get_group("fish"))
         self.assertRaises(TypeError, lambda: kdf.groupby("class").get_group(["bird", "mammal"]))
@@ -2276,3 +2296,7 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         self.assertRaises(
             TypeError, lambda: kdf.groupby("class")["name"].get_group(["bird", "mammal"])
         )
+        self.assertRaises(
+            KeyError, lambda: kdf.groupby(["class", "name"]).get_group(("lion", "mammal"))
+        )
+        self.assertRaises(ValueError, lambda: kdf.groupby(["class", "name"]).get_group("lion"))

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -2257,6 +2257,7 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             columns=["name", "class", "max_speed"],
             index=[0, 2, 3, 1],
         )
+        pdf.columns.name = "Koalas"
         kdf = ks.from_pandas(pdf)
 
         self.assert_eq(
@@ -2300,6 +2301,7 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
 
         # MultiIndex columns
         pdf.columns = pd.MultiIndex.from_tuples([("A", "name"), ("B", "class"), ("C", "max_speed")])
+        pdf.columns.names = ["Hello", "Koalas"]
         kdf = ks.from_pandas(pdf)
         self.assert_eq(
             kdf.groupby(("B", "class")).get_group("bird"),

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -2262,32 +2262,26 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         self.assert_eq(
             kdf.groupby("class").get_group("bird"),
             pdf.groupby("class").get_group("bird"),
-            check_exact=False,
         )
         self.assert_eq(
             kdf.groupby("class")["name"].get_group("mammal"),
             pdf.groupby("class")["name"].get_group("mammal"),
-            check_exact=False,
         )
         self.assert_eq(
             kdf.groupby("class")[["name"]].get_group("mammal"),
             pdf.groupby("class")[["name"]].get_group("mammal"),
-            check_exact=False,
         )
         self.assert_eq(
             kdf.groupby(["class", "name"]).get_group(("mammal", "lion")),
             pdf.groupby(["class", "name"]).get_group(("mammal", "lion")),
-            check_exact=False,
         )
         self.assert_eq(
             kdf.groupby(["class", "name"])["max_speed"].get_group(("mammal", "lion")),
             pdf.groupby(["class", "name"])["max_speed"].get_group(("mammal", "lion")),
-            check_exact=False,
         )
         self.assert_eq(
             kdf.groupby(["class", "name"])[["max_speed"]].get_group(("mammal", "lion")),
             pdf.groupby(["class", "name"])[["max_speed"]].get_group(("mammal", "lion")),
-            check_exact=False,
         )
 
         self.assertRaises(KeyError, lambda: kdf.groupby("class").get_group("fish"))

--- a/docs/source/reference/groupby.rst
+++ b/docs/source/reference/groupby.rst
@@ -9,6 +9,14 @@ GroupBy objects are returned by groupby calls: :func:`DataFrame.groupby`, :func:
 
 .. currentmodule:: databricks.koalas.groupby
 
+
+Indexing, iteration
+-------------------
+.. autosummary::
+   :toctree: api/
+
+   GroupBy.get_group
+
 Function application
 --------------------
 .. autosummary::


### PR DESCRIPTION
This proposes `get_group` for `DataFrameGroupBy` & `SeriesGroupBy`.

```python
>>> kdf = ks.DataFrame([('falcon', 'bird', 389.0),
...                     ('parrot', 'bird', 24.0),
...                     ('lion', 'mammal', 80.5),
...                     ('monkey', 'mammal', np.nan)],
...                    columns=['name', 'class', 'max_speed'],
...                    index=[0, 2, 3, 1])
>>> kdf
     name   class  max_speed
0  falcon    bird      389.0
2  parrot    bird       24.0
3    lion  mammal       80.5
1  monkey  mammal        NaN

>>> kdf.groupby("class").get_group("bird").sort_index()
     name class  max_speed
0  falcon  bird      389.0
2  parrot  bird       24.0

>>> kdf.groupby("class")["name"].get_group("bird").sort_index()
0    falcon
2    parrot
Name: name, dtype: object
```