### PR TITLE
Fix Series.__repr__ when Series.name is None.

### DIFF
--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -5494,10 +5494,18 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             match = REPR_PATTERN.search(prev_footer)
             if match is not None:
                 length = match.group("length")
-                name = str(self.dtype.name)
-                footer = "\nName: {name}, dtype: {dtype}\nShowing only the first {length}".format(
-                    length=length, name=self.name, dtype=pprint_thing(name)
-                )
+                dtype_name = str(self.dtype.name)
+                if self.name is None:
+                    footer = "\ndtype: {dtype}\nShowing only the first {length}".format(
+                        length=length, dtype=pprint_thing(dtype_name)
+                    )
+                else:
+                    footer = (
+                        "\nName: {name}, dtype: {dtype}"
+                        "\nShowing only the first {length}".format(
+                            length=length, name=self.name, dtype=pprint_thing(dtype_name)
+                        )
+                    )
                 return rest + footer
         return pser.to_string(name=self.name, dtype=self.dtype)
 

--- a/databricks/koalas/tests/test_repr.py
+++ b/databricks/koalas/tests/test_repr.py
@@ -118,9 +118,7 @@ class ReprTest(ReusedSQLTestCase):
             kidx = ks.range(ReprTest.max_display_count + 1).index
             self.assert_eq(repr(kidx), repr(kidx.to_pandas()))
 
-        kidx = ks.MultiIndex.from_tuples(
-            [(100 * i, i) for i in range(ReprTest.max_display_count)]
-        )
+        kidx = ks.MultiIndex.from_tuples([(100 * i, i) for i in range(ReprTest.max_display_count)])
         self.assertTrue("Showing only the first" not in repr(kidx))
         self.assert_eq(repr(kidx), repr(kidx.to_pandas()))
 

--- a/databricks/koalas/typedef/typehints.py
+++ b/databricks/koalas/typedef/typehints.py
@@ -127,7 +127,7 @@ def as_spark_type(tpe) -> types.DataType:
 
 def spark_type_to_pandas_dtype(spark_type):
     """ Return the given Spark DataType to pandas dtype. """
-    if isinstance(spark_type, (types.DateType, types.UserDefinedType)):
+    if isinstance(spark_type, (types.DateType, types.StructType, types.UserDefinedType)):
         return np.dtype("object")
     elif isinstance(spark_type, types.TimestampType):
         return np.dtype("datetime64[ns]")


### PR DESCRIPTION
Fix `Series.__repr__` when `Series.name` is `None` and the length is longer than a config `display.max_rows`.
Additional added some more test cases.