### PR TITLE
Implemented GroupBy.median()

### DIFF
--- a/databricks/koalas/missing/groupby.py
+++ b/databricks/koalas/missing/groupby.py
@@ -57,7 +57,6 @@ class MissingPandasLikeDataFrameGroupBy(object):
 
     # Functions
     boxplot = _unsupported_function("boxplot")
-    median = _unsupported_function("median")
     ngroup = _unsupported_function("ngroup")
     nth = _unsupported_function("nth")
     ohlc = _unsupported_function("ohlc")
@@ -94,7 +93,6 @@ class MissingPandasLikeSeriesGroupBy(object):
     agg = _unsupported_function("agg")
     aggregate = _unsupported_function("aggregate")
     describe = _unsupported_function("describe")
-    median = _unsupported_function("median")
     ngroup = _unsupported_function("ngroup")
     nth = _unsupported_function("nth")
     ohlc = _unsupported_function("ohlc")

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -2608,3 +2608,16 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         self.assertRaises(
             ValueError, lambda: kdf.groupby([("B", "class"), ("A", "name")]).get_group("mammal")
         )
+
+    def test_median(self):
+        kdf = ks.DataFrame(
+            {
+                "a": [1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 3.0, 3.0, 3.0],
+                "b": [2.0, 3.0, 1.0, 4.0, 6.0, 9.0, 8.0, 10.0, 7.0, 5.0],
+                "c": [3.0, 5.0, 2.0, 5.0, 1.0, 2.0, 6.0, 4.0, 3.0, 6.0],
+            },
+            columns=["a", "b", "c"],
+            index=[7, 2, 4, 1, 3, 4, 9, 10, 5, 6],
+        )
+        with self.assertRaisesRegex(ValueError, "accuracy must be an integer; however"):
+            kdf.groupby("a").median(accuracy="a")

--- a/docs/source/reference/groupby.rst
+++ b/docs/source/reference/groupby.rst
@@ -51,6 +51,7 @@ Computations / Descriptive Stats
    GroupBy.last
    GroupBy.max
    GroupBy.mean
+   GroupBy.median
    GroupBy.min
    GroupBy.rank
    GroupBy.std


### PR DESCRIPTION
This PR proposes `GroupBy.median()`.

Note: the result can be slightly different from pandas since we use an approximated median based upon approximate percentile computation because computing median across a large dataset is extremely expensive.

```python
>>> kdf = ks.DataFrame({'a': [1., 1., 1., 1., 2., 2., 2., 3., 3., 3.],
...                     'b': [2., 3., 1., 4., 6., 9., 8., 10., 7., 5.],
...                     'c': [3., 5., 2., 5., 1., 2., 6., 4., 3., 6.]},
...                    columns=['a', 'b', 'c'],
...                    index=[7, 2, 4, 1, 3, 4, 9, 10, 5, 6])
>>> kdf
      a     b    c
7   1.0   2.0  3.0
2   1.0   3.0  5.0
4   1.0   1.0  2.0
1   1.0   4.0  5.0
3   2.0   6.0  1.0
4   2.0   9.0  2.0
9   2.0   8.0  6.0
10  3.0  10.0  4.0
5   3.0   7.0  3.0
6   3.0   5.0  6.0

>>> kdf.groupby('a').median().sort_index()  # doctest: +NORMALIZE_WHITESPACE
       b    c
a
1.0  2.0  3.0
2.0  8.0  2.0
3.0  7.0  4.0

>>> kdf.groupby('a')['b'].median().sort_index()
a
1.0    2.0
2.0    8.0
3.0    7.0
Name: b, dtype: float64
```

ref #1929