### PR TITLE
Removed comment for Series.rename test

### DIFF
--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -123,10 +123,10 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         self.assertEqual(kser.name, "renamed")
         self.assert_eq(kser, pser)
 
-        # pser.name = None
-        # kser.name = None
-        # self.assertEqual(kser.name, None)
-        # self.assert_eq(kser, pser)
+        pser.name = None
+        kser.name = None
+        self.assertEqual(kser.name, None)
+        self.assert_eq(kser, pser)
 
         pidx = pser.index
         kidx = kser.index


### PR DESCRIPTION
Since #1712, Koalas is able to support non-names Series.

So now we can remove the comment from related test.