### PR TITLE
Set the lowerbound of numpydoc

### DIFF
--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -2169,7 +2169,6 @@ def isna(obj):
 
     See Also
     --------
-    notnull : Boolean inverse of pandas.isnull.
     Series.isna : Detect missing values in a Series.
     Series.isnull : Detect missing values in a Series.
     DataFrame.isna : Detect missing values in a DataFrame.
@@ -2218,6 +2217,9 @@ def isna(obj):
     2    False
     Name: b, dtype: bool
     """
+    # TODO: Add back:
+    #     notnull : Boolean inverse of pandas.isnull.
+    #   into the See Also in the docstring. It does not find the method in the latest numpydoc.
     if isinstance(obj, (DataFrame, Series)):
         return obj.isnull()
     else:
@@ -2245,8 +2247,6 @@ def notna(obj):
     --------
     isna : Detect missing values for an array-like object.
     Series.notna : Boolean inverse of Series.isna.
-    Series.notnull :Boolean inverse of Series.isnull.
-    DataFrame.notna :Boolean inverse of DataFrame.isna.
     DataFrame.notnull : Boolean inverse of DataFrame.isnull.
     Index.notna : Boolean inverse of Index.isna.
     Index.notnull : Boolean inverse of Index.isnull.
@@ -2290,6 +2290,10 @@ def notna(obj):
     >>> ks.notna(ser.index)
     True
     """
+    # TODO: Add back:
+    #     Series.notnull :Boolean inverse of Series.isnull.
+    #     DataFrame.notna :Boolean inverse of DataFrame.isna.
+    #   into the See Also in the docstring. It does not find the method in the latest numpydoc.
     if isinstance(obj, (DataFrame, Series)):
         return obj.notna()
     else:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,7 +13,7 @@ nbsphinx
 # Temporarily exclude nbconvert 6.0 that is a dependency from nbsphinx.
 # It causes Read the Docs build fails
 nbconvert!=6.0.*
-numpydoc==0.8
+numpydoc>=1.1.0
 pypandoc
 ipython
 pydata-sphinx-theme


### PR DESCRIPTION
This PR proposes to set the lower bound of numpydoc. The main reason to set the bound to 0.8.0 was that `self` argument appeared in the API references (see https://github.com/databricks/koalas/issues/439). This seems fixed now from 1.1.0+

There are a couple of methods not being found in "See Also" via numpydoc but I think they are trivial issues.