### PR TITLE
Fix to_csv to avoid duplicated option 'path' for DataFrameWriter.

### DIFF
--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -828,7 +828,6 @@ class Frame(object, metaclass=ABCMeta):
         if partition_cols is not None:
             builder.partitionBy(partition_cols)
         builder._set_opts(
-            path=path,
             sep=sep,
             nullValue=na_rep,
             header=header,


### PR DESCRIPTION
Spark doesn't allow duplicated option `path` when `DataFrameWriter.save()` since Spark 3.1. (apache/spark#29543)