### PR TITLE
Refine DataFrame/Series.quantile.

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -10200,10 +10200,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         def quantile(spark_column, spark_type):
             if isinstance(spark_type, (BooleanType, NumericType)):
-                spark_column = spark_column.cast(DoubleType())
+                return SF.percentile_approx(spark_column.cast(DoubleType()), q, accuracy)
             else:
                 raise TypeError("Could not convert {} to numeric".format(spark_type.simpleString()))
-            return SF.percentile_approx(spark_column, q, accuracy)
 
         if isinstance(q, list):
             # First calculate the percentiles from all columns and map it to each `quantiles`

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -10137,7 +10137,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         ----------
         q : float or array-like, default 0.5 (50% quantile)
             0 <= q <= 1, the quantile(s) to compute.
-        axis : int, default 0 or 'index'
+        axis : int or str, default 0 or 'index'
             Can only be set to 0 at the moment.
         numeric_only : bool, default True
             If False, the quantile of datetime and timedelta data will be computed as well.

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -10191,7 +10191,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         for v in q if isinstance(q, list) else [q]:
             if not isinstance(v, float):
                 raise ValueError(
-                    "q must be a float of an array of floats; however, [%s] found." % type(v)
+                    "q must be a float or an array of floats; however, [%s] found." % type(v)
                 )
             if v < 0.0 or v > 1.0:
                 raise ValueError("percentiles should all be in the interval [0, 1].")
@@ -10233,7 +10233,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 return DataFrame(index=q)
 
             sdf = self._internal.spark_frame.select(percentile_cols)
-            # Here, after select percntile cols, a spark_frame looks like below:
+            # Here, after select percentile cols, a spark_frame looks like below:
             # +---------+---------+
             # |        a|        b|
             # +---------+---------+

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -10110,7 +10110,11 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
     # TODO: fix parameter 'axis' and 'numeric_only' to work same as pandas'
     def quantile(
-        self, q=0.5, axis=0, numeric_only=True, accuracy=10000
+        self,
+        q: Union[float, Iterable[float]] = 0.5,
+        axis: Union[int, str] = 0,
+        numeric_only: bool = True,
+        accuracy: int = 10000,
     ) -> Union["DataFrame", "Series"]:
         """
         Return value at the given quantile.
@@ -10152,86 +10156,114 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         4  5  0
 
         >>> kdf.quantile(.5)
-        a    3
-        b    7
-        Name: 0.5, dtype: int64
+        a    3.0
+        b    7.0
+        Name: 0.5, dtype: float64
 
         >>> kdf.quantile([.25, .5, .75])
-              a  b
-        0.25  2  6
-        0.5   3  7
-        0.75  4  8
+                a    b
+        0.25  2.0  6.0
+        0.50  3.0  7.0
+        0.75  4.0  8.0
         """
-        result_as_series = False
         axis = validate_axis(axis)
         if axis != 0:
             raise NotImplementedError('axis should be either 0 or "index" currently.')
-        if numeric_only is not True:
-            raise NotImplementedError("quantile currently doesn't supports numeric_only")
-        if isinstance(q, float):
-            result_as_series = True
-            key = str(q)
-            q = (q,)
 
-        quantiles = q
-        # First calculate the percentiles from all columns and map it to each `quantiles`
-        # by creating each entry as a struct. So, it becomes an array of structs as below:
-        #
-        # +-----------------------------------------+
-        # |                                   arrays|
-        # +-----------------------------------------+
-        # |[[0.25, 2, 6], [0.5, 3, 7], [0.75, 4, 8]]|
-        # +-----------------------------------------+
-
-        percentile_cols = []
-        for scol, column_name in zip(
-            self._internal.data_spark_columns, self._internal.data_spark_column_names
-        ):
-            percentile_cols.append(
-                SF.percentile_approx(scol, quantiles, accuracy).alias(column_name)
+        if not isinstance(accuracy, int):
+            raise ValueError(
+                "accuracy must be an integer; however, got [%s]" % type(accuracy).__name__
             )
 
-        sdf = self._internal.spark_frame.select(percentile_cols)
-        # Here, after select percntile cols, a spark_frame looks like below:
-        # +---------+---------+
-        # |        a|        b|
-        # +---------+---------+
-        # |[2, 3, 4]|[6, 7, 8]|
-        # +---------+---------+
+        if isinstance(q, Iterable):
+            q = list(q)
 
-        cols_dict = OrderedDict()  # type: OrderedDict
-        for column in self._internal.data_spark_column_names:
-            cols_dict[column] = list()
-            for i in range(len(quantiles)):
-                cols_dict[column].append(scol_for(sdf, column).getItem(i).alias(column))
+        for v in q if isinstance(q, list) else [q]:
+            if not isinstance(v, float):
+                raise ValueError(
+                    "q must be a float of an array of floats; however, [%s] found." % type(v)
+                )
+            if v < 0.0 or v > 1.0:
+                raise ValueError("percentiles should all be in the interval [0, 1].")
 
-        internal_index_column = SPARK_DEFAULT_INDEX_NAME
-        cols = []
-        for i, col in enumerate(zip(*cols_dict.values())):
-            cols.append(F.struct(F.lit("%s" % quantiles[i]).alias(internal_index_column), *col))
-        sdf = sdf.select(F.array(*cols).alias("arrays"))
+        def quantile(spark_column, spark_type):
+            if isinstance(spark_type, (BooleanType, NumericType)):
+                spark_column = spark_column.cast(DoubleType())
+            else:
+                raise TypeError("Could not convert {} to numeric".format(spark_type.simpleString()))
+            return SF.percentile_approx(spark_column, q, accuracy)
 
-        # And then, explode it and manually set the index.
-        # +-----------------+---+---+
-        # |__index_level_0__|  a|  b|
-        # +-----------------+---+---+
-        # |             0.25|  2|  6|
-        # |              0.5|  3|  7|
-        # |             0.75|  4|  8|
-        # +-----------------+---+---+
-        sdf = sdf.select(F.explode(F.col("arrays"))).selectExpr("col.*")
+        if isinstance(q, list):
+            # First calculate the percentiles from all columns and map it to each `quantiles`
+            # by creating each entry as a struct. So, it becomes an array of structs as below:
+            #
+            # +-----------------------------------------+
+            # |                                   arrays|
+            # +-----------------------------------------+
+            # |[[0.25, 2, 6], [0.5, 3, 7], [0.75, 4, 8]]|
+            # +-----------------------------------------+
 
-        internal = self._internal.copy(
-            spark_frame=sdf,
-            index_spark_columns=[scol_for(sdf, internal_index_column)],
-            index_names=[None],
-            data_spark_columns=[
-                scol_for(sdf, col) for col in self._internal.data_spark_column_names
-            ],
-            column_label_names=None,
-        )
+            percentile_cols = []
+            percentile_col_names = []
+            column_labels = []
+            for label, column in zip(
+                self._internal.column_labels, self._internal.data_spark_column_names
+            ):
+                spark_type = self._internal.spark_type_for(label)
 
-        return DataFrame(internal) if not result_as_series else DataFrame(internal).T[key]
+                is_numeric_or_boolean = isinstance(spark_type, (NumericType, BooleanType))
+                keep_column = not numeric_only or is_numeric_or_boolean
+
+                if keep_column:
+                    percentile_col = quantile(self._internal.spark_column_for(label), spark_type)
+                    percentile_cols.append(percentile_col.alias(column))
+                    percentile_col_names.append(column)
+                    column_labels.append(label)
+
+            if len(percentile_cols) == 0:
+                return DataFrame(index=q)
+
+            sdf = self._internal.spark_frame.select(percentile_cols)
+            # Here, after select percntile cols, a spark_frame looks like below:
+            # +---------+---------+
+            # |        a|        b|
+            # +---------+---------+
+            # |[2, 3, 4]|[6, 7, 8]|
+            # +---------+---------+
+
+            cols_dict = OrderedDict()  # type: OrderedDict
+            for column in percentile_col_names:
+                cols_dict[column] = list()
+                for i in range(len(q)):
+                    cols_dict[column].append(scol_for(sdf, column).getItem(i).alias(column))
+
+            internal_index_column = SPARK_DEFAULT_INDEX_NAME
+            cols = []
+            for i, col in enumerate(zip(*cols_dict.values())):
+                cols.append(F.struct(F.lit(q[i]).alias(internal_index_column), *col))
+            sdf = sdf.select(F.array(*cols).alias("arrays"))
+
+            # And then, explode it and manually set the index.
+            # +-----------------+---+---+
+            # |__index_level_0__|  a|  b|
+            # +-----------------+---+---+
+            # |             0.25|  2|  6|
+            # |              0.5|  3|  7|
+            # |             0.75|  4|  8|
+            # +-----------------+---+---+
+            sdf = sdf.select(F.explode(F.col("arrays"))).selectExpr("col.*")
+
+            internal = InternalFrame(
+                spark_frame=sdf,
+                index_spark_columns=[scol_for(sdf, internal_index_column)],
+                column_labels=column_labels,
+                data_spark_columns=[scol_for(sdf, col) for col in percentile_col_names],
+            )
+            return DataFrame(internal)
+        else:
+            return self._reduce_for_stat_function(
+                quantile, name="quantile", numeric_only=numeric_only
+            ).rename(q)
 
     def query(self, expr, inplace=False) -> Optional["DataFrame"]:
         """

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -1684,10 +1684,9 @@ class Frame(object, metaclass=ABCMeta):
 
         def median(spark_column, spark_type):
             if isinstance(spark_type, (BooleanType, NumericType)):
-                spark_column = spark_column.cast(DoubleType())
+                return SF.percentile_approx(spark_column.cast(DoubleType()), 0.5, accuracy)
             else:
                 raise TypeError("Could not convert {} to numeric".format(spark_type.simpleString()))
-            return SF.percentile_approx(spark_column, 0.5, accuracy)
 
         return self._reduce_for_stat_function(
             median, name="median", numeric_only=numeric_only, axis=axis

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -3299,12 +3299,11 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
             def quantile(spark_column, spark_type):
                 if isinstance(spark_type, (BooleanType, NumericType)):
-                    spark_column = spark_column.cast(DoubleType())
+                    return SF.percentile_approx(spark_column.cast(DoubleType()), q, accuracy)
                 else:
                     raise TypeError(
                         "Could not convert {} to numeric".format(spark_type.simpleString())
                     )
-                return SF.percentile_approx(spark_column, q, accuracy)
 
             return self._reduce_for_stat_function(quantile, name="quantile")
 

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -21,10 +21,10 @@ import re
 import inspect
 import sys
 import warnings
-from collections.abc import Iterable, Mapping
+from collections.abc import Mapping
 from distutils.version import LooseVersion
 from functools import partial, wraps, reduce
-from typing import Any, Generic, List, Optional, Tuple, TypeVar, Union, cast
+from typing import Any, Generic, Iterable, List, Optional, Tuple, TypeVar, Union, cast
 
 import matplotlib
 import numpy as np
@@ -3234,7 +3234,9 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         return self._with_new_scol(scol)
 
     # TODO: add 'interpolation' parameter.
-    def quantile(self, q=0.5, accuracy=10000) -> Union[Scalar, "Series"]:
+    def quantile(
+        self, q: Union[float, Iterable[float]] = 0.5, accuracy: int = 10000
+    ) -> Union[Scalar, "Series"]:
         """
         Return value at the given quantile.
 
@@ -3261,91 +3263,50 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         --------
         >>> s = ks.Series([1, 2, 3, 4, 5])
         >>> s.quantile(.5)
-        3
+        3.0
 
         >>> (s + 1).quantile(.5)
-        4
+        4.0
 
         >>> s.quantile([.25, .5, .75])
-        0.25    2
-        0.5     3
-        0.75    4
-        dtype: int64
+        0.25    2.0
+        0.50    3.0
+        0.75    4.0
+        dtype: float64
 
         >>> (s + 1).quantile([.25, .5, .75])
-        0.25    3
-        0.5     4
-        0.75    5
-        dtype: int64
+        0.25    3.0
+        0.50    4.0
+        0.75    5.0
+        dtype: float64
         """
-        if not isinstance(accuracy, int):
-            raise ValueError(
-                "accuracy must be an integer; however, got [%s]" % type(accuracy).__name__
-            )
-
         if isinstance(q, Iterable):
-            q = list(q)
-
-        for v in q if isinstance(q, list) else [q]:
-            if not isinstance(v, float):
+            return first_series(
+                self.to_frame().quantile(q=q, axis=0, numeric_only=False, accuracy=accuracy)
+            ).rename(self.name)
+        else:
+            if not isinstance(accuracy, int):
                 raise ValueError(
-                    "q must be a float of an array of floats; however, [%s] found." % type(v)
+                    "accuracy must be an integer; however, got [%s]" % type(accuracy).__name__
                 )
-            if v < 0.0 or v > 1.0:
+
+            if not isinstance(q, float):
+                raise ValueError(
+                    "q must be a float of an array of floats; however, [%s] found." % type(q)
+                )
+            if q < 0.0 or q > 1.0:
                 raise ValueError("percentiles should all be in the interval [0, 1].")
 
-        if isinstance(q, list):
-            quantiles = q
-            # TODO: avoid to use dataframe. After this, anchor will be lost.
-
-            # First calculate the percentiles and map it to each `quantiles`
-            # by creating each entry as a struct. So, it becomes an array of
-            # structs as below:
-            #
-            # +--------------------------------+
-            # | arrays                         |
-            # +--------------------------------+
-            # |[[0.25, 2], [0.5, 3], [0.75, 4]]|
-            # +--------------------------------+
-            percentile_col = SF.percentile_approx(self.spark.column, quantiles, accuracy)
-            sdf = self._internal.spark_frame.select(percentile_col.alias("percentiles"))
-
-            internal_index_column = SPARK_DEFAULT_INDEX_NAME
-            value_column = "value"
-            cols = []
-            for i, quantile in enumerate(quantiles):
-                cols.append(
-                    F.struct(
-                        F.lit("%s" % quantile).alias(internal_index_column),
-                        F.expr("percentiles[%s]" % i).alias(value_column),
+            def quantile(spark_column, spark_type):
+                if isinstance(spark_type, (BooleanType, NumericType)):
+                    spark_column = spark_column.cast(DoubleType())
+                else:
+                    raise TypeError(
+                        "Could not convert {} to numeric".format(spark_type.simpleString())
                     )
-                )
-            sdf = sdf.select(F.array(*cols).alias("arrays"))
+                return SF.percentile_approx(spark_column, q, accuracy)
 
-            # And then, explode it and manually set the index.
-            #
-            # +-----------------+-----+
-            # |__index_level_0__|value|
-            # +-----------------+-----+
-            # | 0.25            |    2|
-            # |  0.5            |    3|
-            # | 0.75            |    4|
-            # +-----------------+-----+
-            sdf = sdf.select(F.explode(F.col("arrays"))).selectExpr("col.*")
-
-            internal = InternalFrame(
-                spark_frame=sdf,
-                index_spark_columns=[scol_for(sdf, internal_index_column)],
-                column_labels=None,
-                data_spark_columns=[scol_for(sdf, value_column)],
-                column_label_names=None,
-            )
-
-            return DataFrame(internal)[value_column].rename(self.name)
-        else:
-            return self._reduce_for_stat_function(
-                lambda scol: SF.percentile_approx(scol, q, accuracy), name="quantile"
-            )
+            return self._reduce_for_stat_function(quantile, name="quantile")
 
     # TODO: add axis, numeric_only, pct, na_option parameter
     def rank(self, method="average", ascending=True) -> "Series":

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -3292,7 +3292,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
             if not isinstance(q, float):
                 raise ValueError(
-                    "q must be a float of an array of floats; however, [%s] found." % type(q)
+                    "q must be a float or an array of floats; however, [%s] found." % type(q)
                 )
             if q < 0.0 or q > 1.0:
                 raise ValueError("percentiles should all be in the interval [0, 1].")

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -4271,8 +4271,12 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         pdf = pd.DataFrame({"x": ["a", "b", "c"]})
         kdf = ks.from_pandas(pdf)
 
-        self.assert_eq(kdf.quantile(0.5), pdf.quantile(0.5))
-        self.assert_eq(kdf.quantile([0.25, 0.5, 0.75]), pdf.quantile([0.25, 0.5, 0.75]))
+        if LooseVersion(pd.__version__) >= LooseVersion("1.0.0"):
+            self.assert_eq(kdf.quantile(0.5), pdf.quantile(0.5))
+            self.assert_eq(kdf.quantile([0.25, 0.5, 0.75]), pdf.quantile([0.25, 0.5, 0.75]))
+        else:
+            self.assert_eq(kdf.quantile(0.5), pd.Series(name=0.5))
+            self.assert_eq(kdf.quantile([0.25, 0.5, 0.75]), pd.DataFrame(index=[0.25, 0.5, 0.75]))
 
         with self.assertRaisesRegex(TypeError, "Could not convert string to numeric"):
             kdf.quantile(0.5, numeric_only=False)

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -4243,6 +4243,11 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(kdf.quantile(0.5), pdf.quantile(0.5))
         self.assert_eq(kdf.quantile([0.25, 0.5, 0.75]), pdf.quantile([0.25, 0.5, 0.75]))
 
+        self.assert_eq(kdf.loc[[]].quantile(0.5), pdf.loc[[]].quantile(0.5))
+        self.assert_eq(
+            kdf.loc[[]].quantile([0.25, 0.5, 0.75]), pdf.loc[[]].quantile([0.25, 0.5, 0.75])
+        )
+
         with self.assertRaisesRegex(
             NotImplementedError, 'axis should be either 0 or "index" currently.'
         ):

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -4254,9 +4254,9 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             kdf.quantile(0.5, axis=1)
         with self.assertRaisesRegex(ValueError, "accuracy must be an integer; however"):
             kdf.quantile(accuracy="a")
-        with self.assertRaisesRegex(ValueError, "q must be a float of an array of floats;"):
+        with self.assertRaisesRegex(ValueError, "q must be a float or an array of floats;"):
             kdf.quantile(q="a")
-        with self.assertRaisesRegex(ValueError, "q must be a float of an array of floats;"):
+        with self.assertRaisesRegex(ValueError, "q must be a float or an array of floats;"):
             kdf.quantile(q=["a"])
 
         self.assert_eq(kdf.quantile(0.5, numeric_only=False), pdf.quantile(0.5, numeric_only=False))

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -1240,6 +1240,11 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         with self.assertRaisesRegex(ValueError, "q must be a float of an array of floats;"):
             ks.Series([24.0, 21.0, 25.0, 33.0, 26.0]).quantile(q=["a"])
 
+        with self.assertRaisesRegex(TypeError, "Could not convert string to numeric"):
+            ks.Series(["a", "b", "c"]).quantile()
+        with self.assertRaisesRegex(TypeError, "Could not convert string to numeric"):
+            ks.Series(["a", "b", "c"]).quantile([0.25, 0.5, 0.75])
+
     def test_idxmax(self):
         pser = pd.Series(data=[1, 4, 5], index=["A", "B", "C"])
         kser = ks.Series(pser)

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -1233,6 +1233,12 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
             kser.round(1.5)
 
     def test_quantile(self):
+        pser = pd.Series([])
+        kser = ks.from_pandas(pser)
+
+        self.assert_eq(kser.quantile(0.5), pser.quantile(0.5))
+        self.assert_eq(kser.quantile([0.25, 0.5, 0.75]), pser.quantile([0.25, 0.5, 0.75]))
+
         with self.assertRaisesRegex(ValueError, "accuracy must be an integer; however"):
             ks.Series([24.0, 21.0, 25.0, 33.0, 26.0]).quantile(accuracy="a")
         with self.assertRaisesRegex(ValueError, "q must be a float of an array of floats;"):

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -1262,9 +1262,9 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
 
         with self.assertRaisesRegex(ValueError, "accuracy must be an integer; however"):
             ks.Series([24.0, 21.0, 25.0, 33.0, 26.0]).quantile(accuracy="a")
-        with self.assertRaisesRegex(ValueError, "q must be a float of an array of floats;"):
+        with self.assertRaisesRegex(ValueError, "q must be a float or an array of floats;"):
             ks.Series([24.0, 21.0, 25.0, 33.0, 26.0]).quantile(q="a")
-        with self.assertRaisesRegex(ValueError, "q must be a float of an array of floats;"):
+        with self.assertRaisesRegex(ValueError, "q must be a float or an array of floats;"):
             ks.Series([24.0, 21.0, 25.0, 33.0, 26.0]).quantile(q=["a"])
 
         with self.assertRaisesRegex(TypeError, "Could not convert string to numeric"):

--- a/databricks/koalas/tests/test_stats.py
+++ b/databricks/koalas/tests/test_stats.py
@@ -223,6 +223,14 @@ class StatsTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(len(kdf.kurtosis(numeric_only=True)), len(pdf.kurtosis(numeric_only=True)))
         self.assert_eq(len(kdf.skew(numeric_only=True)), len(pdf.skew(numeric_only=True)))
 
+        self.assert_eq(
+            len(kdf.quantile(q=0.5, numeric_only=True)), len(pdf.quantile(q=0.5, numeric_only=True))
+        )
+        self.assert_eq(
+            len(kdf.quantile(q=[0.25, 0.5, 0.75], numeric_only=True)),
+            len(pdf.quantile(q=[0.25, 0.5, 0.75], numeric_only=True)),
+        )
+
     def test_numeric_only_unsupported(self):
         pdf = pd.DataFrame({"i": [0, 1, 2], "b": [False, False, True], "s": ["x", "y", "z"]})
         kdf = ks.from_pandas(pdf)


### PR DESCRIPTION
Refines `DataFrame/Series.quantile` to:

- Reuse `_reduce_for_stat_function` when `q` is `float`.
- Consolidate the logic when `q` is `Iterable`.

Also support `numeric_only` for `DataFrame`.
