### PR TITLE
Implemented to_list to Index/MultiIndex

### DIFF
--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -2297,11 +2297,7 @@ class Index(IndexOpsMixin):
         >>> midx.to_list()
         [(1, 'red'), (1, 'blue'), (2, 'red'), (2, 'green')]
         """
-        # pandas<0.24 doesn't support `to_list()` as an alias for `tolist()`
-        if LooseVersion(pd.__version__) < LooseVersion("0.24"):
-            return self.to_pandas().tolist()
-        else:
-            return self.to_pandas().to_list()
+        return self.to_pandas().tolist()
 
     tolist = to_list
 

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -2297,7 +2297,11 @@ class Index(IndexOpsMixin):
         >>> midx.to_list()
         [(1, 'red'), (1, 'blue'), (2, 'red'), (2, 'green')]
         """
-        return self._internal.to_pandas_frame.index.to_list()
+        # pandas<0.24 doesn't support `to_list()` as an alias for `tolist()`
+        if LooseVersion(pd.__version__) < LooseVersion("0.24"):
+            return self.to_pandas().tolist()
+        else:
+            return self.to_pandas().to_list()
 
     tolist = to_list
 

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -2271,6 +2271,36 @@ class Index(IndexOpsMixin):
         """
         return self.copy()
 
+    def to_list(self) -> List:
+        """
+        Return a list of the values.
+
+        These are each a scalar type, which is a Python scalar
+        (for str, int, float) or a pandas scalar
+        (for Timestamp/Timedelta/Interval/Period)
+
+        .. note:: This method should only be used if the resulting list is expected
+            to be small, as all the data is loaded into the driver's memory.
+
+        Examples
+        --------
+        Index
+
+        >>> idx = ks.Index([1, 2, 3, 4, 5])
+        >>> idx.to_list()
+        [1, 2, 3, 4, 5]
+
+        MultiIndex
+
+        >>> tuples = [(1, 'red'), (1, 'blue'), (2, 'red'), (2, 'green')]
+        >>> midx = ks.MultiIndex.from_tuples(tuples)
+        >>> midx.to_list()
+        [(1, 'red'), (1, 'blue'), (2, 'red'), (2, 'green')]
+        """
+        return self._internal.to_pandas_frame.index.to_list()
+
+    tolist = to_list
+
     @property
     def inferred_type(self) -> str:
         """

--- a/databricks/koalas/missing/indexes.py
+++ b/databricks/koalas/missing/indexes.py
@@ -75,8 +75,6 @@ class MissingPandasLikeIndex(object):
 
     # Functions we won't support.
     memory_usage = common.memory_usage(_unsupported_function)
-    to_list = common.to_list(_unsupported_function)
-    tolist = common.tolist(_unsupported_function)
     __iter__ = common.__iter__(_unsupported_function)
 
     if LooseVersion(pd.__version__) < LooseVersion("1.0"):
@@ -161,8 +159,6 @@ class MissingPandasLikeMultiIndex(object):
 
     # Properties we won't support.
     memory_usage = common.memory_usage(_unsupported_function)
-    to_list = common.to_list(_unsupported_function)
-    tolist = common.tolist(_unsupported_function)
 
     if LooseVersion(pd.__version__) < LooseVersion("1.0"):
         # Deprecated properties

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -1506,11 +1506,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             to be small, as all the data is loaded into the driver's memory.
 
         """
-        # pandas<0.24 doesn't support `to_list()` as an alias for `tolist()`
-        if LooseVersion(pd.__version__) < LooseVersion("0.24"):
-            return self._to_internal_pandas().tolist()
-        else:
-            return self._to_internal_pandas().to_list()
+        return self._to_internal_pandas().tolist()
 
     tolist = to_list
 

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -2005,16 +2005,30 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
             kidx.astype("int63")
 
     def test_to_list(self):
+        # Index
         pidx = pd.Index([1, 2, 3, 4, 5])
         kidx = ks.from_pandas(pidx)
-        self.assert_eq(kidx.to_list(), pidx.to_list())
-
+        # MultiIndex
         tuples = [(1, "red"), (1, "blue"), (2, "red"), (2, "green")]
         pmidx = pd.MultiIndex.from_tuples(tuples)
         kmidx = ks.from_pandas(pmidx)
-        if LooseVersion(pyspark.__version__) < LooseVersion("2.4"):
-            # PySpark < 2.4 does not support struct type with arrow enabled.
-            with self.sql_conf({SPARK_CONF_ARROW_ENABLED: False}):
-                self.assert_eq(kmidx.to_list(), pmidx.to_list())
+
+        # Only support as `to_list` in pandas < 0.24.0.
+        if LooseVersion(pd.__version__) >= LooseVersion("0.24.0"):
+            self.assert_eq(kidx.to_list(), pidx.to_list())
+
+            if LooseVersion(pyspark.__version__) < LooseVersion("2.4"):
+                # PySpark < 2.4 does not support struct type with arrow enabled.
+                with self.sql_conf({SPARK_CONF_ARROW_ENABLED: False}):
+                    self.assert_eq(kmidx.to_list(), pmidx.to_list())
+            else:
+                self.assert_eq(kidx.to_list(), pidx.to_list())
         else:
-            self.assert_eq(kidx, pidx)
+            self.assert_eq(kidx.tolist(), pidx.tolist())
+
+            if LooseVersion(pyspark.__version__) < LooseVersion("2.4"):
+                # PySpark < 2.4 does not support struct type with arrow enabled.
+                with self.sql_conf({SPARK_CONF_ARROW_ENABLED: False}):
+                    self.assert_eq(kmidx.tolist(), pmidx.tolist())
+            else:
+                self.assert_eq(kidx.tolist(), pidx.tolist())

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -2003,3 +2003,18 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
 
         with self.assertRaisesRegex(TypeError, "not understood"):
             kidx.astype("int63")
+
+    def test_to_list(self):
+        pidx = pd.Index([1, 2, 3, 4, 5])
+        kidx = ks.from_pandas(pidx)
+        self.assert_eq(kidx.to_list(), pidx.to_list())
+
+        tuples = [(1, "red"), (1, "blue"), (2, "red"), (2, "green")]
+        pmidx = pd.MultiIndex.from_tuples(tuples)
+        kmidx = ks.from_pandas(pmidx)
+        if LooseVersion(pyspark.__version__) < LooseVersion("2.4"):
+            # PySpark < 2.4 does not support struct type with arrow enabled.
+            with self.sql_conf({SPARK_CONF_ARROW_ENABLED: False}):
+                self.assert_eq(kmidx.to_list(), pmidx.to_list())
+        else:
+            self.assert_eq(kidx, pidx)

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -2013,22 +2013,11 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         pmidx = pd.MultiIndex.from_tuples(tuples)
         kmidx = ks.from_pandas(pmidx)
 
-        # Only support as `to_list` in pandas < 0.24.0.
-        if LooseVersion(pd.__version__) >= LooseVersion("0.24.0"):
-            self.assert_eq(kidx.to_list(), pidx.to_list())
+        self.assert_eq(kidx.tolist(), pidx.tolist())
 
-            if LooseVersion(pyspark.__version__) < LooseVersion("2.4"):
-                # PySpark < 2.4 does not support struct type with arrow enabled.
-                with self.sql_conf({SPARK_CONF_ARROW_ENABLED: False}):
-                    self.assert_eq(kmidx.to_list(), pmidx.to_list())
-            else:
-                self.assert_eq(kidx.to_list(), pidx.to_list())
+        if LooseVersion(pyspark.__version__) < LooseVersion("2.4"):
+            # PySpark < 2.4 does not support struct type with arrow enabled.
+            with self.sql_conf({SPARK_CONF_ARROW_ENABLED: False}):
+                self.assert_eq(kmidx.tolist(), pmidx.tolist())
         else:
             self.assert_eq(kidx.tolist(), pidx.tolist())
-
-            if LooseVersion(pyspark.__version__) < LooseVersion("2.4"):
-                # PySpark < 2.4 does not support struct type with arrow enabled.
-                with self.sql_conf({SPARK_CONF_ARROW_ENABLED: False}):
-                    self.assert_eq(kmidx.tolist(), pmidx.tolist())
-            else:
-                self.assert_eq(kidx.tolist(), pidx.tolist())

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -1014,10 +1014,7 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         self.assertEqual((pser + 1).is_unique, (kser + 1).is_unique)
 
     def test_to_list(self):
-        if LooseVersion(pd.__version__) >= LooseVersion("0.24.0"):
-            self.assert_eq(self.kser.to_list(), self.pser.to_list())
-        else:
-            self.assert_eq(self.kser.tolist(), self.pser.tolist())
+        self.assert_eq(self.kser.tolist(), self.pser.tolist())
 
     def test_append(self):
         pser1 = pd.Series([1, 2, 3], name="0")

--- a/docs/source/reference/indexing.rst
+++ b/docs/source/reference/indexing.rst
@@ -102,6 +102,7 @@ Conversion
 
    Index.astype
    Index.item
+   Index.to_list
    Index.to_series
    Index.to_frame
    Index.view
@@ -249,6 +250,7 @@ MultiIndex Conversion
 
    MultiIndex.astype
    MultiIndex.item
+   MultiIndex.to_list
    MultiIndex.to_series
    MultiIndex.to_frame
    MultiIndex.view


### PR DESCRIPTION
Added `to_list` - `tolist` as an alias - to the Index and MultiIndex.

This implementation idea is basically inspired from `Series.to_list`.

```python
>>> idx = ks.Index([1, 2, 3, 4, 5])
>>> idx.to_list()
[1, 2, 3, 4, 5]

>>> tuples = [(1, 'red'), (1, 'blue'), (2, 'red'), (2, 'green')]
>>> midx = ks.MultiIndex.from_tuples(tuples)
>>> midx.to_list()
[(1, 'red'), (1, 'blue'), (2, 'red'), (2, 'green')]
```