### PR TITLE
Refine DataFrame/Series.product.

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -72,8 +72,6 @@ from pyspark.sql.types import (
     StructType,
     StructField,
     ArrayType,
-    LongType,
-    FractionalType,
 )
 from pyspark.sql.window import Window
 
@@ -10797,85 +10795,6 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         new_sdf = default_session().createDataFrame(rows, sdf.schema)
 
         return DataFrame(self._internal.with_new_sdf(new_sdf))
-
-    def product(self) -> "Series":
-        """
-        Return the product of the values as Series.
-
-        .. note:: unlike pandas', Koalas' emulates product by ``exp(sum(log(...)))``
-            trick. Therefore, it only works for positive numbers.
-
-        Examples
-        --------
-
-        Non-numeric type column is not included to the result.
-
-        >>> kdf = ks.DataFrame({'A': [1, 2, 3, 4, 5],
-        ...                     'B': [10, 20, 30, 40, 50],
-        ...                     'C': ['a', 'b', 'c', 'd', 'e']})
-        >>> kdf
-           A   B  C
-        0  1  10  a
-        1  2  20  b
-        2  3  30  c
-        3  4  40  d
-        4  5  50  e
-
-        >>> kdf.prod().sort_index()
-        A         120
-        B    12000000
-        dtype: int64
-
-        If there is no numeric type columns, returns empty Series.
-
-        >>> ks.DataFrame({"key": ['a', 'b', 'c'], "val": ['x', 'y', 'z']}).prod()
-        Series([], dtype: float64)
-        """
-        from databricks.koalas.series import first_series
-
-        has_float_col = False
-        column_labels = []
-        # Filtering out only column names of numeric type column.
-        for column_label in self._internal.column_labels:
-            dtype = self._kser_for(column_label).spark.data_type
-            if isinstance(dtype, NumericType):
-                column_labels.append(column_label)
-                if isinstance(dtype, FractionalType):
-                    has_float_col = True
-
-        # Getting spark columns from column names.
-        spark_columns = [
-            self._internal.spark_column_for(column_label) for column_label in column_labels
-        ]
-        if not spark_columns:
-            # If DataFrame has no numeric type columns, return empty Series.
-            return ks.Series([])
-
-        spark_frame = self._internal.spark_frame
-        conds = []
-        for spark_column, column_label in zip(spark_columns, column_labels):
-            cond = F.when(spark_column.isNull(), F.lit(1)).otherwise(spark_column)
-            conds.append(F.exp(F.sum(F.log(cond))).alias(name_like_string(column_label)))
-
-        spark_frame = spark_frame.select(
-            [F.lit(None).cast(StringType()).alias(SPARK_DEFAULT_INDEX_NAME)] + conds
-        )
-
-        internal = InternalFrame(
-            spark_frame=spark_frame,
-            index_spark_columns=[scol_for(spark_frame, SPARK_DEFAULT_INDEX_NAME)],
-            column_labels=column_labels,
-            column_label_names=self._internal.column_label_names,
-        )
-
-        with ks.option_context("compute.max_rows", None):
-            result = first_series(DataFrame(internal).T)
-            if not has_float_col:
-                return result.spark.transform(lambda col: F.round(col).cast(LongType()))
-            else:
-                return result
-
-    prod = product
 
     @staticmethod
     def from_dict(data, orient="columns", dtype=None, columns=None) -> "DataFrame":

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -1289,7 +1289,7 @@ class Frame(object, metaclass=ABCMeta):
 
         def prod(spark_column, spark_type):
             if isinstance(spark_type, BooleanType):
-                scol = F.min(F.coalesce(spark_column, F.lit(True))).cast("long")
+                scol = F.min(F.coalesce(spark_column, F.lit(True))).cast(LongType())
             elif isinstance(spark_type, NumericType):
                 num_zeros = F.sum(F.when(spark_column == 0, 1).otherwise(0))
                 sign = F.when(
@@ -1301,7 +1301,7 @@ class Frame(object, metaclass=ABCMeta):
                 )
 
                 if isinstance(spark_type, IntegralType):
-                    scol = F.round(scol).cast("long")
+                    scol = F.round(scol).cast(LongType())
             else:
                 raise TypeError("Could not convert {} to numeric".format(spark_type.simpleString()))
 

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -2181,28 +2181,24 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         pser = pd.Series([10, 20, 30, 40, 50])
         kser = ks.from_pandas(pser)
         self.assert_eq(pser.prod(min_count=5), kser.prod(min_count=5))
-        # Using `repr` since the result of below will be `np.nan`.
-        self.assert_eq(repr(pser.prod(min_count=6)), repr(kser.prod(min_count=6)))
+        self.assert_eq(pser.prod(min_count=6), kser.prod(min_count=6))
 
         pser = pd.Series([10, np.nan, 30, np.nan, 50])
         kser = ks.from_pandas(pser)
         self.assert_eq(pser.prod(min_count=3), kser.prod(min_count=3), almost=True)
-        # ditto.
-        self.assert_eq(repr(pser.prod(min_count=4)), repr(kser.prod(min_count=4)))
+        self.assert_eq(pser.prod(min_count=4), kser.prod(min_count=4))
 
         pser = pd.Series([np.nan, np.nan, np.nan])
         kser = ks.from_pandas(pser)
-        # ditto.
-        self.assert_eq(repr(pser.prod(min_count=1)), repr(kser.prod(min_count=1)))
+        self.assert_eq(pser.prod(min_count=1), kser.prod(min_count=1))
 
         pser = pd.Series([])
         kser = ks.from_pandas(pser)
-        # ditto.
-        self.assert_eq(repr(pser.prod(min_count=1)), repr(kser.prod(min_count=1)))
+        self.assert_eq(pser.prod(min_count=1), kser.prod(min_count=1))
 
-        with self.assertRaisesRegex(TypeError, "cannot perform prod with type object"):
+        with self.assertRaisesRegex(TypeError, "Could not convert string to numeric"):
             ks.Series(["a", "b", "c"]).prod()
-        with self.assertRaisesRegex(TypeError, "cannot perform prod with type datetime64"):
+        with self.assertRaisesRegex(TypeError, "Could not convert timestamp to numeric"):
             ks.Series([pd.Timestamp("2016-01-01") for _ in range(3)]).prod()
 
     def test_hasnans(self):

--- a/databricks/koalas/tests/test_stats.py
+++ b/databricks/koalas/tests/test_stats.py
@@ -33,7 +33,7 @@ class StatsTest(ReusedSQLTestCase, SQLTestUtils):
         for funcname in functions:
             self.assert_eq(getattr(kdf_or_kser, funcname)(), getattr(pdf_or_pser, funcname)())
 
-        functions = ["std", "var"]
+        functions = ["std", "var", "product"]
         for funcname in functions:
             self.assert_eq(
                 getattr(kdf_or_kser, funcname)(),
@@ -91,6 +91,28 @@ class StatsTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(kdf["a"].loc[[]].sum(), pdf["a"].loc[[]].sum())
         self.assert_eq(kdf["a"].loc[[]].sum(min_count=1), pdf["a"].loc[[]].sum(min_count=1))
 
+    def test_product(self):
+        pdf = pd.DataFrame(
+            {"a": [1, -2, -3, np.nan], "b": [0.1, np.nan, -0.3, np.nan], "c": [10, 20, 0, -10]}
+        )
+        kdf = ks.from_pandas(pdf)
+
+        self.assert_eq(kdf.product(), pdf.product(), check_exact=False)
+        self.assert_eq(kdf.product(axis=1), pdf.product(axis=1))
+        self.assert_eq(kdf.product(min_count=3), pdf.product(min_count=3), check_exact=False)
+        self.assert_eq(kdf.product(axis=1, min_count=1), pdf.product(axis=1, min_count=1))
+        self.assert_eq(kdf.loc[[]].product(), pdf.loc[[]].product())
+        self.assert_eq(kdf.loc[[]].product(min_count=1), pdf.loc[[]].product(min_count=1))
+
+        self.assert_eq(kdf["a"].product(), pdf["a"].product(), check_exact=False)
+        self.assert_eq(
+            kdf["a"].product(min_count=3), pdf["a"].product(min_count=3), check_exact=False
+        )
+        self.assert_eq(kdf["b"].product(min_count=3), pdf["b"].product(min_count=3))
+        self.assert_eq(kdf["c"].product(min_count=3), pdf["c"].product(min_count=3))
+        self.assert_eq(kdf["a"].loc[[]].product(), pdf["a"].loc[[]].product())
+        self.assert_eq(kdf["a"].loc[[]].product(min_count=1), pdf["a"].loc[[]].product(min_count=1))
+
     def test_abs(self):
         pdf = pd.DataFrame(
             {
@@ -127,6 +149,7 @@ class StatsTest(ReusedSQLTestCase, SQLTestUtils):
             self.assert_eq(kdf.max(axis=1), pdf.max(axis=1))
             self.assert_eq(kdf.min(axis=1), pdf.min(axis=1))
             self.assert_eq(kdf.sum(axis=1), pdf.sum(axis=1))
+            self.assert_eq(kdf.product(axis=1), pdf.product(axis=1))
             self.assert_eq(kdf.kurtosis(axis=1), pdf.kurtosis(axis=1))
             self.assert_eq(kdf.skew(axis=1), pdf.skew(axis=1))
             self.assert_eq(kdf.mean(axis=1), pdf.mean(axis=1))
@@ -193,6 +216,7 @@ class StatsTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(kdf.count(), pdf.count())
 
         self.assert_eq(kdf.sum(), pdf.sum())
+        self.assert_eq(kdf.product(), pdf.product())
         self.assert_eq(kdf.mean(), pdf.mean())
 
         self.assert_eq(kdf.var(), pdf.var(), check_exact=False)
@@ -207,6 +231,7 @@ class StatsTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(kser.count(), pser.count())
 
         self.assert_eq(kser.sum(), pser.sum())
+        self.assert_eq(kser.product(), pser.product())
         self.assert_eq(kser.mean(), pser.mean())
 
         self.assert_eq(kser.var(), pser.var(), almost=True)
@@ -232,8 +257,12 @@ class StatsTest(ReusedSQLTestCase, SQLTestUtils):
 
         if LooseVersion(pd.__version__) >= LooseVersion("1.0.0"):
             self.assert_eq(kdf.sum(numeric_only=True), pdf.sum(numeric_only=True))
+            self.assert_eq(kdf.product(numeric_only=True), pdf.product(numeric_only=True))
         else:
             self.assert_eq(kdf.sum(numeric_only=True), pdf.sum(numeric_only=True).astype(int))
+            self.assert_eq(
+                kdf.product(numeric_only=True), pdf.product(numeric_only=True).astype(int)
+            )
 
         self.assert_eq(kdf.mean(numeric_only=True), pdf.mean(numeric_only=True))
 


### PR DESCRIPTION
Refines `DataFrame/Series.product` to:

- Consolidate and reuse `_reduce_for_stat_function`.
- Support `axis`, `numeric_only`, and `min_count` parameters.
- Enable to calculate values including negative values or zeros.