### PR TITLE
Fix GroupBy.descirbe for multi-index columns.

### DIFF
--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -2994,7 +2994,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         dtype: int64
         """
         if isinstance(func, list):
-            return first_series(self.to_frame().agg(func)).rename(self.name)
+            return first_series(self.to_frame().aggregate(func)).rename(self.name)
         elif isinstance(func, str):
             return getattr(self, func)()
         else:


### PR DESCRIPTION
Fixes `GroupBy.describe` for multi-index columns.

```py
>>> kdf = ks.DataFrame({("x", "a"): [1, 1, 3], ("x", "b"): [4, 5, 6], ("y", "c"): [7, 8, 9]})
>>> kdf.groupby(("x", "a")).describe()
Traceback (most recent call last):
...
pyspark.sql.utils.AnalysisException: cannot resolve '`(('x', 'b'), 'quartiles')`' given input columns: ...
```