### PR TITLE
Don't pass stacked in plotly area chart

### DIFF
--- a/databricks/koalas/plot.py
+++ b/databricks/koalas/plot.py
@@ -1336,6 +1336,9 @@ class KoalasPlotAccessor(PandasObject):
         if backend_name != "databricks.koalas.plot":
             data = data_preprocessor_map[kind](data)
 
+        if backend_name == "plotly" and kind == "area" and "stacked" in kwargs:
+            del kwargs["stacked"]
+
         return data, kwargs
 
     def __call__(self, kind="line", backend=None, **kwargs):


### PR DESCRIPTION
`kdf.plot(kind="area")` works but `kdf.plot.area()` fails due to unexpected argument being passed when the plot backend is `plotly`: 

```python
>>> import pandas as pd
>>> import numpy as np
>>>
>>> ks.options.plotting.backend = "plotly"
>>> kdf = ks.DataFrame(
...     np.random.randn(1000, 4),
...     index=pd.date_range('1/1/2000', periods=1000),
...     columns=['A', 'B', 'C', 'D'])
kdf = kdf.cummax()
pdf = kdf.to_pandas()
>>> kdf.plot.area()
```

**Before:**

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/.../koalas/databricks/koalas/plot.py", line 1866, in area
    return self(kind="area", x=x, y=y, stacked=stacked, **kwds)
  File "/.../koalas/databricks/koalas/plot.py", line 1350, in __call__
    return plot_backend.plot(plot_data, kind=kind, **kwds)
  File "/.../opt/miniconda3/envs/python3.9/lib/python3.9/site-packages/plotly/__init__.py", line 104, in plot
    return area(data_frame, **kwargs)
TypeError: area() got an unexpected keyword argument 'stacked'
```

**After:**

```
Figure({
    'data': [{'hovertemplate': 'variable=A<br>index=%{x}<br>value=%{y}<extra></extra>',
              'legendgroup': 'A',
              'line': {'color': '#636efa'},
              'mode': 'lines',
              'name': 'A',
              'orientation': 'v',
              'showlegend': True,
              'stackgroup': '1',
              'type': 'scatter',
              'x': array([datetime.datetime(2000, 1, 1, 0, 0),
                          datetime.datetime(2000, 1, 2, 0, 0),
                          datetime.datetime(2000, 1, 3, 0, 0), ...,
...
```