### PR TITLE
Add note about missing mixed type support to docs

### DIFF
--- a/docs/source/user_guide/types.rst
+++ b/docs/source/user_guide/types.rst
@@ -220,9 +220,9 @@ You can also check the underlying PySpark data type of `Series` or schema of `Da
 
     Koalas currently does not support multiple types of data in single column.
 
-.. code-block:: python
-
-    >>> ks.Series([1, "A"])
-    Traceback (most recent call last):
-    ...
-    TypeError: an integer is required (got type str)
+    .. code-block:: python
+    
+        >>> ks.Series([1, "A"])
+        Traceback (most recent call last):
+        ...
+        TypeError: an integer is required (got type str)

--- a/docs/source/user_guide/types.rst
+++ b/docs/source/user_guide/types.rst
@@ -6,6 +6,8 @@ Type Support In Koalas
 
 In this chapter, we will briefly show you how data types change when converting Koalas DataFrame from/to PySpark DataFrame or pandas DataFrame.
 
+.. note::
+    Koalas doesn't support mixed type because PySpark doesn't support it for now.
 
 Type casting between PySpark and Koalas
 ---------------------------------------

--- a/docs/source/user_guide/types.rst
+++ b/docs/source/user_guide/types.rst
@@ -6,6 +6,7 @@ Type Support In Koalas
 
 In this chapter, we will briefly show you how data types change when converting Koalas DataFrame from/to PySpark DataFrame or pandas DataFrame.
 
+
 Type casting between PySpark and Koalas
 ---------------------------------------
 
@@ -216,8 +217,8 @@ You can also check the underlying PySpark data type of `Series` or schema of `Da
      |-- b: boolean (nullable = false)
 
 .. note::
+
     Koalas currently does not support multiple types of data in single column.
-    This is because Koalas uses Spark DataFrame internally and Spark DataFrame does not support multiple types of data in single column.
 
 .. code-block:: python
 

--- a/docs/source/user_guide/types.rst
+++ b/docs/source/user_guide/types.rst
@@ -6,9 +6,6 @@ Type Support In Koalas
 
 In this chapter, we will briefly show you how data types change when converting Koalas DataFrame from/to PySpark DataFrame or pandas DataFrame.
 
-.. note::
-    Koalas doesn't support mixed type because PySpark doesn't support it for now.
-
 Type casting between PySpark and Koalas
 ---------------------------------------
 
@@ -217,3 +214,14 @@ You can also check the underlying PySpark data type of `Series` or schema of `Da
      |-- d: double (nullable = false)
      |-- s: string (nullable = false)
      |-- b: boolean (nullable = false)
+
+.. note::
+    Koalas currently does not support multiple types of data in single column.
+    This is because Koalas uses Spark DataFrame internally and Spark DataFrame does not support multiple types of data in single column.
+
+.. code-block:: python
+
+    >>> ks.Series([1, "A"])
+    Traceback (most recent call last):
+    ...
+    TypeError: an integer is required (got type str)


### PR DESCRIPTION
Added note about missing support for mixed type to documents.

![Screen Shot 2021-01-05 at 9 36 39 AM](https://user-images.githubusercontent.com/44108233/103610184-d7bfe980-4f62-11eb-9cbb-744623bcbc4d.png)


Resolves #1981 
