### PR TITLE
NotImplementedError for MultiIndex.hasnans

### DIFF
--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -3316,6 +3316,10 @@ class MultiIndex(Index):
         return DataFrame(internal).index  # type: ignore
 
     @property
+    def hasnans(self):
+        raise NotImplementedError("hasnans is not defined for MultiIndex")
+
+    @property
     def inferred_type(self) -> str:
         """
         Return a string of the type inferred from the values.

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -1531,6 +1531,10 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         kser = ks.from_pandas(pser)
         self.assert_eq(pser.hasnans, kser.hasnans)
 
+        # Not supported for MultiIndex
+        kmidx = ks.Index([("a", 1), ("b", 2)])
+        self.assertRaises(NotImplementedError, lambda: kmidx.hasnans())
+
     def test_intersection(self):
         pidx = pd.Index([1, 2, 3, 4], name="Koalas")
         kidx = ks.from_pandas(pidx)


### PR DESCRIPTION
Since `hasnans` is not implemented for `MultiIndex`, we should raise `NotImplementedError` like pandas.