### PR TITLE
Add return type of groupby

### DIFF
--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -34,7 +34,6 @@ from pyspark.sql import functions as F
 from pyspark.sql.types import DataType, DoubleType, FloatType
 
 from databricks import koalas as ks  # For running doctests and reference resolution in PyCharm.
-from databricks.koalas.groupby import DataFrameGroupBy, SeriesGroupBy
 from databricks.koalas.indexing import AtIndexer, iAtIndexer, iLocIndexer, LocIndexer
 from databricks.koalas.internal import InternalFrame, NATURAL_ORDER_COLUMN_NAME
 from databricks.koalas.spark import functions as SF
@@ -1464,7 +1463,7 @@ class Frame(object, metaclass=ABCMeta):
     # should be updated when it's supported.
     def groupby(
         self, by, axis=0, as_index: bool = True, dropna: bool = True
-    ) -> Union[DataFrameGroupBy, SeriesGroupBy]:
+    ) -> Union["DataFrameGroupBy", "SeriesGroupBy"]:
         """
         Group DataFrame or Series using a Series of columns.
 

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -22,7 +22,7 @@ from collections import Counter
 from collections.abc import Iterable
 from distutils.version import LooseVersion
 from functools import reduce
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional, Tuple, Union, TYPE_CHECKING
 import warnings
 
 import numpy as np  # noqa: F401
@@ -46,6 +46,10 @@ from databricks.koalas.utils import (
     validate_axis,
 )
 from databricks.koalas.window import Rolling, Expanding
+
+
+if TYPE_CHECKING:
+    from databricks.koalas.groupby import DataFrameGroupBy, SeriesGroupBy
 
 
 class Frame(object, metaclass=ABCMeta):

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -34,6 +34,7 @@ from pyspark.sql import functions as F
 from pyspark.sql.types import DataType, DoubleType, FloatType
 
 from databricks import koalas as ks  # For running doctests and reference resolution in PyCharm.
+from databricks.koalas.groupby import DataFrameGroupBy, SeriesGroupBy
 from databricks.koalas.indexing import AtIndexer, iAtIndexer, iLocIndexer, LocIndexer
 from databricks.koalas.internal import InternalFrame, NATURAL_ORDER_COLUMN_NAME
 from databricks.koalas.spark import functions as SF
@@ -1461,7 +1462,9 @@ class Frame(object, metaclass=ABCMeta):
 
     # TODO: by argument only support the grouping name and as_index only for now. Documentation
     # should be updated when it's supported.
-    def groupby(self, by, axis=0, as_index: bool = True, dropna: bool = True):
+    def groupby(
+        self, by, axis=0, as_index: bool = True, dropna: bool = True
+    ) -> Union[DataFrameGroupBy, SeriesGroupBy]:
         """
         Group DataFrame or Series using a Series of columns.
 


### PR DESCRIPTION
This PR adds the type hints for its return type at `Series.groupby` and `DataFrame.groupby`.