### PR TITLE
Fix read_excel to support squeeze argument.

### DIFF
--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -65,7 +65,6 @@ from databricks.koalas.internal import (
     InternalFrame,
     DEFAULT_SERIES_NAME,
     HIDDEN_COLUMNS,
-    SPARK_INDEX_NAME_FORMAT,
 )
 from databricks.koalas.series import Series, first_series
 from databricks.koalas.indexes import Index

--- a/databricks/koalas/tests/test_dataframe_spark_io.py
+++ b/databricks/koalas/tests/test_dataframe_spark_io.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 
-from decimal import Decimal
 from distutils.version import LooseVersion
 import unittest
 


### PR DESCRIPTION
Fixes `read_excel` to support squeeze argument.
Currently it always return `DataFrame` when there are multiple Excel files.
