### PR TITLE
Move the words about Koalas in workers

### DIFF
--- a/docs/source/development/design.rst
+++ b/docs/source/development/design.rst
@@ -73,7 +73,9 @@ Note that it is clear from the names that these functions return some local data
 Be a lean API layer and move fast
 ---------------------------------
 
-Koalas is designed as an API overlay layer on top of Spark. The project should be lightweight, and most functions should be implemented as wrappers around Spark or pandas. Koalas does not accept heavyweight implementations, e.g. execution engine changes.
+Koalas is designed as an API overlay layer on top of Spark. The project should be lightweight, and most functions should be implemented as wrappers
+around Spark or pandas - the Koalas library is designed to be used only in the Spark's driver side in general.
+Koalas does not accept heavyweight implementations, e.g. execution engine changes.
 
 This approach enables us to move fast. For the considerable future, we aim to be making monthly releases. If we find a critical bug, we will be making a new release as soon as the bug fix is available.
 

--- a/docs/source/getting_started/install.rst
+++ b/docs/source/getting_started/install.rst
@@ -17,9 +17,6 @@ To install PySpark, you can use:
 - `PyPI <https://pypi.org/project/pyspark>`__
 - `Installation from source <https://github.com/apache/spark#building-spark>`__
 
-Note that Koalas should be used *only* in the Spark's driver side, meaning that you can just install it in your driver side only
-and run it out of the box in the existing Spark cluster.
-
 
 Python version support
 ----------------------


### PR DESCRIPTION
In some cases such as `apply`, `transform`, `apply_batch`, or `tranform_batch`, Koalas still requires to be installed in worker nodes, see https://github.com/databricks/koalas/issues/1826.
This PR removes some wordings about the installation in workers for now, and makes it deferred to future work.