### PR TITLE
Use nullable inferred schema in function apply

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -92,6 +92,7 @@ from databricks.koalas.utils import (
     validate_bool_kwarg,
     verify_temp_column_name,
 )
+from databricks.koalas.spark.utils import as_nullable_spark_type
 from databricks.koalas.generic import Frame
 from databricks.koalas.internal import (
     InternalFrame,
@@ -2398,7 +2399,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 should_return_series = True
                 kdf = kser_or_kdf._kdf
 
-            return_schema = kdf._internal.to_internal_spark_frame.schema
+            return_schema = as_nullable_spark_type(kdf._internal.to_internal_spark_frame.schema)
 
             if should_use_map_in_pandas:
                 output_func = GroupBy._make_pandas_df_builder_func(
@@ -2612,7 +2613,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             ):
                 pudf = pandas_udf(
                     lambda c: func(c, *args, **kwargs),
-                    returnType=kdf._internal.spark_type_for(output_label),
+                    returnType=as_nullable_spark_type(kdf._internal.spark_type_for(output_label)),
                     functionType=PandasUDFType.SCALAR,
                 )
                 kser = self._kser_for(input_label)

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -68,6 +68,7 @@ from databricks.koalas.utils import (
     scol_for,
     verify_temp_column_name,
 )
+from databricks.koalas.spark.utils import as_nullable_spark_type
 from databricks.koalas.window import RollingGroupby, ExpandingGroupby
 from databricks.koalas.exceptions import DataError
 
@@ -1116,7 +1117,9 @@ class GroupBy(object, metaclass=ABCMeta):
             else:
                 kdf_from_pandas = kser_or_kdf  # type: ignore
 
-            return_schema = kdf_from_pandas._internal.spark_frame.drop(*HIDDEN_COLUMNS).schema
+            return_schema = as_nullable_spark_type(
+                kdf_from_pandas._internal.spark_frame.drop(*HIDDEN_COLUMNS).schema
+            )
         else:
             return_type = infer_return_type(func)
             if not is_series_groupby and isinstance(return_type, SeriesType):
@@ -2041,7 +2044,9 @@ class GroupBy(object, metaclass=ABCMeta):
             pdf = kdf.head(limit + 1)._to_internal_pandas()
             pdf = pdf.groupby(groupkey_names).transform(func, *args, **kwargs)
             kdf_from_pandas = DataFrame(pdf)  # type: DataFrame
-            return_schema = kdf_from_pandas._internal.spark_frame.drop(*HIDDEN_COLUMNS).schema
+            return_schema = as_nullable_spark_type(
+                kdf_from_pandas._internal.spark_frame.drop(*HIDDEN_COLUMNS).schema
+            )
             if len(pdf) <= limit:
                 return kdf_from_pandas
 

--- a/databricks/koalas/spark/utils.py
+++ b/databricks/koalas/spark/utils.py
@@ -1,0 +1,67 @@
+#
+# Copyright (C) 2019 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+Helpers and utilities to deal with PySpark instances
+"""
+from pyspark.sql.types import StructType, MapType, ArrayType, StructField, DataType
+
+
+def as_nullable_spark_type(dt: DataType) -> DataType:
+    """
+    Returns a nullable schema or data types.
+
+    Examples
+    --------
+    >>> from pyspark.sql.types import *
+    >>> as_nullable_spark_type(StructType([
+    ...     StructField("A", IntegerType(), True),
+    ...     StructField("B", FloatType(), False)]))  # doctest: +NORMALIZE_WHITESPACE
+    StructType(List(StructField(A,IntegerType,true),StructField(B,FloatType,true)))
+
+    >>> as_nullable_spark_type(StructType([
+    ...     StructField("A",
+    ...         StructType([
+    ...             StructField('a',
+    ...                 MapType(IntegerType(),
+    ...                 ArrayType(IntegerType(), False), False), False),
+    ...             StructField('b', StringType(), True)])),
+    ...     StructField("B", FloatType(), False)]))  # doctest: +NORMALIZE_WHITESPACE
+    StructType(List(StructField(A,StructType(List(StructField(a,MapType(IntegerType,ArrayType\
+(IntegerType,true),true),true),StructField(b,StringType,true))),true),\
+StructField(B,FloatType,true)))
+    """
+    if isinstance(dt, StructType):
+        new_fields = []
+        for field in dt.fields:
+            new_fields.append(
+                StructField(
+                    field.name,
+                    as_nullable_spark_type(field.dataType),
+                    nullable=True,
+                    metadata=field.metadata,
+                )
+            )
+        return StructType(new_fields)
+    elif isinstance(dt, ArrayType):
+        return ArrayType(as_nullable_spark_type(dt.elementType), containsNull=True)
+    elif isinstance(dt, MapType):
+        return MapType(
+            as_nullable_spark_type(dt.keyType),
+            as_nullable_spark_type(dt.valueType),
+            valueContainsNull=True,
+        )
+    else:
+        return dt


### PR DESCRIPTION
This PR proposes to use nullable schema in when to apply a function. We take some to infer the schema. Usually types are matched but null or NaN is sparse often. This behaviour is batch with Spark's JSON schema inference as well.

```python
from pyspark.sql import SparkSession
import databricks.koalas as ks
import numpy as np

spark = SparkSession.builder.getOrCreate()
data = list()
for i in range(1, 10000):
  data.append((str(i % 100), np.nan if i % 9999 == 0 else float(i),))

sdf = spark.createDataFrame(data, 'a string, b float').repartition(10)
kdf = sdf.to_koalas()

def f(df):
  return df

df = kdf\
  .groupby('a')\
  .apply(f)

df.to_spark().printSchema()
df[df['b'] == -1]
```

**Before:**

```
root
 |-- a: string (nullable = false)
 |-- b: float (nullable = false)

java.lang.IllegalStateException: Value at index is null
...
```

**After:**

```
root
 |-- a: string (nullable = true)
 |-- b: float (nullable = true)

Empty DataFrame
Columns: [a, b]
Index: []
```

Resolves #1885