### PR TITLE
Implemented DataFrame.pad & Series.pad

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -10224,6 +10224,40 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         """
         return DataFrame(pd.DataFrame.from_dict(data, orient=orient, dtype=dtype, columns=columns))
 
+    def pad(self, inplace=False):
+        """
+        Synonym for :meth:`DataFrame.fillna` with ``method='ffill'``.
+
+        Returns
+        -------
+        DataFrame or None
+            Object with missing values filled or None if ``inplace=True``.
+
+        Examples
+        --------
+        >>> df = ks.DataFrame({
+        ...     'A': [None, 3, None, None],
+        ...     'B': [2, 4, None, 3],
+        ...     'C': [None, None, None, 1],
+        ...     'D': [0, 1, 5, 4]
+        ...     },
+        ...     columns=['A', 'B', 'C', 'D'])
+        >>> df
+             A    B    C  D
+        0  NaN  2.0  NaN  0
+        1  3.0  4.0  NaN  1
+        2  NaN  NaN  NaN  5
+        3  NaN  3.0  1.0  4
+
+        >>> df.pad()
+             A    B    C  D
+        0  NaN  2.0  NaN  0
+        1  3.0  4.0  NaN  1
+        2  3.0  4.0  NaN  5
+        3  3.0  3.0  1.0  4
+        """
+        return self.fillna(inplace=inplace, method="ffill")
+
     def _to_internal_pandas(self):
         """
         Return a pandas DataFrame directly from _internal to avoid overhead of copy.

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -10224,40 +10224,6 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         """
         return DataFrame(pd.DataFrame.from_dict(data, orient=orient, dtype=dtype, columns=columns))
 
-    def pad(self, inplace=False):
-        """
-        Synonym for :meth:`DataFrame.fillna` with ``method='ffill'``.
-
-        Returns
-        -------
-        DataFrame or None
-            Object with missing values filled or None if ``inplace=True``.
-
-        Examples
-        --------
-        >>> df = ks.DataFrame({
-        ...     'A': [None, 3, None, None],
-        ...     'B': [2, 4, None, 3],
-        ...     'C': [None, None, None, 1],
-        ...     'D': [0, 1, 5, 4]
-        ...     },
-        ...     columns=['A', 'B', 'C', 'D'])
-        >>> df
-             A    B    C  D
-        0  NaN  2.0  NaN  0
-        1  3.0  4.0  NaN  1
-        2  NaN  NaN  NaN  5
-        3  NaN  3.0  1.0  4
-
-        >>> df.pad()
-             A    B    C  D
-        0  NaN  2.0  NaN  0
-        1  3.0  4.0  NaN  1
-        2  3.0  4.0  NaN  5
-        3  3.0  3.0  1.0  4
-        """
-        return self.fillna(inplace=inplace, method="ffill")
-
     def _to_internal_pandas(self):
         """
         Return a pandas DataFrame directly from _internal to avoid overhead of copy.

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -2465,6 +2465,61 @@ class Frame(object, metaclass=ABCMeta):
         """
         return self.fillna(method="ffill", axis=axis, inplace=inplace, limit=limit)
 
+    def pad(self, inplace=False):
+        """
+        Synonym for :meth:`DataFrame.fillna` or :meth:`Series.fillna` with ``method='ffill'``.
+
+        Returns
+        -------
+        DataFrame or Series or None
+            Object with missing values filled or None if ``inplace=True``.
+
+        Examples
+        --------
+        >>> df = ks.DataFrame({
+        ...     'A': [None, 3, None, None],
+        ...     'B': [2, 4, None, 3],
+        ...     'C': [None, None, None, 1],
+        ...     'D': [0, 1, 5, 4]
+        ...     },
+        ...     columns=['A', 'B', 'C', 'D'])
+        >>> df
+             A    B    C  D
+        0  NaN  2.0  NaN  0
+        1  3.0  4.0  NaN  1
+        2  NaN  NaN  NaN  5
+        3  NaN  3.0  1.0  4
+
+        >>> df.pad()
+             A    B    C  D
+        0  NaN  2.0  NaN  0
+        1  3.0  4.0  NaN  1
+        2  3.0  4.0  NaN  5
+        3  3.0  3.0  1.0  4
+
+        Series
+
+        >>> s = ks.Series([np.nan, 2, 3, 4, np.nan, 6], name='x')
+        >>> s
+        0    NaN
+        1    2.0
+        2    3.0
+        3    4.0
+        4    NaN
+        5    6.0
+        Name: x, dtype: float64
+
+        >>> s.pad()
+        0    NaN
+        1    2.0
+        2    3.0
+        3    4.0
+        4    4.0
+        5    6.0
+        Name: x, dtype: float64
+        """
+        return self.fillna(inplace=inplace, method="ffill")
+
     @property
     def at(self):
         return AtIndexer(self)

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -2465,60 +2465,7 @@ class Frame(object, metaclass=ABCMeta):
         """
         return self.fillna(method="ffill", axis=axis, inplace=inplace, limit=limit)
 
-    def pad(self, inplace=False):
-        """
-        Synonym for :meth:`DataFrame.fillna` or :meth:`Series.fillna` with ``method='ffill'``.
-
-        Returns
-        -------
-        DataFrame or Series or None
-            Object with missing values filled or None if ``inplace=True``.
-
-        Examples
-        --------
-        >>> df = ks.DataFrame({
-        ...     'A': [None, 3, None, None],
-        ...     'B': [2, 4, None, 3],
-        ...     'C': [None, None, None, 1],
-        ...     'D': [0, 1, 5, 4]
-        ...     },
-        ...     columns=['A', 'B', 'C', 'D'])
-        >>> df
-             A    B    C  D
-        0  NaN  2.0  NaN  0
-        1  3.0  4.0  NaN  1
-        2  NaN  NaN  NaN  5
-        3  NaN  3.0  1.0  4
-
-        >>> df.pad()  # doctest: +SKIP
-             A    B    C  D
-        0  NaN  2.0  NaN  0
-        1  3.0  4.0  NaN  1
-        2  3.0  4.0  NaN  5
-        3  3.0  3.0  1.0  4
-
-        Series
-
-        >>> s = ks.Series([np.nan, 2, 3, 4, np.nan, 6], name='x')
-        >>> s
-        0    NaN
-        1    2.0
-        2    3.0
-        3    4.0
-        4    NaN
-        5    6.0
-        Name: x, dtype: float64
-
-        >>> s.pad()  # doctest: +SKIP
-        0    NaN
-        1    2.0
-        2    3.0
-        3    4.0
-        4    4.0
-        5    6.0
-        Name: x, dtype: float64
-        """
-        return self.fillna(inplace=inplace, method="ffill")
+    pad = ffill
 
     @property
     def at(self):

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -2490,7 +2490,7 @@ class Frame(object, metaclass=ABCMeta):
         2  NaN  NaN  NaN  5
         3  NaN  3.0  1.0  4
 
-        >>> df.pad()
+        >>> df.pad()  # doctest: +SKIP
              A    B    C  D
         0  NaN  2.0  NaN  0
         1  3.0  4.0  NaN  1
@@ -2509,7 +2509,7 @@ class Frame(object, metaclass=ABCMeta):
         5    6.0
         Name: x, dtype: float64
 
-        >>> s.pad()
+        >>> s.pad()  # doctest: +SKIP
         0    NaN
         1    2.0
         2    3.0

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -4110,9 +4110,25 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         )
         kdf = ks.from_pandas(pdf)
 
-        self.assert_eq(pdf.pad(), kdf.pad())
+        if LooseVersion(pd.__version__) >= LooseVersion("1.1"):
+            self.assert_eq(pdf.pad(), kdf.pad())
 
-        # Test `inplace=True`
-        pdf.pad(inplace=True)
-        kdf.pad(inplace=True)
-        self.assert_eq(pdf, kdf)
+            # Test `inplace=True`
+            pdf.pad(inplace=True)
+            kdf.pad(inplace=True)
+            self.assert_eq(pdf, kdf)
+        else:
+            expected = ks.DataFrame(
+                {
+                    "A": [None, 3, 3, 3],
+                    "B": [2.0, 4.0, 4.0, 3.0],
+                    "C": [None, None, None, 1],
+                    "D": [0, 1, 5, 4],
+                },
+                columns=["A", "B", "C", "D"],
+            )
+            self.assert_eq(expected, kdf.pad())
+
+            # Test `inplace=True`
+            kdf.pad(inplace=True)
+            self.assert_eq(expected, kdf)

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -4019,3 +4019,22 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         pdf = pd.DataFrame.from_dict(data, orient="index", columns=["A", "B", "C", "D"])
         kdf = ks.DataFrame.from_dict(data, orient="index", columns=["A", "B", "C", "D"])
         self.assert_eq(pdf, kdf)
+
+    def test_pad(self):
+        pdf = pd.DataFrame(
+            {
+                "A": [None, 3, None, None],
+                "B": [2, 4, None, 3],
+                "C": [None, None, None, 1],
+                "D": [0, 1, 5, 4],
+            },
+            columns=["A", "B", "C", "D"],
+        )
+        kdf = ks.from_pandas(pdf)
+
+        self.assert_eq(pdf.pad(), kdf.pad())
+
+        # Test `inplace=True`
+        pdf.pad(inplace=True)
+        kdf.pad(inplace=True)
+        self.assert_eq(pdf, kdf)

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -1997,3 +1997,14 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         pser = pd.Series([])
         kser = ks.from_pandas(pser)
         self.assert_eq(pser.first_valid_index(), kser.first_valid_index())
+
+    def test_pad(self):
+        pser = pd.Series([np.nan, 2, 3, 4, np.nan, 6], name="x")
+        kser = ks.from_pandas(pser)
+
+        self.assert_eq(pser.pad(), kser.pad())
+
+        # Test `inplace=True`
+        pser.pad(inplace=True)
+        kser.pad(inplace=True)
+        self.assert_eq(pser, kser)

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -2002,12 +2002,20 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         pser = pd.Series([np.nan, 2, 3, 4, np.nan, 6], name="x")
         kser = ks.from_pandas(pser)
 
-        self.assert_eq(pser.pad(), kser.pad())
+        if LooseVersion(pd.__version__) >= LooseVersion("1.1"):
+            self.assert_eq(pser.pad(), kser.pad())
 
-        # Test `inplace=True`
-        pser.pad(inplace=True)
-        kser.pad(inplace=True)
-        self.assert_eq(pser, kser)
+            # Test `inplace=True`
+            pser.pad(inplace=True)
+            kser.pad(inplace=True)
+            self.assert_eq(pser, kser)
+        else:
+            expected = ks.Series([np.nan, 2, 3, 4, 4, 6], name="x")
+            self.assert_eq(expected, kser.pad())
+
+            # Test `inplace=True`
+            kser.pad(inplace=True)
+            self.assert_eq(expected, kser)
 
     def test_explode(self):
         if LooseVersion(pd.__version__) >= LooseVersion("0.25"):

--- a/docs/source/reference/frame.rst
+++ b/docs/source/reference/frame.rst
@@ -44,6 +44,7 @@ Conversion
    DataFrame.isnull
    DataFrame.notna
    DataFrame.notnull
+   DataFrame.pad
    DataFrame.bool
 
 Indexing, iteration

--- a/docs/source/reference/series.rst
+++ b/docs/source/reference/series.rst
@@ -188,6 +188,7 @@ Missing data handling
    Series.isnull
    Series.notna
    Series.notnull
+   Series.pad
    Series.dropna
    Series.fillna
 


### PR DESCRIPTION
This PR proposes `DataFrame.pad` and `Series.pad`

This is basically synonym for `DataFrame.fillna` and `Series.fillna` with `method='ffill'` or `ffill` function

```python
>>> df = ks.DataFrame({
...     'A': [None, 3, None, None],
...     'B': [2, 4, None, 3],
...     'C': [None, None, None, 1],
...     'D': [0, 1, 5, 4]
...     },
...     columns=['A', 'B', 'C', 'D'])
>>> df
     A    B    C  D
0  NaN  2.0  NaN  0
1  3.0  4.0  NaN  1
2  NaN  NaN  NaN  5
3  NaN  3.0  1.0  4

>>> df.pad()
     A    B    C  D
0  NaN  2.0  NaN  0
1  3.0  4.0  NaN  1
2  3.0  4.0  NaN  5
3  3.0  3.0  1.0  4

>>> s = ks.Series([np.nan, 2, 3, 4, np.nan, 6], name='x')
>>> s
0    NaN
1    2.0
2    3.0
3    4.0
4    NaN
5    6.0
Name: x, dtype: float64

>>> s.pad()
0    NaN
1    2.0
2    3.0
3    4.0
4    4.0
5    6.0
Name: x, dtype: float64
```