### PR TITLE
Standardize multiplication involving string column

### DIFF
--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -254,7 +254,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
                 return column_op(SF.repeat)(self, other)
             else:
                 raise TypeError(
-                    "multiplication involves a string series can only be applied to an int series or literal"
+                    "a string series can only be multiplied to an int series or literal"
                 )
 
         return column_op(Column.__mul__)(self, other)
@@ -360,7 +360,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
                 return column_op(SF.repeat)(self, other)
             else:
                 raise TypeError(
-                    "multiplication involves a string series can only be applied to an int series or literal"
+                    "a string series can only be multiplied to an int series or literal"
                 )
 
         return column_op(Column.__rmul__)(self, other)

--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -254,7 +254,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
                 return column_op(SF.repeat)(self, other)
             else:
                 raise TypeError(
-                    "string multiplication can only be applied between a string series and an int series or literals."
+                    "multiplication involves a string series can only be applied to an int series or literal"
                 )
 
         return column_op(Column.__mul__)(self, other)
@@ -360,7 +360,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
                 return column_op(SF.repeat)(self, other)
             else:
                 raise TypeError(
-                    "string multiplication can only be applied between a string series and an int series or literals."
+                    "multiplication involves a string series can only be applied to an int series or literal"
                 )
 
         return column_op(Column.__rmul__)(self, other)

--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -247,10 +247,8 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
 
         if isinstance(self.spark.data_type, StringType):
             if (
-                isinstance(other, IndexOpsMixin)
-                and isinstance(other.spark.data_type, IntegralType)
-                or isinstance(other, int)
-            ):
+                isinstance(other, IndexOpsMixin) and isinstance(other.spark.data_type, IntegralType)
+            ) or isinstance(other, int):
                 return column_op(SF.repeat)(self, other)
             else:
                 raise TypeError(

--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -245,11 +245,17 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
         ):
             return column_op(SF.repeat)(other, self)
 
-        if isinstance(self.spark.data_type, StringType) and (
-            (isinstance(other, IndexOpsMixin) and isinstance(other.spark.data_type, IntegralType))
-            or isinstance(other, int)
-        ):
-            return column_op(SF.repeat)(self, other)
+        if isinstance(self.spark.data_type, StringType):
+            if (
+                isinstance(other, IndexOpsMixin)
+                and isinstance(other.spark.data_type, IntegralType)
+                or isinstance(other, int)
+            ):
+                return column_op(SF.repeat)(self, other)
+            else:
+                raise TypeError(
+                    "string multiplication can only be applied between a string series and an int series or literals."
+                )
 
         return column_op(Column.__mul__)(self, other)
 
@@ -349,8 +355,13 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
         if isinstance(other, str):
             raise TypeError("multiplication can not be applied to a string literal.")
 
-        if isinstance(self.spark.data_type, StringType) and isinstance(other, int):
-            return column_op(SF.repeat)(self, other)
+        if isinstance(self.spark.data_type, StringType):
+            if isinstance(other, int):
+                return column_op(SF.repeat)(self, other)
+            else:
+                raise TypeError(
+                    "string multiplication can only be applied between a string series and an int series or literals."
+                )
 
         return column_op(Column.__rmul__)(self, other)
 

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -1854,7 +1854,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["a"] * "literal")
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: "literal" * kdf["a"])
 
-        ks_err_msg = "multiplication involves a string series can only be applied to an int series or literal"
+        ks_err_msg = "a string series can only be multiplied to an int series or literal"
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["a"] * kdf["a"])
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["a"] * 0.1)
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: 0.1 * kdf["a"])

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -1854,6 +1854,11 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["a"] * "literal")
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: "literal" * kdf["a"])
 
+        ks_err_msg = "string multiplication can only be applied between a string series and an int series or literal"
+        self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["a"] * kdf["a"])
+        self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["a"] * 0.1)
+        self.assertRaisesRegex(TypeError, ks_err_msg, lambda: 0.1 * kdf["a"])
+
     def test_sample(self):
         pdf = pd.DataFrame({"A": [0, 2, 4]})
         kdf = ks.from_pandas(pdf)

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -1854,7 +1854,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["a"] * "literal")
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: "literal" * kdf["a"])
 
-        ks_err_msg = "string multiplication can only be applied between a string series and an int series or literal"
+        ks_err_msg = "multiplication involves a string series can only be applied to an int series or literal"
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["a"] * kdf["a"])
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["a"] * 0.1)
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: 0.1 * kdf["a"])


### PR DESCRIPTION
## Proposal
Multiplication involves a string column can only be applied to an int column or literal; otherwise, a TypeError should be raised.
