### PR TITLE
Explicitly disallow empty list as index_spark_colum_names and index_names.

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -3495,21 +3495,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             scol_for(sdf, column).alias(name_like_string(name)) for column, name in new_index_map
         ]
 
-        if len(index_map) > 0:  # type: ignore
-            index_scols = [scol_for(sdf, column) for column in index_map]
-            sdf = sdf.select(
-                index_scols
-                + new_data_scols
-                + self._internal.data_spark_columns
-                + list(HIDDEN_COLUMNS)
-            )
-        else:
-            sdf = sdf.select(
-                new_data_scols + self._internal.data_spark_columns + list(HIDDEN_COLUMNS)
-            )
-
-            sdf = InternalFrame.attach_default_index(sdf)
-            index_map = OrderedDict({SPARK_DEFAULT_INDEX_NAME: None})
+        index_scols = [scol_for(sdf, column) for column in index_map]
+        sdf = sdf.select(
+            index_scols + new_data_scols + self._internal.data_spark_columns + list(HIDDEN_COLUMNS)
+        )
 
         if self._internal.column_labels_level > 1:
             column_depth = len(self._internal.column_labels[0])

--- a/databricks/koalas/internal.py
+++ b/databricks/koalas/internal.py
@@ -445,7 +445,7 @@ class InternalFrame(object):
         assert isinstance(spark_frame, spark.DataFrame)
         assert not spark_frame.isStreaming, "Koalas does not support Structured Streaming."
 
-        if index_spark_column_names is None:
+        if not index_spark_column_names:
             assert not any(SPARK_INDEX_NAME_PATTERN.match(name) for name in spark_frame.columns), (
                 "Index columns should not appear in columns of the Spark DataFrame. Avoid "
                 "index column names [%s]." % SPARK_INDEX_NAME_PATTERN
@@ -470,7 +470,7 @@ class InternalFrame(object):
                 NATURAL_ORDER_COLUMN_NAME, F.monotonically_increasing_id()
             )
 
-        if index_names is None:
+        if not index_names:
             index_names = [None] * len(index_spark_column_names)
 
         assert len(index_spark_column_names) == len(index_names), (
@@ -857,11 +857,10 @@ class InternalFrame(object):
                 name=names[0],
             )
 
-        index_names = self.index_names
-        if len(index_names) > 0:
-            pdf.index.names = [
-                name if name is None or len(name) > 1 else name[0] for name in index_names
-            ]
+        pdf.index.names = [
+            name if name is None or len(name) > 1 else name[0] for name in self.index_names
+        ]
+
         return pdf
 
     @lazy_property

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -207,6 +207,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         kdf = ks.from_pandas(pdf)
 
         self.assert_eq(kdf.reset_index(), pdf.reset_index())
+        self.assert_eq(kdf.reset_index().index, pdf.reset_index().index)
         self.assert_eq(kdf.reset_index(drop=True), pdf.reset_index(drop=True))
 
         pdf.index.name = "a"


### PR DESCRIPTION
When an empty list is passed to `IndexFrame.index_spark_column_names` or `.index_names`, currently it passes without any errors and it will cause an unexpected error in other places.
We should handle the empty list the same as `None`.