### PR TITLE
Integrated 'assert_array_eq' and 'assert_list_eq' into 'assert_eq'

### DIFF
--- a/databricks/koalas/testing/utils.py
+++ b/databricks/koalas/testing/utils.py
@@ -302,7 +302,7 @@ class ComparisonTestBase(ReusedSQLTestCase):
 
     @property
     def pdf(self):
-        return self.kdf.to_andas()
+        return self.kdf.to_pandas()
 
 
 def compare_both(f=None, almost=True):

--- a/databricks/koalas/testing/utils.py
+++ b/databricks/koalas/testing/utils.py
@@ -263,8 +263,9 @@ class ReusedSQLTestCase(unittest.TestCase, SQLTestUtils):
             else:
                 self.assertPandasEqual(lobj, robj, check_exact=check_exact)
         elif is_list_like(lobj) and is_list_like(robj):
+            self.assertTrue(len(left) == len(right))
             for litem, ritem in zip(left, right):
-                self.assert_eq(litem, ritem)
+                self.assert_eq(litem, ritem, check_exact=check_exact, almost=almost)
         else:
             if almost:
                 self.assertAlmostEqual(lobj, robj)
@@ -274,7 +275,7 @@ class ReusedSQLTestCase(unittest.TestCase, SQLTestUtils):
     @staticmethod
     def _to_pandas(obj):
         if isinstance(obj, (DataFrame, Series, Index)):
-            return obj.toPandas()
+            return obj.to_pandas()
         else:
             return obj
 
@@ -301,7 +302,7 @@ class ComparisonTestBase(ReusedSQLTestCase):
 
     @property
     def pdf(self):
-        return self.kdf.toPandas()
+        return self.kdf.to_andas()
 
 
 def compare_both(f=None, almost=True):
@@ -319,7 +320,7 @@ def compare_both(f=None, almost=True):
             compare = self.assertPandasEqual
 
         for result_pandas, result_spark in zip(f(self, self.pdf), f(self, self.kdf)):
-            compare(result_pandas, result_spark.toPandas())
+            compare(result_pandas, result_spark.to_pandas())
 
     return wrapped
 

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -1141,7 +1141,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         kdf = ks.from_pandas(pdf)
 
-        np.testing.assert_equal(kdf.to_numpy(), pdf.values)
+        np.testing.assert_eq(kdf.to_numpy(), pdf.values)
 
     def test_to_pandas(self):
         pdf, kdf = self.df_pair

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -3528,13 +3528,13 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
     def test_axes(self):
         pdf = self.pdf
         kdf = ks.from_pandas(pdf)
-        self.assert_list_eq(pdf.axes, kdf.axes)
+        self.assert_eq(pdf.axes, kdf.axes)
 
         # multi-index columns
         columns = pd.MultiIndex.from_tuples([("x", "a"), ("y", "b")])
         pdf.columns = columns
         kdf.columns = columns
-        self.assert_list_eq(pdf.axes, kdf.axes)
+        self.assert_eq(pdf.axes, kdf.axes)
 
     def test_udt(self):
         sparse_values = {0: 0.1, 1: 1.1}

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -1141,7 +1141,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         kdf = ks.from_pandas(pdf)
 
-        np.testing.assert_eq(kdf.to_numpy(), pdf.values)
+        self.assert_eq(kdf.to_numpy(), pdf.values)
 
     def test_to_pandas(self):
         pdf, kdf = self.df_pair

--- a/databricks/koalas/tests/test_dataframe_conversion.py
+++ b/databricks/koalas/tests/test_dataframe_conversion.py
@@ -208,11 +208,9 @@ class DataFrameConversionTest(ReusedSQLTestCase, SQLTestUtils, TestUtils):
 
             kdf = ks.from_pandas(pdf)
 
-            self.assert_array_eq(kdf.to_records(), pdf.to_records())
-            self.assert_array_eq(kdf.to_records(index=False), pdf.to_records(index=False))
-            self.assert_array_eq(
-                kdf.to_records(index_dtypes="<S2"), pdf.to_records(index_dtypes="<S2")
-            )
+            self.assert_eq(kdf.to_records(), pdf.to_records())
+            self.assert_eq(kdf.to_records(index=False), pdf.to_records(index=False))
+            self.assert_eq(kdf.to_records(index_dtypes="<S2"), pdf.to_records(index_dtypes="<S2"))
 
     def test_from_records(self):
         # Assert using a dict as input

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -1525,10 +1525,10 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         # Integer
         pidx = pd.Index([1, 2, 3])
         kidx = ks.from_pandas(pidx)
-        self.assert_array_eq(pidx.asi8, kidx.asi8)
-        self.assert_array_eq(pidx.astype("int").asi8, kidx.astype("int").asi8)
-        self.assert_array_eq(pidx.astype("int16").asi8, kidx.astype("int16").asi8)
-        self.assert_array_eq(pidx.astype("int8").asi8, kidx.astype("int8").asi8)
+        self.assert_eq(pidx.asi8, kidx.asi8)
+        self.assert_eq(pidx.astype("int").asi8, kidx.astype("int").asi8)
+        self.assert_eq(pidx.astype("int16").asi8, kidx.astype("int16").asi8)
+        self.assert_eq(pidx.astype("int8").asi8, kidx.astype("int8").asi8)
 
         # Integer with missing value
         pidx = pd.Index([1, 2, None, 4, 5])
@@ -1538,7 +1538,7 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         # Datetime
         pidx = pd.date_range(end="1/1/2018", periods=3)
         kidx = ks.from_pandas(pidx)
-        self.assert_array_eq(pidx.asi8, kidx.asi8)
+        self.assert_eq(pidx.asi8, kidx.asi8)
 
         # Floating
         pidx = pd.Index([1.0, 2.0, 3.0])

--- a/databricks/koalas/tests/test_indexing.py
+++ b/databricks/koalas/tests/test_indexing.py
@@ -151,8 +151,8 @@ class IndexingTest(ReusedSQLTestCase):
         # Assert .at for DataFrames
         self.assertEqual(kdf.at[3, "b"], 6)
         self.assertEqual(kdf.at[3, "b"], pdf.at[3, "b"])
-        np.testing.assert_array_equal(kdf.at[9, "b"], np.array([0, 0, 0]))
-        np.testing.assert_array_equal(kdf.at[9, "b"], pdf.at[9, "b"])
+        np.testing.assert_equal(kdf.at[9, "b"], np.array([0, 0, 0]))
+        np.testing.assert_equal(kdf.at[9, "b"], pdf.at[9, "b"])
 
         # Assert .at for Series
         self.assertEqual(test_series.at["b"], 6)

--- a/databricks/koalas/tests/test_indexing.py
+++ b/databricks/koalas/tests/test_indexing.py
@@ -151,8 +151,8 @@ class IndexingTest(ReusedSQLTestCase):
         # Assert .at for DataFrames
         self.assertEqual(kdf.at[3, "b"], 6)
         self.assertEqual(kdf.at[3, "b"], pdf.at[3, "b"])
-        np.testing.assert_eq(kdf.at[9, "b"], np.array([0, 0, 0]))
-        np.testing.assert_eq(kdf.at[9, "b"], pdf.at[9, "b"])
+        self.assert_eq(kdf.at[9, "b"], np.array([0, 0, 0]))
+        self.assert_eq(kdf.at[9, "b"], pdf.at[9, "b"])
 
         # Assert .at for Series
         self.assertEqual(test_series.at["b"], 6)

--- a/databricks/koalas/tests/test_indexing.py
+++ b/databricks/koalas/tests/test_indexing.py
@@ -151,8 +151,8 @@ class IndexingTest(ReusedSQLTestCase):
         # Assert .at for DataFrames
         self.assertEqual(kdf.at[3, "b"], 6)
         self.assertEqual(kdf.at[3, "b"], pdf.at[3, "b"])
-        np.testing.assert_equal(kdf.at[9, "b"], np.array([0, 0, 0]))
-        np.testing.assert_equal(kdf.at[9, "b"], pdf.at[9, "b"])
+        np.testing.assert_eq(kdf.at[9, "b"], np.array([0, 0, 0]))
+        np.testing.assert_eq(kdf.at[9, "b"], pdf.at[9, "b"])
 
         # Assert .at for Series
         self.assertEqual(test_series.at["b"], 6)

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -198,7 +198,7 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         pser = pd.Series([1, 2, 3, 4, 5, 6, 7], name="x")
 
         kser = ks.from_pandas(pser)
-        np.testing.assert_eq(kser.to_numpy(), pser.values)
+        self.assert_eq(kser.to_numpy(), pser.values)
 
     def test_isin(self):
         pser = pd.Series(["lama", "cow", "lama", "beetle", "lama", "hippo"], name="animal")

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -1362,7 +1362,7 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
     def test_axes(self):
         pser = pd.Series([90, 91, 85], index=[2, 4, 1])
         kser = ks.from_pandas(pser)
-        self.assert_list_eq(kser.axes, pser.axes)
+        self.assert_eq(kser.axes, pser.axes)
 
         # for MultiIndex
         midx = pd.MultiIndex(
@@ -1371,7 +1371,7 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         )
         pser = pd.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3], index=midx)
         kser = ks.from_pandas(pser)
-        self.assert_list_eq(kser.axes, pser.axes)
+        self.assert_eq(kser.axes, pser.axes)
 
     def test_combine_first(self):
         pser1 = pd.Series({"falcon": 330.0, "eagle": 160.0})

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -198,7 +198,7 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         pser = pd.Series([1, 2, 3, 4, 5, 6, 7], name="x")
 
         kser = ks.from_pandas(pser)
-        np.testing.assert_equal(kser.to_numpy(), pser.values)
+        np.testing.assert_eq(kser.to_numpy(), pser.values)
 
     def test_isin(self):
         pser = pd.Series(["lama", "cow", "lama", "beetle", "lama", "hippo"], name="animal")


### PR DESCRIPTION
This PR proposes integration of `assert_array_eq` and `assert_list_eq` into `assert_eq` for avoiding confusion when tests.