### PR TITLE
Add numpy to Dependencies table

### DIFF
--- a/docs/source/getting_started/install.rst
+++ b/docs/source/getting_started/install.rst
@@ -121,10 +121,11 @@ Dependencies
 ============= =========================
 Package       Minimum supported version
 ============= =========================
-`pandas`      0.23
+`pandas`      0.23.2
 `PySpark`     2.4
 `pyarrow`     0.10
 `matplotlib`  3.0.0
+`numpy     `  1.14
 ============= =========================
 
 

--- a/docs/source/getting_started/install.rst
+++ b/docs/source/getting_started/install.rst
@@ -118,22 +118,22 @@ Likewise, make sure you set ``SPARK_HOME`` environment variable to the git-clone
 Dependencies
 ------------
 
-============= =========================
-Package       Minimum supported version
-============= =========================
-`pandas`      0.23.2
-`PySpark`     2.4
-`pyarrow`     0.10
-`matplotlib`  3.0.0
-`numpy`       1.14
-============= =========================
+============= ================
+Package       Required version
+============= ================
+`pandas`      >=0.23.2
+`pyspark`     >=2.4.0
+`pyarrow`     >=0.10
+`matplotlib`  >=3.0.0,<3.3.0
+`numpy`       >=1.14,<1.19.0
+============= ================
 
 
 Optional dependencies
 ~~~~~~~~~~~~~~~~~~~~~
 
-============= =========================
-Package       Minimum supported version
-============= =========================
-`mlflow`      1.0
-============= =========================
+============= ================
+Package       Required version
+============= ================
+`mlflow`      >=1.0
+============= ================

--- a/docs/source/getting_started/install.rst
+++ b/docs/source/getting_started/install.rst
@@ -125,7 +125,7 @@ Package       Minimum supported version
 `PySpark`     2.4
 `pyarrow`     0.10
 `matplotlib`  3.0.0
-`numpy     `  1.14
+`numpy`       1.14
 ============= =========================
 
 


### PR DESCRIPTION
Added `numpy` to the Dependencies table in the documents.
And fixed "Minimum supported version" of `pandas` properly - from `0.23` to `0.23.2` - .

<img width="402" alt="스크린샷 2020-09-25 오전 12 45 55" src="https://user-images.githubusercontent.com/44108233/94168339-7cdd1780-fec8-11ea-977f-0466bd2ebf89.png">
