### PR TITLE
Implemented argmin & argmax for Series

### DIFF
--- a/databricks/koalas/missing/series.py
+++ b/databricks/koalas/missing/series.py
@@ -127,8 +127,6 @@ class MissingPandasLikeSeries(object):
         compound = _unsupported_function("compound", deprecated=True)
         put = _unsupported_function("put", deprecated=True)
         ptp = _unsupported_function("ptp", deprecated=True)
-        argmax = _unsupported_function("argmax", deprecated=True)
-        argmin = _unsupported_function("argmin", deprecated=True)
 
         # Functions we won't support.
         real = _unsupported_property(

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -5217,21 +5217,24 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         >>> s.argmax()  # doctest: +SKIP
         2
         """
-        sdf = self._internal.spark_frame.select(self._internal.data_spark_columns)
-
+        sdf = self._internal.spark_frame.select(self.spark.column, NATURAL_ORDER_COLUMN_NAME)
+        max_value = sdf.select(
+            F.max(scol_for(sdf, self._internal.data_spark_column_names[0])),
+            F.first(NATURAL_ORDER_COLUMN_NAME),
+        ).head()
+        if max_value[1] is None:
+            raise ValueError("attempt to get argmax of an empty sequence")
+        elif max_value[0] is None:
+            return -1
         # We should remember the natural sequence started from 0
         seq_col_name = verify_temp_column_name(sdf, "__distributed_sequence_column__")
-        sdf = InternalFrame.attach_distributed_sequence_column(sdf, seq_col_name)
-
-        scol = scol_for(sdf, self._internal.data_spark_column_names[0])
-        max_value = sdf.select(F.max(scol)).head(1)[0][0]
-        if max_value is None:
-            raise ValueError("attempt to get argmax of an empty sequence")
-
+        sdf = InternalFrame.attach_distributed_sequence_column(
+            sdf.drop(NATURAL_ORDER_COLUMN_NAME), seq_col_name
+        )
         # If the maximum is achieved in multiple locations, the first row position is returned.
-        max_value_position = sdf.filter(scol == max_value).head(1)[0][0]
-
-        return max_value_position
+        return sdf.filter(
+            scol_for(sdf, self._internal.data_spark_column_names[0]) == max_value[0]
+        ).head()[0]
 
     def argmin(self):
         """
@@ -5261,21 +5264,24 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         >>> s.argmin()  # doctest: +SKIP
         0
         """
-        sdf = self._internal.spark_frame.select(self._internal.data_spark_columns)
-
+        sdf = self._internal.spark_frame.select(self.spark.column, NATURAL_ORDER_COLUMN_NAME)
+        min_value = sdf.select(
+            F.min(scol_for(sdf, self._internal.data_spark_column_names[0])),
+            F.first(NATURAL_ORDER_COLUMN_NAME),
+        ).head()
+        if min_value[1] is None:
+            raise ValueError("attempt to get argmin of an empty sequence")
+        elif min_value[0] is None:
+            return -1
         # We should remember the natural sequence started from 0
         seq_col_name = verify_temp_column_name(sdf, "__distributed_sequence_column__")
-        sdf = InternalFrame.attach_distributed_sequence_column(sdf, seq_col_name)
-
-        scol = scol_for(sdf, self._internal.data_spark_column_names[0])
-        min_value = sdf.select(F.min(scol)).head(1)[0][0]
-        if min_value is None:
-            raise ValueError("attempt to get argmin of an empty sequence")
-
+        sdf = InternalFrame.attach_distributed_sequence_column(
+            sdf.drop(NATURAL_ORDER_COLUMN_NAME), seq_col_name
+        )
         # If the minimum is achieved in multiple locations, the first row position is returned.
-        min_value_position = sdf.filter(scol == min_value).head(1)[0][0]
-
-        return min_value_position
+        return sdf.filter(
+            scol_for(sdf, self._internal.data_spark_column_names[0]) == min_value[0]
+        ).head()[0]
 
     def _cum(self, func, skipna, part_cols=(), ascending=True):
         # This is used to cummin, cummax, cumsum, etc.

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -5207,14 +5207,14 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         >>> s = ks.Series({'Corn Flakes': 100.0, 'Almond Delight': 110.0,
         ...                'Cinnamon Toast Crunch': 120.0, 'Cocoa Puff': 110.0})
-        >>> s.sort_index()
+        >>> s  # doctest: +SKIP
+        Corn Flakes              100.0
         Almond Delight           110.0
         Cinnamon Toast Crunch    120.0
         Cocoa Puff               110.0
-        Corn Flakes              100.0
         dtype: float64
 
-        >>> s.argmax()
+        >>> s.argmax()  # doctest: +SKIP
         2
         """
         if self.empty:
@@ -5254,14 +5254,14 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         >>> s = ks.Series({'Corn Flakes': 100.0, 'Almond Delight': 110.0,
         ...                'Cinnamon Toast Crunch': 120.0, 'Cocoa Puff': 110.0})
-        >>> s
+        >>> s  # doctest: +SKIP
         Corn Flakes              100.0
         Almond Delight           110.0
         Cinnamon Toast Crunch    120.0
         Cocoa Puff               110.0
         dtype: float64
 
-        >>> s.argmin()
+        >>> s.argmin()  # doctest: +SKIP
         0
         """
         if self.empty:

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -5249,11 +5249,11 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         >>> s = ks.Series({'Corn Flakes': 100.0, 'Almond Delight': 110.0,
         ...                'Cinnamon Toast Crunch': 120.0, 'Cocoa Puff': 110.0})
-        >>> s.sort_index()
+        >>> s
+        Corn Flakes              100.0
         Almond Delight           110.0
         Cinnamon Toast Crunch    120.0
         Cocoa Puff               110.0
-        Corn Flakes              100.0
         dtype: float64
 
         >>> s.argmin()

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -5217,13 +5217,18 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         >>> s.argmax()
         2
         """
-        sdf = self._kdf.to_spark()
+        if self.empty:
+            raise ValueError("attempt to get argmax of an empty sequence")
+
+        sdf = self._internal.spark_frame.select(self._internal.data_spark_columns)
 
         # We should remember the natural sequence started from 0
         seq_col_name = verify_temp_column_name(sdf, "__distributed_sequence_column__")
         sdf = InternalFrame.attach_distributed_sequence_column(sdf, seq_col_name)
 
-        col_name = SPARK_DEFAULT_SERIES_NAME if self._column_label is None else self._column_label
+        col_name = (
+            SPARK_DEFAULT_SERIES_NAME if self._column_label is None else self._column_label[0]
+        )
         max_value = sdf.select(F.max(col_name)).head(1)[0][0]
 
         # If the maximum is achieved in multiple locations, the first row position is returned.
@@ -5259,13 +5264,18 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         >>> s.argmin()
         0
         """
-        sdf = self._kdf.to_spark()
+        if self.empty:
+            raise ValueError("attempt to get argmin of an empty sequence")
+
+        sdf = self._internal.spark_frame.select(self._internal.data_spark_columns)
 
         # We should remember the natural sequence started from 0
         seq_col_name = verify_temp_column_name(sdf, "__distributed_sequence_column__")
         sdf = InternalFrame.attach_distributed_sequence_column(sdf, seq_col_name)
 
-        col_name = SPARK_DEFAULT_SERIES_NAME if self._column_label is None else self._column_label
+        col_name = (
+            SPARK_DEFAULT_SERIES_NAME if self._column_label is None else self._column_label[0]
+        )
         min_value = sdf.select(F.min(col_name)).head(1)[0][0]
 
         # If the minimum is achieved in multiple locations, the first row position is returned.

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -5249,7 +5249,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         >>> s = ks.Series({'Corn Flakes': 100.0, 'Almond Delight': 110.0,
         ...                'Cinnamon Toast Crunch': 120.0, 'Cocoa Puff': 110.0})
-        >>> s
+        >>> s.sort_index()
         Almond Delight           110.0
         Cinnamon Toast Crunch    120.0
         Cocoa Puff               110.0

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -5217,22 +5217,19 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         >>> s.argmax()  # doctest: +SKIP
         2
         """
-        if self.empty:
-            raise ValueError("attempt to get argmax of an empty sequence")
-
         sdf = self._internal.spark_frame.select(self._internal.data_spark_columns)
 
         # We should remember the natural sequence started from 0
         seq_col_name = verify_temp_column_name(sdf, "__distributed_sequence_column__")
         sdf = InternalFrame.attach_distributed_sequence_column(sdf, seq_col_name)
 
-        col_name = (
-            SPARK_DEFAULT_SERIES_NAME if self._column_label is None else self._column_label[0]
-        )
-        max_value = sdf.select(F.max(col_name)).head(1)[0][0]
+        scol = scol_for(sdf, self._internal.data_spark_column_names[0])
+        max_value = sdf.select(F.max(scol)).head(1)[0][0]
+        if max_value is None:
+            raise ValueError("attempt to get argmax of an empty sequence")
 
         # If the maximum is achieved in multiple locations, the first row position is returned.
-        max_value_position = sdf.filter(F.col(col_name) == max_value).head(1)[0][0]
+        max_value_position = sdf.filter(scol == max_value).head(1)[0][0]
 
         return max_value_position
 
@@ -5264,22 +5261,19 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         >>> s.argmin()  # doctest: +SKIP
         0
         """
-        if self.empty:
-            raise ValueError("attempt to get argmin of an empty sequence")
-
         sdf = self._internal.spark_frame.select(self._internal.data_spark_columns)
 
         # We should remember the natural sequence started from 0
         seq_col_name = verify_temp_column_name(sdf, "__distributed_sequence_column__")
         sdf = InternalFrame.attach_distributed_sequence_column(sdf, seq_col_name)
 
-        col_name = (
-            SPARK_DEFAULT_SERIES_NAME if self._column_label is None else self._column_label[0]
-        )
-        min_value = sdf.select(F.min(col_name)).head(1)[0][0]
+        scol = scol_for(sdf, self._internal.data_spark_column_names[0])
+        min_value = sdf.select(F.min(scol)).head(1)[0][0]
+        if min_value is None:
+            raise ValueError("attempt to get argmin of an empty sequence")
 
         # If the minimum is achieved in multiple locations, the first row position is returned.
-        min_value_position = sdf.filter(F.col(col_name) == min_value).head(1)[0][0]
+        min_value_position = sdf.filter(scol == min_value).head(1)[0][0]
 
         return min_value_position
 

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -5207,11 +5207,11 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         >>> s = ks.Series({'Corn Flakes': 100.0, 'Almond Delight': 110.0,
         ...                'Cinnamon Toast Crunch': 120.0, 'Cocoa Puff': 110.0})
-        >>> s
-        Corn Flakes              100.0
+        >>> s.sort_index()
         Almond Delight           110.0
         Cinnamon Toast Crunch    120.0
         Cocoa Puff               110.0
+        Corn Flakes              100.0
         dtype: float64
 
         >>> s.argmax()
@@ -5250,10 +5250,10 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         >>> s = ks.Series({'Corn Flakes': 100.0, 'Almond Delight': 110.0,
         ...                'Cinnamon Toast Crunch': 120.0, 'Cocoa Puff': 110.0})
         >>> s
-        Corn Flakes              100.0
         Almond Delight           110.0
         Cinnamon Toast Crunch    120.0
         Cocoa Puff               110.0
+        Corn Flakes              100.0
         dtype: float64
 
         >>> s.argmin()

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -5189,6 +5189,90 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         internal = internal.copy(spark_frame=internal.spark_frame.drop(NATURAL_ORDER_COLUMN_NAME))
         return first_series(DataFrame(internal))
 
+    def argmax(self):
+        """
+        Return int position of the largest value in the Series.
+
+        If the maximum is achieved in multiple locations,
+        the first row position is returned.
+
+        Returns
+        -------
+        int
+            Row position of the maximum value.
+
+        Examples
+        --------
+        Consider dataset containing cereal calories
+
+        >>> s = ks.Series({'Corn Flakes': 100.0, 'Almond Delight': 110.0,
+        ...                'Cinnamon Toast Crunch': 120.0, 'Cocoa Puff': 110.0})
+        >>> s
+        Corn Flakes              100.0
+        Almond Delight           110.0
+        Cinnamon Toast Crunch    120.0
+        Cocoa Puff               110.0
+        dtype: float64
+
+        >>> s.argmax()
+        2
+        """
+        sdf = self._kdf.to_spark()
+
+        # We should remember the natural sequence started from 0
+        seq_col_name = verify_temp_column_name(sdf, "__distributed_sequence_column__")
+        sdf = InternalFrame.attach_distributed_sequence_column(sdf, seq_col_name)
+
+        col_name = SPARK_DEFAULT_SERIES_NAME if self._column_label is None else self._column_label
+        max_value = sdf.select(F.max(col_name)).head(1)[0][0]
+
+        # If the maximum is achieved in multiple locations, the first row position is returned.
+        max_value_position = sdf.filter(F.col(col_name) == max_value).head(1)[0][0]
+
+        return max_value_position
+
+    def argmin(self):
+        """
+        Return int position of the smallest value in the Series.
+
+        If the minimum is achieved in multiple locations,
+        the first row position is returned.
+
+        Returns
+        -------
+        int
+            Row position of the minimum value.
+
+        Examples
+        --------
+        Consider dataset containing cereal calories
+
+        >>> s = ks.Series({'Corn Flakes': 100.0, 'Almond Delight': 110.0,
+        ...                'Cinnamon Toast Crunch': 120.0, 'Cocoa Puff': 110.0})
+        >>> s
+        Corn Flakes              100.0
+        Almond Delight           110.0
+        Cinnamon Toast Crunch    120.0
+        Cocoa Puff               110.0
+        dtype: float64
+
+        >>> s.argmin()
+        0
+        """
+        sdf = self._kdf.to_spark()
+
+        # We should remember the natural sequence started from 0
+        seq_col_name = verify_temp_column_name(sdf, "__distributed_sequence_column__")
+        sdf = InternalFrame.attach_distributed_sequence_column(sdf, seq_col_name)
+
+        col_name = SPARK_DEFAULT_SERIES_NAME if self._column_label is None else self._column_label
+        min_value = sdf.select(F.min(col_name)).head(1)[0][0]
+
+        # If the minimum is achieved in multiple locations, the first row position is returned.
+        min_value_position = sdf.filter(F.col(col_name) == min_value).head(1)[0][0]
+
+        return min_value_position
+
     def _cum(self, func, skipna, part_cols=(), ascending=True):
         # This is used to cummin, cummax, cumsum, etc.
 

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -2054,6 +2054,7 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
                 "Cinnamon Toast Crunch": 120.0,
                 "Cocoa Puff": 110.0,
                 "Expensive Flakes": 120.0,
+                "Tasteless Flakes": None,
                 "Cheap Flakes": 100.0,
             },
             name="Koalas",
@@ -2066,7 +2067,7 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
 
             # MultiIndex
             pser.index = pd.MultiIndex.from_tuples(
-                [("a", "u"), ("b", "v"), ("c", "w"), ("d", "x"), ("e", "y"), ("f", "z")]
+                [("a", "t"), ("b", "u"), ("c", "v"), ("d", "w"), ("e", "x"), ("f", "u"), ("g", "z")]
             )
             kser = ks.from_pandas(pser)
             self.assert_eq(pser.argmin(), kser.argmin())
@@ -2077,7 +2078,7 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
 
             # MultiIndex
             pser.index = pd.MultiIndex.from_tuples(
-                [("a", "u"), ("b", "v"), ("c", "w"), ("d", "x"), ("e", "y"), ("f", "z")]
+                [("a", "t"), ("b", "u"), ("c", "v"), ("d", "w"), ("e", "x"), ("f", "u"), ("g", "z")]
             )
             kser = ks.from_pandas(pser)
             self.assert_eq(pser.values.argmin(), kser.argmin())

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -2045,3 +2045,18 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
             kser = ks.from_pandas(pser)
             expected = pser
             self.assert_eq(kser.explode(), expected)
+
+    def test_argmin_argmax(self):
+        pser = pd.Series(
+            {
+                "Corn Flakes": 100.0,
+                "Almond Delight": 110.0,
+                "Cinnamon Toast Crunch": 120.0,
+                "Cocoa Puff": 110.0,
+                "Expensive Flakes": 120.0,
+                "Cheap Flakes": 100.0,
+            }
+        )
+        kser = ks.from_pandas(pser)
+        self.assert_eq(pser.argmin(), kser.argmin())
+        self.assert_eq(pser.argmax(), kser.argmax())

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -2054,7 +2054,6 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
                 "Cinnamon Toast Crunch": 120.0,
                 "Cocoa Puff": 110.0,
                 "Expensive Flakes": 120.0,
-                "Tasteless Flakes": None,
                 "Cheap Flakes": 100.0,
             },
             name="Koalas",
@@ -2067,22 +2066,30 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
 
             # MultiIndex
             pser.index = pd.MultiIndex.from_tuples(
-                [("a", "t"), ("b", "u"), ("c", "v"), ("d", "w"), ("e", "x"), ("f", "u"), ("g", "z")]
+                [("a", "t"), ("b", "u"), ("c", "v"), ("d", "w"), ("e", "x"), ("f", "u")]
             )
             kser = ks.from_pandas(pser)
             self.assert_eq(pser.argmin(), kser.argmin())
             self.assert_eq(pser.argmax(), kser.argmax())
+
+            # Null Series
+            self.assert_eq(pd.Series([np.nan]).argmin(), ks.Series([np.nan]).argmin())
+            self.assert_eq(pd.Series([np.nan]).argmax(), ks.Series([np.nan]).argmax())
         else:
             self.assert_eq(pser.values.argmin(), kser.argmin())
             self.assert_eq(pser.values.argmax(), kser.argmax())
 
             # MultiIndex
             pser.index = pd.MultiIndex.from_tuples(
-                [("a", "t"), ("b", "u"), ("c", "v"), ("d", "w"), ("e", "x"), ("f", "u"), ("g", "z")]
+                [("a", "t"), ("b", "u"), ("c", "v"), ("d", "w"), ("e", "x"), ("f", "u")]
             )
             kser = ks.from_pandas(pser)
             self.assert_eq(pser.values.argmin(), kser.argmin())
             self.assert_eq(pser.values.argmax(), kser.argmax())
+
+            # Null Series
+            self.assert_eq(pd.Series([np.nan]).argmin(), ks.Series([np.nan]).argmin())
+            self.assert_eq(pd.Series([np.nan]).argmax(), ks.Series([np.nan]).argmax())
 
         with self.assertRaisesRegex(ValueError, "attempt to get argmin of an empty sequence"):
             ks.Series([]).argmin()

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -2088,8 +2088,8 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
             self.assert_eq(pser.values.argmax(), kser.argmax())
 
             # Null Series
-            self.assert_eq(pd.Series([np.nan]).argmin(), ks.Series([np.nan]).argmin())
-            self.assert_eq(pd.Series([np.nan]).argmax(), ks.Series([np.nan]).argmax())
+            self.assert_eq(pd.Series([np.nan]).values.argmin(), ks.Series([np.nan]).argmin())
+            self.assert_eq(pd.Series([np.nan]).values.argmax(), ks.Series([np.nan]).argmax())
 
         with self.assertRaisesRegex(ValueError, "attempt to get argmin of an empty sequence"):
             ks.Series([]).argmin()

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -2058,13 +2058,26 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
             }
         )
         kser = ks.from_pandas(pser)
-        self.assert_eq(pser.argmin(), kser.argmin())
-        self.assert_eq(pser.argmax(), kser.argmax())
 
-        # MultiIndex
-        pser.index = pd.MultiIndex.from_tuples(
-            [("a", "u"), ("b", "v"), ("c", "w"), ("d", "x"), ("e", "y"), ("f", "z")]
-        )
-        kser = ks.from_pandas(pser)
-        self.assert_eq(pser.argmin(), kser.argmin())
-        self.assert_eq(pser.argmax(), kser.argmax())
+        if LooseVersion(pd.__version__) >= LooseVersion("1.0"):
+            self.assert_eq(pser.argmin(), kser.argmin())
+            self.assert_eq(pser.argmax(), kser.argmax())
+
+            # MultiIndex
+            pser.index = pd.MultiIndex.from_tuples(
+                [("a", "u"), ("b", "v"), ("c", "w"), ("d", "x"), ("e", "y"), ("f", "z")]
+            )
+            kser = ks.from_pandas(pser)
+            self.assert_eq(pser.argmin(), kser.argmin())
+            self.assert_eq(pser.argmax(), kser.argmax())
+        else:
+            self.assert_eq(pser.values.argmin(), kser.argmin())
+            self.assert_eq(pser.values.argmax(), kser.argmax())
+
+            # MultiIndex
+            pser.index = pd.MultiIndex.from_tuples(
+                [("a", "u"), ("b", "v"), ("c", "w"), ("d", "x"), ("e", "y"), ("f", "z")]
+            )
+            kser = ks.from_pandas(pser)
+            self.assert_eq(pser.values.argmin(), kser.argmin())
+            self.assert_eq(pser.values.argmax(), kser.argmax())

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -2060,3 +2060,11 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         kser = ks.from_pandas(pser)
         self.assert_eq(pser.argmin(), kser.argmin())
         self.assert_eq(pser.argmax(), kser.argmax())
+
+        # MultiIndex
+        pser.index = pd.MultiIndex.from_tuples(
+            [("a", "u"), ("b", "v"), ("c", "w"), ("d", "x"), ("e", "y"), ("f", "z")]
+        )
+        kser = ks.from_pandas(pser)
+        self.assert_eq(pser.argmin(), kser.argmin())
+        self.assert_eq(pser.argmax(), kser.argmax())

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -2088,8 +2088,8 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
             self.assert_eq(pser.values.argmax(), kser.argmax())
 
             # Null Series
-            self.assert_eq(pd.Series([np.nan]).values.argmin(), ks.Series([np.nan]).argmin())
-            self.assert_eq(pd.Series([np.nan]).values.argmax(), ks.Series([np.nan]).argmax())
+            self.assert_eq(-1, ks.Series([np.nan]).argmin())
+            self.assert_eq(-1, ks.Series([np.nan]).argmax())
 
         with self.assertRaisesRegex(ValueError, "attempt to get argmin of an empty sequence"):
             ks.Series([]).argmin()

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -2055,7 +2055,8 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
                 "Cocoa Puff": 110.0,
                 "Expensive Flakes": 120.0,
                 "Cheap Flakes": 100.0,
-            }
+            },
+            name="Koalas",
         )
         kser = ks.from_pandas(pser)
 
@@ -2081,3 +2082,8 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
             kser = ks.from_pandas(pser)
             self.assert_eq(pser.values.argmin(), kser.argmin())
             self.assert_eq(pser.values.argmax(), kser.argmax())
+
+        with self.assertRaisesRegex(ValueError, "attempt to get argmin of an empty sequence"):
+            ks.Series([]).argmin()
+        with self.assertRaisesRegex(ValueError, "attempt to get argmax of an empty sequence"):
+            ks.Series([]).argmax()

--- a/docs/source/reference/series.rst
+++ b/docs/source/reference/series.rst
@@ -196,6 +196,8 @@ Reshaping, sorting, transposing
 .. autosummary::
    :toctree: api/
 
+   Series.argmin
+   Series.argmax
    Series.sort_index
    Series.sort_values
    Series.unstack


### PR DESCRIPTION
This PR proposes `Series.argmin` & `Series.argmax`.

```python
>>> kser = ks.Series(
...     {
...         "Corn Flakes": 100.0,
...         "Almond Delight": 110.0,
...         "Cinnamon Toast Crunch": 120.0,
...         "Cocoa Puff": 110.0,
...         "Expensive Flakes": 120.0,
...         "Cheap Flakes": 100.0,
...     }
... )
>>> kser.argmin()
0
>>> kser.argmax()
2
```