### PR TITLE
Upgrade pandas to 1.1.3 for CI.

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -115,7 +115,7 @@ jobs:
             pyarrow-version: 0.15.1
           - python-version: 3.8
             spark-version: 3.0.1
-            pandas-version: 1.1.2
+            pandas-version: 1.1.3
             pyarrow-version: 1.0.1
             default-index-type: 'distributed-sequence'
     env:


### PR DESCRIPTION
pandas 1.1.3 has been released on October 5, 2020.

- https://pandas.pydata.org/docs/whatsnew/v1.1.3.html