### PR TITLE
Enable index operations.

### DIFF
--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -472,6 +472,9 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
     __rand__ = column_op(Column.__rand__)
     __ror__ = column_op(Column.__ror__)
 
+    def __len__(self):
+        return len(self._kdf)
+
     # NDArray Compat
     def __array_ufunc__(self, ufunc: Callable, method: str, *inputs: Any, **kwargs: Any):
         # Try dunder methods first.

--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -99,6 +99,13 @@ def column_op(f):
         # extract Spark Column. For other arguments, they are used as are.
         cols = [arg for arg in args if isinstance(arg, IndexOpsMixin)]
 
+        # TODO: support ops between different types.
+        assert all(
+            type(self) == type(col) for col in cols
+        ), "All arguments must be the same types: [{}, {}]".format(
+            type(self).__name__, ", ".join(type(col).__name__ for col in cols)
+        )
+
         if all(not self._need_alignment_for_column_op(col) for col in cols):
             # Same DataFrame anchors
             args = [arg.spark.column if isinstance(arg, IndexOpsMixin) else arg for arg in args]

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -1153,6 +1153,8 @@ class Index(IndexOpsMixin):
                         scol_for(sdf, col) for col in self._internal.index_spark_column_names
                     ],
                     index_names=self._internal.index_names,
+                    column_labels=[],
+                    data_spark_columns=[],
                 )
             )
         )
@@ -3161,6 +3163,8 @@ class MultiIndex(Index):
                         scol_for(sdf, col) for col in internal.index_spark_column_names
                     ],
                     index_names=internal.index_names,
+                    column_labels=[],
+                    data_spark_columns=[],
                 )
             )
         )

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -170,7 +170,7 @@ class Index(IndexOpsMixin):
         if get_option("compute.ops_on_diff_frames"):
             # This could cause as many counts, reset_index calls, joins for combining
             # as the number of `Index`s in `args`. So far it's fine since we can assume the ops
-            # only work between two `Index`s at the most. We might need to fix it in the future.
+            # only work between at most two `Index`s. We might need to fix it in the future.
             self_len = len(self)
             if any(len(col) != self_len for col in args if isinstance(col, IndexOpsMixin)):
                 raise ValueError("operands could not be broadcast together with shapes")

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -168,6 +168,9 @@ class Index(IndexOpsMixin):
 
     def _align_and_column_op(self, f, *args) -> "Index":
         if get_option("compute.ops_on_diff_frames"):
+            # This could cause as many counts, reset_index calls, joins for combining
+            # as the number of `Index`s in `args`. So far it's fine since we can assume the ops
+            # only work between two `Index`s at the most. We might need to fix it in the future.
             self_len = len(self)
             if any(len(col) != self_len for col in args if isinstance(col, IndexOpsMixin)):
                 raise ValueError("operands could not be broadcast together with shapes")

--- a/databricks/koalas/indexes.py
+++ b/databricks/koalas/indexes.py
@@ -3127,8 +3127,9 @@ class MultiIndex(Index):
         MultiIndex([('c', 'z')],
                    )
         """
-        sdf = self._internal.spark_frame
-        index_scols = self._internal.index_spark_columns
+        internal = self._internal.resolved_copy
+        sdf = internal.spark_frame
+        index_scols = internal.index_spark_columns
         if level is None:
             scol = index_scols[0]
         elif isinstance(level, int):
@@ -3136,7 +3137,7 @@ class MultiIndex(Index):
         else:
             scol = None
             for index_spark_column, index_name in zip(
-                self._internal.index_spark_columns, self._internal.index_names
+                internal.index_spark_columns, internal.index_names
             ):
                 if not isinstance(level, tuple):
                     level = (level,)
@@ -3157,9 +3158,9 @@ class MultiIndex(Index):
                 InternalFrame(
                     spark_frame=sdf,
                     index_spark_columns=[
-                        scol_for(sdf, col) for col in self._internal.index_spark_column_names
+                        scol_for(sdf, col) for col in internal.index_spark_column_names
                     ],
-                    index_names=self._internal.index_names,
+                    index_names=internal.index_names,
                 )
             )
         )

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -51,7 +51,7 @@ from pyspark.sql.window import Window
 from databricks import koalas as ks  # For running doctests and reference resolution in PyCharm.
 from databricks.koalas.accessors import KoalasSeriesMethods
 from databricks.koalas.config import get_option
-from databricks.koalas.base import IndexOpsMixin
+from databricks.koalas.base import IndexOpsMixin, booleanize_null
 from databricks.koalas.exceptions import SparkPandasIndexingError
 from databricks.koalas.frame import DataFrame
 from databricks.koalas.generic import Frame
@@ -66,6 +66,7 @@ from databricks.koalas.missing.series import MissingPandasLikeSeries
 from databricks.koalas.plot import KoalasPlotAccessor
 from databricks.koalas.ml import corr
 from databricks.koalas.utils import (
+    align_diff_series,
     combine_frames,
     is_name_like_tuple,
     is_name_like_value,
@@ -400,12 +401,21 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         :param scol: the new Spark Column
         :return: the copied Series
         """
-        internal = self._kdf._internal.copy(
-            column_labels=[self._column_label],
-            data_spark_columns=[scol.alias(name_like_string(self._column_label))],
-            column_label_names=None,
+        internal = self._internal.copy(
+            data_spark_columns=[scol.alias(name_like_string(self._column_label))]
         )
         return first_series(DataFrame(internal))
+
+    def _need_alignment_for_column_op(self, other: "IndexOpsMixin") -> bool:
+        return not same_anchor(self, other)
+
+    def _align_and_column_op(self, f, *args) -> "Series":
+        # Different DataFrame anchors
+        def apply_func(this_column, *that_columns):
+            scol = f(this_column, *that_columns)
+            return booleanize_null(this_column, scol, f)
+
+        return align_diff_series(apply_func, self, *args, how="full")
 
     spark = CachedAccessor("spark", SparkSeriesMethods)
 

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -5831,9 +5831,6 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             scol = sfun(scol, spark_type)
         return unpack_scalar(self._internal.spark_frame.select(scol))
 
-    def __len__(self):
-        return len(self.to_dataframe())
-
     def __getitem__(self, key):
         try:
             if (isinstance(key, slice) and any(type(n) == int for n in [key.start, key.stop])) or (

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -2021,3 +2021,14 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
                 self.assert_eq(kmidx.tolist(), pmidx.tolist())
         else:
             self.assert_eq(kidx.tolist(), pidx.tolist())
+
+    def test_index_ops(self):
+        pidx = pd.Index([1, 2, 3, 4, 5])
+        kidx = ks.from_pandas(pidx)
+
+        self.assert_eq((kidx * 100) + (kidx * 10) + kidx, (pidx * 100) + (pidx * 10) + pidx)
+
+        pidx = pd.Index([1, 2, 3, 4, 5], name="a")
+        kidx = ks.from_pandas(pidx)
+
+        self.assert_eq((kidx * 100) + (kidx * 10) + kidx, (pidx * 100) + (pidx * 10) + pidx)

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -2032,3 +2032,15 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         kidx = ks.from_pandas(pidx)
 
         self.assert_eq((kidx * 100) + (kidx * 10) + kidx, (pidx * 100) + (pidx * 10) + pidx)
+
+        pdf = pd.DataFrame(
+            index=pd.MultiIndex.from_tuples([(1, 2), (3, 4), (5, 6)], names=["a", "b"])
+        )
+        kdf = ks.from_pandas(pdf)
+
+        pidx1 = pdf.index.get_level_values(0)
+        pidx2 = pdf.index.get_level_values(1)
+        kidx1 = kdf.index.get_level_values(0)
+        kidx2 = kdf.index.get_level_values(1)
+
+        self.assert_eq(kidx1 + kidx2, pidx1 + pidx2)

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -2026,12 +2026,12 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         pidx = pd.Index([1, 2, 3, 4, 5])
         kidx = ks.from_pandas(pidx)
 
-        self.assert_eq((kidx * 100) + (kidx * 10) + kidx, (pidx * 100) + (pidx * 10) + pidx)
+        self.assert_eq(kidx * 100 + kidx * 10 + kidx, pidx * 100 + pidx * 10 + pidx)
 
         pidx = pd.Index([1, 2, 3, 4, 5], name="a")
         kidx = ks.from_pandas(pidx)
 
-        self.assert_eq((kidx * 100) + (kidx * 10) + kidx, (pidx * 100) + (pidx * 10) + pidx)
+        self.assert_eq(kidx * 100 + kidx * 10 + kidx, pidx * 100 + pidx * 10 + pidx)
 
         pdf = pd.DataFrame(
             index=pd.MultiIndex.from_tuples([(1, 2), (3, 4), (5, 6)], names=["a", "b"])
@@ -2043,4 +2043,4 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         kidx1 = kdf.index.get_level_values(0)
         kidx2 = kdf.index.get_level_values(1)
 
-        self.assert_eq(kidx1 + kidx2, pidx1 + pidx2)
+        self.assert_eq(kidx1 * 10 + kidx2, pidx1 * 10 + pidx2)

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -2043,4 +2043,7 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         kidx1 = kdf.index.get_level_values(0)
         kidx2 = kdf.index.get_level_values(1)
 
-        self.assert_eq(kidx1 * 10 + kidx2, pidx1 * 10 + pidx2)
+        if LooseVersion(pd.__version__) >= LooseVersion("1.0"):
+            self.assert_eq(kidx1 * 10 + kidx2, pidx1 * 10 + pidx2)
+        else:
+            self.assert_eq(kidx1 * 10 + kidx2, (pidx1 * 10 + pidx2).rename(None))

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -626,6 +626,7 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
 
         self.assert_eq(pidx.drop(1), kidx.drop(1))
         self.assert_eq(pidx.drop([1, 2]), kidx.drop([1, 2]))
+        self.assert_eq((pidx + 1).drop([2, 3]), (kidx + 1).drop([2, 3]))
 
     def test_multiindex_drop(self):
         pidx = pd.MultiIndex.from_tuples(

--- a/databricks/koalas/tests/test_ops_on_diff_frames.py
+++ b/databricks/koalas/tests/test_ops_on_diff_frames.py
@@ -1222,6 +1222,32 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
         else:
             self.assert_eq(kser1.repeat(kser2).sort_index(), pser1.repeat(pser2).sort_index())
 
+    def test_index_ops(self):
+        pidx1 = pd.Index([1, 2, 3, 4, 5])
+        pidx2 = pd.Index([6, 7, 8, 9, 10])
+        kidx1 = ks.from_pandas(pidx1)
+        kidx2 = ks.from_pandas(pidx2)
+
+        self.assert_eq(((kidx1 * 10) + kidx2).sort_values(), ((pidx1 * 10) + pidx2).sort_values())
+
+        pidx3 = pd.Index([11, 12, 13])
+        kidx3 = ks.from_pandas(pidx3)
+
+        with self.assertRaisesRegex(
+            ValueError, "operands could not be broadcast together with shapes"
+        ):
+            kidx1 + kidx3
+
+        pidx1 = pd.Index([1, 2, 3, 4, 5], name="a")
+        pidx2 = pd.Index([6, 7, 8, 9, 10], name="a")
+        pidx3 = pd.Index([11, 12, 13, 14, 15], name="x")
+        kidx1 = ks.from_pandas(pidx1)
+        kidx2 = ks.from_pandas(pidx2)
+        kidx3 = ks.from_pandas(pidx3)
+
+        self.assert_eq(((kidx1 * 10) + kidx2).sort_values(), ((pidx1 * 10) + pidx2).sort_values())
+        self.assert_eq(((kidx1 * 10) + kidx3).sort_values(), ((pidx1 * 10) + pidx3).sort_values())
+
 
 class OpsOnDiffFramesDisabledTest(ReusedSQLTestCase, SQLTestUtils):
     @classmethod

--- a/databricks/koalas/tests/test_ops_on_diff_frames.py
+++ b/databricks/koalas/tests/test_ops_on_diff_frames.py
@@ -1228,7 +1228,7 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
         kidx1 = ks.from_pandas(pidx1)
         kidx2 = ks.from_pandas(pidx2)
 
-        self.assert_eq(((kidx1 * 10) + kidx2).sort_values(), ((pidx1 * 10) + pidx2).sort_values())
+        self.assert_eq((kidx1 * 10 + kidx2).sort_values(), (pidx1 * 10 + pidx2).sort_values())
 
         pidx3 = pd.Index([11, 12, 13])
         kidx3 = ks.from_pandas(pidx3)
@@ -1245,8 +1245,8 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
         kidx2 = ks.from_pandas(pidx2)
         kidx3 = ks.from_pandas(pidx3)
 
-        self.assert_eq(((kidx1 * 10) + kidx2).sort_values(), ((pidx1 * 10) + pidx2).sort_values())
-        self.assert_eq(((kidx1 * 10) + kidx3).sort_values(), ((pidx1 * 10) + pidx3).sort_values())
+        self.assert_eq((kidx1 * 10 + kidx2).sort_values(), (pidx1 * 10 + pidx2).sort_values())
+        self.assert_eq((kidx1 * 10 + kidx3).sort_values(), (pidx1 * 10 + pidx3).sort_values())
 
 
 class OpsOnDiffFramesDisabledTest(ReusedSQLTestCase, SQLTestUtils):

--- a/databricks/koalas/tests/test_ops_on_diff_frames.py
+++ b/databricks/koalas/tests/test_ops_on_diff_frames.py
@@ -1246,7 +1246,13 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
         kidx3 = ks.from_pandas(pidx3)
 
         self.assert_eq((kidx1 * 10 + kidx2).sort_values(), (pidx1 * 10 + pidx2).sort_values())
-        self.assert_eq((kidx1 * 10 + kidx3).sort_values(), (pidx1 * 10 + pidx3).sort_values())
+
+        if LooseVersion(pd.__version__) >= LooseVersion("1.0"):
+            self.assert_eq((kidx1 * 10 + kidx3).sort_values(), (pidx1 * 10 + pidx3).sort_values())
+        else:
+            self.assert_eq(
+                (kidx1 * 10 + kidx3).sort_values(), (pidx1 * 10 + pidx3).rename(None).sort_values()
+            )
 
 
 class OpsOnDiffFramesDisabledTest(ReusedSQLTestCase, SQLTestUtils):


### PR DESCRIPTION
Currently Koalas can't handle index operations very well.

```py
>>> kidx = ks.Index([1, 2, 3, 4, 5])
>>> kidx + kidx
Int64Index([2, 4, 6, 8, 10], dtype='int64')
>>> kidx + kidx + kidx
Traceback (most recent call last):
...
AssertionError: args should be single DataFrame or single/multiple Series
```

or

```py
>>> ks.Index([1, 2, 3, 4, 5]) + ks.Index([6, 7, 8, 9, 10])
Traceback (most recent call last):
...
AssertionError: args should be single DataFrame or single/multiple Series
```

This PR enables those operations:

```py
>>> kidx + kidx + kidx
Int64Index([3, 6, 9, 12, 15], dtype='int64')

>>> ks.options.compute.ops_on_diff_frames = True
>>> ks.Index([1, 2, 3, 4, 5]) + ks.Index([6, 7, 8, 9, 10])
Int64Index([7, 9, 13, 11, 15], dtype='int64')
```