### PR TITLE
Update the installation guide for Databricks users.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,21 +52,7 @@ pip install koalas
 
 See [Installation](https://koalas.readthedocs.io/en/latest/getting_started/install.html) for more details.
 
-If you are a Databricks Runtime user, you can install Koalas using the Libraries tab on the cluster UI, or using `dbutils` in a notebook as below for the regular Databricks Runtime,
-
-```python
-dbutils.library.installPyPI("koalas")
-dbutils.library.restartPython()
-```
-
-For Databricks Runtime for Machine Learning 6.0 and above, you can install it as follows.
-
-```sh
-%sh
-pip install koalas
-```
-
-Note that Koalas requires Databricks Runtime 5.x or above. In the future, we will package Koalas out-of-the-box in both the regular Databricks Runtime and Databricks Runtime for Machine Learning.
+For Databricks Runtime users, Koalas is pre-installed in Databricks Runtime 7.1 and above, or you can follow these [steps](https://docs.databricks.com/libraries/index.html) to install a library on Databricks.
 
 Lastly, if your PyArrow version is 0.15+ and your PySpark version is lower than 3.0, it is best for you to set `ARROW_PRE_0_15_IPC_FORMAT` environment variable to `1` manually.
 Koalas will try its best to set it for you but it is impossible to set it if there is a Spark context already launched.


### PR DESCRIPTION
The installation guide for Databricks users is out-dated. Let's just refer the official guide.