### PR TITLE
Fix the build error.

### DIFF
--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -36,6 +36,7 @@ import pyspark
 from pyspark import sql as spark
 from pyspark.sql import functions as F, Column
 from pyspark.sql.types import (
+    BooleanType,
     DoubleType,
     FloatType,
     IntegerType,


### PR DESCRIPTION
The build failed due to conflicts between recent PRs.

```
flake8 checks failed:
./databricks/koalas/series.py:5741:45: F821 undefined name 'BooleanType'
        if isinstance(kser.spark.data_type, BooleanType):
                                            ^
./databricks/koalas/series.py:5750:45: F821 undefined name 'BooleanType'
        if isinstance(self.spark.data_type, BooleanType):
                                            ^
```