### PR TITLE
Refactor Spark accessor and add type annotations.

### DIFF
--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -21,13 +21,12 @@ from abc import ABCMeta, abstractmethod
 from collections import OrderedDict
 import datetime
 from functools import wraps, partial
-from typing import Union, Callable, Any
+from typing import Any, Callable, Tuple, Union
 import warnings
 
 import numpy as np
 import pandas as pd  # noqa: F401
 from pandas.api.types import is_list_like
-from pandas.core.accessor import CachedAccessor
 from pyspark import sql as spark
 from pyspark.sql import functions as F, Window, Column
 from pyspark.sql.types import (
@@ -156,10 +155,18 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
     def _with_new_scol(self, scol: spark.Column):
         pass
 
-    spark = CachedAccessor("spark", SparkIndexOpsMethods)
+    @property
+    @abstractmethod
+    def _column_label(self) -> Tuple:
+        pass
 
     @property
-    def spark_column(self):
+    @abstractmethod
+    def spark(self) -> SparkIndexOpsMethods:
+        pass
+
+    @property
+    def spark_column(self) -> Column:
         warnings.warn(
             "Series.spark_column is deprecated as of Series.spark.column. "
             "Please use the API instead.",

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -35,6 +35,7 @@ from pandas.api.types import (
     is_numeric_dtype,
     is_object_dtype,
 )
+from pandas.core.accessor import CachedAccessor
 from pandas.io.formats.printing import pprint_thing
 from pandas.api.types import is_hashable
 from pandas._libs import lib
@@ -51,6 +52,7 @@ from databricks.koalas.base import IndexOpsMixin
 from databricks.koalas.frame import DataFrame
 from databricks.koalas.missing.indexes import MissingPandasLikeIndex, MissingPandasLikeMultiIndex
 from databricks.koalas.series import Series, first_series
+from databricks.koalas.spark.accessors import SparkIndexMethods
 from databricks.koalas.utils import (
     compare_allow_null,
     compare_disallow_null,
@@ -158,6 +160,8 @@ class Index(IndexOpsMixin):
             index_map=OrderedDict(zip(sdf.columns, self._internal.index_names)),  # type: ignore
         )
         return DataFrame(internal).index
+
+    spark = CachedAccessor("spark", SparkIndexMethods)
 
     # This method is used via `DataFrame.info` API internally.
     def _summary(self, name=None):

--- a/databricks/koalas/tests/test_indexops_spark.py
+++ b/databricks/koalas/tests/test_indexops_spark.py
@@ -59,7 +59,3 @@ class SparkIndexOpsMethodsTest(ReusedSQLTestCase, SQLTestUtils):
 
         with self.assertRaisesRegex(AnalysisException, "cannot resolve.*non-existent.*"):
             self.kser.spark.transform(lambda scol: F.col("non-existent"))
-
-    def test_index_apply_negative(self):
-        with self.assertRaisesRegex(NotImplementedError, "Index does not support spark.apply yet"):
-            ks.range(10).index.spark.apply(lambda scol: scol)


### PR DESCRIPTION
Separates `SparkIndexOpsMethods` into `SparkSeriesMethods` and `SparkIndexMethods` and adds type annotations.