### PR TITLE
Exception handling for from_frame properly

### DIFF
--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -2352,6 +2352,8 @@ class MultiIndex(Index):
                     ('NJ', 'Precip')],
                    names=['state', 'observation'])
         """
+        if not isinstance(df, DataFrame):
+            raise TypeError("Input must be a DataFrame")
         sdf = df.to_spark()
         if names is None:
             names = df._internal.column_labels

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -1485,6 +1485,10 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
 
         self.assert_eq(pidx, kidx)
 
+        err_msg = "Input must be a DataFrame"
+        with self.assertRaisesRegex(TypeError, err_msg):
+            ks.MultiIndex.from_frame({"a": [1, 2, 3], "b": [4, 5, 6]})
+
     def test_is_type_compatible(self):
         data_types = ["integer", "floating", "string", "boolean"]
         # Integer


### PR DESCRIPTION
`MultiIndex.from_frame` doesn't raise exception properly when given parameter is not a `DataFrame`.

```python
>>> pd.MultiIndex.from_frame(10)
Traceback (most recent call last):
...
TypeError: Input must be a DataFrame

>>> ks.MultiIndex.from_frame(10)
Traceback (most recent call last):
...
AttributeError: 'int' object has no attribute 'to_spark'
```

This PR fixed it and added related tests.