### PR TITLE
Added ddof parameter for GroupBy.std() and GroupBy.var()

### DIFF
--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -463,17 +463,27 @@ class GroupBy(object, metaclass=ABCMeta):
         """
         return self._reduce_for_stat_function(F.sum, only_numeric=True)
 
-    # TODO: sync the doc and implement `ddof`.
-    def var(self) -> Union[DataFrame, Series]:
+    # TODO: sync the doc.
+    def var(self, ddof: int = 1) -> Union[DataFrame, Series]:
         """
         Compute variance of groups, excluding missing values.
+
+        Parameters
+        ----------
+        ddof : int, default 1
+            Delta Degrees of Freedom. The divisor used in calculations is N - ddof,
+            where N represents the number of elements.
 
         See Also
         --------
         databricks.koalas.Series.groupby
         databricks.koalas.DataFrame.groupby
         """
-        return self._reduce_for_stat_function(F.variance, only_numeric=True)
+        assert ddof in (0, 1)
+
+        return self._reduce_for_stat_function(
+            F.var_pop if ddof == 0 else F.var_samp, only_numeric=True
+        )
 
     # TODO: skipna should be implemented.
     def all(self) -> Union[DataFrame, Series]:

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -430,18 +430,27 @@ class GroupBy(object, metaclass=ABCMeta):
         """
         return self._reduce_for_stat_function(F.min, only_numeric=False)
 
-    # TODO: sync the doc and implement `ddof`.
-    def std(self) -> Union[DataFrame, Series]:
+    # TODO: sync the doc.
+    def std(self, ddof: int = 1) -> Union[DataFrame, Series]:
         """
         Compute standard deviation of groups, excluding missing values.
+
+        Parameters
+        ----------
+        ddof : int, default 1
+            Delta Degrees of Freedom. The divisor used in calculations is N - ddof,
+            where N represents the number of elements.
 
         See Also
         --------
         databricks.koalas.Series.groupby
         databricks.koalas.DataFrame.groupby
         """
+        assert ddof in (0, 1)
 
-        return self._reduce_for_stat_function(F.stddev, only_numeric=True)
+        return self._reduce_for_stat_function(
+            F.stddev_pop if ddof == 0 else F.stddev_samp, only_numeric=True
+        )
 
     def sum(self) -> Union[DataFrame, Series]:
         """

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -2767,6 +2767,7 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         kdf = ks.from_pandas(pdf)
 
         for ddof in (0, 1):
+            # std
             self.assert_eq(
                 pdf.groupby("a").std(ddof=ddof).sort_index(),
                 kdf.groupby("a").std(ddof=ddof).sort_index(),
@@ -2775,5 +2776,16 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             self.assert_eq(
                 pdf.groupby("a")["b"].std(ddof=ddof).sort_index(),
                 kdf.groupby("a")["b"].std(ddof=ddof).sort_index(),
+                check_exact=False,
+            )
+            # var
+            self.assert_eq(
+                pdf.groupby("a").var(ddof=ddof).sort_index(),
+                kdf.groupby("a").var(ddof=ddof).sort_index(),
+                check_exact=False,
+            )
+            self.assert_eq(
+                pdf.groupby("a")["b"].var(ddof=ddof).sort_index(),
+                kdf.groupby("a")["b"].var(ddof=ddof).sort_index(),
                 check_exact=False,
             )

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -2754,3 +2754,26 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             pdf.groupby(("x", "a")).tail(100000).sort_index(),
             kdf.groupby(("x", "a")).tail(100000).sort_index(),
         )
+
+    def test_ddof(self):
+        pdf = pd.DataFrame(
+            {
+                "a": [1, 1, 1, 1, 2, 2, 2, 3, 3, 3] * 3,
+                "b": [2, 3, 1, 4, 6, 9, 8, 10, 7, 5] * 3,
+                "c": [3, 5, 2, 5, 1, 2, 6, 4, 3, 6] * 3,
+            },
+            index=np.random.rand(10 * 3),
+        )
+        kdf = ks.from_pandas(pdf)
+
+        for ddof in (0, 1):
+            self.assert_eq(
+                pdf.groupby("a").std(ddof=ddof).sort_index(),
+                kdf.groupby("a").std(ddof=ddof).sort_index(),
+                check_exact=False,
+            )
+            self.assert_eq(
+                pdf.groupby("a")["b"].std(ddof=ddof).sort_index(),
+                kdf.groupby("a")["b"].std(ddof=ddof).sort_index(),
+                check_exact=False,
+            )


### PR DESCRIPTION
Added missing parameter `ddof` for `GroupBy.std()` and `GroupBy.var()`.

```python
>>> kdf = ks.DataFrame(
...     {
...         "a": [1, 2, 6, 4, 4, 6, 4, 3, 7],
...         "b": [4, 2, 7, 3, 3, 1, 1, 1, 2],
...         "c": [4, 2, 7, 3, None, 1, 1, 1, 2],
...         "d": list("abcdefght"),
...     },
...     index=[0, 1, 3, 5, 6, 8, 9, 9, 9],
... )
>>> kdf
   a  b    c  d
0  1  4  4.0  a
1  2  2  2.0  b
3  6  7  7.0  c
5  4  3  3.0  d
6  4  3  NaN  e
8  6  1  1.0  f
9  4  1  1.0  g
9  3  1  1.0  h
9  7  2  2.0  t

# std
>>> kdf.groupby("a").std(ddof=1)
          b         c
a
7       NaN       NaN
6  4.242641  4.242641
1       NaN       NaN
3       NaN       NaN
2       NaN       NaN
4  1.154701  1.414214

>>> kdf.groupby("a").std(ddof=0)
          b    c
a
7  0.000000  0.0
6  3.000000  3.0
1  0.000000  0.0
3  0.000000  0.0
2  0.000000  0.0
4  0.942809  1.0

# var
>>> kdf.groupby("a").var(ddof=1)
           b     c
a
7        NaN   NaN
6  18.000000  18.0
1        NaN   NaN
3        NaN   NaN
2        NaN   NaN
4   1.333333   2.0

>>> kdf.groupby("a").var(ddof=0)
          b    c
a
7  0.000000  0.0
6  9.000000  9.0
1  0.000000  0.0
3  0.000000  0.0
2  0.000000  0.0
4  0.888889  1.0
```