### PR TITLE
Modify input check for indexers to support non-string column names.

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -64,16 +64,17 @@ from databricks.koalas.config import option_context, get_option
 from databricks.koalas.spark import functions as SF
 from databricks.koalas.spark.accessors import SparkFrameMethods, CachedSparkFrameMethods
 from databricks.koalas.utils import (
-    validate_arguments_and_invoke_function,
     align_diff_frames,
-    validate_bool_kwarg,
     column_labels_level,
+    default_session,
+    is_name_like_value,
     name_like_string,
     same_anchor,
     scol_for,
+    validate_arguments_and_invoke_function,
     validate_axis,
+    validate_bool_kwarg,
     verify_temp_column_name,
-    default_session,
 )
 from databricks.koalas.generic import Frame
 from databricks.koalas.internal import (
@@ -10309,18 +10310,18 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         if key is None:
             raise KeyError("none key")
-        if isinstance(key, Series):
+        elif isinstance(key, Series):
             return self.loc[key.astype(bool)]
-        elif isinstance(key, (str, tuple)):
-            return self.loc[:, key]
-        elif is_list_like(key):
-            return self.loc[:, list(key)]
         elif isinstance(key, slice):
             if any(type(n) == int or None for n in [key.start, key.stop]):
                 # Seems like pandas Frame always uses int as positional search when slicing
                 # with ints.
                 return self.iloc[key]
             return self.loc[key]
+        elif is_name_like_value(key):
+            return self.loc[:, key]
+        elif is_list_like(key):
+            return self.loc[:, list(key)]
         raise NotImplementedError(key)
 
     def __setitem__(self, key, value):

--- a/databricks/koalas/indexing.py
+++ b/databricks/koalas/indexing.py
@@ -37,11 +37,13 @@ from databricks.koalas.internal import (
 )
 from databricks.koalas.exceptions import SparkPandasIndexingError, SparkPandasNotImplementedError
 from databricks.koalas.utils import (
+    is_name_like_tuple,
+    is_name_like_value,
     lazy_property,
     name_like_string,
-    verify_temp_column_name,
     same_anchor,
     scol_for,
+    verify_temp_column_name,
 )
 
 if TYPE_CHECKING:
@@ -134,19 +136,18 @@ class AtIndexer(IndexerLike):
             col_sel = self._kdf_or_kser._column_label
 
         if len(self._internal.index_map) == 1:
-            if is_list_like(row_sel):
+            if not is_name_like_value(row_sel, allow_none=False, allow_tuple=False):
                 raise ValueError("At based indexing on a single index can only have a single value")
             row_sel = (row_sel,)
-        elif not isinstance(row_sel, tuple):
-            raise ValueError("At based indexing on multi-index can only have tuple values")
-        if not (
-            col_sel is None
-            or isinstance(col_sel, str)
-            or (isinstance(col_sel, tuple) and all(isinstance(col, str) for col in col_sel))
-        ):
-            raise ValueError("At based indexing on multi-index can only have tuple values")
-        if isinstance(col_sel, str):
-            col_sel = (col_sel,)
+        else:
+            if not is_name_like_tuple(row_sel, allow_none=False):
+                raise ValueError("At based indexing on multi-index can only have tuple values")
+
+        if col_sel is not None:
+            if not is_name_like_value(col_sel, allow_none=False):
+                raise ValueError("At based indexing on multi-index can only have tuple values")
+            if not is_name_like_tuple(col_sel):
+                col_sel = (col_sel,)
 
         cond = reduce(
             lambda x, y: x & y,
@@ -262,18 +263,16 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
                 # If slice is None - select everything, so nothing to do
                 return None, None, None
             return self._select_rows_by_slice(rows_sel)
-        elif isinstance(rows_sel, (str, tuple)):
+        elif isinstance(rows_sel, tuple):
             return self._select_rows_else(rows_sel)
-        elif isinstance(rows_sel, Iterable):
+        elif is_list_like(rows_sel):
             return self._select_rows_by_iterable(rows_sel)
         else:
             return self._select_rows_else(rows_sel)
 
     def _select_cols(
-        self, cols_sel: Any, missing_keys: Optional[List[Tuple[str, ...]]] = None
-    ) -> Tuple[
-        List[Tuple[str, ...]], Optional[List[spark.Column]], bool, Optional[Tuple[str, ...]]
-    ]:
+        self, cols_sel: Any, missing_keys: Optional[List[Tuple]] = None
+    ) -> Tuple[List[Tuple], Optional[List[spark.Column]], bool, Optional[Tuple]]:
         """
         Dispatch the logic for select columns to more specific methods by `cols_sel` argument types.
 
@@ -307,9 +306,9 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
                 data_spark_columns = self._internal.data_spark_columns
                 return column_labels, data_spark_columns, False, None
             return self._select_cols_by_slice(cols_sel, missing_keys)
-        elif isinstance(cols_sel, (str, tuple)):
+        elif isinstance(cols_sel, tuple):
             return self._select_cols_else(cols_sel, missing_keys)
-        elif isinstance(cols_sel, Iterable):
+        elif is_list_like(cols_sel):
             return self._select_cols_by_iterable(cols_sel, missing_keys)
         else:
             return self._select_cols_else(cols_sel, missing_keys)
@@ -355,46 +354,36 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
 
     @abstractmethod
     def _select_cols_by_series(
-        self, cols_sel: "Series", missing_keys: Optional[List[Tuple[str, ...]]]
-    ) -> Tuple[
-        List[Tuple[str, ...]], Optional[List[spark.Column]], bool, Optional[Tuple[str, ...]]
-    ]:
+        self, cols_sel: "Series", missing_keys: Optional[List[Tuple]]
+    ) -> Tuple[List[Tuple], Optional[List[spark.Column]], bool, Optional[Tuple]]:
         """ Select columns by `Series` type key. """
         pass
 
     @abstractmethod
     def _select_cols_by_spark_column(
-        self, cols_sel: spark.Column, missing_keys: Optional[List[Tuple[str, ...]]]
-    ) -> Tuple[
-        List[Tuple[str, ...]], Optional[List[spark.Column]], bool, Optional[Tuple[str, ...]]
-    ]:
+        self, cols_sel: spark.Column, missing_keys: Optional[List[Tuple]]
+    ) -> Tuple[List[Tuple], Optional[List[spark.Column]], bool, Optional[Tuple]]:
         """ Select columns by Spark `Column` type key. """
         pass
 
     @abstractmethod
     def _select_cols_by_slice(
-        self, cols_sel: slice, missing_keys: Optional[List[Tuple[str, ...]]]
-    ) -> Tuple[
-        List[Tuple[str, ...]], Optional[List[spark.Column]], bool, Optional[Tuple[str, ...]]
-    ]:
+        self, cols_sel: slice, missing_keys: Optional[List[Tuple]]
+    ) -> Tuple[List[Tuple], Optional[List[spark.Column]], bool, Optional[Tuple]]:
         """ Select columns by `slice` type key. """
         pass
 
     @abstractmethod
     def _select_cols_by_iterable(
-        self, cols_sel: Iterable, missing_keys: Optional[List[Tuple[str, ...]]]
-    ) -> Tuple[
-        List[Tuple[str, ...]], Optional[List[spark.Column]], bool, Optional[Tuple[str, ...]]
-    ]:
+        self, cols_sel: Iterable, missing_keys: Optional[List[Tuple]]
+    ) -> Tuple[List[Tuple], Optional[List[spark.Column]], bool, Optional[Tuple]]:
         """ Select columns by `Iterable` type key. """
         pass
 
     @abstractmethod
     def _select_cols_else(
-        self, cols_sel: Any, missing_keys: Optional[List[Tuple[str, ...]]]
-    ) -> Tuple[
-        List[Tuple[str, ...]], Optional[List[spark.Column]], bool, Optional[Tuple[str, ...]]
-    ]:
+        self, cols_sel: Any, missing_keys: Optional[List[Tuple]]
+    ) -> Tuple[List[Tuple], Optional[List[spark.Column]], bool, Optional[Tuple]]:
         """ Select columns by other type key. """
         pass
 
@@ -684,7 +673,7 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
 
             column_labels = self._internal.column_labels.copy()
             for label in missing_keys:
-                if isinstance(label, str):
+                if not is_name_like_tuple(label):
                     label = (label,)
                 if len(label) < self._internal.column_labels_level:
                     label = tuple(
@@ -1073,9 +1062,7 @@ class LocIndexer(LocIndexerLike):
 
     def _get_from_multiindex_column(
         self, key, missing_keys, labels=None, recursed=0
-    ) -> Tuple[
-        List[Tuple[str, ...]], Optional[List[spark.Column]], bool, Optional[Tuple[str, ...]]
-    ]:
+    ) -> Tuple[List[Tuple], Optional[List[spark.Column]], bool, Optional[Tuple]]:
         """ Select columns from multi-index columns. """
         assert isinstance(key, tuple)
         if labels is None:
@@ -1121,40 +1108,32 @@ class LocIndexer(LocIndexerLike):
             return column_labels, data_spark_columns, returns_series, series_name
 
     def _select_cols_by_series(
-        self, cols_sel: "Series", missing_keys: Optional[List[Tuple[str, ...]]]
-    ) -> Tuple[
-        List[Tuple[str, ...]], Optional[List[spark.Column]], bool, Optional[Tuple[str, ...]]
-    ]:
+        self, cols_sel: "Series", missing_keys: Optional[List[Tuple]]
+    ) -> Tuple[List[Tuple], Optional[List[spark.Column]], bool, Optional[Tuple]]:
         column_labels = [cols_sel._column_label]
         data_spark_columns = [cols_sel.spark.column]
         return column_labels, data_spark_columns, True, None
 
     def _select_cols_by_spark_column(
-        self, cols_sel: spark.Column, missing_keys: Optional[List[Tuple[str, ...]]]
-    ) -> Tuple[
-        List[Tuple[str, ...]], Optional[List[spark.Column]], bool, Optional[Tuple[str, ...]]
-    ]:
+        self, cols_sel: spark.Column, missing_keys: Optional[List[Tuple]]
+    ) -> Tuple[List[Tuple], Optional[List[spark.Column]], bool, Optional[Tuple]]:
         column_labels = [
             (self._internal.spark_frame.select(cols_sel).columns[0],)
-        ]  # type: List[Tuple[str, ...]]
+        ]  # type: List[Tuple]
         data_spark_columns = [cols_sel]
         return column_labels, data_spark_columns, True, None
 
     def _select_cols_by_slice(
-        self, cols_sel: slice, missing_keys: Optional[List[Tuple[str, ...]]]
-    ) -> Tuple[
-        List[Tuple[str, ...]], Optional[List[spark.Column]], bool, Optional[Tuple[str, ...]]
-    ]:
+        self, cols_sel: slice, missing_keys: Optional[List[Tuple]]
+    ) -> Tuple[List[Tuple], Optional[List[spark.Column]], bool, Optional[Tuple]]:
         start, stop = self._kdf_or_kser.columns.slice_locs(start=cols_sel.start, end=cols_sel.stop)
         column_labels = self._internal.column_labels[start:stop]
         data_spark_columns = self._internal.data_spark_columns[start:stop]
         return column_labels, data_spark_columns, False, None
 
     def _select_cols_by_iterable(
-        self, cols_sel: Iterable, missing_keys: Optional[List[Tuple[str, ...]]]
-    ) -> Tuple[
-        List[Tuple[str, ...]], Optional[List[spark.Column]], bool, Optional[Tuple[str, ...]]
-    ]:
+        self, cols_sel: Iterable, missing_keys: Optional[List[Tuple]]
+    ) -> Tuple[List[Tuple], Optional[List[spark.Column]], bool, Optional[Tuple]]:
         from databricks.koalas.series import Series
 
         if all(isinstance(key, Series) for key in cols_sel):
@@ -1165,10 +1144,14 @@ class LocIndexer(LocIndexerLike):
                 (self._internal.spark_frame.select(col).columns[0],) for col in cols_sel
             ]
             data_spark_columns = list(cols_sel)
-        elif any(isinstance(key, str) for key in cols_sel) and any(
-            isinstance(key, tuple) for key in cols_sel
+        elif any(isinstance(key, tuple) for key in cols_sel) and any(
+            not is_name_like_tuple(key) for key in cols_sel
         ):
-            raise TypeError("Expected tuple, got str")
+            raise TypeError(
+                "Expected tuple, got {}".format(
+                    type(set(key for key in cols_sel if not is_name_like_tuple(key)).pop())
+                )
+            )
         else:
             if missing_keys is None and all(isinstance(key, tuple) for key in cols_sel):
                 level = self._internal.column_labels_level
@@ -1193,11 +1176,9 @@ class LocIndexer(LocIndexerLike):
         return column_labels, data_spark_columns, False, None
 
     def _select_cols_else(
-        self, cols_sel: Any, missing_keys: Optional[List[Tuple[str, ...]]]
-    ) -> Tuple[
-        List[Tuple[str, ...]], Optional[List[spark.Column]], bool, Optional[Tuple[str, ...]]
-    ]:
-        if isinstance(cols_sel, str):
+        self, cols_sel: Any, missing_keys: Optional[List[Tuple]]
+    ) -> Tuple[List[Tuple], Optional[List[spark.Column]], bool, Optional[Tuple]]:
+        if not is_name_like_tuple(cols_sel):
             cols_sel = (cols_sel,)
         return self._get_from_multiindex_column(cols_sel, missing_keys)
 
@@ -1513,30 +1494,24 @@ class iLocIndexer(LocIndexerLike):
             )
 
     def _select_cols_by_series(
-        self, cols_sel: "Series", missing_keys: Optional[List[Tuple[str, ...]]]
-    ) -> Tuple[
-        List[Tuple[str, ...]], Optional[List[spark.Column]], bool, Optional[Tuple[str, ...]]
-    ]:
+        self, cols_sel: "Series", missing_keys: Optional[List[Tuple]]
+    ) -> Tuple[List[Tuple], Optional[List[spark.Column]], bool, Optional[Tuple]]:
         raise ValueError(
             "Location based indexing can only have [integer, integer slice, "
             "listlike of integers, boolean array] types, got {}".format(cols_sel)
         )
 
     def _select_cols_by_spark_column(
-        self, cols_sel: spark.Column, missing_keys: Optional[List[Tuple[str, ...]]]
-    ) -> Tuple[
-        List[Tuple[str, ...]], Optional[List[spark.Column]], bool, Optional[Tuple[str, ...]]
-    ]:
+        self, cols_sel: spark.Column, missing_keys: Optional[List[Tuple]]
+    ) -> Tuple[List[Tuple], Optional[List[spark.Column]], bool, Optional[Tuple]]:
         raise ValueError(
             "Location based indexing can only have [integer, integer slice, "
             "listlike of integers, boolean array] types, got {}".format(cols_sel)
         )
 
     def _select_cols_by_slice(
-        self, cols_sel: slice, missing_keys: Optional[List[Tuple[str, ...]]]
-    ) -> Tuple[
-        List[Tuple[str, ...]], Optional[List[spark.Column]], bool, Optional[Tuple[str, ...]]
-    ]:
+        self, cols_sel: slice, missing_keys: Optional[List[Tuple]]
+    ) -> Tuple[List[Tuple], Optional[List[spark.Column]], bool, Optional[Tuple]]:
         if all(
             s is None or isinstance(s, int) for s in (cols_sel.start, cols_sel.stop, cols_sel.step)
         ):
@@ -1558,10 +1533,8 @@ class iLocIndexer(LocIndexerLike):
         return column_labels, data_spark_columns, False, None
 
     def _select_cols_by_iterable(
-        self, cols_sel: Iterable, missing_keys: Optional[List[Tuple[str, ...]]]
-    ) -> Tuple[
-        List[Tuple[str, ...]], Optional[List[spark.Column]], bool, Optional[Tuple[str, ...]]
-    ]:
+        self, cols_sel: Iterable, missing_keys: Optional[List[Tuple]]
+    ) -> Tuple[List[Tuple], Optional[List[spark.Column]], bool, Optional[Tuple]]:
         if all(isinstance(s, bool) for s in cols_sel):
             cols_sel = [i for i, s in enumerate(cols_sel) if s]
         if all(isinstance(s, int) for s in cols_sel):
@@ -1572,10 +1545,8 @@ class iLocIndexer(LocIndexerLike):
             raise TypeError("cannot perform reduce with flexible type")
 
     def _select_cols_else(
-        self, cols_sel: Any, missing_keys: Optional[List[Tuple[str, ...]]]
-    ) -> Tuple[
-        List[Tuple[str, ...]], Optional[List[spark.Column]], bool, Optional[Tuple[str, ...]]
-    ]:
+        self, cols_sel: Any, missing_keys: Optional[List[Tuple]]
+    ) -> Tuple[List[Tuple], Optional[List[spark.Column]], bool, Optional[Tuple]]:
         if isinstance(cols_sel, int):
             if cols_sel > len(self._internal.column_labels):
                 raise KeyError(cols_sel)

--- a/databricks/koalas/tests/test_indexing.py
+++ b/databricks/koalas/tests/test_indexing.py
@@ -133,6 +133,17 @@ class IndexingTest(ReusedSQLTestCase):
     def kdf(self):
         return ks.from_pandas(self.pdf)
 
+    @property
+    def pdf2(self):
+        return pd.DataFrame(
+            {0: [1, 2, 3, 4, 5, 6, 7, 8, 9], 1: [4, 5, 6, 3, 2, 1, 0, 0, 0]},
+            index=[0, 1, 3, 5, 6, 8, 9, 9, 9],
+        )
+
+    @property
+    def kdf2(self):
+        return ks.from_pandas(self.pdf2)
+
     def test_at(self):
         pdf = self.pdf
         kdf = self.kdf
@@ -179,6 +190,16 @@ class IndexingTest(ReusedSQLTestCase):
         with self.assertRaises(TypeError):
             kdf.at[3, "b"] = 10
 
+        # non-string column names
+        pdf = self.pdf2
+        kdf = self.kdf2
+
+        # Assert .at for DataFrames
+        self.assertEqual(kdf.at[3, 1], 6)
+        self.assertEqual(kdf.at[3, 1], pdf.at[3, 1])
+        self.assert_eq(kdf.at[9, 1], np.array([0, 0, 0]))
+        self.assert_eq(kdf.at[9, 1], pdf.at[9, 1])
+
     def test_at_multiindex(self):
         pdf = self.pdf.set_index("b", append=True)
         kdf = self.kdf.set_index("b", append=True)
@@ -208,6 +229,14 @@ class IndexingTest(ReusedSQLTestCase):
 
         with self.assertRaises(KeyError):
             kdf.at["B", "bar"]
+
+        # non-string column names
+        arrays = [np.array([0, 0, 1, 1]), np.array([1, 2, 1, 2])]
+
+        pdf = pd.DataFrame(np.random.randn(3, 4), index=["A", "B", "C"], columns=arrays)
+        kdf = ks.from_pandas(pdf)
+
+        self.assert_eq(kdf.at["B", (0, 1)], pdf.at["B", (0, 1)])
 
     def test_iat(self):
         pdf = self.pdf
@@ -533,6 +562,19 @@ class IndexingTest(ReusedSQLTestCase):
         self.assert_eq(kdf.loc[:, "a":"d"], pdf.loc[:, "a":"d"])
         self.assert_eq(kdf.loc[:, "c":"d"], pdf.loc[:, "c":"d"])
 
+        # non-string column names
+        kdf = self.kdf2
+        pdf = self.pdf2
+
+        self.assert_eq(kdf.loc[5:5, 0], pdf.loc[5:5, 0])
+        self.assert_eq(kdf.loc[5:5, [0]], pdf.loc[5:5, [0]])
+        self.assert_eq(kdf.loc[3:8, 0], pdf.loc[3:8, 0])
+        self.assert_eq(kdf.loc[3:8, [0]], pdf.loc[3:8, [0]])
+
+        self.assert_eq(kdf.loc[:, 0:0], pdf.loc[:, 0:0])
+        self.assert_eq(kdf.loc[:, 0:3], pdf.loc[:, 0:3])
+        self.assert_eq(kdf.loc[:, 2:3], pdf.loc[:, 2:3])
+
     def test_loc2d_multiindex_columns(self):
         arrays = [np.array(["bar", "bar", "baz", "baz"]), np.array(["one", "two", "one", "two"])]
 
@@ -568,6 +610,20 @@ class IndexingTest(ReusedSQLTestCase):
 
         self.assertRaises(KeyError, lambda: kdf.loc[:, "bar":("baz", "one")])
         self.assertRaises(KeyError, lambda: kdf.loc[:, ("bar", "two"):"bar"])
+
+        # non-string column names
+        arrays = [np.array([0, 0, 1, 1]), np.array([1, 2, 1, 2])]
+
+        pdf = pd.DataFrame(np.random.randn(3, 4), index=["A", "B", "C"], columns=arrays)
+        kdf = ks.from_pandas(pdf)
+
+        self.assert_eq(kdf.loc["B":"B", 0], pdf.loc["B":"B", 0])
+        self.assert_eq(kdf.loc["B":"B", [0]], pdf.loc["B":"B", [0]])
+        self.assert_eq(kdf.loc[:, 0:0], pdf.loc[:, 0:0])
+        self.assert_eq(kdf.loc[:, 0:(1, 1)], pdf.loc[:, 0:(1, 1)])
+        self.assert_eq(kdf.loc[:, (0, 2):(1, 1)], pdf.loc[:, (0, 2):(1, 1)])
+        self.assert_eq(kdf.loc[:, (0, 2):0], pdf.loc[:, (0, 2):0])
+        self.assert_eq(kdf.loc[:, -1:2], pdf.loc[:, -1:2])
 
     def test_loc2d_with_known_divisions(self):
         pdf = pd.DataFrame(
@@ -638,6 +694,19 @@ class IndexingTest(ReusedSQLTestCase):
 
         # TODO?: self.assertRaises(KeyError, lambda: pdf[8])
         # TODO?: self.assertRaises(KeyError, lambda: pdf[[1, 8]])
+
+        # non-string column names
+        pdf = pd.DataFrame(
+            {
+                10: [1, 2, 3, 4, 5, 6, 7, 8, 9],
+                20: [9, 8, 7, 6, 5, 4, 3, 2, 1],
+                30: [True, False, True] * 3,
+            }
+        )
+        kdf = ks.from_pandas(pdf)
+
+        self.assert_eq(kdf[10], pdf[10])
+        self.assert_eq(kdf[[10, 20]], pdf[[10, 20]])
 
     def test_getitem_slice(self):
         pdf = pd.DataFrame(

--- a/databricks/koalas/utils.py
+++ b/databricks/koalas/utils.py
@@ -539,7 +539,9 @@ def name_like_string(name: Optional[Union[str, Tuple]]) -> str:
     return ("(%s)" % ", ".join(name)) if len(name) > 1 else name[0]
 
 
-def is_name_like_tuple(value: Tuple, allow_none: bool = True, check_type: bool = False) -> bool:
+def is_name_like_tuple(
+    value: Optional[Tuple], allow_none: bool = True, check_type: bool = False
+) -> bool:
     """
     Check the given tuple is be able to be used as a name.
 

--- a/databricks/koalas/utils.py
+++ b/databricks/koalas/utils.py
@@ -21,7 +21,7 @@ import functools
 from collections import OrderedDict
 from distutils.version import LooseVersion
 import os
-from typing import Callable, Dict, List, Optional, Tuple, Union, TYPE_CHECKING
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union, TYPE_CHECKING
 
 import pyarrow
 import pyspark
@@ -33,6 +33,7 @@ from pandas.api.types import is_list_like
 
 # For running doctests and reference resolution in PyCharm.
 from databricks import koalas as ks  # noqa: F401
+from databricks.koalas.typedef.typehints import as_spark_type
 
 if TYPE_CHECKING:
     # This is required in old Python 3.5 to prevent circular reference.
@@ -536,6 +537,94 @@ def name_like_string(name: Optional[Union[str, Tuple]]) -> str:
     else:
         name = (str(name),)
     return ("(%s)" % ", ".join(name)) if len(name) > 1 else name[0]
+
+
+def is_name_like_tuple(value: Tuple, allow_none: bool = True, check_type: bool = False) -> bool:
+    """
+    Check the given tuple is be able to be used as a name.
+
+    Examples
+    --------
+    >>> is_name_like_tuple(('abc',))
+    True
+    >>> is_name_like_tuple((1,))
+    True
+    >>> is_name_like_tuple(('abc', 1, None))
+    True
+    >>> is_name_like_tuple(('abc', 1, None), check_type=True)
+    True
+    >>> is_name_like_tuple((1.0j,))
+    True
+    >>> is_name_like_tuple(tuple())
+    False
+    >>> is_name_like_tuple((list('abc'),))
+    False
+    >>> is_name_like_tuple(('abc', 1, None), allow_none=False)
+    False
+    >>> is_name_like_tuple((1.0j,), check_type=True)
+    False
+    """
+    if value is None:
+        return allow_none
+    elif not isinstance(value, tuple):
+        return False
+    elif len(value) == 0:
+        return False
+    elif not allow_none and any(v is None for v in value):
+        return False
+    elif any(is_list_like(v) or isinstance(v, slice) for v in value):
+        return False
+    elif check_type:
+        try:
+            return all(v is None or as_spark_type(type(v)) is not None for v in value)
+        except TypeError:
+            return False
+    else:
+        return True
+
+
+def is_name_like_value(
+    value: Any, allow_none: bool = True, allow_tuple: bool = True, check_type: bool = False
+) -> bool:
+    """
+    Check the given value is like a name.
+
+    Examples
+    --------
+    >>> is_name_like_value('abc')
+    True
+    >>> is_name_like_value(1)
+    True
+    >>> is_name_like_value(None)
+    True
+    >>> is_name_like_value(('abc',))
+    True
+    >>> is_name_like_value(1.0j)
+    True
+    >>> is_name_like_value(list('abc'))
+    False
+    >>> is_name_like_value(None, allow_none=False)
+    False
+    >>> is_name_like_value(('abc',), allow_tuple=False)
+    False
+    >>> is_name_like_value(1.0j, check_type=True)
+    False
+    """
+    if value is None:
+        return allow_none
+    elif isinstance(value, tuple):
+        return allow_tuple and is_name_like_tuple(
+            value, allow_none=allow_none, check_type=check_type
+        )
+    elif is_list_like(value) or isinstance(value, slice):
+        return False
+    elif check_type:
+        try:
+            return as_spark_type(type(value)) is not None
+        except TypeError:
+            return False
+    else:
+        return True
 
 
 def validate_axis(axis=0, none_axis=0):


### PR DESCRIPTION
Enables column indexing for non-string column names as currently it is not available. 

```py
>>> kdf = ks.DataFrame({0: [1, 2, 3, 4, 5, 6, 7, 8, 9], 1: [4, 5, 6, 3, 2, 1, 0, 0, 0]}, index=[0, 1, 3, 5, 6, 8, 9, 9, 9])
>>> kdf.loc[:, 0]
Traceback (most recent call last):
...
AssertionError

>>> kdf[0]
Traceback (most recent call last):
...
NotImplementedError: 0
```