### PR TITLE
Implement DataFrame/Series rename_axis

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -9278,16 +9278,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         )
         index_map = OrderedDict(zip(self._internal.index_spark_column_names, index_names))
 
-        spark_frame = self._internal.resolved_copy.spark_frame
-        internal = InternalFrame(
-            spark_frame=spark_frame,
-            index_map=index_map,
-            column_labels=self._internal.column_labels,
-            data_spark_columns=[
-                scol_for(spark_frame, col) for col in self._internal.data_spark_column_names
-            ],
-            column_label_names=column_label_names,
-        )
+        internal = self._internal.copy(index_map=index_map, column_label_names=column_label_names)
 
         if inplace:
             self._update_internal_frame(internal)

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -9129,7 +9129,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         columns: Optional[Any] = None,
         axis: Optional[Union[int, str]] = 0,
         inplace: Optional[bool] = False,
-    ):
+    ) -> Optional["DataFrame"]:
         """
         Set the name of the axis for the index or columns.
 
@@ -9186,6 +9186,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         dog            4         0
         cat            4         0
         monkey         2         2
+
         >>> df = df.rename_axis("animal").sort_index()
         >>> df  # doctest: +NORMALIZE_WHITESPACE
                 num_legs  num_arms
@@ -9193,6 +9194,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         cat            4         0
         dog            4         0
         monkey         2         2
+
         >>> df = df.rename_axis("limbs", axis="columns").sort_index()
         >>> df # doctest: +NORMALIZE_WHITESPACE
         limbs   num_legs  num_arms
@@ -9265,8 +9267,6 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 index = mapper
             elif axis == 1:
                 columns = mapper
-            else:
-                raise ValueError("No axis named %s for object type %s." % (axis, type(axis)))
 
         column_label_names = (
             gen_names(columns, self.columns.names)
@@ -9278,19 +9278,20 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         )
         index_map = OrderedDict(zip(self._internal.index_spark_column_names, index_names))
 
+        spark_frame = self._internal.resolved_copy.spark_frame
         internal = InternalFrame(
-            self._internal.spark_frame,
+            spark_frame=spark_frame,
             index_map=index_map,
             column_labels=self._internal.column_labels,
             data_spark_columns=[
-                scol_for(self._internal.spark_frame, col)
-                for col in self._internal.data_spark_column_names
+                scol_for(spark_frame, col) for col in self._internal.data_spark_column_names
             ],
             column_label_names=column_label_names,
         )
 
         if inplace:
             self._update_internal_frame(internal)
+            return None
         else:
             return DataFrame(internal)
 

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -31,7 +31,6 @@ from typing import Any, Optional, List, Tuple, Union, Generic, TypeVar, Iterable
 
 import numpy as np
 import pandas as pd
-import pandas.core.common as com
 from pandas.api.types import is_list_like, is_dict_like, is_scalar
 
 if LooseVersion(pd.__version__) >= LooseVersion("0.24"):
@@ -9236,9 +9235,15 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 newnames = [v]
             elif is_list_like(v) and not is_dict_like(v):
                 newnames = list(v)
+            elif is_dict_like(v):
+                newnames = [v[name] if name in v else name for name in curnames]
+            elif callable(v):
+                newnames = [v(name) for name in curnames]
             else:
-                f = com.get_rename_function(v)
-                newnames = [f(name) for name in curnames]
+                raise ValueError(
+                    "`mapper` or `index` or `columns` should be "
+                    "either dict-like or function type."
+                )
 
             if len(newnames) != len(curnames):
                 raise ValueError(

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -9255,9 +9255,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                     "Length of new names must be {}, got {}".format(len(curnames), len(newnames))
                 )
 
-            return [
-                name if name is None or isinstance(name, tuple) else (name,) for name in newnames
-            ]
+            return [name if is_name_like_tuple(name) else (name,) for name in newnames]
 
         if mapper is not None and (index is not None or columns is not None):
             raise TypeError("Cannot specify both 'mapper' and any of 'index' or 'columns'.")

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -9156,6 +9156,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         See Also
         --------
+        Series.rename : Alter Series index labels or name.
         DataFrame.rename : Alter DataFrame index labels or name.
         Index.rename : Set new names on index.
 

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -9280,7 +9280,6 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         index_map = OrderedDict(zip(self._internal.index_spark_column_names, index_names))
 
         internal = self._internal.copy(index_map=index_map, column_label_names=column_label_names)
-
         if inplace:
             self._update_internal_frame(internal)
             return None

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -9177,9 +9177,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = ks.DataFrame({"num_legs": [4, 4, 2],
+        >>> df = pd.DataFrame({"num_legs": [4, 4, 2],
         ...                    "num_arms": [0, 0, 2]},
-        ...                   ["dog", "cat", "monkey"])
+        ...                   index=["dog", "cat", "monkey"],
+        ...                   columns=["num_legs", "num_arms"])
         >>> df
                 num_legs  num_arms
         dog            4         0
@@ -9203,11 +9204,12 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         **MultiIndex**
 
         >>> index = pd.MultiIndex.from_product([['mammal'],
-        ...                                        ['dog', 'cat', 'monkey']],
-        ...                                       names=['type', 'name'])
+        ...                                     ['dog', 'cat', 'monkey']],
+        ...                                    names=['type', 'name'])
         >>> df = ks.DataFrame({"num_legs": [4, 4, 2],
         ...                    "num_arms": [0, 0, 2]},
-        ...                   index=index)
+        ...                   index=index,
+        ...                   columns=["num_legs", "num_arms"])
         >>> df  # doctest: +NORMALIZE_WHITESPACE
                        num_legs  num_arms
         type   name

--- a/databricks/koalas/missing/frame.py
+++ b/databricks/koalas/missing/frame.py
@@ -58,7 +58,6 @@ class _MissingPandasLikeDataFrame(object):
     lookup = _unsupported_function("lookup")
     mode = _unsupported_function("mode")
     reindex_like = _unsupported_function("reindex_like")
-    rename_axis = _unsupported_function("rename_axis")
     reorder_levels = _unsupported_function("reorder_levels")
     resample = _unsupported_function("resample")
     sem = _unsupported_function("sem")

--- a/databricks/koalas/missing/series.py
+++ b/databricks/koalas/missing/series.py
@@ -51,7 +51,6 @@ class MissingPandasLikeSeries(object):
     interpolate = _unsupported_function("interpolate")
     last = _unsupported_function("last")
     reindex_like = _unsupported_function("reindex_like")
-    rename_axis = _unsupported_function("rename_axis")
     reorder_levels = _unsupported_function("reorder_levels")
     resample = _unsupported_function("resample")
     searchsorted = _unsupported_function("searchsorted")

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -1115,6 +1115,71 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         else:
             return first_series(kdf)
 
+    def rename_axis(
+        self, mapper: Optional[Any] = None, index: Optional[Any] = None, inplace: bool = False
+    ):
+        """
+        Set the name of the axis for the index or columns.
+
+        Parameters
+        ----------
+        mapper, index :  scalar, list-like, dict-like or function, optional
+            A scalar, list-like, dict-like or functions transformations to
+            apply to the index values.
+        inplace : bool, default False
+            Modifies the object directly, instead of creating a new Series.
+
+        Returns
+        -------
+        Series, or None if `inplace` is True.
+
+        See Also
+        --------
+        Series.rename : Alter Series index labels or name.
+        Index.rename : Set new names on index.
+
+        Examples
+        --------
+        >>> s = ks.Series(["dog", "cat", "monkey"], name="animal")
+        >>> s  # doctest: +NORMALIZE_WHITESPACE
+        0       dog
+        1       cat
+        2    monkey
+        Name: animal, dtype: object
+        >>> s.rename_axis("index").sort_index()  # doctest: +NORMALIZE_WHITESPACE
+        index
+        0       dog
+        1       cat
+        2    monkey
+        Name: animal, dtype: object
+
+        **MultiIndex**
+
+        >>> index = pd.MultiIndex.from_product([['mammal'],
+        ...                                        ['dog', 'cat', 'monkey']],
+        ...                                       names=['type', 'name'])
+        >>> s = ks.Series([4, 4, 2], index=index, name='num_legs')
+        >>> s  # doctest: +NORMALIZE_WHITESPACE
+        type    name
+        mammal  dog       4
+                cat       4
+                monkey    2
+        Name: num_legs, dtype: int64
+        >>> s.rename_axis(index={'type': 'class'}).sort_index()  # doctest: +NORMALIZE_WHITESPACE
+        class   name
+        mammal  cat       4
+                dog       4
+                monkey    2
+        Name: num_legs, dtype: int64
+        >>> s.rename_axis(index=str.upper).sort_index()  # doctest: +NORMALIZE_WHITESPACE
+        TYPE    NAME
+        mammal  cat       4
+                dog       4
+                monkey    2
+        Name: num_legs, dtype: int64
+        """
+        return first_series(self.to_frame().rename_axis(mapper=mapper, index=index))
+
     @property
     def index(self):
         """The index (axis labels) Column of the Series.

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -1117,7 +1117,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
     def rename_axis(
         self, mapper: Optional[Any] = None, index: Optional[Any] = None, inplace: bool = False
-    ):
+    ) -> Optional["Series"]:
         """
         Set the name of the axis for the index or columns.
 

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -1178,7 +1178,9 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
                 monkey    2
         Name: num_legs, dtype: int64
         """
-        return first_series(self.to_frame().rename_axis(mapper=mapper, index=index))
+        return first_series(
+            self.to_frame().rename_axis(mapper=mapper, index=index, inplace=inplace)
+        )
 
     @property
     def index(self):

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -1179,9 +1179,12 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
                 monkey    2
         Name: num_legs, dtype: int64
         """
-        return first_series(
-            self.to_frame().rename_axis(mapper=mapper, index=index, inplace=inplace)
-        )
+        kdf = self.to_frame().rename_axis(mapper=mapper, index=index, inplace=False)
+        if inplace:
+            self._update_anchor(kdf)
+            return None
+        else:
+            return first_series(kdf)
 
     @property
     def index(self):

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -1136,6 +1136,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         See Also
         --------
         Series.rename : Alter Series index labels or name.
+        DataFrame.rename : Alter DataFrame index labels or name.
         Index.rename : Set new names on index.
 
         Examples
@@ -2216,7 +2217,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
     def sort_values(
         self, ascending: bool = True, inplace: bool = False, na_position: str = "last"
-    ) -> Union["Series", None]:
+    ) -> Optional["Series"]:
         """
         Sort by the values.
 

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -600,33 +600,46 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             )
 
         self.assert_eq(
-            pdf.rename_axis(index="index2", columns="cols2").sort_index(),
-            kdf.rename_axis(index="index2", columns="cols2").sort_index(),
+            pdf.rename_axis(["index2"]).sort_index(), kdf.rename_axis(["index2"]).sort_index(),
         )
 
         self.assert_eq(
-            pdf.rename_axis(index=["index2"], columns=["cols2"]).sort_index(),
-            kdf.rename_axis(index=["index2"], columns=["cols2"]).sort_index(),
+            pdf.rename_axis(["index2"], axis=1).sort_index(),
+            kdf.rename_axis(["index2"], axis=1).sort_index(),
         )
 
-        self.assert_eq(
-            pdf.rename_axis(index={"index": "index2"}, columns={"columns": "cols2"}).sort_index(),
-            kdf.rename_axis(index={"index": "index2"}, columns={"columns": "cols2"}).sort_index(),
-        )
+        self.assertRaises(ValueError, lambda: kdf.rename_axis(["index2", "index3"], axis=0))
+        self.assertRaises(ValueError, lambda: kdf.rename_axis(["cols2", "cols3"], axis=1))
 
-        self.assert_eq(
-            pdf.rename_axis(index={"missing": "index2"}, columns={"missing": "cols2"}).sort_index(),
-            kdf.rename_axis(index={"missing": "index2"}, columns={"missing": "cols2"}).sort_index(),
-        )
+        # index/columns parameters and dict_like/functions mappers introduced in pandas 0.24.0
+        if LooseVersion(pd.__version__) >= LooseVersion("0.24.0"):
 
-        self.assert_eq(
-            pdf.rename_axis(index=str.upper, columns=str.upper).sort_index(),
-            kdf.rename_axis(index=str.upper, columns=str.upper).sort_index(),
-        )
+            self.assert_eq(
+                pdf.rename_axis(
+                    index={"index": "index2"}, columns={"columns": "cols2"}
+                ).sort_index(),
+                kdf.rename_axis(
+                    index={"index": "index2"}, columns={"columns": "cols2"}
+                ).sort_index(),
+            )
 
-        self.assertRaises(TypeError, lambda: kdf.rename_axis(mapper=["index2"], index=["index3"]))
-        self.assertRaises(ValueError, lambda: kdf.rename_axis(index=["index2", "index3"]))
-        self.assertRaises(ValueError, lambda: kdf.rename_axis(columns=["cols2", "cols3"]))
+            self.assert_eq(
+                pdf.rename_axis(
+                    index={"missing": "index2"}, columns={"missing": "cols2"}
+                ).sort_index(),
+                kdf.rename_axis(
+                    index={"missing": "index2"}, columns={"missing": "cols2"}
+                ).sort_index(),
+            )
+
+            self.assert_eq(
+                pdf.rename_axis(index=str.upper, columns=str.upper).sort_index(),
+                kdf.rename_axis(index=str.upper, columns=str.upper).sort_index(),
+            )
+
+            self.assertRaises(
+                TypeError, lambda: kdf.rename_axis(mapper=["index2"], index=["index3"])
+            )
 
         index = pd.MultiIndex.from_tuples(
             [("A", "B"), ("C", "D"), ("E", "F")], names=["index1", "index2"]
@@ -651,41 +664,48 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
                 kdf.rename_axis(["cols3", "cols4"], axis=axis).sort_index(),
             )
 
-        self.assert_eq(
-            pdf.rename_axis(index=["index3", "index4"], columns=["cols3", "cols4"]).sort_index(),
-            kdf.rename_axis(index=["index3", "index4"], columns=["cols3", "cols4"]).sort_index(),
-        )
-
-        self.assert_eq(
-            pdf.rename_axis(index={"index1": "index3"}, columns={"cols1": "cols3"}).sort_index(),
-            kdf.rename_axis(index={"index1": "index3"}, columns={"cols1": "cols3"}).sort_index(),
-        )
-
-        self.assert_eq(
-            pdf.rename_axis(index={"missing": "index2"}, columns={"missing": "cols2"}).sort_index(),
-            kdf.rename_axis(index={"missing": "index2"}, columns={"missing": "cols2"}).sort_index(),
-        )
-
-        self.assert_eq(
-            pdf.rename_axis(
-                index={"index1": "index3", "index2": "index4"},
-                columns={"cols1": "cols3", "cols2": "cols4"},
-            ).sort_index(),
-            kdf.rename_axis(
-                index={"index1": "index3", "index2": "index4"},
-                columns={"cols1": "cols3", "cols2": "cols4"},
-            ).sort_index(),
-        )
-
-        self.assert_eq(
-            pdf.rename_axis(index=str.upper, columns=str.upper).sort_index(),
-            kdf.rename_axis(index=str.upper, columns=str.upper).sort_index(),
-        )
-
-        self.assertRaises(ValueError, lambda: kdf.rename_axis(index=["index3", "index4", "index5"]))
         self.assertRaises(
-            ValueError, lambda: kdf.rename_axis(columns=["columns3", "columns4", "columns5"])
+            ValueError, lambda: kdf.rename_axis(["index3", "index4", "index5"], axis=0)
         )
+        self.assertRaises(
+            ValueError, lambda: kdf.rename_axis(["columns3", "columns4", "columns5"], axis=1)
+        )
+
+        # index/columns parameters and dict_like/functions mappers introduced in pandas 0.24.0
+        if LooseVersion(pd.__version__) >= LooseVersion("0.24.0"):
+            self.assert_eq(
+                pdf.rename_axis(
+                    index={"index1": "index3"}, columns={"cols1": "cols3"}
+                ).sort_index(),
+                kdf.rename_axis(
+                    index={"index1": "index3"}, columns={"cols1": "cols3"}
+                ).sort_index(),
+            )
+
+            self.assert_eq(
+                pdf.rename_axis(
+                    index={"missing": "index2"}, columns={"missing": "cols2"}
+                ).sort_index(),
+                kdf.rename_axis(
+                    index={"missing": "index2"}, columns={"missing": "cols2"}
+                ).sort_index(),
+            )
+
+            self.assert_eq(
+                pdf.rename_axis(
+                    index={"index1": "index3", "index2": "index4"},
+                    columns={"cols1": "cols3", "cols2": "cols4"},
+                ).sort_index(),
+                kdf.rename_axis(
+                    index={"index1": "index3", "index2": "index4"},
+                    columns={"cols1": "cols3", "cols2": "cols4"},
+                ).sort_index(),
+            )
+
+            self.assert_eq(
+                pdf.rename_axis(index=str.upper, columns=str.upper).sort_index(),
+                kdf.rename_axis(index=str.upper, columns=str.upper).sort_index(),
+            )
 
     def test_dot_in_column_name(self):
         self.assert_eq(

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -607,6 +607,12 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
                 kdf.rename_axis(["cols2"], axis=axis).sort_index(),
             )
 
+        pdf2 = pdf.copy()
+        kdf2 = kdf.copy()
+        pdf2.rename_axis("index2", axis="index", inplace=True)
+        kdf2.rename_axis("index2", axis="index", inplace=True)
+        self.assert_eq(pdf2.sort_index(), kdf2.sort_index())
+
         self.assertRaises(ValueError, lambda: kdf.rename_axis(["index2", "index3"], axis=0))
         self.assertRaises(ValueError, lambda: kdf.rename_axis(["cols2", "cols3"], axis=1))
         self.assertRaises(TypeError, lambda: kdf.rename_axis(mapper=["index2"], index=["index3"]))

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -581,6 +581,112 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         kdf5 = kdf3 + 1
         self.assert_eq(kdf5.rename(index=str_lower), pdf5.rename(index=str_lower))
 
+    def test_rename_axis(self):
+        index = pd.Index(["A", "B", "C"], name="index")
+        columns = pd.Index(["numbers", "values"], name="cols")
+        pdf = pd.DataFrame([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], index=index, columns=columns)
+        kdf = ks.from_pandas(pdf)
+
+        for axis in [0, "index"]:
+            self.assert_eq(
+                pdf.rename_axis("index2", axis=axis).sort_index(),
+                kdf.rename_axis("index2", axis=axis).sort_index(),
+            )
+
+        for axis in [1, "columns"]:
+            self.assert_eq(
+                pdf.rename_axis("cols2", axis=axis).sort_index(),
+                kdf.rename_axis("cols2", axis=axis).sort_index(),
+            )
+
+        self.assert_eq(
+            pdf.rename_axis(index="index2", columns="cols2").sort_index(),
+            kdf.rename_axis(index="index2", columns="cols2").sort_index(),
+        )
+
+        self.assert_eq(
+            pdf.rename_axis(index=["index2"], columns=["cols2"]).sort_index(),
+            kdf.rename_axis(index=["index2"], columns=["cols2"]).sort_index(),
+        )
+
+        self.assert_eq(
+            pdf.rename_axis(index={"index": "index2"}, columns={"columns": "cols2"}).sort_index(),
+            kdf.rename_axis(index={"index": "index2"}, columns={"columns": "cols2"}).sort_index(),
+        )
+
+        self.assert_eq(
+            pdf.rename_axis(index={"missing": "index2"}, columns={"missing": "cols2"}).sort_index(),
+            kdf.rename_axis(index={"missing": "index2"}, columns={"missing": "cols2"}).sort_index(),
+        )
+
+        self.assert_eq(
+            pdf.rename_axis(index=str.upper, columns=str.upper).sort_index(),
+            kdf.rename_axis(index=str.upper, columns=str.upper).sort_index(),
+        )
+
+        self.assertRaises(TypeError, lambda: kdf.rename_axis(mapper=["index2"], index=["index3"]))
+        self.assertRaises(ValueError, lambda: kdf.rename_axis(index=["index2", "index3"]))
+        self.assertRaises(ValueError, lambda: kdf.rename_axis(columns=["cols2", "cols3"]))
+
+        index = pd.MultiIndex.from_tuples(
+            [("A", "B"), ("C", "D"), ("E", "F")], names=["index1", "index2"]
+        )
+
+        columns = pd.MultiIndex.from_tuples(
+            [("numbers", "first"), ("values", "second")], names=["cols1", "cols2"]
+        )
+
+        pdf = pd.DataFrame([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], index=index, columns=columns)
+        kdf = ks.from_pandas(pdf)
+
+        for axis in [0, "index"]:
+            self.assert_eq(
+                pdf.rename_axis(["index3", "index4"], axis=axis).sort_index(),
+                kdf.rename_axis(["index3", "index4"], axis=axis).sort_index(),
+            )
+
+        for axis in [1, "columns"]:
+            self.assert_eq(
+                pdf.rename_axis(["cols3", "cols4"], axis=axis).sort_index(),
+                kdf.rename_axis(["cols3", "cols4"], axis=axis).sort_index(),
+            )
+
+        self.assert_eq(
+            pdf.rename_axis(index=["index3", "index4"], columns=["cols3", "cols4"]).sort_index(),
+            kdf.rename_axis(index=["index3", "index4"], columns=["cols3", "cols4"]).sort_index(),
+        )
+
+        self.assert_eq(
+            pdf.rename_axis(index={"index1": "index3"}, columns={"cols1": "cols3"}).sort_index(),
+            kdf.rename_axis(index={"index1": "index3"}, columns={"cols1": "cols3"}).sort_index(),
+        )
+
+        self.assert_eq(
+            pdf.rename_axis(index={"missing": "index2"}, columns={"missing": "cols2"}).sort_index(),
+            kdf.rename_axis(index={"missing": "index2"}, columns={"missing": "cols2"}).sort_index(),
+        )
+
+        self.assert_eq(
+            pdf.rename_axis(
+                index={"index1": "index3", "index2": "index4"},
+                columns={"cols1": "cols3", "cols2": "cols4"},
+            ).sort_index(),
+            kdf.rename_axis(
+                index={"index1": "index3", "index2": "index4"},
+                columns={"cols1": "cols3", "cols2": "cols4"},
+            ).sort_index(),
+        )
+
+        self.assert_eq(
+            pdf.rename_axis(index=str.upper, columns=str.upper).sort_index(),
+            kdf.rename_axis(index=str.upper, columns=str.upper).sort_index(),
+        )
+
+        self.assertRaises(ValueError, lambda: kdf.rename_axis(index=["index3", "index4", "index5"]))
+        self.assertRaises(
+            ValueError, lambda: kdf.rename_axis(columns=["columns3", "columns4", "columns5"])
+        )
+
     def test_dot_in_column_name(self):
         self.assert_eq(
             ks.DataFrame(ks.range(1)._internal.spark_frame.selectExpr("1L as `a.b`"))["a.b"],

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -655,11 +655,9 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         index = pd.MultiIndex.from_tuples(
             [("A", "B"), ("C", "D"), ("E", "F")], names=["index1", "index2"]
         )
-
         columns = pd.MultiIndex.from_tuples(
             [("numbers", "first"), ("values", "second")], names=["cols1", "cols2"]
         )
-
         pdf = pd.DataFrame([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], index=index, columns=columns)
         kdf = ks.from_pandas(pdf)
 
@@ -715,7 +713,6 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
                 pdf.rename_axis(index=str.upper, columns=str.upper).sort_index(),
                 kdf.rename_axis(index=str.upper, columns=str.upper).sort_index(),
             )
-
         else:
             expected = pdf
             expected.index.names = ["index3", "index2"]

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -180,23 +180,23 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
             pser.rename_axis("index2").sort_index(), kser.rename_axis("index2").sort_index(),
         )
 
-        self.assert_eq(
-            pser.rename_axis(index="index2").sort_index(),
-            kser.rename_axis(index="index2").sort_index(),
-        )
-
-        self.assert_eq(
-            pser.rename_axis(index={"index": "index2", "missing": "index4"}).sort_index(),
-            kser.rename_axis(index={"index": "index2", "missing": "index4"}).sort_index(),
-        )
-
-        self.assert_eq(
-            pser.rename_axis(index=str.upper).sort_index(),
-            kser.rename_axis(index=str.upper).sort_index(),
-        )
-
-        self.assertRaises(TypeError, lambda: kser.rename_axis(mapper=["index2"], index=["index3"]))
         self.assertRaises(ValueError, lambda: kser.rename_axis(["index2", "index3"]))
+
+        # index/columns parameters and dict_like/functions mappers introduced in pandas 0.24.0
+        if LooseVersion(pd.__version__) >= LooseVersion("0.24.0"):
+            self.assert_eq(
+                pser.rename_axis(index={"index": "index2", "missing": "index4"}).sort_index(),
+                kser.rename_axis(index={"index": "index2", "missing": "index4"}).sort_index(),
+            )
+
+            self.assert_eq(
+                pser.rename_axis(index=str.upper).sort_index(),
+                kser.rename_axis(index=str.upper).sort_index(),
+            )
+
+            self.assertRaises(
+                TypeError, lambda: kser.rename_axis(mapper=["index2"], index=["index3"])
+            )
 
         index = pd.MultiIndex.from_tuples(
             [("A", "B"), ("C", "D"), ("E", "F")], names=["index1", "index2"]
@@ -210,26 +210,24 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
             kser.rename_axis(["index3", "index4"]).sort_index(),
         )
 
-        self.assert_eq(
-            pser.rename_axis(index=["index3", "index4"]).sort_index(),
-            kser.rename_axis(index=["index3", "index4"]).sort_index(),
-        )
-
-        self.assert_eq(
-            pser.rename_axis(
-                index={"index1": "index3", "index2": "index4", "missing": "index5"}
-            ).sort_index(),
-            kser.rename_axis(
-                index={"index1": "index3", "index2": "index4", "missing": "index5"}
-            ).sort_index(),
-        )
-
-        self.assert_eq(
-            pser.rename_axis(index=str.upper).sort_index(),
-            kser.rename_axis(index=str.upper).sort_index(),
-        )
-
         self.assertRaises(ValueError, lambda: kser.rename_axis(["index3", "index4", "index5"]))
+
+        # index/columns parameters and dict_like/functions mappers introduced in pandas 0.24.0
+        if LooseVersion(pd.__version__) >= LooseVersion("0.24.0"):
+
+            self.assert_eq(
+                pser.rename_axis(
+                    index={"index1": "index3", "index2": "index4", "missing": "index5"}
+                ).sort_index(),
+                kser.rename_axis(
+                    index={"index1": "index3", "index2": "index4", "missing": "index5"}
+                ).sort_index(),
+            )
+
+            self.assert_eq(
+                pser.rename_axis(index=str.upper).sort_index(),
+                kser.rename_axis(index=str.upper).sort_index(),
+            )
 
     def test_or(self):
         pdf = pd.DataFrame(

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -184,6 +184,12 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
             (kser + 1).rename_axis("index2").sort_index(),
         )
 
+        pser2 = pser.copy()
+        kser2 = kser.copy()
+        pser2.rename_axis("index2", inplace=True)
+        kser2.rename_axis("index2", inplace=True)
+        self.assert_eq(pser2.sort_index(), kser2.sort_index())
+
         self.assertRaises(ValueError, lambda: kser.rename_axis(["index2", "index3"]))
         self.assertRaises(TypeError, lambda: kser.rename_axis(mapper=["index2"], index=["index3"]))
 

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -180,6 +180,11 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
             pser.rename_axis("index2").sort_index(), kser.rename_axis("index2").sort_index(),
         )
 
+        self.assert_eq(
+            (pser + 1).rename_axis("index2").sort_index(),
+            (kser + 1).rename_axis("index2").sort_index(),
+        )
+
         self.assertRaises(ValueError, lambda: kser.rename_axis(["index2", "index3"]))
 
         # index/columns parameters and dict_like/functions mappers introduced in pandas 0.24.0

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -170,6 +170,67 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         # s.rename(lambda x: x**2, inplace=True)
         # self.assert_eq(kser, pser)
 
+    def test_rename_axis(self):
+
+        index = pd.Index(["A", "B", "C"], name="index")
+        pser = pd.Series([1.0, 2.0, 3.0], index=index, name="name")
+        kser = ks.from_pandas(pser)
+
+        self.assert_eq(
+            pser.rename_axis("index2").sort_index(), kser.rename_axis("index2").sort_index(),
+        )
+
+        self.assert_eq(
+            pser.rename_axis(index="index2").sort_index(),
+            kser.rename_axis(index="index2").sort_index(),
+        )
+
+        self.assert_eq(
+            pser.rename_axis(index={"index": "index2", "missing": "index4"}).sort_index(),
+            kser.rename_axis(index={"index": "index2", "missing": "index4"}).sort_index(),
+        )
+
+        self.assert_eq(
+            pser.rename_axis(index=str.upper).sort_index(),
+            kser.rename_axis(index=str.upper).sort_index(),
+        )
+
+        self.assertRaises(TypeError, lambda: kser.rename_axis(mapper=["index2"], index=["index3"]))
+        self.assertRaises(ValueError, lambda: kser.rename_axis(["index2", "index3"]))
+
+        index = pd.MultiIndex.from_tuples(
+            [("A", "B"), ("C", "D"), ("E", "F")], names=["index1", "index2"]
+        )
+
+        pser = pd.Series([1.0, 2.0, 3.0], index=index, name="name")
+        kser = ks.from_pandas(pser)
+
+        self.assert_eq(
+            pser.rename_axis(["index3", "index4"]).sort_index(),
+            kser.rename_axis(["index3", "index4"]).sort_index(),
+        )
+
+        self.assert_eq(
+            pser.rename_axis(index=["index3", "index4"]).sort_index(),
+            kser.rename_axis(index=["index3", "index4"]).sort_index(),
+        )
+
+        self.assert_eq(
+            pser.rename_axis(
+                index={"index1": "index3", "index2": "index4", "missing": "index5"}
+            ).sort_index(),
+            kser.rename_axis(
+                index={"index1": "index3", "index2": "index4", "missing": "index5"}
+            ).sort_index(),
+        )
+
+        self.assert_eq(
+            pser.rename_axis(index=str.upper).sort_index(),
+            kser.rename_axis(index=str.upper).sort_index(),
+        )
+
+        self.assertRaises(ValueError, lambda: kser.rename_axis(["index3", "index4", "index5"]))
+
     def test_or(self):
         pdf = pd.DataFrame(
             {

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -186,6 +186,7 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         )
 
         self.assertRaises(ValueError, lambda: kser.rename_axis(["index2", "index3"]))
+        self.assertRaises(TypeError, lambda: kser.rename_axis(mapper=["index2"], index=["index3"]))
 
         # index/columns parameters and dict_like/functions mappers introduced in pandas 0.24.0
         if LooseVersion(pd.__version__) >= LooseVersion("0.24.0"):
@@ -198,10 +199,16 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
                 pser.rename_axis(index=str.upper).sort_index(),
                 kser.rename_axis(index=str.upper).sort_index(),
             )
+        else:
+            expected = kser
+            expected.index.name = "index2"
+            result = kser.rename_axis(index={"index": "index2", "missing": "index4"}).sort_index()
+            self.assert_eq(expected, result)
 
-            self.assertRaises(
-                TypeError, lambda: kser.rename_axis(mapper=["index2"], index=["index3"])
-            )
+            expected = kser
+            expected.index.name = "INDEX"
+            result = kser.rename_axis(index=str.upper).sort_index()
+            self.assert_eq(expected, result)
 
         index = pd.MultiIndex.from_tuples(
             [("A", "B"), ("C", "D"), ("E", "F")], names=["index1", "index2"]
@@ -233,6 +240,17 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
                 pser.rename_axis(index=str.upper).sort_index(),
                 kser.rename_axis(index=str.upper).sort_index(),
             )
+        else:
+            expected = kser
+            expected.index.names = ["index3", "index4"]
+            result = kser.rename_axis(
+                index={"index1": "index3", "index2": "index4", "missing": "index5"}
+            ).sort_index()
+            self.assert_eq(expected, result)
+
+            expected.index.names = ["INDEX1", "INDEX2"]
+            result = kser.rename_axis(index=str.upper).sort_index()
+            self.assert_eq(expected, result)
 
     def test_or(self):
         pdf = pd.DataFrame(

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -171,7 +171,6 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         # self.assert_eq(kser, pser)
 
     def test_rename_axis(self):
-
         index = pd.Index(["A", "B", "C"], name="index")
         pser = pd.Series([1.0, 2.0, 3.0], index=index, name="name")
         kser = ks.from_pandas(pser)
@@ -213,7 +212,6 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         index = pd.MultiIndex.from_tuples(
             [("A", "B"), ("C", "D"), ("E", "F")], names=["index1", "index2"]
         )
-
         pser = pd.Series([1.0, 2.0, 3.0], index=index, name="name")
         kser = ks.from_pandas(pser)
 
@@ -226,7 +224,6 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
 
         # index/columns parameters and dict_like/functions mappers introduced in pandas 0.24.0
         if LooseVersion(pd.__version__) >= LooseVersion("0.24.0"):
-
             self.assert_eq(
                 pser.rename_axis(
                     index={"index1": "index3", "index2": "index4", "missing": "index5"}

--- a/docs/source/reference/frame.rst
+++ b/docs/source/reference/frame.rst
@@ -168,6 +168,7 @@ Reindexing / Selection / Label manipulation
    DataFrame.filter
    DataFrame.head
    DataFrame.rename
+   DataFrame.rename_axis
    DataFrame.reset_index
    DataFrame.set_index
    DataFrame.take

--- a/docs/source/reference/series.rst
+++ b/docs/source/reference/series.rst
@@ -170,6 +170,7 @@ Reindexing / Selection / Label manipulation
    Series.idxmin
    Series.isin
    Series.rename
+   Series.rename_axis
    Series.reindex
    Series.reset_index
    Series.sample


### PR DESCRIPTION
Hi, this PR implements `DataFrame.rename_axis` and `Series.rename_axis`.
I did not add `copy` parameter as a copy is performed anyway.