### PR TITLE
Fix to_list work properly in pandas==0.23

### DIFF
--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -1478,7 +1478,11 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             to be small, as all the data is loaded into the driver's memory.
 
         """
-        return self._to_internal_pandas().to_list()
+        # pandas<0.24 doesn't support `to_list()` as an alias for `tolist()`
+        if LooseVersion(pd.__version__) < LooseVersion("0.24"):
+            return self._to_internal_pandas().tolist()
+        else:
+            return self._to_internal_pandas().to_list()
 
     tolist = to_list
 

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -860,8 +860,7 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         self.assertEqual((pser + 1).is_unique, (kser + 1).is_unique)
 
     def test_to_list(self):
-        if LooseVersion(pd.__version__) >= LooseVersion("0.24.0"):
-            self.assertEqual(self.kser.to_list(), self.pser.to_list())
+        self.assert_eq(self.kser.to_list(), self.pser.to_list())
 
     def test_append(self):
         pser1 = pd.Series([1, 2, 3], name="0")

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -860,7 +860,10 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         self.assertEqual((pser + 1).is_unique, (kser + 1).is_unique)
 
     def test_to_list(self):
-        self.assert_eq(self.kser.to_list(), self.pser.to_list())
+        if LooseVersion(pd.__version__) >= LooseVersion("0.24.0"):
+            self.assert_eq(self.kser.to_list(), self.pser.to_list())
+        else:
+            self.assert_eq(self.kser.tolist(), self.pser.tolist())
 
     def test_append(self):
         pser1 = pd.Series([1, 2, 3], name="0")


### PR DESCRIPTION
`Koalas` doesn't support `to_list` in `pandas<0.24` because `pandas<0.24` doesn't support `to_list` as an alias for `tolist`.

```python
>>> pd.__version__
'0.23.2'
>>> pser.to_list()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/haejoon.lee/opt/miniconda3/envs/koalas-dev-3.6/lib/python3.6/site-packages/pandas/core/generic.py", line 4372, in __getattr__
    return object.__getattribute__(self, name)
AttributeError: 'Series' object has no attribute 'to_list'
>>> pser.tolist()
[1, 2, 3]
```

This PR fix it to make working `to_list` properly in pandas<0.24.