### PR TITLE
Use typing.cast in return statements that call functions with union return types

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -9587,7 +9587,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         kdf = DataFrame(self._internal.with_filter(cond))  # type: "DataFrame"
 
-        return ks.from_pandas(kdf._to_internal_pandas().idxmax())  # type: ignore
+        return cast(Series, ks.from_pandas(kdf._to_internal_pandas().idxmax()))
 
     # TODO: axis = 1
     def idxmin(self, axis=0) -> "Series":
@@ -9659,7 +9659,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         kdf = DataFrame(self._internal.with_filter(cond))  # type: "DataFrame"
 
-        return ks.from_pandas(kdf._to_internal_pandas().idxmin())  # type: ignore
+        return cast(Series, ks.from_pandas(kdf._to_internal_pandas().idxmin()))
 
     def info(self, verbose=None, buf=None, max_cols=None, null_counts=None) -> None:
         """
@@ -10091,9 +10091,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         if not is_list_like(indices) or isinstance(indices, (dict, set)):
             raise ValueError("`indices` must be a list-like except dict or set")
         if axis == 0:
-            return self.iloc[indices, :]  # type: ignore
+            return cast(DataFrame, self.iloc[indices, :])
         else:
-            return self.iloc[:, indices]  # type: ignore
+            return cast(DataFrame, self.iloc[:, indices])
 
     def eval(self, expr, inplace=False) -> Optional[Union["DataFrame", "Series"]]:
         """

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -9587,7 +9587,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         kdf = DataFrame(self._internal.with_filter(cond))  # type: "DataFrame"
 
-        return cast(Series, ks.from_pandas(kdf._to_internal_pandas().idxmax()))
+        return cast(ks.Series, ks.from_pandas(kdf._to_internal_pandas().idxmax()))
 
     # TODO: axis = 1
     def idxmin(self, axis=0) -> "Series":
@@ -9659,7 +9659,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         kdf = DataFrame(self._internal.with_filter(cond))  # type: "DataFrame"
 
-        return cast(Series, ks.from_pandas(kdf._to_internal_pandas().idxmin()))
+        return cast(ks.Series, ks.from_pandas(kdf._to_internal_pandas().idxmin()))
 
     def info(self, verbose=None, buf=None, max_cols=None, null_counts=None) -> None:
         """

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -19,7 +19,7 @@ Wrappers for Indexes to behave similar to pandas Index, MultiIndex.
 """
 from distutils.version import LooseVersion
 from functools import partial
-from typing import Any, List, Optional, Tuple, Union
+from typing import Any, List, Optional, Tuple, Union, cast
 import warnings
 
 import pandas as pd
@@ -2417,9 +2417,12 @@ class MultiIndex(Index):
                     (2, 'blue')],
                    names=['number', 'color'])
         """
-        return DataFrame(  # type: ignore
-            index=pd.MultiIndex.from_tuples(tuples=tuples, sortorder=sortorder, names=names)
-        ).index
+        return cast(
+            MultiIndex,
+            DataFrame(
+                index=pd.MultiIndex.from_tuples(tuples=tuples, sortorder=sortorder, names=names)
+            ).index,
+        )
 
     @staticmethod
     def from_arrays(arrays, sortorder=None, names=None) -> "MultiIndex":
@@ -2451,9 +2454,12 @@ class MultiIndex(Index):
                     (2, 'blue')],
                    names=['number', 'color'])
         """
-        return DataFrame(  # type: ignore
-            index=pd.MultiIndex.from_arrays(arrays=arrays, sortorder=sortorder, names=names)
-        ).index
+        return cast(
+            MultiIndex,
+            DataFrame(
+                index=pd.MultiIndex.from_arrays(arrays=arrays, sortorder=sortorder, names=names)
+            ).index,
+        )
 
     @staticmethod
     def from_product(iterables, sortorder=None, names=None) -> "MultiIndex":
@@ -2493,9 +2499,14 @@ class MultiIndex(Index):
                     (2, 'purple')],
                    names=['number', 'color'])
         """
-        return DataFrame(  # type: ignore
-            index=pd.MultiIndex.from_product(iterables=iterables, sortorder=sortorder, names=names)
-        ).index
+        return cast(
+            MultiIndex,
+            DataFrame(
+                index=pd.MultiIndex.from_product(
+                    iterables=iterables, sortorder=sortorder, names=names
+                )
+            ).index,
+        )
 
     @staticmethod
     def from_frame(df, names=None) -> "MultiIndex":
@@ -2565,7 +2576,7 @@ class MultiIndex(Index):
         internal = InternalFrame(
             spark_frame=sdf, index_spark_column_names=sdf.columns, index_names=names
         )
-        return DataFrame(internal).index  # type: ignore
+        return cast(MultiIndex, DataFrame(internal).index)
 
     @property
     def name(self) -> str:
@@ -2644,7 +2655,7 @@ class MultiIndex(Index):
         internal = self._kdf._internal.copy(
             index_spark_column_names=list(index_spark_column_names), index_names=list(index_names),
         )
-        return DataFrame(internal).index  # type: ignore
+        return cast(MultiIndex, DataFrame(internal).index)
 
     @property
     def levshape(self) -> Tuple[int, ...]:
@@ -3313,7 +3324,7 @@ class MultiIndex(Index):
             index_spark_column_names=index_spark_column_names,
             index_names=index_names,
         )
-        return DataFrame(internal).index  # type: ignore
+        return cast(MultiIndex, DataFrame(internal).index)
 
     @property
     def inferred_type(self) -> str:


### PR DESCRIPTION
Use `typing.cast` in return statements that call functions with union return types. This saves us from `# type: ignore` comments.