### PR TITLE
Fix a test caused by a bug introduced in pandas 1.1.3.

### DIFF
--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -173,10 +173,19 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         #     kdf.groupby(("x", "a"))[("y", "c")].sum().sort_index(),
         #     pdf.groupby(("x", "a"))[("y", "c")].sum().sort_index(),
         # )
-        self.assert_eq(
-            kdf[("x", "a")].groupby(kdf[("x", "b")]).sum().sort_index(),
-            pdf[("x", "a")].groupby(pdf[("x", "b")]).sum().sort_index(),
-        )
+        if LooseVersion(pd.__version__) < LooseVersion("1.1.3"):
+            self.assert_eq(
+                kdf[("x", "a")].groupby(kdf[("x", "b")]).sum().sort_index(),
+                pdf[("x", "a")].groupby(pdf[("x", "b")]).sum().sort_index(),
+            )
+        else:
+            # seems like a pandas bug introduced in pandas 1.1.3.
+            expected_result = ks.Series(
+                [13, 9, 8, 1, 6], name=("x", "a"), index=pd.Index([1, 2, 3, 4, 7], name=("x", "b"))
+            )
+            self.assert_eq(
+                kdf[("x", "a")].groupby(kdf[("x", "b")]).sum().sort_index(), expected_result
+            )
 
     def test_split_apply_combine_on_series(self):
         pdf = pd.DataFrame(


### PR DESCRIPTION
There is a bug introduced in pandas 1.1.3.

```py
>>> pdf = pd.DataFrame({("x", "a"): [1, 2, 6, 4, 4, 6, 4, 3, 7], ("x", "b"): [4, 2, 7, 3, 3, 1, 1, 1, 2], ("y", "c"): [4, 2, 7, 3, None, 1, 1, 1, 2], ("z", "d"): list("abcdefght")}, index=[0, 1, 3, 5, 6, 8, 9, 9, 9])
>>> pdf
   x       y  z
   a  b    c  d
0  1  4  4.0  a
1  2  2  2.0  b
3  6  7  7.0  c
5  4  3  3.0  d
6  4  3  NaN  e
8  6  1  1.0  f
9  4  1  1.0  g
9  3  1  1.0  h
9  7  2  2.0  t
>>> pdf[("x", "a")].groupby(pdf[("x", "b")]).sum().sort_index()
Traceback (most recent call last):

...

TypeError: only integer scalar arrays can be converted to a scalar index
```