### PR TITLE
Compare Series from the same anchor

### DIFF
--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -5627,7 +5627,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
                 self._internal.with_new_columns(
                     [self._internal.data_spark_columns[0]]
                     + [other._internal.data_spark_columns[0]],
-                    column_labels=[self_column_label] + [other_column_label],
+                    column_labels=[self_column_label, other_column_label],
                 )
             )  # type: DataFrame
         else:

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -5629,7 +5629,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
                     + [other._internal.data_spark_columns[0]],
                     column_labels=[self_column_label] + [other_column_label],
                 )
-            )
+            )  # type: DataFrame
         else:
             if not self.index.equals(other.index):
                 raise ValueError("Can only compare identically-labeled Series objects")

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -5625,8 +5625,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             other_column_label = verify_temp_column_name(self.to_frame(), "__other_column__")
             combined = DataFrame(
                 self._internal.with_new_columns(
-                    [self._internal.data_spark_columns[0]]
-                    + [other._internal.data_spark_columns[0]],
+                    [self._internal.data_spark_columns[0], other._internal.data_spark_columns[0]],
                     column_labels=[self_column_label, other_column_label],
                 )
             )  # type: DataFrame

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -5620,9 +5620,21 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         >>> reset_option("compute.ops_on_diff_frames")
         """
-        if not self.index.equals(other.index):
-            raise ValueError("Can only compare identically-labeled Series objects")
-        combined = combine_frames(self.to_frame(), other.to_frame())
+        if same_anchor(self, other):
+            self_column_label = verify_temp_column_name(other.to_frame(), "__self_column__")
+            other_column_label = verify_temp_column_name(self.to_frame(), "__other_column__")
+            combined = DataFrame(
+                self._internal.with_new_columns(
+                    [self._internal.data_spark_columns[0]]
+                    + [other._internal.data_spark_columns[0]],
+                    column_labels=[self_column_label] + [other_column_label],
+                )
+            )
+        else:
+            if not self.index.equals(other.index):
+                raise ValueError("Can only compare identically-labeled Series objects")
+
+            combined = combine_frames(self.to_frame(), other.to_frame())
 
         this_column_label = "self"
         that_column_label = "other"

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -991,6 +991,32 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         str_kser = ks.Series(["a", "b", "c"])
         self.assert_eq(str_kser.clip(1, 3), str_kser)
 
+    def test_compare(self):
+        if LooseVersion(pd.__version__) >= LooseVersion("1.1"):
+            pser = pd.Series([1, 2])
+            kser = ks.from_pandas(pser)
+
+            res_kdf = kser.compare(kser)
+            self.assertTrue(res_kdf.empty)
+            self.assert_eq(res_kdf.columns, pd.Index(["self", "other"]))
+
+            self.assert_eq(pser.compare(pser + 1).sort_index(), kser.compare(kser + 1).sort_index())
+
+            pser = pd.Series([1, 2], index=["x", "y"])
+            kser = ks.from_pandas(pser)
+            self.assert_eq(pser.compare(pser + 1).sort_index(), kser.compare(kser + 1).sort_index())
+        else:
+            kser = ks.Series([1, 2])
+            res_kdf = kser.compare(kser)
+            self.assertTrue(res_kdf.empty)
+            self.assert_eq(res_kdf.columns, pd.Index(["self", "other"]))
+            expected = ks.DataFrame([[1, 2], [2, 3]], columns=["self", "other"])
+            self.assert_eq(expected, kser.compare(kser + 1).sort_index())
+
+            kser = ks.Series([1, 2], index=["x", "y"])
+            expected = ks.DataFrame([[1, 2], [2, 3]], index=["x", "y"], columns=["self", "other"])
+            self.assert_eq(expected, kser.compare(kser + 1).sort_index())
+
     def test_is_unique(self):
         # We can't use pandas' is_unique for comparison. pandas 0.23 ignores None
         pser = pd.Series([1, 2, 2, None, None])


### PR DESCRIPTION
Enable Series.compare to compare Series from the same anchor 

Preivous behavior:
```
>>> kser = ks.Series([1, 2])
>>> kser.compare(kser)
Traceback (most recent call last):
...
AssertionError: We don't need to combine. `this` and `that` are same.

>>> kser.compare(kser + 1)
Traceback (most recent call last):
...
AssertionError: We don't need to combine. `this` and `that` are same.
```

Current behavior:
```
>>> kser = ks.Series([1, 2])
>>> kser.compare(kser)
Empty DataFrame
Columns: [self, other]
Index: []

>>> kser.compare(kser + 1)
   self  other
0     1      2
1     2      3
```