### PR TITLE
Show type name rather than type class in error messages

### DIFF
--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -1143,7 +1143,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
 
     def _shift(self, periods, fill_value, part_cols=()):
         if not isinstance(periods, int):
-            raise ValueError("periods should be an int; however, got [%s]" % type(periods))
+            raise ValueError("periods should be an int; however, got [%s]" % type(periods).__name__)
 
         col = self.spark.column
         window = (

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -666,7 +666,7 @@ class DataFrame(Frame, Generic[T]):
             return DataFrame(sdf)[SPARK_DEFAULT_SERIES_NAME].rename(pser.name)
 
         else:
-            raise ValueError("No axis named %s for object type %s." % (axis, type(axis)))
+            raise ValueError("No axis named %s for object type %s." % (axis, type(axis).__name__))
 
     def _kser_for(self, label):
         """
@@ -715,7 +715,7 @@ class DataFrame(Frame, Generic[T]):
         ):
             raise ValueError(
                 "%s with a sequence is currently not supported; "
-                "however, got %s." % (op, type(other))
+                "however, got %s." % (op, type(other).__name__)
             )
 
         if isinstance(other, DataFrame):
@@ -4850,7 +4850,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         if value is not None:
             if not isinstance(value, (float, int, str, bool, dict, pd.Series)):
-                raise TypeError("Unsupported type %s" % type(value))
+                raise TypeError("Unsupported type %s" % type(value).__name__)
             if limit is not None:
                 raise ValueError("limit parameter for value is not support now")
             if isinstance(value, pd.Series):
@@ -4858,7 +4858,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             if isinstance(value, dict):
                 for v in value.values():
                     if not isinstance(v, (float, int, str, bool)):
-                        raise TypeError("Unsupported type %s" % type(v))
+                        raise TypeError("Unsupported type %s" % type(v).__name__)
                 value = {k if is_name_like_tuple(k) else (k,): v for k, v in value.items()}
 
                 def op(kser):
@@ -4977,9 +4977,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         inplace = validate_bool_kwarg(inplace, "inplace")
 
         if value is not None and not isinstance(value, (int, float, str, list, dict)):
-            raise TypeError("Unsupported type {}".format(type(value)))
+            raise TypeError("Unsupported type {}".format(type(value).__name__))
         if to_replace is not None and not isinstance(to_replace, (int, float, str, list, dict)):
-            raise TypeError("Unsupported type {}".format(type(to_replace)))
+            raise TypeError("Unsupported type {}".format(type(to_replace).__name__))
 
         if isinstance(value, list) and isinstance(to_replace, list):
             if len(value) != len(to_replace):
@@ -7812,7 +7812,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             elif axis == 1:
                 columns = labels
             else:
-                raise ValueError("No axis named %s for object type %s." % (axis, type(axis)))
+                raise ValueError(
+                    "No axis named %s for object type %s." % (axis, type(axis).__name__)
+                )
 
         if index is not None and not is_list_like(index):
             raise TypeError(
@@ -7929,7 +7931,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             label_columns = list(columns)
             for col in label_columns:
                 if not isinstance(col, tuple):
-                    raise TypeError("Expected tuple, got {}".format(type(col)))
+                    raise TypeError("Expected tuple, got {}".format(type(col).__name__))
         else:
             label_columns = [(col,) for col in columns]
         for col in label_columns:
@@ -8847,7 +8849,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                     col = None
                     for item in items:
                         if not isinstance(item, tuple):
-                            raise TypeError("Unsupported type {}".format(type(item)))
+                            raise TypeError("Unsupported type {}".format(type(item).__name__))
                         if not item:
                             raise ValueError("The item should not be empty.")
                         midx_col = None
@@ -9675,7 +9677,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         if isinstance(self.columns, pd.MultiIndex):
             raise ValueError("Doesn't support for MultiIndex columns")
         if not isinstance(expr, str):
-            raise ValueError("expr must be a string to be evaluated, {} given".format(type(expr)))
+            raise ValueError(
+                "expr must be a string to be evaluated, {} given".format(type(expr).__name__)
+            )
         inplace = validate_bool_kwarg(inplace, "inplace")
 
         data_columns = [label[0] for label in self._internal.column_labels]

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -1544,7 +1544,7 @@ class Frame(object, metaclass=ABCMeta):
         from databricks.koalas.groupby import DataFrameGroupBy, SeriesGroupBy
 
         if isinstance(by, ks.DataFrame):
-            raise ValueError("Grouper for '{}' not 1-dimensional".format(type(by)))
+            raise ValueError("Grouper for '{}' not 1-dimensional".format(type(by).__name__))
         elif isinstance(by, ks.Series):
             by = [by]
         elif is_name_like_tuple(by):
@@ -1559,7 +1559,9 @@ class Frame(object, metaclass=ABCMeta):
             new_by = []  # type: List[Union[Tuple, ks.Series]]
             for key in by:
                 if isinstance(key, ks.DataFrame):
-                    raise ValueError("Grouper for '{}' not 1-dimensional".format(type(key)))
+                    raise ValueError(
+                        "Grouper for '{}' not 1-dimensional".format(type(key).__name__)
+                    )
                 elif isinstance(key, ks.Series):
                     new_by.append(key)
                 elif is_name_like_tuple(key):
@@ -1571,10 +1573,12 @@ class Frame(object, metaclass=ABCMeta):
                         raise KeyError(key)
                     new_by.append((key,))
                 else:
-                    raise ValueError("Grouper for '{}' not 1-dimensional".format(type(key)))
+                    raise ValueError(
+                        "Grouper for '{}' not 1-dimensional".format(type(key).__name__)
+                    )
             by = new_by
         else:
-            raise ValueError("Grouper for '{}' not 1-dimensional".format(type(by)))
+            raise ValueError("Grouper for '{}' not 1-dimensional".format(type(by).__name__))
         if not len(by):
             raise ValueError("No group keys passed!")
         axis = validate_axis(axis)
@@ -1912,7 +1916,9 @@ class Frame(object, metaclass=ABCMeta):
         125.0
         """
         if not isinstance(accuracy, int):
-            raise ValueError("accuracy must be an integer; however, got [%s]" % type(accuracy))
+            raise ValueError(
+                "accuracy must be an integer; however, got [%s]" % type(accuracy).__name__
+            )
 
         return self._reduce_for_stat_function(
             lambda scol: SF.percentile_approx(scol, 0.5, accuracy),

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -1050,7 +1050,7 @@ class GroupBy(object, metaclass=ABCMeta):
         from pandas.core.base import SelectionMixin
 
         if not isinstance(func, Callable):
-            raise TypeError("%s object is not callable" % type(func))
+            raise TypeError("%s object is not callable" % type(func).__name__)
 
         spec = inspect.getfullargspec(func)
         return_sig = spec.annotations.get("return", None)
@@ -1238,7 +1238,7 @@ class GroupBy(object, metaclass=ABCMeta):
         from pandas.core.base import SelectionMixin
 
         if not isinstance(func, Callable):
-            raise TypeError("%s object is not callable" % type(func))
+            raise TypeError("%s object is not callable" % type(func).__name__)
 
         is_series_groupby = isinstance(self, SeriesGroupBy)
 
@@ -2012,7 +2012,7 @@ class GroupBy(object, metaclass=ABCMeta):
         2  31  35
         """
         if not isinstance(func, Callable):
-            raise TypeError("%s object is not callable" % type(func))
+            raise TypeError("%s object is not callable" % type(func).__name__)
 
         spec = inspect.getfullargspec(func)
         return_sig = spec.annotations.get("return", None)

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -699,7 +699,7 @@ class Index(IndexOpsMixin):
         Float64Index([1.0, 2.0, 0.0], dtype='float64')
         """
         if not isinstance(value, (float, int, str, bool)):
-            raise TypeError("Unsupported type %s" % type(value))
+            raise TypeError("Unsupported type %s" % type(value).__name__)
         sdf = self._internal.spark_frame.fillna(value)
         result = DataFrame(self._kdf._internal.with_new_sdf(sdf)).index
         return result
@@ -1900,7 +1900,9 @@ class Index(IndexOpsMixin):
         MultiIndex([], )
         """
         if not isinstance(repeats, int):
-            raise ValueError("`repeats` argument must be integer, but got {}".format(type(repeats)))
+            raise ValueError(
+                "`repeats` argument must be integer, but got {}".format(type(repeats).__name__)
+            )
         elif repeats < 0:
             raise ValueError("negative dimensions are not allowed")
 

--- a/databricks/koalas/indexing.py
+++ b/databricks/koalas/indexing.py
@@ -576,7 +576,9 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
 
             if isinstance(value, (Series, spark.Column)):
                 if remaining_index is not None and remaining_index == 0:
-                    raise ValueError("No axis named {} for object type {}".format(key, type(value)))
+                    raise ValueError(
+                        "No axis named {} for object type {}".format(key, type(value).__name__)
+                    )
                 if isinstance(value, Series):
                     value = value.spark.column
             else:

--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -125,7 +125,7 @@ def from_pandas(
     elif isinstance(pobj, pd.Index):
         return DataFrame(pd.DataFrame(index=pobj)).index
     else:
-        raise ValueError("Unknown data type: {}".format(type(pobj)))
+        raise ValueError("Unknown data type: {}".format(type(pobj).__name__))
 
 
 _range = range  # built-in range
@@ -2539,7 +2539,7 @@ def broadcast(obj):
     ...
     """
     if not isinstance(obj, DataFrame):
-        raise ValueError("Invalid type : expected DataFrame got {}".format(type(obj)))
+        raise ValueError("Invalid type : expected DataFrame got {}".format(type(obj).__name__))
     return DataFrame(obj._internal.with_new_sdf(F.broadcast(obj._internal.spark_frame)))
 
 

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -1775,7 +1775,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         if value is not None:
             if not isinstance(value, (float, int, str, bool)):
-                raise TypeError("Unsupported type %s" % type(value))
+                raise TypeError("Unsupported type %s" % type(value).__name__)
             if limit is not None:
                 raise ValueError("limit parameter for value is not support now")
             scol = F.when(cond, value).otherwise(scol)
@@ -3117,7 +3117,9 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         dtype: int64
         """
         if not isinstance(accuracy, int):
-            raise ValueError("accuracy must be an integer; however, got [%s]" % type(accuracy))
+            raise ValueError(
+                "accuracy must be an integer; however, got [%s]" % type(accuracy).__name__
+            )
 
         if isinstance(q, Iterable):
             q = list(q)
@@ -3397,7 +3399,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
     def _diff(self, periods, part_cols=()):
         if not isinstance(periods, int):
-            raise ValueError("periods should be an int; however, got [%s]" % type(periods))
+            raise ValueError("periods should be an int; however, got [%s]" % type(periods).__name__)
         window = (
             Window.partitionBy(*part_cols)
             .orderBy(NATURAL_ORDER_COLUMN_NAME)

--- a/databricks/koalas/sql.py
+++ b/databricks/koalas/sql.py
@@ -298,4 +298,4 @@ class SQLProcessor(object):
             return "(" + ", ".join([self._convert_var(v) for v in var]) + ")"
         if isinstance(var, (tuple, range)):
             return self._convert_var(list(var))
-        raise ValueError("Unsupported variable type {}: {}".format(type(var), str(var)))
+        raise ValueError("Unsupported variable type {}: {}".format(type(var).__name__, str(var)))

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -1007,7 +1007,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             kdf.fillna(-1, limit=1)
         with self.assertRaisesRegex(TypeError, "Unsupported.*DataFrame"):
             kdf.fillna(pd.DataFrame({"x": [-1], "y": [-1], "z": [-1]}))
-        with self.assertRaisesRegex(TypeError, "Unsupported.*numpy.int64"):
+        with self.assertRaisesRegex(TypeError, "Unsupported.*int64"):
             kdf.fillna({"x": np.int64(-6), "y": np.int64(-4), "z": -5})
         with self.assertRaisesRegex(ValueError, "Expecting 'pad', 'ffill', 'backfill' or 'bfill'."):
             kdf.fillna(method="xxx")
@@ -2032,9 +2032,9 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         ):
             kdf.replace(regex="")
 
-        with self.assertRaisesRegex(TypeError, "Unsupported type <class 'tuple'>"):
+        with self.assertRaisesRegex(TypeError, "Unsupported type tuple"):
             kdf.replace(value=(1, 2, 3))
-        with self.assertRaisesRegex(TypeError, "Unsupported type <class 'tuple'>"):
+        with self.assertRaisesRegex(TypeError, "Unsupported type tuple"):
             kdf.replace(to_replace=(1, 2, 3))
 
         with self.assertRaisesRegex(ValueError, "Length of to_replace and value must be same"):
@@ -3411,7 +3411,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             pdf.filter(items=[("aa", 1), ("bd", 2)], axis=0).sort_index(),
         )
 
-        with self.assertRaisesRegex(TypeError, "Unsupported type <class 'list'>"):
+        with self.assertRaisesRegex(TypeError, "Unsupported type list"):
             kdf.filter(items=[["aa", 1], ("bd", 2)], axis=0)
 
         with self.assertRaisesRegex(ValueError, "The item should not be empty."):
@@ -3864,7 +3864,8 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         invalid_exprs = (1, 1.0, (exprs[0],), [exprs[0]])
         for expr in invalid_exprs:
             with self.assertRaisesRegex(
-                ValueError, "expr must be a string to be evaluated, {} given".format(type(expr))
+                ValueError,
+                "expr must be a string to be evaluated, {} given".format(type(expr).__name__),
             ):
                 kdf.query(expr)
 

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -1876,7 +1876,7 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             pdf.a.rename().groupby(pdf.b.rename()).apply(lambda x: x + x.min()).sort_index(),
         )
 
-        with self.assertRaisesRegex(TypeError, "<class 'int'> object is not callable"):
+        with self.assertRaisesRegex(TypeError, "int object is not callable"):
             kdf.groupby("b").apply(1)
 
         # multi-index columns
@@ -2120,7 +2120,7 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             pdf.a.rename().groupby(pdf.b.rename()).filter(lambda x: any(x == 2)).sort_index(),
         )
 
-        with self.assertRaisesRegex(TypeError, "<class 'int'> object is not callable"):
+        with self.assertRaisesRegex(TypeError, "int object is not callable"):
             kdf.groupby("b").filter(1)
 
         # multi-index columns

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -607,7 +607,7 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         self.assert_eq(pidx.fillna(0), kidx.fillna(0), almost=True)
         self.assert_eq(pidx.rename("name").fillna(0), kidx.rename("name").fillna(0), almost=True)
 
-        with self.assertRaisesRegex(TypeError, "Unsupported type <class 'list'>"):
+        with self.assertRaisesRegex(TypeError, "Unsupported type list"):
             kidx.fillna([1, 2])
 
     def test_index_drop(self):

--- a/databricks/koalas/tests/test_namespace.py
+++ b/databricks/koalas/tests/test_namespace.py
@@ -43,7 +43,7 @@ class NamespaceTest(ReusedSQLTestCase, SQLTestUtils):
 
         self.assert_eq(kmidx, pmidx)
 
-        expected_error_message = "Unknown data type: {}".format(type(kidx))
+        expected_error_message = "Unknown data type: {}".format(type(kidx).__name__)
         with self.assertRaisesRegex(ValueError, expected_error_message):
             ks.from_pandas(kidx)
 
@@ -254,6 +254,8 @@ class NamespaceTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(kdf, ks.broadcast(kdf))
 
         kser = ks.Series([1, 2, 3])
-        expected_error_message = "Invalid type : expected DataFrame got {}".format(type(kser))
+        expected_error_message = "Invalid type : expected DataFrame got {}".format(
+            type(kser).__name__
+        )
         with self.assertRaisesRegex(ValueError, expected_error_message):
             ks.broadcast(kser)

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -1786,7 +1786,7 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
             kser.filter(items=[("one", "x"), ("three", "z")]),
         )
 
-        with self.assertRaisesRegex(TypeError, "Unsupported type <class 'list'>"):
+        with self.assertRaisesRegex(TypeError, "Unsupported type list"):
             kser.filter(items=[["one", "x"], ("three", "z")])
 
         with self.assertRaisesRegex(ValueError, "The item should not be empty."):

--- a/databricks/koalas/tests/test_sql.py
+++ b/databricks/koalas/tests/test_sql.py
@@ -27,7 +27,7 @@ class SQLTest(ReusedSQLTestCase, SQLTestUtils):
             ks.sql("select * from {variable_foo}")
 
     def test_error_unsupported_type(self):
-        msg = "Unsupported variable type <class 'dict'>: {'a': 1}"
+        msg = "Unsupported variable type dict: {'a': 1}"
         with self.assertRaisesRegex(ValueError, msg):
             some_dict = {"a": 1}
             ks.sql("select * from {some_dict}")


### PR DESCRIPTION
Use `type(...).__name__` rather than `type(...)` in error messages.