### PR TITLE
Add a doc for DataFrameGroupBy.describe.

### DIFF
--- a/docs/source/reference/groupby.rst
+++ b/docs/source/reference/groupby.rst
@@ -68,6 +68,13 @@ Computations / Descriptive Stats
    GroupBy.backfill
    GroupBy.shift
 
+The following methods are available only for `DataFrameGroupBy` objects.
+
+.. autosummary::
+   :toctree: api/
+
+   DataFrameGroupBy.describe
+
 The following methods are available only for `SeriesGroupBy` objects.
 
 .. autosummary::


### PR DESCRIPTION
The document for `DataFrameGroupBy.describe` is missing in https://koalas.readthedocs.io/en/latest/reference/groupby.html.