### PR TITLE
Add a constructor to GroupBy for attribute type hints

### DIFF
--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -85,6 +85,7 @@ class GroupBy(object, metaclass=ABCMeta):
     """
 
     def __init__(self):
+        """A constructor for attribute type hints."""
         self._kser = cast(Series, None)
         self._kdf = cast(DataFrame, None)
         self._groupkeys = cast(List[Series], None)


### PR DESCRIPTION
Add a constructor to GroupBy for attribute type hints. This proposal can save a lot of "# type: ignore" comments.