### PR TITLE
Ignore docs/mlruns directory generated during doc creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,5 @@ spark-warehouse/
 pandoc*
 whatsnew
 
+# Mlflow directory during documentation generation
+docs/mlruns


### PR DESCRIPTION
Currently `docs/mlruns` directory can be generated during documentation generation for some reasons. This PR adds it to the `.gitignore`.