### PR TITLE
The test in test_groupby is working after pandas 1.0.4.

### DIFF
--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -168,7 +168,11 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             kdf.groupby(("x", "a"))[[("y", "c")]].sum().sort_index(),
             pdf.groupby(("x", "a"))[[("y", "c")]].sum().sort_index(),
         )
-
+        # TODO: should work?
+        # self.assert_eq(
+        #     kdf.groupby(("x", "a"))[("y", "c")].sum().sort_index(),
+        #     pdf.groupby(("x", "a"))[("y", "c")].sum().sort_index(),
+        # )
         self.assert_eq(
             kdf[("x", "a")].groupby(kdf[("x", "b")]).sum().sort_index(),
             pdf[("x", "a")].groupby(pdf[("x", "b")]).sum().sort_index(),

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -168,23 +168,11 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             kdf.groupby(("x", "a"))[[("y", "c")]].sum().sort_index(),
             pdf.groupby(("x", "a"))[[("y", "c")]].sum().sort_index(),
         )
-        # TODO: seems like a pandas' bug. it works well in Koalas like the below.
-        # >>> pdf[('x', 'a')].groupby(pdf[('x', 'b')]).sum().sort_index()
-        # Traceback (most recent call last):
-        # ...
-        # ValueError: Can only tuple-index with a MultiIndex
-        # >>> kdf[('x', 'a')].groupby(kdf[('x', 'b')]).sum().sort_index()
-        # (x, b)
-        # 1    13
-        # 2     9
-        # 3     8
-        # 4     1
-        # 7     6
-        # Name: (x, a), dtype: int64
-        expected_result = ks.Series(
-            [13, 9, 8, 1, 6], name=("x", "a"), index=pd.Index([1, 2, 3, 4, 7], name=("x", "b"))
+
+        self.assert_eq(
+            kdf[("x", "a")].groupby(kdf[("x", "b")]).sum().sort_index(),
+            pdf[("x", "a")].groupby(pdf[("x", "b")]).sum().sort_index(),
         )
-        self.assert_eq(kdf[("x", "a")].groupby(kdf[("x", "b")]).sum().sort_index(), expected_result)
 
     def test_split_apply_combine_on_series(self):
         pdf = pd.DataFrame(


### PR DESCRIPTION
Previously there was a behavior we suspected a bug in pandas, but seems like it's working since pandas 1.0.4:

```py
>>> pdf = pd.DataFrame({("x", "a"): [1, 2, 6, 4, 4, 6, 4, 3, 7], ("x", "b"): [4, 2, 7, 3, 3, 1, 1, 1, 2], ("y", "c"): [4, 2, 7, 3, None, 1, 1, 1, 2], ("z", "d"): list("abcdefght")}, index=[0, 1, 3, 5, 6, 8, 9, 9, 9])
>>> pdf
   x       y  z
   a  b    c  d
0  1  4  4.0  a
1  2  2  2.0  b
3  6  7  7.0  c
5  4  3  3.0  d
6  4  3  NaN  e
8  6  1  1.0  f
9  4  1  1.0  g
9  3  1  1.0  h
9  7  2  2.0  t
>>> pdf[("x", "a")].groupby(pdf[("x", "b")]).sum().sort_index()
(x, b)
1    13
2     9
3     8
4     1
7     6
Name: (x, a), dtype: int64
```

We should use the pandas result.
