### PR TITLE
Calculate fliers correctly in Series.plot.box

### DIFF
--- a/databricks/koalas/tests/test_series_plot.py
+++ b/databricks/koalas/tests/test_series_plot.py
@@ -365,7 +365,7 @@ class SeriesPlotTest(ReusedSQLTestCase, TestUtils):
             self.assertEqual(expected_fliers, fliers)
 
         check_box_summary(self.kdf1, self.pdf1)
-        check_box_summary(self.kdf1 * -1, -self.pdf1)
+        check_box_summary(-self.kdf1, -self.pdf1)
 
     def test_kde_plot(self):
         def moving_average(a, n=10):


### PR DESCRIPTION
Koalas:

```python
from databricks import koalas as ks
from matplotlib import pyplot as plt
import pandas as pd
pdf = pd.DataFrame({"a": [1, 2, 3, 4, 5, 6, 7, 8, 9, 15, 50],}, index=[0, 1, 3, 5, 6, 8, 9, 9, 9, 10, 10])
ks.from_pandas(-pdf).a.plot.box()
plt.savefig('koalas_series_box.png')
```


pandas:

```python
from matplotlib import pyplot as plt
import pandas as pd
pdf = pd.DataFrame({"a": [1, 2, 3, 4, 5, 6, 7, 8, 9, 15, 50],}, index=[0, 1, 3, 5, 6, 8, 9, 9, 9, 10, 10])
(-pdf).a.plot.box()
plt.savefig('pandas_series_box.png')
```

![pandas_series_box](https://user-images.githubusercontent.com/6477701/95815385-7b7c6d80-0d57-11eb-9159-52a8757c137c.png)

**Before:**

![koalas_series_box](https://user-images.githubusercontent.com/6477701/95815195-1f194e00-0d57-11eb-9ef4-69dfec7ebc34.png)


**After:**

![koalas_series_box](https://user-images.githubusercontent.com/6477701/95815281-4d972900-0d57-11eb-8a18-822a14872a7a.png)


Resolves #1827