### PR TITLE
Force to use the Spark's system default precision and scale when inferred data type contains DecimalType.

### DIFF
--- a/databricks/koalas/accessors.py
+++ b/databricks/koalas/accessors.py
@@ -33,7 +33,7 @@ from databricks.koalas.internal import (
     SPARK_DEFAULT_SERIES_NAME,
 )
 from databricks.koalas.typedef import infer_return_type, DataFrameType, SeriesType
-from databricks.koalas.spark.utils import as_nullable_spark_type
+from databricks.koalas.spark.utils import as_nullable_spark_type, force_decimal_precision_scale
 from databricks.koalas.utils import (
     is_name_like_value,
     is_name_like_tuple,
@@ -347,7 +347,9 @@ class KoalasFrameMethods(object):
             if len(pdf) <= limit:
                 return kdf
 
-            return_schema = as_nullable_spark_type(kdf._internal.to_internal_spark_frame.schema)
+            return_schema = force_decimal_precision_scale(
+                as_nullable_spark_type(kdf._internal.to_internal_spark_frame.schema)
+            )
             if should_use_map_in_pandas:
                 output_func = GroupBy._make_pandas_df_builder_func(
                     self_applied, func, return_schema, retain_index=True
@@ -574,7 +576,9 @@ class KoalasFrameMethods(object):
                 kser = kdf_or_kser
                 pudf = pandas_udf(
                     func if should_by_pass else pandas_series_func(func),
-                    returnType=as_nullable_spark_type(kser.spark.data_type),
+                    returnType=force_decimal_precision_scale(
+                        as_nullable_spark_type(kser.spark.data_type)
+                    ),
                     functionType=PandasUDFType.SCALAR,
                 )
                 columns = self._kdf._internal.spark_columns
@@ -597,7 +601,9 @@ class KoalasFrameMethods(object):
                     return cast(ks.DataFrame, kdf)
 
                 # Force nullability.
-                return_schema = as_nullable_spark_type(kdf._internal.to_internal_spark_frame.schema)
+                return_schema = force_decimal_precision_scale(
+                    as_nullable_spark_type(kdf._internal.to_internal_spark_frame.schema)
+                )
 
                 self_applied = DataFrame(self._kdf._internal.resolved_copy)  # type: DataFrame
 
@@ -835,7 +841,9 @@ class KoalasSeriesMethods(object):
             pser = self._kser.head(limit)._to_internal_pandas()
             transformed = pser.transform(func)
             kser = Series(transformed)
-            spark_return_type = as_nullable_spark_type(kser.spark.data_type)
+            spark_return_type = force_decimal_precision_scale(
+                as_nullable_spark_type(kser.spark.data_type)
+            )
         else:
             spark_return_type = return_schema
 

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -94,7 +94,7 @@ from databricks.koalas.utils import (
     validate_bool_kwarg,
     verify_temp_column_name,
 )
-from databricks.koalas.spark.utils import as_nullable_spark_type
+from databricks.koalas.spark.utils import as_nullable_spark_type, force_decimal_precision_scale
 from databricks.koalas.generic import Frame
 from databricks.koalas.internal import (
     InternalFrame,
@@ -2401,7 +2401,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 should_return_series = True
                 kdf = kser_or_kdf._kdf
 
-            return_schema = as_nullable_spark_type(kdf._internal.to_internal_spark_frame.schema)
+            return_schema = force_decimal_precision_scale(
+                as_nullable_spark_type(kdf._internal.to_internal_spark_frame.schema)
+            )
 
             if should_use_map_in_pandas:
                 output_func = GroupBy._make_pandas_df_builder_func(
@@ -2615,7 +2617,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             ):
                 pudf = pandas_udf(
                     lambda c: func(c, *args, **kwargs),
-                    returnType=as_nullable_spark_type(kdf._internal.spark_type_for(output_label)),
+                    returnType=force_decimal_precision_scale(
+                        as_nullable_spark_type(kdf._internal.spark_type_for(output_label))
+                    ),
                     functionType=PandasUDFType.SCALAR,
                 )
                 kser = self._kser_for(input_label)

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -68,7 +68,7 @@ from databricks.koalas.utils import (
     scol_for,
     verify_temp_column_name,
 )
-from databricks.koalas.spark.utils import as_nullable_spark_type
+from databricks.koalas.spark.utils import as_nullable_spark_type, force_decimal_precision_scale
 from databricks.koalas.window import RollingGroupby, ExpandingGroupby
 from databricks.koalas.exceptions import DataError
 
@@ -1117,8 +1117,10 @@ class GroupBy(object, metaclass=ABCMeta):
             else:
                 kdf_from_pandas = kser_or_kdf  # type: ignore
 
-            return_schema = as_nullable_spark_type(
-                kdf_from_pandas._internal.spark_frame.drop(*HIDDEN_COLUMNS).schema
+            return_schema = force_decimal_precision_scale(
+                as_nullable_spark_type(
+                    kdf_from_pandas._internal.spark_frame.drop(*HIDDEN_COLUMNS).schema
+                )
             )
         else:
             return_type = infer_return_type(func)
@@ -2044,8 +2046,10 @@ class GroupBy(object, metaclass=ABCMeta):
             pdf = kdf.head(limit + 1)._to_internal_pandas()
             pdf = pdf.groupby(groupkey_names).transform(func, *args, **kwargs)
             kdf_from_pandas = DataFrame(pdf)  # type: DataFrame
-            return_schema = as_nullable_spark_type(
-                kdf_from_pandas._internal.spark_frame.drop(*HIDDEN_COLUMNS).schema
+            return_schema = force_decimal_precision_scale(
+                as_nullable_spark_type(
+                    kdf_from_pandas._internal.spark_frame.drop(*HIDDEN_COLUMNS).schema
+                )
             )
             if len(pdf) <= limit:
                 return kdf_from_pandas

--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -67,6 +67,7 @@ from databricks.koalas.internal import (
     SPARK_INDEX_NAME_FORMAT,
 )
 from databricks.koalas.series import Series, first_series
+from databricks.koalas.spark.utils import as_nullable_spark_type, force_decimal_precision_scale
 from databricks.koalas.indexes import Index
 
 
@@ -1093,7 +1094,9 @@ def read_excel(
         def read_excel_on_spark(pdf, sn):
 
             kdf = from_pandas(pdf)
-            return_schema = kdf._internal.to_internal_spark_frame.schema
+            return_schema = force_decimal_precision_scale(
+                as_nullable_spark_type(kdf._internal.to_internal_spark_frame.schema)
+            )
 
             def output_func(pdf):
                 pdf = pd.concat([pd_read_excel(bin, sn=sn) for bin in pdf[pdf.columns[0]]])


### PR DESCRIPTION
The return type inference sometimes fails when the inferred type contains `DecimalType` to infer the precision or the scale smaller.

```py
>>> from decimal import Decimal
>>> kdf = ks.DataFrame({'a': [Decimal('1.1'), Decimal('2.2'), Decimal('10.01')]})
>>> kdf
       a
0   1.10
1   2.20
2  10.01
>>> kdf.spark.print_schema()
root
 |-- a: decimal(4,2) (nullable = false)

>>> with ks.option_context("compute.shortcut_limit", 1):
...   kdf.transform(lambda x: x).spark.print_schema()
...
root
 |-- a: decimal(3,2) (nullable = true)

>>> with ks.option_context("compute.shortcut_limit", 1):
...   kdf.transform(lambda x: x)
...
Traceback (most recent call last):
...
pyarrow.lib.ArrowInvalid: Decimal type with precision 4 does not fit into precision inferred from first array element: 3
...
```

We should use the Spark's system default precision and scale instead to avoid as many such cases as possible:

```py
>>> with ks.option_context("compute.shortcut_limit", 1):
...   kdf.transform(lambda x: x).spark.print_schema()
...
root
 |-- a: decimal(38,18) (nullable = true)

>>> with ks.option_context("compute.shortcut_limit", 1):
...   kdf.transform(lambda x: x)
...
                       a
0   1.100000000000000000
1   2.200000000000000000
2  10.010000000000000000
```
