### PR TITLE
Fix tail to use the resolved copy

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -10599,7 +10599,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             n = len(self) + n
         if n <= 0:
             return ks.DataFrame(self._internal.with_filter(F.lit(False)))
-        sdf = self._internal.spark_frame
+        # Should use `resolved_copy` here for the case like `(kdf + 1).tail()`
+        sdf = self._internal.resolved_copy.spark_frame
         rows = sdf.tail(n)
         new_sdf = default_session().createDataFrame(rows, sdf.schema)
 

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -5224,7 +5224,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         4    5
         dtype: int64
         """
-        return first_series(self.spark.analyzed.to_frame().tail(n=n)).rename(self.name)
+        return first_series(self.to_frame().tail(n=n)).rename(self.name)
 
     def product(self, min_count=0) -> Union[int, float]:
         """

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -1307,7 +1307,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             renamed = self.rename(DEFAULT_SERIES_NAME)
         else:
             renamed = self
-        return DataFrame(renamed._internal.resolved_copy)
+        return DataFrame(renamed._internal)
 
     to_dataframe = to_frame
 

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -1307,7 +1307,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             renamed = self.rename(DEFAULT_SERIES_NAME)
         else:
             renamed = self
-        return DataFrame(renamed._internal)
+        return DataFrame(renamed._internal.resolved_copy)
 
     to_dataframe = to_frame
 

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -5224,7 +5224,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         4    5
         dtype: int64
         """
-        return first_series(self.to_frame().tail(n=n)).rename(self.name)
+        return first_series(self.spark.analyzed.to_frame().tail(n=n)).rename(self.name)
 
     def product(self, min_count=0) -> Union[int, float]:
         """

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -4780,6 +4780,12 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(pdf.tail(0), kdf.tail(0))
         self.assert_eq(pdf.tail(-1001), kdf.tail(-1001))
         self.assert_eq(pdf.tail(1001), kdf.tail(1001))
+        self.assert_eq((pdf + 1).tail(), (kdf + 1).tail())
+        self.assert_eq((pdf + 1).tail(10), (kdf + 1).tail(10))
+        self.assert_eq((pdf + 1).tail(-990), (kdf + 1).tail(-990))
+        self.assert_eq((pdf + 1).tail(0), (kdf + 1).tail(0))
+        self.assert_eq((pdf + 1).tail(-1001), (kdf + 1).tail(-1001))
+        self.assert_eq((pdf + 1).tail(1001), (kdf + 1).tail(1001))
         with self.assertRaisesRegex(TypeError, "bad operand type for unary -: 'str'"):
             kdf.tail("10")
 

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -2137,6 +2137,12 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(pser.tail(0), kser.tail(0))
         self.assert_eq(pser.tail(1001), kser.tail(1001))
         self.assert_eq(pser.tail(-1001), kser.tail(-1001))
+        self.assert_eq((pser + 1).tail(), (kser + 1).tail())
+        self.assert_eq((pser + 1).tail(10), (kser + 1).tail(10))
+        self.assert_eq((pser + 1).tail(-990), (kser + 1).tail(-990))
+        self.assert_eq((pser + 1).tail(0), (kser + 1).tail(0))
+        self.assert_eq((pser + 1).tail(1001), (kser + 1).tail(1001))
+        self.assert_eq((pser + 1).tail(-1001), (kser + 1).tail(-1001))
         with self.assertRaisesRegex(TypeError, "bad operand type for unary -: 'str'"):
             kser.tail("10")
 


### PR DESCRIPTION
When use `tail()`, the result is not correct after modifying the data.

```python
>>> kdf = ks.DataFrame({"A": [1, 2, 3]})
>>> kdf.tail(2)
   A
1  2
2  3
>>> (kdf + 1).tail(2)
   A
1  2
2  3
>>> (kdf.to_pandas() + 1).tail(2)
   A
1  3
2  4
```

This should resolve #1941 

