### PR TITLE
Simplify plot backend support

### DIFF
--- a/databricks/koalas/config.py
+++ b/databricks/koalas/config.py
@@ -225,7 +225,7 @@ _options = [
         doc=(
             "Backend to use for plotting. Default is matplotlib. "
             "Supports any package that has a top-level `.plot` method. "
-            "Some options are: [matplotlib, plotly, pandas_bokeh, pandas_altair]."
+            "Known options are: [matplotlib, plotly]."
         ),
         default="matplotlib",
         types=str,

--- a/databricks/koalas/plot/core.py
+++ b/databricks/koalas/plot/core.py
@@ -189,10 +189,10 @@ class KoalasPlotAccessor(PandasObject):
                 "area": SampledPlot().get_sampled,
                 "line": SampledPlot().get_sampled,
             }
-            if data_preprocessor_map[kind]:
+            if not data_preprocessor_map[kind]:
                 raise NotImplementedError(
                     "'%s' plot is not supported with '%s' plot "
-                    "backend yet." % plot_backend.__name__
+                    "backend yet." % (kind, plot_backend.__name__)
                 )
             plot_data = data_preprocessor_map[kind](plot_data)
             return plot_backend.plot(plot_data, kind=kind, **kwargs)

--- a/databricks/koalas/plot/core.py
+++ b/databricks/koalas/plot/core.py
@@ -176,7 +176,7 @@ class KoalasPlotAccessor(PandasObject):
         KoalasPlotAccessor._backends[backend] = module
         return module
 
-    def __call__(self, *, kind="line", backend=None, **kwargs):
+    def __call__(self, kind="line", backend=None, **kwargs):
         plot_backend = KoalasPlotAccessor._get_plot_backend(backend)
         plot_data = self.data
 

--- a/databricks/koalas/plot/core.py
+++ b/databricks/koalas/plot/core.py
@@ -176,128 +176,26 @@ class KoalasPlotAccessor(PandasObject):
         KoalasPlotAccessor._backends[backend] = module
         return module
 
-    @staticmethod
-    def _format_args(backend_name, data, kind, kwargs):
-        """
-        Format the arguments.
-        Assigns default values to plotting functions.
-        Maps the argument to the appropriate backend.
-        """
-        from databricks.koalas import DataFrame, Series
-
-        data_preprocessor_map = {
-            "pie": TopNPlot().get_top_n,
-            "bar": TopNPlot().get_top_n,
-            "barh": TopNPlot().get_top_n,
-            "scatter": TopNPlot().get_top_n,
-            "area": SampledPlot().get_sampled,
-            "line": SampledPlot().get_sampled,
-        }
-        # make the arguments values of matplotlib compatible with that of plotting backend
-        args_map = {
-            "plotly": {
-                "logx": "log_x",
-                "logy": "log_y",
-                "xlim": "range_x",
-                "ylim": "range_y",
-                "yerr": "error_y",
-                "xerr": "error_x",
-            }
-        }
-
-        if isinstance(data, Series):
-            positional_args = {
-                ("ax", None),
-                ("figsize", None),
-                ("use_index", True),
-                ("title", None),
-                ("grid", None),
-                ("legend", False),
-                ("style", None),
-                ("logx", False),
-                ("logy", False),
-                ("loglog", False),
-                ("xticks", None),
-                ("yticks", None),
-                ("xlim", None),
-                ("ylim", None),
-                ("rot", None),
-                ("fontsize", None),
-                ("colormap", None),
-                ("table", False),
-                ("yerr", None),
-                ("xerr", None),
-                ("label", None),
-                ("secondary_y", False),
-            }
-        elif isinstance(data, DataFrame):
-            positional_args = {
-                ("x", None),
-                ("y", None),
-                ("ax", None),
-                ("subplots", None),
-                ("sharex", None),
-                ("sharey", False),
-                ("layout", None),
-                ("figsize", None),
-                ("use_index", True),
-                ("title", None),
-                ("grid", None),
-                ("legend", True),
-                ("style", None),
-                ("logx", False),
-                ("logy", False),
-                ("loglog", False),
-                ("xticks", None),
-                ("yticks", None),
-                ("xlim", None),
-                ("ylim", None),
-                ("rot", None),
-                ("fontsize", None),
-                ("colormap", None),
-                ("table", False),
-                ("yerr", None),
-                ("xerr", None),
-                ("secondary_y", False),
-                ("sort_columns", False),
-            }
-        # removing keys that are not required
-        attrs_to_ignore = ["self", "kind", "data", "data", "kwargs", "backend"]
-        # no need to map and remove anything  if the backend is the default
-        for temp in attrs_to_ignore:
-            kwargs.pop(temp, None)
-
-        for arg, def_val in positional_args:
-            # map the argument if possible
-            if backend_name != "databricks.koalas.plot":
-                if backend_name in args_map:
-                    if arg in kwargs and arg in args_map[backend_name]:
-                        kwargs[args_map[backend_name][arg]] = kwargs.pop(arg)
-                # remove argument is default and not mapped
-                if arg in kwargs and kwargs[arg] == def_val:
-                    kwargs.pop(arg, None)
-            else:
-                if arg not in kwargs:
-                    kwargs[arg] = def_val
-
-        if backend_name != "databricks.koalas.plot":
-            data = data_preprocessor_map[kind](data)
-
-        if backend_name == "plotly" and kind == "area" and "stacked" in kwargs:
-            del kwargs["stacked"]
-
-        return data, kwargs
-
-    def __call__(self, kind="line", backend=None, **kwargs):
-
-        positional_args = locals()
+    def __call__(self, *, kind="line", backend=None, **kwargs):
         plot_backend = KoalasPlotAccessor._get_plot_backend(backend)
-        args = {**positional_args, **kwargs}
-        # when using another backend, let the backend take the charge
-        plot_data, kwds = self._format_args(plot_backend.__name__, self.data, kind, args)
+        plot_data = self.data
 
         if plot_backend.__name__ != "databricks.koalas.plot":
-            return plot_backend.plot(plot_data, kind=kind, **kwds)
+            data_preprocessor_map = {
+                "pie": TopNPlot().get_top_n,
+                "bar": TopNPlot().get_top_n,
+                "barh": TopNPlot().get_top_n,
+                "scatter": TopNPlot().get_top_n,
+                "area": SampledPlot().get_sampled,
+                "line": SampledPlot().get_sampled,
+            }
+            if data_preprocessor_map[kind]:
+                raise NotImplementedError(
+                    "'%s' plot is not supported with '%s' plot "
+                    "backend yet." % plot_backend.__name__
+                )
+            plot_data = data_preprocessor_map[kind](plot_data)
+            return plot_backend.plot(plot_data, kind=kind, **kwargs)
 
         if kind not in KoalasPlotAccessor._koalas_all_kinds:
             raise ValueError("{} is not a valid plot kind".format(kind))
@@ -308,11 +206,11 @@ class KoalasPlotAccessor(PandasObject):
         if isinstance(self.data, Series):
             if kind not in KoalasPlotAccessor._series_kinds:
                 return unsupported_function(class_name="pd.Series", method_name=kind)()
-            return plot_series(data=self.data, kind=kind, **kwds)
+            return plot_series(data=self.data, kind=kind, **kwargs)
         elif isinstance(self.data, DataFrame):
             if kind not in KoalasPlotAccessor._dataframe_kinds:
                 return unsupported_function(class_name="pd.DataFrame", method_name=kind)()
-            return plot_frame(data=self.data, kind=kind, **kwds)
+            return plot_frame(data=self.data, kind=kind, **kwargs)
 
     def line(self, x=None, y=None, **kwargs):
         """
@@ -583,7 +481,7 @@ class KoalasPlotAccessor(PandasObject):
         precision: scalar, default = 0.01
             This argument is used by Koalas to compute approximate statistics
             for building a boxplot. Use *smaller* values to get more precise
-            statistics.
+            statistics (matplotlib-only).
 
         Returns
         -------
@@ -754,7 +652,7 @@ class KoalasPlotAccessor(PandasObject):
 
     density = kde
 
-    def area(self, x=None, y=None, stacked=True, **kwds):
+    def area(self, x=None, y=None, **kwds):
         """
         Draw a stacked area plot.
 
@@ -769,7 +667,7 @@ class KoalasPlotAccessor(PandasObject):
             Column to plot. By default uses all columns.
         stacked : bool, default True
             Area plots are stacked by default. Set to False to create a
-            unstacked plot.
+            unstacked plot (matplotlib-only).
         **kwds : optional
             Additional keyword arguments are documented in
             :meth:`DataFrame.plot`.
@@ -814,7 +712,7 @@ class KoalasPlotAccessor(PandasObject):
         if isinstance(self.data, Series):
             return self(kind="area", **kwds)
         elif isinstance(self.data, DataFrame):
-            return self(kind="area", x=x, y=y, stacked=stacked, **kwds)
+            return self(kind="area", x=x, y=y, **kwds)
 
     def pie(self, y=None, **kwds):
         """
@@ -870,7 +768,7 @@ class KoalasPlotAccessor(PandasObject):
                 raise ValueError("pie requires either y column or 'subplots=True'")
             return self(kind="pie", y=y, **kwds)
 
-    def scatter(self, x, y, s=None, c=None, **kwds):
+    def scatter(self, x, y, **kwds):
         """
         Create a scatter plot with varying marker point size and color.
 
@@ -890,7 +788,9 @@ class KoalasPlotAccessor(PandasObject):
             The column name or column position to be used as vertical
             coordinates for each point.
         s : scalar or array_like, optional
+            (matplotlib-only).
         c : str, int or array_like, optional
+            (matplotlib-only).
 
         **kwds: Optional
             Keyword arguments to pass on to :meth:`databricks.koalas.DataFrame.plot`.
@@ -930,7 +830,7 @@ class KoalasPlotAccessor(PandasObject):
             ...                       c='species',
             ...                       colormap='viridis')
         """
-        return self(kind="scatter", x=x, y=y, s=s, c=c, **kwds)
+        return self(kind="scatter", x=x, y=y, **kwds)
 
     def hexbin(self, **kwds):
         return unsupported_function(class_name="pd.DataFrame", method_name="hexbin")()


### PR DESCRIPTION
This PR proposes to simplify plot implementation. Current Koalas implementation attempts to map the argument between other plotting backends (e.g., matplotlib vs plotly). Keeping this map is a huge maintenance cost and it's unrealistic to track their change and keep updating this map.

Pandas itself does not keep this map either:

```python
>>> import pandas as pd
>>> pd.DataFrame([1,2,3]).plot.line(logx=1)
<AxesSubplot:>
>>> pd.options.plotting.backend = "plotly"
>>> pd.DataFrame([1,2,3]).plot.line(logx=1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/.../opt/miniconda3/envs/python3.8/lib/python3.8/site-packages/pandas/plotting/_core.py", line 1017, in line
    return self(kind="line", x=x, y=y, **kwargs)
  File "/.../opt/miniconda3/envs/python3.8/lib/python3.8/site-packages/pandas/plotting/_core.py", line 879, in __call__
    return plot_backend.plot(self._parent, x=x, y=y, kind=kind, **kwargs)
  File "/.../miniconda3/envs/python3.8/lib/python3.8/site-packages/plotly/__init__.py", line 102, in plot
    return line(data_frame, **kwargs)
TypeError: line() got an unexpected keyword argument 'logx'
```