### PR TITLE
Remove FutureWarning when use cache in the context manager

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -10573,7 +10573,7 @@ class CachedDataFrame(DataFrame):
         return self
 
     def __exit__(self, exception_type, exception_value, traceback):
-        self.unpersist()
+        self.spark.unpersist()
 
     # create accessor for Spark related methods.
     spark = CachedAccessor("spark", CachedSparkFrameMethods)


### PR DESCRIPTION
When use `CachedDataFrame` in the context manager, It raises `FutureWarning` as below.

```python
>>> kdf = ks.range(10)
>>> with kdf.spark.cache() as cached:
...     cached.spark.storage_level
...
StorageLevel(True, True, False, True, 1)
.../koalas/databricks/koalas/frame.py:10593: FutureWarning: DataFrame.unpersist is deprecated as of DataFrame.spark.unpersist. Please use the API instead.
```

This warning is unavoidable since It's fixed in the code, so this PR proposes removing this.

```python
>>> kdf = ks.range(10)
>>> with kdf.spark.cache() as cached:
...     cached.spark.storage_level
...
StorageLevel(True, True, False, True, 1)
```