### PR TITLE
Use pandas' transpose when the data is expected to be small.

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -661,7 +661,7 @@ class DataFrame(Frame, Generic[T]):
             sdf = self._internal.spark_frame.select(*exprs)
 
             # The data is expected to be small so it's fine to transpose/use default index.
-            with ks.option_context("compute.max_rows", None):
+            with ks.option_context("compute.max_rows", 1):
                 internal = InternalFrame(
                     spark_frame=sdf,
                     index_spark_column_names=[SPARK_DEFAULT_INDEX_NAME],
@@ -3806,7 +3806,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         )
 
         # The data is expected to be small so it's fine to transpose/use default index.
-        with ks.option_context("compute.max_rows", None):
+        with ks.option_context("compute.max_rows", 1):
             internal = self._internal.copy(
                 spark_frame=sdf,
                 index_spark_column_names=[SPARK_DEFAULT_INDEX_NAME],
@@ -3815,7 +3815,6 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                     scol_for(sdf, col) for col in self._internal.data_spark_column_names
                 ],
             )
-
             return first_series(DataFrame(internal).transpose())
 
     def round(self, decimals=0) -> "DataFrame":
@@ -10495,14 +10494,14 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 [F.lit(None).cast(StringType()).alias(SPARK_DEFAULT_INDEX_NAME)] + new_columns
             )
 
-            with ks.option_context("compute.max_rows", None):
+            # The data is expected to be small so it's fine to transpose/use default index.
+            with ks.option_context("compute.max_rows", 1):
                 internal = InternalFrame(
                     spark_frame=sdf,
                     index_spark_column_names=[SPARK_DEFAULT_INDEX_NAME],
                     column_labels=new_column_labels,
                     column_label_names=self._internal.column_label_names,
                 )
-
                 return first_series(DataFrame(internal).transpose())
 
         else:

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -4956,7 +4956,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         # The data is expected to be small so it's fine to transpose/use default index.
         with ks.option_context(
-            "compute.default_index_type", "distributed", "compute.max_rows", None
+            "compute.default_index_type", "distributed", "compute.max_rows", 1
         ):
             kdf = ks.DataFrame(sdf)  # type: DataFrame
             kdf.columns = pd.Index(where)

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -4955,9 +4955,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             return result if result is not None else np.nan
 
         # The data is expected to be small so it's fine to transpose/use default index.
-        with ks.option_context(
-            "compute.default_index_type", "distributed", "compute.max_rows", 1
-        ):
+        with ks.option_context("compute.default_index_type", "distributed", "compute.max_rows", 1):
             kdf = ks.DataFrame(sdf)  # type: DataFrame
             kdf.columns = pd.Index(where)
             return first_series(kdf.transpose()).rename(self.name)


### PR DESCRIPTION
As per the discussion https://github.com/databricks/koalas/issues/1927#issuecomment-733943694, we should just use pandas' transpose when the expected data size is small enough.