### PR TITLE
Implemented MultiIndex.equal_levels

### DIFF
--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -2973,6 +2973,30 @@ class MultiIndex(Index):
         """
         return self._kdf.head(2)._to_internal_pandas().index.item()
 
+    def equal_levels(self, other):
+        """
+        Return True if the levels of both MultiIndex objects are the same
+
+        Examples
+        --------
+        >>> kmidx1 = ks.MultiIndex.from_tuples([("a", "x"), ("b", "y"), ("c", "z")])
+        >>> kmidx2 = ks.MultiIndex.from_tuples([("b", "y"), ("a", "x"), ("c", "z")])
+        >>> kmidx1.equal_levels(kmidx2)
+        True
+        """
+        nlevels = self.nlevels
+        if nlevels != other.nlevels:
+            return False
+        self = self.sort_values()
+        other = other.sort_values()
+        with ks.option_context("compute.ops_on_diff_frames", True):
+            for i in range(nlevels):
+                self_level_values = self.get_level_values(i)
+                other_level_values = other.get_level_values(i)
+                if not self_level_values.equals(other_level_values):
+                    return False
+        return True
+
     @property
     def inferred_type(self):
         """

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -1581,3 +1581,16 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
             kdf = ks.from_pandas(pdf)
 
             self.assertEqual(kdf.index.is_unique, expected)
+
+    def test_multiindex_equal_levels(self):
+        pmidx1 = pd.MultiIndex.from_tuples([("a", "x"), ("b", "y"), ("c", "z")])
+        pmidx2 = pd.MultiIndex.from_tuples([("b", "y"), ("a", "x"), ("c", "z")])
+        kmidx1 = ks.from_pandas(pmidx1)
+        kmidx2 = ks.from_pandas(pmidx2)
+
+        self.assert_eq(pmidx1.equal_levels(pmidx2), kmidx1.equal_levels(kmidx2))
+
+        pmidx2 = pd.MultiIndex.from_tuples([("a", "x"), ("b", "y")])
+        kmidx2 = ks.from_pandas(pmidx2)
+
+        self.assert_eq(pmidx1.equal_levels(pmidx2), kmidx1.equal_levels(kmidx2))


### PR DESCRIPTION
This PR proposes `MultiIndex.equal_levels`.

```python
>>> kmidx1 = ks.MultiIndex.from_tuples([("a", "x"), ("b", "y"), ("c", "z")])
>>> kmidx2 = ks.MultiIndex.from_tuples([("b", "y"), ("a", "x"), ("c", "z")])
>>> kmidx1.equal_levels(kmidx2)
True
```