### PR TITLE
Standardize binary operations between int and str columns

### DIFF
--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -235,13 +235,15 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
         return column_op(Column.__sub__)(self, other)
 
     def __mul__(self, other):
-        if isinstance(self.spark.data_type, NumericType):
-            if isinstance(other, IndexOpsMixin) and isinstance(other.spark.data_type, StringType):
-                return column_op(SF.repeat)(other, self)
-            elif isinstance(other, str):
-                raise TypeError(
-                    "multiplication can not be applied to an int series and a string literal"
-                )
+        if isinstance(self, str) or isinstance(other, str):
+            raise TypeError("multiplication can not be applied to a string literal")
+
+        if (
+            isinstance(self.spark.data_type, NumericType)
+            and isinstance(other, IndexOpsMixin)
+            and isinstance(other.spark.data_type, StringType)
+        ):
+            return column_op(SF.repeat)(other, self)
 
         if isinstance(self.spark.data_type, StringType) and (
             (isinstance(other, IndexOpsMixin) and isinstance(other.spark.data_type, NumericType))
@@ -291,7 +293,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
             or (isinstance(other, IndexOpsMixin) and isinstance(other.spark.data_type, StringType))
             or isinstance(other, str)
         ):
-            raise TypeError("mod can not be applied on string series or literals.")
+            raise TypeError("modulo can not be applied on string series or literals.")
 
         def mod(left, right):
             return ((left % right) + right) % right
@@ -345,14 +347,12 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
         return column_op(Column.__rsub__)(self, other)
 
     def __rmul__(self, other):
+        if isinstance(other, str):
+            raise TypeError("multiplication can not be applied to a string literal")
+
         if isinstance(self.spark.data_type, StringType):
             if isinstance(other, int):
                 return column_op(SF.repeat)(self, other)
-        if isinstance(self.spark.data_type, NumericType):
-            if isinstance(other, str):
-                raise TypeError(
-                    "multiplication can not be applied to an int series and a string literal"
-                )
 
         return column_op(Column.__rmul__)(self, other)
 

--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -417,7 +417,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
 
     def __rmod__(self, other):
         if isinstance(self.spark.data_type, StringType) or isinstance(other, str):
-            raise TypeError("mod can not be applied on string series or literals.")
+            raise TypeError("modulo can not be applied on string series or literals.")
 
         def rmod(left, right):
             return ((right % left) + left) % left

--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -262,6 +262,13 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
         +-----------------------|---------|---------+
         """
 
+        if (
+            isinstance(self.spark.data_type, StringType)
+            or (isinstance(other, IndexOpsMixin) and isinstance(other.spark.data_type, StringType))
+            or isinstance(other, str)
+        ):
+            raise TypeError("division can not be applied on string series or literals.")
+
         def truediv(left, right):
             return F.when(F.lit(right != 0) | F.lit(right).isNull(), left.__div__(right)).otherwise(
                 F.when(F.lit(left == np.inf) | F.lit(left == -np.inf), left).otherwise(
@@ -334,6 +341,9 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
     __rmul__ = column_op(Column.__rmul__)
 
     def __rtruediv__(self, other):
+        if isinstance(self.spark.data_type, StringType) or isinstance(other, str):
+            raise TypeError("division can not be applied on string series or literals.")
+
         def rtruediv(left, right):
             return F.when(left == 0, F.lit(np.inf).__div__(right)).otherwise(
                 F.lit(right).__truediv__(left)
@@ -358,6 +368,12 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
         |          -10          |   null  | -np.inf |
         +-----------------------|---------|---------+
         """
+        if (
+            isinstance(self.spark.data_type, StringType)
+            or (isinstance(other, IndexOpsMixin) and isinstance(other.spark.data_type, StringType))
+            or isinstance(other, str)
+        ):
+            raise TypeError("division can not be applied on string series or literals.")
 
         def floordiv(left, right):
             return F.when(F.lit(right is np.nan), np.nan).otherwise(
@@ -373,6 +389,9 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
         return numpy_column_op(floordiv)(self, other)
 
     def __rfloordiv__(self, other):
+        if isinstance(self.spark.data_type, StringType) or isinstance(other, str):
+            raise TypeError("division can not be applied on string series or literals.")
+
         def rfloordiv(left, right):
             return F.when(F.lit(left == 0), F.lit(np.inf).__div__(right)).otherwise(
                 F.when(F.lit(left) == np.nan, np.nan).otherwise(F.floor(F.lit(right).__div__(left)))

--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -37,6 +37,7 @@ from pyspark.sql.types import (
     LongType,
     StringType,
     TimestampType,
+    NumericType
 )
 
 from databricks import koalas as ks  # For running doctests and reference resolution in PyCharm.
@@ -171,7 +172,10 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
     __neg__ = column_op(Column.__neg__)
 
     def __add__(self, other):
-        if isinstance(self.spark.data_type, StringType):
+        if isinstance(self.spark.data_type, NumericType):
+            if (isinstance(other, IndexOpsMixin) and isinstance(other.spark.data_type, StringType)) or isinstance(other, str):
+                raise TypeError("string addition can only be applied to string series or literals.")
+        elif isinstance(self.spark.data_type, StringType):
             # Concatenate string columns
             if isinstance(other, IndexOpsMixin) and isinstance(other.spark.data_type, StringType):
                 return column_op(F.concat)(self, other)

--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -295,6 +295,13 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
         return numpy_column_op(truediv)(self, other)
 
     def __mod__(self, other):
+        if (
+            isinstance(self.spark.data_type, StringType)
+            or (isinstance(other, IndexOpsMixin) and isinstance(other.spark.data_type, StringType))
+            or isinstance(other, str)
+        ):
+            raise TypeError("mod can not be applied on string series or literals.")
+
         def mod(left, right):
             return ((left % right) + right) % right
 
@@ -426,6 +433,9 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
         return numpy_column_op(rfloordiv)(self, other)
 
     def __rmod__(self, other):
+        if isinstance(self.spark.data_type, StringType) or isinstance(other, str):
+            raise TypeError("mod can not be applied on string series or literals.")
+
         def rmod(left, right):
             return ((right % left) + left) % left
 

--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -173,11 +173,11 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
     __neg__ = column_op(Column.__neg__)
 
     def __add__(self, other):
-        if not isinstance(self.spark.data_type, StringType):
-            if (
-                isinstance(other, IndexOpsMixin) and isinstance(other.spark.data_type, StringType)
-            ) or isinstance(other, str):
-                raise TypeError("string addition can only be applied to string series or literals.")
+        if not isinstance(self.spark.data_type, StringType) and (
+            (isinstance(other, IndexOpsMixin) and isinstance(other.spark.data_type, StringType))
+            or isinstance(other, str)
+        ):
+            raise TypeError("string addition can only be applied to string series or literals.")
         if isinstance(self.spark.data_type, StringType):
             # Concatenate string columns
             if isinstance(other, IndexOpsMixin) and isinstance(other.spark.data_type, StringType):
@@ -302,9 +302,8 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
 
     def __radd__(self, other):
         # Handle 'literal' + df['col']
-        if not isinstance(self.spark.data_type, StringType):
-            if isinstance(other, str):
-                raise TypeError("string addition can only be applied to string series or literals.")
+        if not isinstance(self.spark.data_type, StringType) and isinstance(other, str):
+            raise TypeError("string addition can only be applied to string series or literals.")
 
         if isinstance(self.spark.data_type, StringType):
             if isinstance(other, str):
@@ -350,9 +349,8 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
         if isinstance(other, str):
             raise TypeError("multiplication can not be applied to a string literal")
 
-        if isinstance(self.spark.data_type, StringType):
-            if isinstance(other, int):
-                return column_op(SF.repeat)(self, other)
+        if isinstance(self.spark.data_type, StringType) and isinstance(other, int):
+            return column_op(SF.repeat)(self, other)
 
         return column_op(Column.__rmul__)(self, other)
 

--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -34,10 +34,10 @@ from pyspark.sql.types import (
     DateType,
     DoubleType,
     FloatType,
+    IntegralType,
     LongType,
     StringType,
     TimestampType,
-    NumericType,
 )
 
 from databricks import koalas as ks  # For running doctests and reference resolution in PyCharm.
@@ -173,7 +173,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
     __neg__ = column_op(Column.__neg__)
 
     def __add__(self, other):
-        if isinstance(self.spark.data_type, NumericType):
+        if not isinstance(self.spark.data_type, StringType):
             if (
                 isinstance(other, IndexOpsMixin) and isinstance(other.spark.data_type, StringType)
             ) or isinstance(other, str):
@@ -235,18 +235,18 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
         return column_op(Column.__sub__)(self, other)
 
     def __mul__(self, other):
-        if isinstance(self, str) or isinstance(other, str):
+        if isinstance(other, str):
             raise TypeError("multiplication can not be applied to a string literal")
 
         if (
-            isinstance(self.spark.data_type, NumericType)
+            isinstance(self.spark.data_type, IntegralType)
             and isinstance(other, IndexOpsMixin)
             and isinstance(other.spark.data_type, StringType)
         ):
             return column_op(SF.repeat)(other, self)
 
         if isinstance(self.spark.data_type, StringType) and (
-            (isinstance(other, IndexOpsMixin) and isinstance(other.spark.data_type, NumericType))
+            (isinstance(other, IndexOpsMixin) and isinstance(other.spark.data_type, IntegralType))
             or isinstance(other, int)
         ):
             return column_op(SF.repeat)(self, other)
@@ -302,7 +302,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
 
     def __radd__(self, other):
         # Handle 'literal' + df['col']
-        if isinstance(self.spark.data_type, NumericType):
+        if not isinstance(self.spark.data_type, StringType):
             if isinstance(other, str):
                 raise TypeError("string addition can only be applied to string series or literals.")
 

--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -191,21 +191,12 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
             return column_op(Column.__add__)(self, other)
 
     def __sub__(self, other):
-        if isinstance(self.spark.data_type, NumericType):
-            if (
-                isinstance(other, IndexOpsMixin) and isinstance(other.spark.data_type, StringType)
-            ) or isinstance(other, str):
-                raise TypeError(
-                    "string substraction can only be applied to string series or literals."
-                )
-        elif isinstance(self.spark.data_type, StringType):
-            if not (
-                (isinstance(other, IndexOpsMixin) and isinstance(other.spark.data_type, StringType))
-                or isinstance(other, str)
-            ):
-                raise TypeError(
-                    "string substraction can only be applied to string series or literals."
-                )
+        if (
+            isinstance(self.spark.data_type, StringType)
+            or (isinstance(other, IndexOpsMixin) and isinstance(other.spark.data_type, StringType))
+            or isinstance(other, str)
+        ):
+            raise TypeError("substraction can not be applied to string series or literals.")
 
         if isinstance(self.spark.data_type, TimestampType):
             # Note that timestamp subtraction casts arguments to integer. This is to mimic pandas's
@@ -322,16 +313,8 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
             return column_op(Column.__radd__)(self, other)
 
     def __rsub__(self, other):
-        if isinstance(self.spark.data_type, NumericType):
-            if isinstance(other, str):
-                raise TypeError(
-                    "string substraction can only be applied to string series or literals."
-                )
-        elif isinstance(self.spark.data_type, StringType):
-            if not isinstance(other, str):
-                raise TypeError(
-                    "string substraction can only be applied to string series or literals."
-                )
+        if isinstance(self.spark.data_type, StringType) or isinstance(other, str):
+            raise TypeError("substraction can not be applied to string series or literals.")
 
         if isinstance(self.spark.data_type, TimestampType):
             # Note that timestamp subtraction casts arguments to integer. This is to mimic pandas's

--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -236,7 +236,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
 
     def __mul__(self, other):
         if isinstance(other, str):
-            raise TypeError("multiplication can not be applied to a string literal")
+            raise TypeError("multiplication can not be applied to a string literal.")
 
         if (
             isinstance(self.spark.data_type, IntegralType)
@@ -347,7 +347,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
 
     def __rmul__(self, other):
         if isinstance(other, str):
-            raise TypeError("multiplication can not be applied to a string literal")
+            raise TypeError("multiplication can not be applied to a string literal.")
 
         if isinstance(self.spark.data_type, StringType) and isinstance(other, int):
             return column_op(SF.repeat)(self, other)

--- a/databricks/koalas/spark/functions.py
+++ b/databricks/koalas/spark/functions.py
@@ -77,6 +77,15 @@ def array_repeat(col, count):
     )
 
 
+def repeat(col, n):
+    """
+    Repeats a string column n times, and returns it as a new string column.
+    """
+    sc = SparkContext._active_spark_context
+    n = _to_java_column(n) if isinstance(n, Column) else _create_column_from_literal(n)
+    return _call_udf(sc, "repeat", _to_java_column(col), n)
+
+
 def _call_udf(sc, name, *cols):
     return Column(sc._jvm.functions.callUDF(name, _make_arguments(sc, *cols)))
 

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -1752,6 +1752,9 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         )
 
     def test_binary_operator_add(self):
+        kdf = ks.DataFrame({"a": ["x", "y"], "b": ["i", "j"]})
+        kdf["a"] + kdf["b"]
+
         kdf = ks.DataFrame({"a": ["x"], "b": [1]})
         ks_err_msg = re.escape("string addition can only be applied to string series or literals")
 
@@ -1848,6 +1851,26 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assertRaises(TypeError, lambda: "literal" // pdf["b"])
 
         self.assertRaises(TypeError, lambda: 1 // pdf["a"])
+
+    def test_binary_operator_multiply(self):
+        kdf = ks.DataFrame({"a": ["x", "y"], "b": [1, 2]})
+        pdf = pd.DataFrame({"a": ["x", "y"], "b": [1, 2]})
+
+        self.assert_eq(kdf["a"] * kdf["b"], pdf["a"] * pdf["b"])
+        self.assert_eq(kdf["b"] * kdf["a"], pdf["b"] * pdf["a"])
+        self.assert_eq(kdf["a"] * 2, pdf["a"] * 2)
+        self.assert_eq(kdf["b"] * 2, pdf["b"] * 2)
+        self.assert_eq(2 * kdf["a"], 2 * pdf["a"])
+        self.assert_eq(2 * kdf["b"], 2 * pdf["b"])
+
+        kdf = ks.DataFrame({"a": ["x"], "b": [2]})
+        ks_err_msg = "multiplication can not be applied to an int series and a string literal"
+        self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["b"] * "literal")
+        self.assertRaisesRegex(TypeError, ks_err_msg, lambda: "literal" * kdf["b"])
+
+        pdf = pd.DataFrame({"a": ["x"], "b": [2]})
+        self.assertRaises(TypeError, lambda: pdf["b"] * "literal")
+        self.assertRaises(TypeError, lambda: "literal" * pdf["b"])
 
     def test_sample(self):
         pdf = pd.DataFrame({"A": [0, 2, 4]})

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -16,7 +16,6 @@
 from datetime import datetime
 from distutils.version import LooseVersion
 import inspect
-import re
 import sys
 import unittest
 from io import StringIO
@@ -1753,20 +1752,21 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
     def test_binary_operator_add(self):
         # Positive
-        pdf = pd.DataFrame({"a": ["x"], "b": ["y"]})
+        pdf = pd.DataFrame({"a": ["x"], "b": ["y"], "c": [1], "d": [2]})
         kdf = ks.from_pandas(pdf)
 
         self.assert_eq(kdf["a"] + kdf["b"], pdf["a"] + pdf["b"])
+        self.assert_eq(kdf["c"] + kdf["d"], pdf["c"] + pdf["d"])
 
         # Negative
-        kdf = ks.DataFrame({"a": ["x"], "b": [1]})
-        ks_err_msg = re.escape("string addition can only be applied to string series or literals")
+        ks_err_msg = "string addition can only be applied to string series or literals"
 
-        self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["a"] + kdf["b"])
-        self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["b"] + kdf["a"])
-        self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["b"] + "literal")
-        self.assertRaisesRegex(TypeError, ks_err_msg, lambda: "literal" + kdf["b"])
+        self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["a"] + kdf["c"])
+        self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["c"] + kdf["a"])
+        self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["c"] + "literal")
+        self.assertRaisesRegex(TypeError, ks_err_msg, lambda: "literal" + kdf["c"])
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: 1 + kdf["a"])
+        self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["a"] + 1)
 
         # pdf = pd.DataFrame({"a": ["x"], "b": [1]})
         # self.assertRaises(TypeError, lambda: pdf["a"] + pdf["b"])
@@ -1783,7 +1783,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         # Negative
         kdf = ks.DataFrame({"a": ["x"], "b": [1]})
-        ks_err_msg = re.escape("substraction can not be applied to string series or literals.")
+        ks_err_msg = "substraction can not be applied to string series or literals."
 
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["a"] - kdf["b"])
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["b"] - kdf["a"])
@@ -1813,7 +1813,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         # Negative
         kdf = ks.DataFrame({"a": ["x"], "b": [1]})
-        ks_err_msg = re.escape("division can not be applied on string series or literals")
+        ks_err_msg = "division can not be applied on string series or literals"
 
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["a"] / kdf["b"])
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["b"] / kdf["a"])
@@ -1829,7 +1829,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
     def test_binary_operator_floordiv(self):
         kdf = ks.DataFrame({"a": ["x"], "b": [1]})
-        ks_err_msg = re.escape("division can not be applied on string series or literals")
+        ks_err_msg = "division can not be applied on string series or literals"
 
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["a"] // kdf["b"])
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["b"] // kdf["a"])
@@ -1852,7 +1852,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         # Negative
         kdf = ks.DataFrame({"a": ["x"], "b": [1]})
-        ks_err_msg = re.escape("modulo can not be applied on string series or literals")
+        ks_err_msg = "modulo can not be applied on string series or literals"
 
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["a"] % kdf["b"])
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["b"] % kdf["a"])
@@ -1866,9 +1866,11 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
     def test_binary_operator_multiply(self):
         # Positive
-        pdf = pd.DataFrame({"a": ["x", "y"], "b": [1, 2]})
+        pdf = pd.DataFrame({"a": ["x", "y"], "b": [1, 2], "c": [3, 4]})
         kdf = ks.from_pandas(pdf)
 
+        self.assert_eq(kdf["b"] * kdf["c"], pdf["b"] * pdf["c"])
+        self.assert_eq(kdf["c"] * kdf["b"], pdf["c"] * pdf["b"])
         self.assert_eq(kdf["a"] * kdf["b"], pdf["a"] * pdf["b"])
         self.assert_eq(kdf["b"] * kdf["a"], pdf["b"] * pdf["a"])
         self.assert_eq(kdf["a"] * 2, pdf["a"] * 2)

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -1848,13 +1848,17 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(2 * kdf["b"], 2 * pdf["b"])
 
         kdf = ks.DataFrame({"a": ["x"], "b": [2]})
-        ks_err_msg = "multiplication can not be applied to an int series and a string literal"
+        ks_err_msg = "multiplication can not be applied to a string literal"
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["b"] * "literal")
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: "literal" * kdf["b"])
+        self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["a"] * "literal")
+        self.assertRaisesRegex(TypeError, ks_err_msg, lambda: "literal" * kdf["a"])
 
         # pdf = pd.DataFrame({"a": ["x"], "b": [2]})
         # self.assertRaises(TypeError, lambda: pdf["b"] * "literal")
         # self.assertRaises(TypeError, lambda: "literal" * pdf["b"])
+        # self.assertRaises(TypeError, lambda: pdf["a"] * "literal")
+        # self.assertRaises(TypeError, lambda: "literal" * pdf["a"])
 
     def test_sample(self):
         pdf = pd.DataFrame({"A": [0, 2, 4]})

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -1750,6 +1750,41 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             lambda: ks.range(10).add(ks.range(10).id),
         )
 
+    def test_binary_operator_add(self):
+        kdf = ks.DataFrame({'a': ['x'], 'b': [1]})
+
+        self.assertRaisesRegex(
+            TypeError,
+            "string addition can only be applied to string series or literals",
+            lambda: kdf['a'] + kdf['b'])
+
+        self.assertRaisesRegex(
+            TypeError,
+            "string addition can only be applied to string series or literals",
+            lambda: kdf['b'] + kdf['a'])
+
+        self.assertRaisesRegex(
+            TypeError,
+            "string addition can only be applied to string series or literals",
+            lambda: kdf['b'] + 'literal')
+
+        kdf = ks.DataFrame({'a': ['x'], 'b': [0.1]})
+
+        self.assertRaisesRegex(
+            TypeError,
+            "string addition can only be applied to string series or literals",
+            lambda: kdf['a'] + kdf['b'])
+
+        self.assertRaisesRegex(
+                TypeError,
+                "string addition can only be applied to string series or literals",
+                lambda: kdf['b'] + kdf['a'])
+
+        self.assertRaisesRegex(
+            TypeError,
+            "string addition can only be applied to string series or literals",
+            lambda: kdf['b'] + 'literal')
+
     def test_sample(self):
         pdf = pd.DataFrame({"A": [0, 2, 4]})
         kdf = ks.from_pandas(pdf)

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -1801,6 +1801,54 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         self.assertRaises(TypeError, lambda: 1 - pdf["a"])
 
+    def test_binary_operator_truediv(self):
+        kdf = ks.DataFrame({"a": ["x"], "b": [1]})
+        ks_err_msg = re.escape("division can not be applied on string series or literals")
+
+        self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["a"] / kdf["b"])
+
+        self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["b"] / kdf["a"])
+
+        self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["b"] / "literal")
+
+        self.assertRaisesRegex(TypeError, ks_err_msg, lambda: "literal" / kdf["b"])
+
+        self.assertRaisesRegex(TypeError, ks_err_msg, lambda: 1 / kdf["a"])
+
+        pdf = pd.DataFrame({"a": ["x"], "b": [1]})
+
+        self.assertRaises(TypeError, lambda: pdf["a"] / pdf["b"])
+
+        self.assertRaises(TypeError, lambda: pdf["b"] / pdf["a"])
+
+        self.assertRaises(TypeError, lambda: "literal" / pdf["b"])
+
+        self.assertRaises(TypeError, lambda: 1 / pdf["a"])
+
+    def test_binary_operator_floordiv(self):
+        kdf = ks.DataFrame({"a": ["x"], "b": [1]})
+        ks_err_msg = re.escape("division can not be applied on string series or literals")
+
+        self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["a"] // kdf["b"])
+
+        self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["b"] // kdf["a"])
+
+        self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["b"] // "literal")
+
+        self.assertRaisesRegex(TypeError, ks_err_msg, lambda: "literal" // kdf["b"])
+
+        self.assertRaisesRegex(TypeError, ks_err_msg, lambda: 1 // kdf["a"])
+
+        pdf = pd.DataFrame({"a": ["x"], "b": [1]})
+
+        self.assertRaises(TypeError, lambda: pdf["a"] // pdf["b"])
+
+        self.assertRaises(TypeError, lambda: pdf["b"] // pdf["a"])
+
+        self.assertRaises(TypeError, lambda: "literal" // pdf["b"])
+
+        self.assertRaises(TypeError, lambda: 1 // pdf["a"])
+
     def test_sample(self):
         pdf = pd.DataFrame({"A": [0, 2, 4]})
         kdf = ks.from_pandas(pdf)

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -16,6 +16,7 @@
 from datetime import datetime
 from distutils.version import LooseVersion
 import inspect
+import re
 import sys
 import unittest
 from io import StringIO
@@ -1751,39 +1752,54 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         )
 
     def test_binary_operator_add(self):
-        kdf = ks.DataFrame({'a': ['x'], 'b': [1]})
+        kdf = ks.DataFrame({"a": ["x"], "b": [1]})
+        ks_err_msg = re.escape("string addition can only be applied to string series or literals")
 
-        self.assertRaisesRegex(
-            TypeError,
-            "string addition can only be applied to string series or literals",
-            lambda: kdf['a'] + kdf['b'])
+        self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["a"] + kdf["b"])
 
-        self.assertRaisesRegex(
-            TypeError,
-            "string addition can only be applied to string series or literals",
-            lambda: kdf['b'] + kdf['a'])
+        self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["b"] + kdf["a"])
 
-        self.assertRaisesRegex(
-            TypeError,
-            "string addition can only be applied to string series or literals",
-            lambda: kdf['b'] + 'literal')
+        self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["b"] + "literal")
 
-        kdf = ks.DataFrame({'a': ['x'], 'b': [0.1]})
+        self.assertRaisesRegex(TypeError, ks_err_msg, lambda: "literal" + kdf["b"])
 
-        self.assertRaisesRegex(
-            TypeError,
-            "string addition can only be applied to string series or literals",
-            lambda: kdf['a'] + kdf['b'])
+        self.assertRaisesRegex(TypeError, ks_err_msg, lambda: 1 + kdf["a"])
 
-        self.assertRaisesRegex(
-                TypeError,
-                "string addition can only be applied to string series or literals",
-                lambda: kdf['b'] + kdf['a'])
+        pdf = pd.DataFrame({"a": ["x"], "b": [1]})
 
-        self.assertRaisesRegex(
-            TypeError,
-            "string addition can only be applied to string series or literals",
-            lambda: kdf['b'] + 'literal')
+        self.assertRaises(TypeError, lambda: pdf["a"] + pdf["b"])
+
+        self.assertRaises(TypeError, lambda: pdf["b"] + pdf["a"])
+
+        self.assertRaises(np.core._exceptions.UFuncTypeError, lambda: "literal" + pdf["b"])
+
+        self.assertRaises(TypeError, lambda: 1 + pdf["a"])
+
+    def test_binary_operator_sub(self):
+        kdf = ks.DataFrame({"a": ["x"], "b": [1]})
+        ks_err_msg = re.escape(
+            "string substraction can only be applied to string series or literals."
+        )
+
+        self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["a"] - kdf["b"])
+
+        self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["b"] - kdf["a"])
+
+        self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["b"] - "literal")
+
+        self.assertRaisesRegex(TypeError, ks_err_msg, lambda: "literal" - kdf["b"])
+
+        self.assertRaisesRegex(TypeError, ks_err_msg, lambda: 1 - kdf["a"])
+
+        pdf = pd.DataFrame({"a": ["x"], "b": [1]})
+
+        self.assertRaises(TypeError, lambda: pdf["a"] - pdf["b"])
+
+        self.assertRaises(TypeError, lambda: pdf["b"] - pdf["a"])
+
+        self.assertRaises(np.core._exceptions.UFuncTypeError, lambda: "literal" - pdf["b"])
+
+        self.assertRaises(TypeError, lambda: 1 - pdf["a"])
 
     def test_sample(self):
         pdf = pd.DataFrame({"A": [0, 2, 4]})

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -1768,12 +1768,6 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: 1 + kdf["a"])
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["a"] + 1)
 
-        # pdf = pd.DataFrame({"a": ["x"], "b": [1]})
-        # self.assertRaises(TypeError, lambda: pdf["a"] + pdf["b"])
-        # self.assertRaises(TypeError, lambda: pdf["b"] + pdf["a"])
-        # self.assertRaises(np.core._exceptions.UFuncTypeError, lambda: "literal" + pdf["b"])
-        # self.assertRaises(TypeError, lambda: 1 + pdf["a"])
-
     def test_binary_operator_sub(self):
         # Positive
         pdf = pd.DataFrame({"a": [2], "b": [1]})
@@ -1795,15 +1789,6 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         kdf = ks.DataFrame({"a": ["x"], "b": ["y"]})
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["a"] - kdf["b"])
 
-        # pdf = pd.DataFrame({"a": ["x"], "b": [1]})
-        # self.assertRaises(TypeError, lambda: pdf["a"] - pdf["b"])
-        # self.assertRaises(TypeError, lambda: pdf["b"] - pdf["a"])
-        # self.assertRaises(np.core._exceptions.UFuncTypeError, lambda: "literal" - pdf["b"])
-        # self.assertRaises(TypeError, lambda: 1 - pdf["a"])
-        # self.assertRaises(TypeError, lambda: pdf["a"] - 1)
-        # pdf = pd.DataFrame({"a": ["x"], "b": ["y"]})
-        # self.assertRaises(TypeError, lambda: pdf["a"] - pdf["b"])
-
     def test_binary_operator_truediv(self):
         # Positive
         pdf = pd.DataFrame({"a": [3], "b": [2]})
@@ -1821,12 +1806,6 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: "literal" / kdf["b"])
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: 1 / kdf["a"])
 
-        # pdf = pd.DataFrame({"a": ["x"], "b": [1]})
-        # self.assertRaises(TypeError, lambda: pdf["a"] / pdf["b"])
-        # self.assertRaises(TypeError, lambda: pdf["b"] / pdf["a"])
-        # self.assertRaises(TypeError, lambda: "literal" / pdf["b"])
-        # self.assertRaises(TypeError, lambda: 1 / pdf["a"])
-
     def test_binary_operator_floordiv(self):
         kdf = ks.DataFrame({"a": ["x"], "b": [1]})
         ks_err_msg = "division can not be applied on string series or literals"
@@ -1836,12 +1815,6 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["b"] // "literal")
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: "literal" // kdf["b"])
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: 1 // kdf["a"])
-
-        # pdf = pd.DataFrame({"a": ["x"], "b": [1]})
-        # self.assertRaises(TypeError, lambda: pdf["a"] // pdf["b"])
-        # self.assertRaises(TypeError, lambda: pdf["b"] // pdf["a"])
-        # self.assertRaises(TypeError, lambda: "literal" // pdf["b"])
-        # self.assertRaises(TypeError, lambda: 1 // pdf["a"])
 
     def test_binary_operator_mod(self):
         # Positive
@@ -1858,11 +1831,6 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["b"] % kdf["a"])
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["b"] % "literal")
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: 1 % kdf["a"])
-
-        # pdf = pd.DataFrame({"a": ["x"], "b": [1]})
-        # self.assertRaises(TypeError, lambda: pdf["a"] % pdf["b"])
-        # self.assertRaises(TypeError, lambda: pdf["b"] % pdf["a"])
-        # self.assertRaises(TypeError, lambda: 1 % pdf["a"])
 
     def test_binary_operator_multiply(self):
         # Positive
@@ -1885,12 +1853,6 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: "literal" * kdf["b"])
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["a"] * "literal")
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: "literal" * kdf["a"])
-
-        # pdf = pd.DataFrame({"a": ["x"], "b": [2]})
-        # self.assertRaises(TypeError, lambda: pdf["b"] * "literal")
-        # self.assertRaises(TypeError, lambda: "literal" * pdf["b"])
-        # self.assertRaises(TypeError, lambda: pdf["a"] * "literal")
-        # self.assertRaises(TypeError, lambda: "literal" * pdf["a"])
 
     def test_sample(self):
         pdf = pd.DataFrame({"A": [0, 2, 4]})

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -1824,7 +1824,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
     def test_binary_operator_mod(self):
         kdf = ks.DataFrame({"a": ["x"], "b": [1]})
-        ks_err_msg = re.escape("mod can not be applied on string series or literals")
+        ks_err_msg = re.escape("modulo can not be applied on string series or literals")
 
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["a"] % kdf["b"])
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["b"] % kdf["a"])

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -1752,31 +1752,20 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         )
 
     def test_binary_operator_add(self):
-        kdf = ks.DataFrame({"a": ["x", "y"], "b": ["i", "j"]})
-        kdf["a"] + kdf["b"]
-
         kdf = ks.DataFrame({"a": ["x"], "b": [1]})
         ks_err_msg = re.escape("string addition can only be applied to string series or literals")
 
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["a"] + kdf["b"])
-
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["b"] + kdf["a"])
-
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["b"] + "literal")
-
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: "literal" + kdf["b"])
-
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: 1 + kdf["a"])
 
-        pdf = pd.DataFrame({"a": ["x"], "b": [1]})
-
-        self.assertRaises(TypeError, lambda: pdf["a"] + pdf["b"])
-
-        self.assertRaises(TypeError, lambda: pdf["b"] + pdf["a"])
-
-        self.assertRaises(np.core._exceptions.UFuncTypeError, lambda: "literal" + pdf["b"])
-
-        self.assertRaises(TypeError, lambda: 1 + pdf["a"])
+        # pdf = pd.DataFrame({"a": ["x"], "b": [1]})
+        # self.assertRaises(TypeError, lambda: pdf["a"] + pdf["b"])
+        # self.assertRaises(TypeError, lambda: pdf["b"] + pdf["a"])
+        # self.assertRaises(np.core._exceptions.UFuncTypeError, lambda: "literal" + pdf["b"])
+        # self.assertRaises(TypeError, lambda: 1 + pdf["a"])
 
     def test_binary_operator_sub(self):
         kdf = ks.DataFrame({"a": ["x"], "b": [1]})
@@ -1785,72 +1774,48 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         )
 
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["a"] - kdf["b"])
-
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["b"] - kdf["a"])
-
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["b"] - "literal")
-
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: "literal" - kdf["b"])
-
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: 1 - kdf["a"])
 
-        pdf = pd.DataFrame({"a": ["x"], "b": [1]})
-
-        self.assertRaises(TypeError, lambda: pdf["a"] - pdf["b"])
-
-        self.assertRaises(TypeError, lambda: pdf["b"] - pdf["a"])
-
-        self.assertRaises(np.core._exceptions.UFuncTypeError, lambda: "literal" - pdf["b"])
-
-        self.assertRaises(TypeError, lambda: 1 - pdf["a"])
+        # pdf = pd.DataFrame({"a": ["x"], "b": [1]})
+        # self.assertRaises(TypeError, lambda: pdf["a"] - pdf["b"])
+        # self.assertRaises(TypeError, lambda: pdf["b"] - pdf["a"])
+        # self.assertRaises(np.core._exceptions.UFuncTypeError, lambda: "literal" - pdf["b"])
+        # self.assertRaises(TypeError, lambda: 1 - pdf["a"])
 
     def test_binary_operator_truediv(self):
         kdf = ks.DataFrame({"a": ["x"], "b": [1]})
         ks_err_msg = re.escape("division can not be applied on string series or literals")
 
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["a"] / kdf["b"])
-
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["b"] / kdf["a"])
-
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["b"] / "literal")
-
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: "literal" / kdf["b"])
-
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: 1 / kdf["a"])
 
-        pdf = pd.DataFrame({"a": ["x"], "b": [1]})
-
-        self.assertRaises(TypeError, lambda: pdf["a"] / pdf["b"])
-
-        self.assertRaises(TypeError, lambda: pdf["b"] / pdf["a"])
-
-        self.assertRaises(TypeError, lambda: "literal" / pdf["b"])
-
-        self.assertRaises(TypeError, lambda: 1 / pdf["a"])
+        # pdf = pd.DataFrame({"a": ["x"], "b": [1]})
+        # self.assertRaises(TypeError, lambda: pdf["a"] / pdf["b"])
+        # self.assertRaises(TypeError, lambda: pdf["b"] / pdf["a"])
+        # self.assertRaises(TypeError, lambda: "literal" / pdf["b"])
+        # self.assertRaises(TypeError, lambda: 1 / pdf["a"])
 
     def test_binary_operator_floordiv(self):
         kdf = ks.DataFrame({"a": ["x"], "b": [1]})
         ks_err_msg = re.escape("division can not be applied on string series or literals")
 
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["a"] // kdf["b"])
-
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["b"] // kdf["a"])
-
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["b"] // "literal")
-
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: "literal" // kdf["b"])
-
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: 1 // kdf["a"])
 
-        pdf = pd.DataFrame({"a": ["x"], "b": [1]})
-
-        self.assertRaises(TypeError, lambda: pdf["a"] // pdf["b"])
-
-        self.assertRaises(TypeError, lambda: pdf["b"] // pdf["a"])
-
-        self.assertRaises(TypeError, lambda: "literal" // pdf["b"])
-
-        self.assertRaises(TypeError, lambda: 1 // pdf["a"])
+        # pdf = pd.DataFrame({"a": ["x"], "b": [1]})
+        # self.assertRaises(TypeError, lambda: pdf["a"] // pdf["b"])
+        # self.assertRaises(TypeError, lambda: pdf["b"] // pdf["a"])
+        # self.assertRaises(TypeError, lambda: "literal" // pdf["b"])
+        # self.assertRaises(TypeError, lambda: 1 // pdf["a"])
 
     def test_binary_operator_mod(self):
         kdf = ks.DataFrame({"a": ["x"], "b": [1]})
@@ -1861,10 +1826,10 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["b"] % "literal")
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: 1 % kdf["a"])
 
-        pdf = pd.DataFrame({"a": ["x"], "b": [1]})
-        self.assertRaises(TypeError, lambda: pdf["a"] % pdf["b"])
-        self.assertRaises(TypeError, lambda: pdf["b"] % pdf["a"])
-        self.assertRaises(TypeError, lambda: 1 % pdf["a"])
+        # pdf = pd.DataFrame({"a": ["x"], "b": [1]})
+        # self.assertRaises(TypeError, lambda: pdf["a"] % pdf["b"])
+        # self.assertRaises(TypeError, lambda: pdf["b"] % pdf["a"])
+        # self.assertRaises(TypeError, lambda: 1 % pdf["a"])
 
     def test_binary_operator_multiply(self):
         kdf = ks.DataFrame({"a": ["x", "y"], "b": [1, 2]})
@@ -1882,9 +1847,9 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["b"] * "literal")
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: "literal" * kdf["b"])
 
-        pdf = pd.DataFrame({"a": ["x"], "b": [2]})
-        self.assertRaises(TypeError, lambda: pdf["b"] * "literal")
-        self.assertRaises(TypeError, lambda: "literal" * pdf["b"])
+        # pdf = pd.DataFrame({"a": ["x"], "b": [2]})
+        # self.assertRaises(TypeError, lambda: pdf["b"] * "literal")
+        # self.assertRaises(TypeError, lambda: "literal" * pdf["b"])
 
     def test_sample(self):
         pdf = pd.DataFrame({"A": [0, 2, 4]})

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -1777,7 +1777,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         # Negative
         kdf = ks.DataFrame({"a": ["x"], "b": [1]})
-        ks_err_msg = "substraction can not be applied to string series or literals."
+        ks_err_msg = "substraction can not be applied to string series or literals"
 
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["a"] - kdf["b"])
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["b"] - kdf["a"])

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -1752,6 +1752,13 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         )
 
     def test_binary_operator_add(self):
+        # Positive
+        pdf = pd.DataFrame({"a": ["x"], "b": ["y"]})
+        kdf = ks.from_pandas(pdf)
+
+        self.assert_eq(kdf["a"] + kdf["b"], pdf["a"] + pdf["b"])
+
+        # Negative
         kdf = ks.DataFrame({"a": ["x"], "b": [1]})
         ks_err_msg = re.escape("string addition can only be applied to string series or literals")
 
@@ -1768,6 +1775,13 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         # self.assertRaises(TypeError, lambda: 1 + pdf["a"])
 
     def test_binary_operator_sub(self):
+        # Positive
+        pdf = pd.DataFrame({"a": [2], "b": [1]})
+        kdf = ks.from_pandas(pdf)
+
+        self.assert_eq(kdf["a"] - kdf["b"], pdf["a"] - pdf["b"])
+
+        # Negative
         kdf = ks.DataFrame({"a": ["x"], "b": [1]})
         ks_err_msg = re.escape("substraction can not be applied to string series or literals.")
 
@@ -1791,6 +1805,13 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         # self.assertRaises(TypeError, lambda: pdf["a"] - pdf["b"])
 
     def test_binary_operator_truediv(self):
+        # Positive
+        pdf = pd.DataFrame({"a": [3], "b": [2]})
+        kdf = ks.from_pandas(pdf)
+
+        self.assert_eq(kdf["a"] / kdf["b"], pdf["a"] / pdf["b"])
+
+        # Negative
         kdf = ks.DataFrame({"a": ["x"], "b": [1]})
         ks_err_msg = re.escape("division can not be applied on string series or literals")
 
@@ -1823,6 +1844,13 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         # self.assertRaises(TypeError, lambda: 1 // pdf["a"])
 
     def test_binary_operator_mod(self):
+        # Positive
+        pdf = pd.DataFrame({"a": [3], "b": [2]})
+        kdf = ks.from_pandas(pdf)
+
+        self.assert_eq(kdf["a"] % kdf["b"], pdf["a"] % pdf["b"])
+
+        # Negative
         kdf = ks.DataFrame({"a": ["x"], "b": [1]})
         ks_err_msg = re.escape("modulo can not be applied on string series or literals")
 
@@ -1837,8 +1865,9 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         # self.assertRaises(TypeError, lambda: 1 % pdf["a"])
 
     def test_binary_operator_multiply(self):
-        kdf = ks.DataFrame({"a": ["x", "y"], "b": [1, 2]})
+        # Positive
         pdf = pd.DataFrame({"a": ["x", "y"], "b": [1, 2]})
+        kdf = ks.from_pandas(pdf)
 
         self.assert_eq(kdf["a"] * kdf["b"], pdf["a"] * pdf["b"])
         self.assert_eq(kdf["b"] * kdf["a"], pdf["b"] * pdf["a"])
@@ -1847,6 +1876,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(2 * kdf["a"], 2 * pdf["a"])
         self.assert_eq(2 * kdf["b"], 2 * pdf["b"])
 
+        # Negative
         kdf = ks.DataFrame({"a": ["x"], "b": [2]})
         ks_err_msg = "multiplication can not be applied to a string literal"
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["b"] * "literal")

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -1769,21 +1769,26 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
     def test_binary_operator_sub(self):
         kdf = ks.DataFrame({"a": ["x"], "b": [1]})
-        ks_err_msg = re.escape(
-            "string substraction can only be applied to string series or literals."
-        )
+        ks_err_msg = re.escape("substraction can not be applied to string series or literals.")
 
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["a"] - kdf["b"])
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["b"] - kdf["a"])
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["b"] - "literal")
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: "literal" - kdf["b"])
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: 1 - kdf["a"])
+        self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["a"] - 1)
+
+        kdf = ks.DataFrame({"a": ["x"], "b": ["y"]})
+        self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["a"] - kdf["b"])
 
         # pdf = pd.DataFrame({"a": ["x"], "b": [1]})
         # self.assertRaises(TypeError, lambda: pdf["a"] - pdf["b"])
         # self.assertRaises(TypeError, lambda: pdf["b"] - pdf["a"])
         # self.assertRaises(np.core._exceptions.UFuncTypeError, lambda: "literal" - pdf["b"])
         # self.assertRaises(TypeError, lambda: 1 - pdf["a"])
+        # self.assertRaises(TypeError, lambda: pdf["a"] - 1)
+        # pdf = pd.DataFrame({"a": ["x"], "b": ["y"]})
+        # self.assertRaises(TypeError, lambda: pdf["a"] - pdf["b"])
 
     def test_binary_operator_truediv(self):
         kdf = ks.DataFrame({"a": ["x"], "b": [1]})

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -1852,6 +1852,20 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         self.assertRaises(TypeError, lambda: 1 // pdf["a"])
 
+    def test_binary_operator_mod(self):
+        kdf = ks.DataFrame({"a": ["x"], "b": [1]})
+        ks_err_msg = re.escape("mod can not be applied on string series or literals")
+
+        self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["a"] % kdf["b"])
+        self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["b"] % kdf["a"])
+        self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["b"] % "literal")
+        self.assertRaisesRegex(TypeError, ks_err_msg, lambda: 1 % kdf["a"])
+
+        pdf = pd.DataFrame({"a": ["x"], "b": [1]})
+        self.assertRaises(TypeError, lambda: pdf["a"] % pdf["b"])
+        self.assertRaises(TypeError, lambda: pdf["b"] % pdf["a"])
+        self.assertRaises(TypeError, lambda: 1 % pdf["a"])
+
     def test_binary_operator_multiply(self):
         kdf = ks.DataFrame({"a": ["x", "y"], "b": [1, 2]})
         pdf = pd.DataFrame({"a": ["x", "y"], "b": [1, 2]})


### PR DESCRIPTION
## Notes
- New test cases related to **Pandas only** are added for PR reviewers to visualize Pandas' behavior.
They are commented out and will be removed before the PR merge (after PR review).
- This PR doesn't aim to cover all binary operations: only `+`, `-`, `*`, `/`, `//`, `%` are concerned.

## Proposal
Make behaviors of binary operations (`+`, `-`, `*`, `/`, `//`, `%`) between **int** and **str** columns consistent with respective pandas behaviors.

- Standardize binary operations as follows:

    `+`: raise TypeError between int column and str column (or string literal)
    `*`: act as spark SQL `repeat` between int column(or int literal) and str columns; raise TypeError if a string literal is involved
    `-`, `/`, `//`, `%(modulo)`: raise TypeError if a str column (or string literal) is involved

- Add `def repeat(col, n):` in databricks/koalas/spark/functions.py

    [`repeat` defined in scala API](https://github.com/apache/spark/blob/master/sql/core/src/main/scala/org/apache/spark/sql/functions.scala#L2580) only accepts integer literal as the method's second parameter.
    But internal [StringRepeat](https://github.com/apache/spark/blob/master/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala#L1607) accepts `IntegerType` as the method's second parameter.

    In order to pass int columns as the second parameter, we take advantage of `callUDF`.

## Test
databricks/koalas/tests/test_dataframe.py

Resolves #1819