### PR TITLE
Upgrade pandas version in CI

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -107,7 +107,7 @@ jobs:
             pyarrow-version: 1.0.1
           - python-version: 3.8
             spark-version: 3.0.1
-            pandas-version: 1.1.4
+            pandas-version: 1.1.5
             pyarrow-version: 2.0.0
             default-index-type: 'distributed-sequence'
     env:


### PR DESCRIPTION
Since pandas 1.1.5 was released, we should match the behavior to the latest version.

https://pandas.pydata.org/docs/whatsnew/v1.1.5.html