### PR TITLE
Fix first/last_valid_index to support empty column DataFrame.

### DIFF
--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -1688,7 +1688,7 @@ class Frame(object, metaclass=ABCMeta):
             raise TypeError("bool() expects DataFrame or Series; however, " "got [%s]" % (self,))
         return df.head(2)._to_internal_pandas().bool()
 
-    def first_valid_index(self) -> Optional[Union[Any, Tuple[Any, ...]]]:
+    def first_valid_index(self) -> Optional[Union[Scalar, Tuple[Scalar, ...]]]:
         """
         Retrieves the index of the first valid value.
 
@@ -1787,7 +1787,7 @@ class Frame(object, metaclass=ABCMeta):
         else:
             return tuple(first_valid_row)
 
-    def last_valid_index(self) -> Optional[Union[Any, Tuple[Any, ...]]]:
+    def last_valid_index(self) -> Optional[Union[Scalar, Tuple[Scalar, ...]]]:
         """
         Return index for last non-NA/null value.
 

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -1694,7 +1694,7 @@ class Frame(object, metaclass=ABCMeta):
 
         Returns
         -------
-        idx_first_valid : type of index
+        scalar, tuple, or None
 
         Examples
         --------
@@ -1793,7 +1793,7 @@ class Frame(object, metaclass=ABCMeta):
 
         Returns
         -------
-        scalar : type of index
+        scalar, tuple, or None
 
         Notes
         -----

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -1688,7 +1688,7 @@ class Frame(object, metaclass=ABCMeta):
             raise TypeError("bool() expects DataFrame or Series; however, " "got [%s]" % (self,))
         return df.head(2)._to_internal_pandas().bool()
 
-    def first_valid_index(self) -> Union[Any, Tuple[Any, ...]]:
+    def first_valid_index(self) -> Optional[Union[Any, Tuple[Any, ...]]]:
         """
         Retrieves the index of the first valid value.
 
@@ -1787,7 +1787,7 @@ class Frame(object, metaclass=ABCMeta):
         else:
             return tuple(first_valid_row)
 
-    def last_valid_index(self) -> Union[Any, Tuple[Any, ...]]:
+    def last_valid_index(self) -> Optional[Union[Any, Tuple[Any, ...]]]:
         """
         Return index for last non-NA/null value.
 

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -4713,27 +4713,43 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         with self.assertRaisesRegex(TypeError, "bad operand type for unary -: 'str'"):
             kdf.tail("10")
 
+    @unittest.skipIf(
+        LooseVersion(pyspark.__version__) < LooseVersion("3.0"),
+        "last_valid_index won't work properly with PySpark<3.0",
+    )
     def test_last_valid_index(self):
-        # `pyspark.sql.dataframe.DataFrame.tail` is new in pyspark >= 3.0.
-        if LooseVersion(pyspark.__version__) >= LooseVersion("3.0"):
-            pdf = pd.DataFrame(
-                {"a": [1, 2, 3, None], "b": [1.0, 2.0, 3.0, None], "c": [100, 200, 400, None]},
-                index=["Q", "W", "E", "R"],
-            )
-            kdf = ks.from_pandas(pdf)
-            self.assert_eq(pdf.last_valid_index(), kdf.last_valid_index())
+        pdf = pd.DataFrame(
+            {"a": [1, 2, 3, None], "b": [1.0, 2.0, 3.0, None], "c": [100, 200, 400, None]},
+            index=["Q", "W", "E", "R"],
+        )
+        kdf = ks.from_pandas(pdf)
+        self.assert_eq(pdf.last_valid_index(), kdf.last_valid_index())
+        self.assert_eq(pdf[[]].last_valid_index(), kdf[[]].last_valid_index())
 
-            # MultiIndex columns
-            pdf.columns = pd.MultiIndex.from_tuples([("a", "x"), ("b", "y"), ("c", "z")])
-            kdf = ks.from_pandas(pdf)
-            self.assert_eq(pdf.last_valid_index(), kdf.last_valid_index())
+        # MultiIndex columns
+        pdf.columns = pd.MultiIndex.from_tuples([("a", "x"), ("b", "y"), ("c", "z")])
+        kdf = ks.from_pandas(pdf)
+        self.assert_eq(pdf.last_valid_index(), kdf.last_valid_index())
 
-            # Empty DataFrame
-            pdf = pd.Series([]).to_frame()
-            kdf = ks.Series([]).to_frame()
-            self.assert_eq(pdf.last_valid_index(), kdf.last_valid_index())
+        # Empty DataFrame
+        pdf = pd.Series([]).to_frame()
+        kdf = ks.Series([]).to_frame()
+        self.assert_eq(pdf.last_valid_index(), kdf.last_valid_index())
 
     def test_first_valid_index(self):
+        pdf = pd.DataFrame(
+            {"a": [None, 2, 3, 2], "b": [None, 2.0, 3.0, 1.0], "c": [None, 200, 400, 200]},
+            index=["Q", "W", "E", "R"],
+        )
+        kdf = ks.from_pandas(pdf)
+        self.assert_eq(pdf.first_valid_index(), kdf.first_valid_index())
+        self.assert_eq(pdf[[]].first_valid_index(), kdf[[]].first_valid_index())
+
+        # MultiIndex columns
+        pdf.columns = pd.MultiIndex.from_tuples([("a", "x"), ("b", "y"), ("c", "z")])
+        kdf = ks.from_pandas(pdf)
+        self.assert_eq(pdf.first_valid_index(), kdf.first_valid_index())
+
         # Empty DataFrame
         pdf = pd.Series([]).to_frame()
         kdf = ks.Series([]).to_frame()

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -2188,26 +2188,28 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         kser = ks.from_pandas(pser)
         self.assert_eq(pser.hasnans, kser.hasnans)
 
+    @unittest.skipIf(
+        LooseVersion(pyspark.__version__) < LooseVersion("3.0"),
+        "last_valid_index won't work properly with PySpark<3.0",
+    )
     def test_last_valid_index(self):
-        # `pyspark.sql.dataframe.DataFrame.tail` is new in pyspark >= 3.0.
-        if LooseVersion(pyspark.__version__) >= LooseVersion("3.0"):
-            pser = pd.Series([250, 1.5, 320, 1, 0.3, None, None, None, None])
-            kser = ks.from_pandas(pser)
-            self.assert_eq(pser.last_valid_index(), kser.last_valid_index())
+        pser = pd.Series([250, 1.5, 320, 1, 0.3, None, None, None, None])
+        kser = ks.from_pandas(pser)
+        self.assert_eq(pser.last_valid_index(), kser.last_valid_index())
 
-            # MultiIndex columns
-            midx = pd.MultiIndex(
-                [["lama", "cow", "falcon"], ["speed", "weight", "length"]],
-                [[0, 0, 0, 1, 1, 1, 2, 2, 2], [0, 1, 2, 0, 1, 2, 0, 1, 2]],
-            )
-            pser.index = midx
-            kser = ks.from_pandas(pser)
-            self.assert_eq(pser.last_valid_index(), kser.last_valid_index())
+        # MultiIndex columns
+        midx = pd.MultiIndex(
+            [["lama", "cow", "falcon"], ["speed", "weight", "length"]],
+            [[0, 0, 0, 1, 1, 1, 2, 2, 2], [0, 1, 2, 0, 1, 2, 0, 1, 2]],
+        )
+        pser.index = midx
+        kser = ks.from_pandas(pser)
+        self.assert_eq(pser.last_valid_index(), kser.last_valid_index())
 
-            # Empty Series
-            pser = pd.Series([])
-            kser = ks.from_pandas(pser)
-            self.assert_eq(pser.last_valid_index(), kser.last_valid_index())
+        # Empty Series
+        pser = pd.Series([])
+        kser = ks.from_pandas(pser)
+        self.assert_eq(pser.last_valid_index(), kser.last_valid_index())
 
     def test_first_valid_index(self):
         # Empty Series


### PR DESCRIPTION
Fixes `first/last_valid_index` to support empty column DataFrame.

E.g.,:

```py
>>> kdf = ks.DataFrame({"a": [None, 2, 3, 2], "b": [None, 2.0, 3.0, 1.0], "c": [None, 200, 400, 200]}, index=["Q", "W", "E", "R"])
>>> kdf
     a    b      c
Q  NaN  NaN    NaN
W  2.0  2.0  200.0
E  3.0  3.0  400.0
R  2.0  1.0  200.0
>>> kdf.first_valid_index()
'W'
>>> kdf[[]].first_valid_index()
Traceback (most recent call last):
...
TypeError: reduce() of empty sequence with no initial value
```

, which should return `None`:

```py
>>> kdf[[]].to_pandas().first_valid_index()
```

This PR also includes:

- small optimizations
- explicitly raise an error in last_valid_index for PySpark<3.0
- explicitly make tests skip for PySpark<3.0
