### PR TITLE
Set upperbound of matplotlib to avoid failure on Ubuntu

### DIFF
--- a/docs/source/getting_started/install.rst
+++ b/docs/source/getting_started/install.rst
@@ -124,7 +124,7 @@ Package       Required version
 `pandas`      >=0.23.2
 `pyspark`     >=2.4.0
 `pyarrow`     >=0.10
-`matplotlib`  >=3.0.0
+`matplotlib`  >=3.0.0,<3.3.0
 `numpy`       >=1.14
 ============= ================
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 # Dependencies in Koalas. When you update don't forget to update setup.py and install.rst in docs.
 pandas>=0.23.2
 pyarrow>=0.10
-matplotlib>=3.0.0
+matplotlib>=3.0.0,<3.3.0
 numpy>=1.14
 
 # Optional dependencies in Koalas.

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
         'pandas>=0.23.2',
         'pyarrow>=0.10',
         'numpy>=1.14',
-        'matplotlib>=3.0.0',
+        'matplotlib>=3.0.0,<3.3.0',
     ],
     author="Databricks",
     author_email="koalas@databricks.com",


### PR DESCRIPTION
This was caused from https://github.com/databricks/koalas/commit/c7b69799ea3b03343d85bceb4008bc1915b7decb. On Ubuntu 18, seems like there's a problem about packaging PIL (Pillow) somewhere, see also `https://github.com/spotify/dh-virtualenv/issues/273`.

From matplotlib 3.3.0, they started to use Pillow dependency (matplotlib/matplotlib@370e9a2#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7)

This PR simply works around for now by setting uppberbound of matplotlib.

Resolves #1958 