### PR TITLE
Add apt-get update to refresh the repo

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -53,6 +53,7 @@ jobs:
     - name: Setup Python ${{ matrix.python-version }}
       run: |
         sudo add-apt-repository ppa:deadsnakes/ppa
+        sudo apt-get update
         sudo apt-get install tk-dev python$PYTHON_VERSION-tk python$PYTHON_VERSION
         sudo rm /usr/bin/python
         sudo ln -s /usr/bin/python$PYTHON_VERSION /usr/bin/python


### PR DESCRIPTION
Python 3.5 installation is being failed with:

```
E: Failed to fetch https://packages.microsoft.com/ubuntu/18.04/prod/dists/bionic/main/binary-amd64/Packages.bz2  File has unexpected size (141364 != 141252). Mirror sync in progress? [IP: 13.90.56.68 443]
   Hashes of expected file:
    - Filesize:141252 [weak]
    - SHA512:dffbaf15f537ae643df110b279248993b2828e99352dff51a5df9648cf39531ffb7022ec2f0d9e553287c9889addcb5e734d9df95f749c456db04fd328a67ef4
    - SHA256:6757f7f09fb2a0491657aac899faa29bd67fe7b9dfd849844f7fafca9afcc33e
    - SHA1:37be76673db70e808db91294af54fddf476aae7f [weak]
    - MD5Sum:ecc0d5d8d9373eee7aeceda58d7be8f9 [weak]
   Release file created at: Tue, 13 Oct 2020 22:35:00 +0000
E: Some index files failed to download. They have been ignored, or old ones used instead.
```

This PR adds apt-get update to refresh the repo to fix this test failure.