### PR TITLE
Introduce InternalFrame.index_level.

### DIFF
--- a/databricks/koalas/accessors.py
+++ b/databricks/koalas/accessors.py
@@ -173,8 +173,7 @@ class KoalasFrameMethods(object):
             InternalFrame(
                 spark_frame=sdf,
                 index_spark_column_names=[
-                    SPARK_INDEX_NAME_FORMAT(i)
-                    for i in range(len(internal.index_spark_column_names))
+                    SPARK_INDEX_NAME_FORMAT(i) for i in range(internal.index_level)
                 ],
                 index_names=internal.index_names,
                 column_labels=internal.column_labels + [column],

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -2799,10 +2799,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         if not is_name_like_tuple(key):
             key = (key,)
-        if len(key) > len(self._internal.index_spark_columns):
+        if len(key) > self._internal.index_level:
             raise KeyError(
                 "Key length ({}) exceeds index depth ({})".format(
-                    len(key), len(self._internal.index_spark_columns)
+                    len(key), self._internal.index_level
                 )
             )
         if level is None:
@@ -2815,7 +2815,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         sdf = self._internal.spark_frame.filter(reduce(lambda x, y: x & y, rows)).select(scols)
 
-        if len(key) == len(self._internal.index_spark_columns):
+        if len(key) == self._internal.index_level:
             result = first_series(
                 DataFrame(InternalFrame(spark_frame=sdf, index_spark_column_names=None)).T
             ).rename(key)
@@ -3116,7 +3116,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         """
         from databricks.koalas.indexes import Index, MultiIndex
 
-        if len(self._internal.index_map) == 1:
+        if self._internal.index_level == 1:
             return Index(self)
         else:
             return MultiIndex(self)
@@ -3412,7 +3412,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         monkey         mammal    NaN    jump
         """
         inplace = validate_bool_kwarg(inplace, "inplace")
-        multi_index = len(self._internal.index_map) > 1
+        multi_index = self._internal.index_level > 1
 
         def rename(index):
             if multi_index:
@@ -3444,10 +3444,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
             if all(isinstance(l, int) for l in level):
                 for lev in level:
-                    if lev >= len(self._internal.index_map):
+                    if lev >= self._internal.index_level:
                         raise IndexError(
                             "Too many levels: Index has only {} level, not {}".format(
-                                len(self._internal.index_map), lev + 1
+                                self._internal.index_level, lev + 1
                             )
                         )
                 idx = level
@@ -4748,7 +4748,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             internal = self._internal.resolved_copy
 
             if labels is not None:
-                if any(len(lbl) != len(internal.index_map) for lbl in labels):
+                if any(len(lbl) != internal.index_level for lbl in labels):
                     raise ValueError(
                         "The length of each subset must be the same as the index size."
                     )
@@ -5560,7 +5560,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             # as a dummy to avoid overhead.
             with option_context("compute.default_index_type", "distributed"):
                 df = self.reset_index()
-            index = df._internal.column_labels[: len(self._internal.index_spark_column_names)]
+            index = df._internal.column_labels[: self._internal.index_level]
 
         df = df.pivot_table(index=index, columns=columns, values=values, aggfunc="first")
 
@@ -6996,7 +6996,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         if on:
             if not is_list_like(on):
                 on = [on]  # type: ignore
-            if len(on) != right.index.nlevels:
+            if len(on) != right._internal.index_level:
                 raise ValueError(
                     'len(left_on) must equal the number of levels in the index of "right"'
                 )
@@ -7064,7 +7064,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         if not ignore_index:
             index_scols = self._internal.index_spark_columns
-            if len(index_scols) != len(other._internal.index_spark_columns):
+            if len(index_scols) != other._internal.index_level:
                 raise ValueError("Both DataFrames have to have the same number of index levels")
 
             if verify_integrity and len(index_scols) > 0:
@@ -7890,7 +7890,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
     def _reindex_index(self, index, fill_value):
         # When axis is index, we can mimic pandas' by a right outer join.
-        nlevels = len(self._internal.index_spark_column_names)
+        nlevels = self._internal.index_level
         assert nlevels <= 1 or (
             isinstance(index, ks.MultiIndex) and nlevels == index.nlevels
         ), "MultiIndex DataFrame can only be reindexed with a similar Koalas MultiIndex."
@@ -8430,7 +8430,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         if len(column_label_names) == 0:
             column_label_names = [None]
 
-        index_column = SPARK_INDEX_NAME_FORMAT(len(self._internal.index_map))
+        index_column = SPARK_INDEX_NAME_FORMAT(self._internal.index_level)
         data_columns = [name_like_string(label) for label in column_labels]
 
         structs = [
@@ -8552,13 +8552,13 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         """
         from databricks.koalas.series import first_series
 
-        if len(self._internal.index_spark_column_names) > 1:
+        if self._internal.index_level > 1:
             # The index after `reset_index()` will never be used, so use "distributed" index
             # as a dummy to avoid overhead.
             with option_context("compute.default_index_type", "distributed"):
                 df = self.reset_index()
-            index = df._internal.column_labels[: len(self._internal.index_spark_column_names) - 1]
-            columns = df.columns[len(self._internal.index_spark_column_names) - 1]
+            index = df._internal.column_labels[: self._internal.index_level - 1]
+            columns = df.columns[self._internal.index_level - 1]
             df = df.pivot_table(
                 index=index, columns=columns, values=self._internal.column_labels, aggfunc="first"
             )
@@ -10694,7 +10694,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             ):
                 kdf = self.reset_index()
                 kdf[key] = ks.DataFrame(value)
-                kdf = kdf.set_index(kdf.columns[: len(self._internal.index_map)])
+                kdf = kdf.set_index(kdf.columns[: self._internal.index_level])
                 kdf.index.names = self.index.names
 
         elif isinstance(key, list):

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -1474,7 +1474,7 @@ class GroupBy(object, metaclass=ABCMeta):
         2  3  2
         3  4  4
         """
-        if len(self._kdf._internal.index_names) != 1:
+        if self._kdf._internal.index_level != 1:
             raise ValueError("idxmax only support one-level index now")
 
         groupkey_names = ["__groupkey_{}__".format(i) for i in range(len(self._groupkeys))]
@@ -1552,7 +1552,7 @@ class GroupBy(object, metaclass=ABCMeta):
         2  2  3
         3  4  4
         """
-        if len(self._kdf._internal.index_names) != 1:
+        if self._kdf._internal.index_level != 1:
             raise ValueError("idxmin only support one-level index now")
 
         groupkey_names = ["__groupkey_{}__".format(i) for i in range(len(self._groupkeys))]
@@ -2706,7 +2706,7 @@ class SeriesGroupBy(GroupBy):
         3  6    3
         Name: b, dtype: int64
         """
-        if len(self._kser._internal.index_names) > 1:
+        if self._kser._internal.index_level > 1:
             raise ValueError("nsmallest do not support multi-index now")
 
         groupkey_col_names = [SPARK_INDEX_NAME_FORMAT(i) for i in range(len(self._groupkeys))]
@@ -2738,7 +2738,7 @@ class SeriesGroupBy(GroupBy):
                 groupkey_col_names
                 + [
                     SPARK_INDEX_NAME_FORMAT(i + len(self._groupkeys))
-                    for i in range(len(self._kdf._internal.index_spark_column_names))
+                    for i in range(self._kdf._internal.index_level)
                 ]
             ),
             index_names=(
@@ -2779,7 +2779,7 @@ class SeriesGroupBy(GroupBy):
         3  7    4
         Name: b, dtype: int64
         """
-        if len(self._kser._internal.index_names) > 1:
+        if self._kser._internal.index_level > 1:
             raise ValueError("nlargest do not support multi-index now")
 
         groupkey_col_names = [SPARK_INDEX_NAME_FORMAT(i) for i in range(len(self._groupkeys))]
@@ -2811,7 +2811,7 @@ class SeriesGroupBy(GroupBy):
                 groupkey_col_names
                 + [
                     SPARK_INDEX_NAME_FORMAT(i + len(self._groupkeys))
-                    for i in range(len(self._kdf._internal.index_spark_column_names))
+                    for i in range(self._kdf._internal.index_level)
                 ]
             ),
             index_names=(

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -604,7 +604,7 @@ class Index(IndexOpsMixin):
         >>> kdf.index.nlevels
         2
         """
-        return len(self._internal.index_spark_column_names)
+        return self._internal.index_level
 
     def rename(
         self, name: Union[Any, Tuple, List[Union[Any, Tuple]]], inplace: bool = False
@@ -677,10 +677,10 @@ class Index(IndexOpsMixin):
         elif is_name_like_value(name):
             return [(name,)]
         elif is_list_like(name):
-            if len(self._internal.index_map) != len(name):
+            if self._internal.index_level != len(name):
                 raise ValueError(
                     "Length of new names must be {}, got {}".format(
-                        len(self._internal.index_map), len(name)
+                        self._internal.index_level, len(name)
                     )
                 )
             return [n if is_name_like_tuple(n) else (n,) for n in name]
@@ -783,7 +783,7 @@ class Index(IndexOpsMixin):
         scol = self.spark.column
         if name is not None:
             scol = scol.alias(name_like_string(name))
-        elif len(kdf._internal.index_map) == 1:
+        elif kdf._internal.index_level == 1:
             name = self.name
         column_labels = [
             name if is_name_like_tuple(name) else (name,)
@@ -1552,7 +1552,7 @@ class Index(IndexOpsMixin):
         sdf = self._internal._sdf
         index_value_column_names = [
             verify_temp_column_name(sdf, index_value_column_format.format(i))
-            for i in range(len(self._internal.index_spark_columns))
+            for i in range(self._internal.index_level)
         ]
         index_value_columns = [
             index_scol.alias(index_vcol_name)
@@ -2353,7 +2353,7 @@ class MultiIndex(Index):
     """
 
     def __new__(cls, kdf: DataFrame):
-        assert len(kdf._internal.index_map) > 1
+        assert kdf._internal.index_level > 1
 
         return super().__new__(cls, data=kdf)
 
@@ -2571,10 +2571,10 @@ class MultiIndex(Index):
 
     def _verify_for_rename(self, name):
         if is_list_like(name):
-            if len(self._internal.index_map) != len(name):
+            if self._internal.index_level != len(name):
                 raise ValueError(
                     "Length of new names must be {}, got {}".format(
-                        len(self._internal.index_map), len(name)
+                        self._internal.index_level, len(name)
                     )
                 )
             return [n if is_name_like_tuple(n) else (n,) for n in name]
@@ -2803,7 +2803,7 @@ class MultiIndex(Index):
                 for i, name in enumerate(self._internal.index_names)
             ]
         elif is_list_like(name):
-            if len(name) != len(self._internal.index_map):
+            if len(name) != self._internal.index_level:
                 raise ValueError("'name' should have same length as number of levels on index.")
             name = [n if is_name_like_tuple(n) else (n,) for n in name]
         else:

--- a/databricks/koalas/internal.py
+++ b/databricks/koalas/internal.py
@@ -780,6 +780,11 @@ class InternalFrame(object):
         """ Return the managed index names. """
         return self._index_names
 
+    @lazy_property
+    def index_level(self) -> int:
+        """ Return the level of the index. """
+        return len(self._index_names)
+
     @property
     def column_labels(self) -> List[Tuple]:
         """ Return the managed column index. """


### PR DESCRIPTION
Currently there are different ways to check the number of the index columns. We should introduce `InternalFrame.index_level` and use it.