### PR TITLE
Fix DataFrame.xs to handle internal changes properly.

### DIFF
--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -1399,14 +1399,25 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(kdf.xs("mammal"), pdf.xs("mammal"))
         self.assert_eq(kdf.xs(("mammal",)), pdf.xs(("mammal",)))
         self.assert_eq(kdf.xs(("mammal", "dog", "walks")), pdf.xs(("mammal", "dog", "walks")))
+        self.assert_eq(
+            ks.concat([kdf, kdf]).xs(("mammal", "dog", "walks")),
+            pd.concat([pdf, pdf]).xs(("mammal", "dog", "walks")),
+        )
         self.assert_eq(kdf.xs("cat", level=1), pdf.xs("cat", level=1))
+        self.assert_eq(kdf.xs("flies", level=2), pdf.xs("flies", level=2))
+        self.assert_eq(kdf.xs("mammal", level=-3), pdf.xs("mammal", level=-3))
 
         msg = 'axis should be either 0 or "index" currently.'
         with self.assertRaisesRegex(NotImplementedError, msg):
             kdf.xs("num_wings", axis=1)
+        with self.assertRaises(KeyError):
+            kdf.xs(("mammal", "dog", "walk"))
         msg = r"'Key length \(4\) exceeds index depth \(3\)'"
         with self.assertRaisesRegex(KeyError, msg):
             kdf.xs(("mammal", "dog", "walks", "foo"))
+
+        self.assertRaises(IndexError, lambda: kdf.xs("foo", level=-4))
+        self.assertRaises(IndexError, lambda: kdf.xs("foo", level=3))
 
         self.assertRaises(KeyError, lambda: kdf.xs(("dog", "walks"), level=1))
 
@@ -1417,6 +1428,9 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         self.assert_eq(kdf.xs(("mammal", "dog", 4)), pdf.xs(("mammal", "dog", 4)))
         self.assert_eq(kdf.xs(2, level=2), pdf.xs(2, level=2))
+
+        self.assert_eq((kdf + "a").xs(("mammal", "dog", 4)), (pdf + "a").xs(("mammal", "dog", 4)))
+        self.assert_eq((kdf + "a").xs(2, level=2), (pdf + "a").xs(2, level=2))
 
     def test_missing(self):
         kdf = self.kdf


### PR DESCRIPTION
Fixes `DataFrame.xs` to handle internal changes properly.

Also fixes:
- the return type and type annotation.
- a bug when `level` is out of range.
- a bug when the result is duplicated with the key whose length is the same as index level.
