### PR TITLE
Support a non-string name in Series' boxplot

### DIFF
--- a/databricks/koalas/plot.py
+++ b/databricks/koalas/plot.py
@@ -434,7 +434,7 @@ class KoalasBoxPlot(BoxPlot):
                 ).alias("{}_{}%".format(colname, int(q * 100)))
                 for q in [0.25, 0.50, 0.75]
             ],
-            F.mean(colname).alias("{}_mean".format(colname))
+            F.mean("`%s`" % colname).alias("{}_mean".format(colname))
         ).toPandas()
 
         # Computes IQR and Tukey's fences
@@ -462,7 +462,7 @@ class KoalasBoxPlot(BoxPlot):
     @staticmethod
     def _outliers(data, colname, lfence, ufence):
         # Builds expression to identify outliers
-        expression = F.col(colname).between(lfence, ufence)
+        expression = F.col("`%s`" % colname).between(lfence, ufence)
         # Creates a column to flag rows as outliers or not
         return data._kdf._internal.resolved_copy.spark_frame.withColumn(
             "__{}_outlier".format(colname), ~expression
@@ -472,8 +472,8 @@ class KoalasBoxPlot(BoxPlot):
     def _calc_whiskers(colname, outliers):
         # Computes min and max values of non-outliers - the whiskers
         minmax = (
-            outliers.filter("not __{}_outlier".format(colname))
-            .agg(F.min(colname).alias("min"), F.max(colname).alias("max"))
+            outliers.filter("not `__{}_outlier`".format(colname))
+            .agg(F.min("`%s`" % colname).alias("min"), F.max(colname).alias("max"))
             .toPandas()
         )
         return minmax.iloc[0][["min", "max"]].values
@@ -481,7 +481,7 @@ class KoalasBoxPlot(BoxPlot):
     @staticmethod
     def _get_fliers(colname, outliers):
         # Filters only the outliers, should "showfliers" be True
-        fliers_df = outliers.filter("__{}_outlier".format(colname))
+        fliers_df = outliers.filter("`__{}_outlier`".format(colname))
 
         # If shows fliers, takes the top 1k with highest absolute values
         fliers = (

--- a/databricks/koalas/tests/test_series_plot.py
+++ b/databricks/koalas/tests/test_series_plot.py
@@ -284,11 +284,11 @@ class SeriesPlotTest(ReusedSQLTestCase, TestUtils):
         self.assertEqual(bin1, bin2)
 
     def test_box_plot(self):
-        def check_box_plot(pdf, kdf, *args, **kwargs):
+        def check_box_plot(pser, kser, *args, **kwargs):
             _, ax1 = plt.subplots(1, 1)
-            ax1 = pdf["a"].plot.box(*args, **kwargs)
+            ax1 = pser.plot.box(*args, **kwargs)
             _, ax2 = plt.subplots(1, 1)
-            ax2 = kdf["a"].plot.box(*args, **kwargs)
+            ax2 = kser.plot.box(*args, **kwargs)
 
             diffs = [
                 np.array([0, 0.5, 0, 0.5, 0, -0.5, 0, -0.5, 0, 0.5]),
@@ -307,13 +307,20 @@ class SeriesPlotTest(ReusedSQLTestCase, TestUtils):
                 ax1.cla()
                 ax2.cla()
 
-        check_box_plot(self.pdf1, self.kdf1)
-        check_box_plot(self.pdf1, self.kdf1, showfliers=True)
-        check_box_plot(self.pdf1, self.kdf1, sym="")
-        check_box_plot(self.pdf1, self.kdf1, sym=".", color="r")
-        check_box_plot(self.pdf1, self.kdf1, use_index=False, labels=["Test"])
-        check_box_plot(self.pdf1, self.kdf1, usermedians=[2.0])
-        check_box_plot(self.pdf1, self.kdf1, conf_intervals=[(1.0, 3.0)])
+        # Non-named Series
+        pser = pd.Series([1, 2, 3, 4, 5, 6, 7, 8, 9, 15, 50], [0, 1, 3, 5, 6, 8, 9, 9, 9, 10, 10])
+        kser = ks.from_pandas(pser)
+
+        spec = [(self.pdf1.a, self.kdf1.a), (pser, kser)]
+
+        for p, k in spec:
+            check_box_plot(p, k)
+            check_box_plot(p, k, showfliers=True)
+            check_box_plot(p, k, sym="")
+            check_box_plot(p, k, sym=".", color="r")
+            check_box_plot(p, k, use_index=False, labels=["Test"])
+            check_box_plot(p, k, usermedians=[2.0])
+            check_box_plot(p, k, conf_intervals=[(1.0, 3.0)])
 
         val = (1, 3)
         self.assertRaises(


### PR DESCRIPTION
This PR fixes `Series.boxplot` to support non-string name in Series's boxplot.

```python
from databricks import koalas as ks
ks.Series([1, 2, 3]).plot.box()
```

**Before:**

```python
<matplotlib.axes._subplots.AxesSubplot object at 0x12251a340>
```

**After:**

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/.../koalas/databricks/koalas/plot.py", line 1654, in box
    return self(kind="box", **kwds)
  File "/.../koalas/databricks/koalas/plot.py", line 1340, in __call__
    return plot_series(data=self.data, kind=kind, **kwds)
  File "/.../koalas/databricks/koalas/plot.py", line 892, in plot_series
    return _plot(
  File "/.../koalas/databricks/koalas/plot.py", line 1117, in _plot
    plot_obj.generate()
  File "/usr/local/lib/python3.8/site-packages/pandas/plotting/_matplotlib/core.py", line 269, in generate
    self._compute_plot_data()
  File "/.../koalas/databricks/koalas/plot.py", line 317, in _compute_plot_data
    col_stats, col_fences = KoalasBoxPlot._compute_stats(data, colname, whis, precision)
  File "/.../koalas/databricks/koalas/plot.py", line 434, in _compute_stats
    F.mean(colname).alias("{}_mean".format(colname))
  File "/.../spark/python/pyspark/sql/functions.py", line 63, in _
    jc = getattr(sc._jvm.functions, name)(_to_java_column(col))
  File "/.../spark/python/pyspark/sql/column.py", line 45, in _to_java_column
    raise TypeError(
TypeError: Invalid argument, not a string or column: None of type <class 'NoneType'>. For column literals, use 'lit', 'array', 'struct' or 'create_map' function.
```