### PR TITLE
Set PYARROW_IGNORE_TIMEZONE for binder.

### DIFF
--- a/postBuild
+++ b/postBuild
@@ -10,3 +10,4 @@ cd jdk1.8.0_131
 echo "export JAVA_HOME="`pwd` >> ~/.profile
 cd bin
 echo "export PATH="`pwd`":$PATH" >> ~/.profile
+echo "export PYARROW_IGNORE_TIMEZONE=1" >> ~/.profile


### PR DESCRIPTION
We should set `PYARROW_IGNORE_TIMEZONE` environment variable for binder; otherwise it shows a warning:

<img width="1084" alt="Screen Shot 2020-12-10 at 6 26 53 PM" src="https://user-images.githubusercontent.com/506656/101853967-66347d00-3b15-11eb-8ec7-cac195f72f17.png">
