### PR TITLE
Fix Series.astype to work properly

### DIFF
--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -1025,6 +1025,10 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
                 scol = F.when(self.spark.column.isNull(), F.lit(False)).otherwise(
                     self.spark.column.cast(spark_type)
                 )
+        elif isinstance(spark_type, StringType):
+            scol = F.when(self.spark.column.isNull(), str(None)).otherwise(
+                self.spark.column.cast(spark_type)
+            )
         else:
             scol = self.spark.column.cast(spark_type)
         return self._with_new_scol(scol)

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -1121,6 +1121,7 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         kser = ks.Series(pser)
 
         self.assert_eq(kser.astype(bool), pser.astype(bool))
+        self.assert_eq(kser.astype(str).tolist(), pser.astype(str).tolist())
         self.assert_eq(kser.str.strip().astype(bool), pser.str.strip().astype(bool))
 
         pser = pd.Series([True, False, None], name="x")

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -1123,7 +1123,9 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         kser = ks.Series(pser)
 
         self.assert_eq(kser.astype(bool), pser.astype(bool))
-        self.assert_eq(kser.astype(str).tolist(), pser.astype(str).tolist())
+        # TODO: restore after pandas 1.1.4 is released.
+        # self.assert_eq(kser.astype(str).tolist(), pser.astype(str).tolist())
+        self.assert_eq(kser.astype(str).tolist(), ["hi", "hi ", " ", " \t", "", "None"])
         self.assert_eq(kser.str.strip().astype(bool), pser.str.strip().astype(bool))
 
         pser = pd.Series([True, False, None], name="x")


### PR DESCRIPTION
This should fix #1806 

```python
>>> data = ks.Series(['a', 'b', 'c', None])
>>> sorted(data.astype(str).tolist())
['None', 'a', 'b', 'c']
```

For `DataFrame.astype` also works.

```python
>>> kdf
   A     B     C
0  3  10.0     a
1  4  20.0     b
2  5  30.0     c
3  6  40.0     d
4  7  50.0  None

>>> sorted(kdf.astype(str).C.tolist())
['None', 'a', 'b', 'c', 'd']
```