### PR TITLE
Ignore mlruns directory globally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,4 +59,4 @@ pandoc*
 whatsnew
 
 # Mlflow directory during documentation generation
-docs/mlruns
+mlruns


### PR DESCRIPTION
Looks like mlflow creates that directory when it imports:

```python
>>> import mlflow
```

```bash
ls -al mlruns
```
```
total 0
drwxr-xr-x   4 hyukjin.kwon  staff  128 Oct 27 11:42 .
drwxr-xr-x@ 30 hyukjin.kwon  staff  960 Oct 27 11:42 ..
drwxr-xr-x   2 hyukjin.kwon  staff   64 Oct 27 11:42 .trash
drwxr-xr-x   3 hyukjin.kwon  staff   96 Oct 27 11:42 0
```