### PR TITLE
Moved Series.astype to base.py for sharing implementation with Index

### DIFF
--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -42,7 +42,6 @@ from pyspark.sql.types import (
     IntegerType,
     LongType,
     NumericType,
-    StringType,
     StructType,
     IntegralType,
     ArrayType,
@@ -983,63 +982,6 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             return self._with_new_scol(current)
         else:
             return self.apply(arg)
-
-    def astype(self, dtype) -> "Series":
-        """
-        Cast a Koalas object to a specified dtype ``dtype``.
-
-        Parameters
-        ----------
-        dtype : data type
-            Use a numpy.dtype or Python type to cast entire pandas object to
-            the same type.
-
-        Returns
-        -------
-        casted : same type as caller
-
-        See Also
-        --------
-        to_datetime : Convert argument to datetime.
-
-        Examples
-        --------
-        >>> ser = ks.Series([1, 2], dtype='int32')
-        >>> ser
-        0    1
-        1    2
-        dtype: int32
-
-        >>> ser.astype('int64')
-        0    1
-        1    2
-        dtype: int64
-        """
-        from databricks.koalas.typedef import as_spark_type
-
-        spark_type = as_spark_type(dtype)
-        if not spark_type:
-            raise ValueError("Type {} not understood".format(dtype))
-        if isinstance(spark_type, BooleanType):
-            if isinstance(self.spark.data_type, StringType):
-                scol = F.when(self.spark.column.isNull(), F.lit(False)).otherwise(
-                    F.length(self.spark.column) > 0
-                )
-            elif isinstance(self.spark.data_type, (FloatType, DoubleType)):
-                scol = F.when(
-                    self.spark.column.isNull() | F.isnan(self.spark.column), F.lit(True)
-                ).otherwise(self.spark.column.cast(spark_type))
-            else:
-                scol = F.when(self.spark.column.isNull(), F.lit(False)).otherwise(
-                    self.spark.column.cast(spark_type)
-                )
-        elif isinstance(spark_type, StringType):
-            scol = F.when(self.spark.column.isNull(), str(None)).otherwise(
-                self.spark.column.cast(spark_type)
-            )
-        else:
-            scol = self.spark.column.cast(spark_type)
-        return self._with_new_scol(scol)
 
     def alias(self, name) -> "Series":
         """An alias for :meth:`Series.rename`."""

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -1931,3 +1931,61 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         err_msg = "index 4 is out of bounds for axis 0 with size 3"
         with self.assertRaisesRegex(IndexError, err_msg):
             kmidx.insert(4, ("b", "y"))
+
+    def test_astype(self):
+        pidx = pd.Index([10, 20, 15, 30, 45], name="x")
+        kidx = ks.Index(pidx)
+
+        self.assert_eq(kidx.astype(int), pidx.astype(int))
+        self.assert_eq(kidx.astype(np.int), pidx.astype(np.int))
+        self.assert_eq(kidx.astype(np.int8), pidx.astype(np.int8))
+        self.assert_eq(kidx.astype(np.int16), pidx.astype(np.int16))
+        self.assert_eq(kidx.astype(np.int32), pidx.astype(np.int32))
+        self.assert_eq(kidx.astype(np.int64), pidx.astype(np.int64))
+        self.assert_eq(kidx.astype(np.byte), pidx.astype(np.byte))
+        self.assert_eq(kidx.astype("int"), pidx.astype("int"))
+        self.assert_eq(kidx.astype("int8"), pidx.astype("int8"))
+        self.assert_eq(kidx.astype("int16"), pidx.astype("int16"))
+        self.assert_eq(kidx.astype("int32"), pidx.astype("int32"))
+        self.assert_eq(kidx.astype("int64"), pidx.astype("int64"))
+        self.assert_eq(kidx.astype("b"), pidx.astype("b"))
+        self.assert_eq(kidx.astype("byte"), pidx.astype("byte"))
+        self.assert_eq(kidx.astype("i"), pidx.astype("i"))
+        self.assert_eq(kidx.astype("long"), pidx.astype("long"))
+        self.assert_eq(kidx.astype("short"), pidx.astype("short"))
+        self.assert_eq(kidx.astype(np.float), pidx.astype(np.float))
+        self.assert_eq(kidx.astype(np.float32), pidx.astype(np.float32))
+        self.assert_eq(kidx.astype(np.float64), pidx.astype(np.float64))
+        self.assert_eq(kidx.astype("float"), pidx.astype("float"))
+        self.assert_eq(kidx.astype("float32"), pidx.astype("float32"))
+        self.assert_eq(kidx.astype("float64"), pidx.astype("float64"))
+        self.assert_eq(kidx.astype("double"), pidx.astype("double"))
+        self.assert_eq(kidx.astype("f"), pidx.astype("f"))
+        self.assert_eq(kidx.astype(bool), pidx.astype(bool))
+        self.assert_eq(kidx.astype("bool"), pidx.astype("bool"))
+        self.assert_eq(kidx.astype("?"), pidx.astype("?"))
+        self.assert_eq(kidx.astype(np.unicode_), pidx.astype(np.unicode_))
+        self.assert_eq(kidx.astype("str"), pidx.astype("str"))
+        self.assert_eq(kidx.astype("U"), pidx.astype("U"))
+
+        pidx = pd.Index([10, 20, 15, 30, 45, None], name="x")
+        kidx = ks.Index(pidx)
+
+        pidx = pd.Index(["hi", "hi ", " ", " \t", "", None], name="x")
+        kidx = ks.Index(pidx)
+
+        self.assert_eq(kidx.astype(bool), pidx.astype(bool))
+        self.assert_eq(kidx.astype(str).to_numpy(), ["hi", "hi ", " ", " \t", "", "None"])
+
+        pidx = pd.Index([True, False, None], name="x")
+        kidx = ks.Index(pidx)
+
+        self.assert_eq(kidx.astype(bool), pidx.astype(bool))
+
+        pidx = pd.Index(["2020-10-27"], name="x")
+        kidx = ks.Index(pidx)
+
+        self.assert_eq(kidx.astype("datetime64[ns]"), pidx.astype("datetime64[ns]"))
+
+        with self.assertRaisesRegex(TypeError, "not understood"):
+            kidx.astype("int63")


### PR DESCRIPTION
For some cases, `Index.astype` is not working properly unlike `Series.astype`.

```python
>>> pser = pd.Index(['a', 'b', None], name="x")
>>> kser = ks.Index(pser)
>>> pser.astype(bool)
Index([True, True, False], dtype='object', name='x')
>>> kser.astype(bool)
Index([None, None, None], dtype='object', name='x')
```

This PR would suggest sharing the implementation of `Series.astype` for `Index.astype`, and adding tests for `Index.astype`.