### PR TITLE
Type annotations to frame

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -9410,7 +9410,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         return self._apply_series_op(op)
 
     # TODO: axis = 1
-    def idxmax(self, axis=0) -> Union["ks.Series", "DataFrame", "ks.Index"]:
+    def idxmax(self, axis=0) -> "ks.Series":
         """
         Return index of first occurrence of maximum over requested axis.
         NA/null values are excluded.
@@ -9485,10 +9485,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         kdf = DataFrame(self._internal.with_filter(cond))  # type: "DataFrame"
 
-        return ks.from_pandas(kdf._to_internal_pandas().idxmax())
+        return ks.from_pandas(kdf._to_internal_pandas().idxmax())  # type: ignore
 
     # TODO: axis = 1
-    def idxmin(self, axis=0) -> Union["ks.Series", "DataFrame", "ks.Index"]:
+    def idxmin(self, axis=0) -> "ks.Series":
         """
         Return index of first occurrence of minimum over requested axis.
         NA/null values are excluded.
@@ -9557,7 +9557,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         kdf = DataFrame(self._internal.with_filter(cond))  # type: "DataFrame"
 
-        return ks.from_pandas(kdf._to_internal_pandas().idxmin())
+        return ks.from_pandas(kdf._to_internal_pandas().idxmin())   # type: ignore
 
     def info(self, verbose=None, buf=None, max_cols=None, null_counts=None):
         """

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -9557,7 +9557,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         kdf = DataFrame(self._internal.with_filter(cond))  # type: "DataFrame"
 
-        return ks.from_pandas(kdf._to_internal_pandas().idxmin())   # type: ignore
+        return ks.from_pandas(kdf._to_internal_pandas().idxmin())  # type: ignore
 
     def info(self, verbose=None, buf=None, max_cols=None, null_counts=None):
         """
@@ -9674,7 +9674,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 self.count = count_func
 
     # TODO: fix parameter 'axis' and 'numeric_only' to work same as pandas'
-    def quantile(self, q=0.5, axis=0, numeric_only=True, accuracy=10000) -> Frame:
+    def quantile(
+        self, q=0.5, axis=0, numeric_only=True, accuracy=10000
+    ) -> Union["DataFrame", "ks.Series"]:
         """
         Return value at the given quantile.
 

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -8904,7 +8904,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 else:
                     raise ValueError("Single or multi index must be specified.")
                 return DataFrame(self._internal.with_filter(col))
-            else:  # if axis == 1
+            else:
                 return self[items]
         elif like is not None:
             if axis == 0:
@@ -8915,7 +8915,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                     else:
                         col = col | index_scol.contains(like)
                 return DataFrame(self._internal.with_filter(col))
-            else:  # if axis == 1
+            else:
                 column_labels = self._internal.column_labels
                 output_labels = [label for label in column_labels if any(like in i for i in label)]
                 return self[output_labels]
@@ -8928,7 +8928,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                     else:
                         col = col | index_scol.rlike(regex)
                 return DataFrame(self._internal.with_filter(col))
-            else:  # if axis == 1
+            else:
                 column_labels = self._internal.column_labels
                 matcher = re.compile(regex)
                 output_labels = [
@@ -9988,7 +9988,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             raise ValueError("`indices` must be a list-like except dict or set")
         if axis == 0:
             return self.iloc[indices, :]
-        else:  # if axis == 1
+        else:
             return self.iloc[:, indices]
 
     def eval(self, expr, inplace=False) -> Optional["DataFrame"]:
@@ -10247,7 +10247,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
                 return first_series(DataFrame(internal).transpose())
 
-        else:  # if axis == 1
+        else:
 
             @pandas_udf(returnType=DoubleType())
             def calculate_columns_axis(*cols):


### PR DESCRIPTION
## Proposal
Add type annotations to frame. This is helpful to Autocompletion and Static Error Check in various editors. 

## About type comments
A few type comments are added in order to pass mypy check.

Most type comments `# type: ignore` are related to Optional type. We are considering enabling `--no-strict-optional` option of mypy in order to discard these type comments. However, this is not the scope of this PR.