### PR TITLE
Fix Python version and Koalas version in installation docs

### DIFF
--- a/docs/source/getting_started/install.rst
+++ b/docs/source/getting_started/install.rst
@@ -21,7 +21,7 @@ To install PySpark, you can use:
 Python version support
 ----------------------
 
-Officially Python 3.5 and above.
+Officially Python 3.5 to 3.8.
 
 
 Installing Koalas
@@ -49,7 +49,7 @@ following command::
 
 To install a specific Koalas version::
 
-    conda install -c conda-forge koalas=0.19.0
+    conda install -c conda-forge koalas=1.3.0
 
 
 Installing from PyPI


### PR DESCRIPTION
This PR proposes:
- Fix supported Python version from `Python 3.5 and above` to `Python 3.5 to 3.8` since we doesn't support Python 3.9 yet.
- Fix Koalas version in installation guide from `0.19.0` to `1.3.0` since it's too old.