### PR TITLE
Adjust Series.mode to match pandas Series.mode

### DIFF
--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -4025,9 +4025,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         sdf = sdf_most_value.select(
             F.col(SPARK_DEFAULT_INDEX_NAME).alias(SPARK_DEFAULT_SERIES_NAME)
         )
-        internal = InternalFrame(
-            spark_frame=sdf, index_spark_columns=None, column_labels=[self._column_label]
-        )
+        internal = InternalFrame(spark_frame=sdf, index_spark_columns=None, column_labels=[None])
 
         return first_series(DataFrame(internal))
 

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -1775,6 +1775,17 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         kdf = ks.from_pandas(pdf)
         self.assert_eq(kdf.a.mod(kdf.b), pdf.a.mod(pdf.b))
 
+    def test_mode(self):
+        pser = pd.Series([0, 0, 1, 1, 1, np.nan, np.nan, np.nan])
+        kser = ks.from_pandas(pser)
+        self.assert_eq(kser.mode(), pser.mode())
+        self.assert_eq(kser.mode(False).sort_values().values, pser.mode(False).sort_values().values)
+
+        pser.name = "x"
+        kser = ks.from_pandas(pser)
+        self.assert_eq(kser.mode(), pser.mode())
+        self.assert_eq(kser.mode(False).sort_values().values, pser.mode(False).sort_values().values)
+
     def test_rmod(self):
         pser = pd.Series([100, None, -300, None, 500, -700], name="Koalas")
         kser = ks.from_pandas(pser)

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -1782,7 +1782,8 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         if LooseVersion(pd.__version__) >= LooseVersion("0.24"):
             # The `dropna` argument is added in pandas 0.24.
             self.assert_eq(
-                kser.mode(False).sort_values().values, pser.mode(False).sort_values().values
+                kser.mode(dropna=False).sort_values().reset_index(drop=True),
+                pser.mode(dropna=False).sort_values().reset_index(drop=True),
             )
 
         pser.name = "x"
@@ -1791,7 +1792,8 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         if LooseVersion(pd.__version__) >= LooseVersion("0.24"):
             # The `dropna` argument is added in pandas 0.24.
             self.assert_eq(
-                kser.mode(False).sort_values().values, pser.mode(False).sort_values().values
+                kser.mode(dropna=False).sort_values().reset_index(drop=True),
+                pser.mode(dropna=False).sort_values().reset_index(drop=True),
             )
 
     def test_rmod(self):

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -1779,12 +1779,20 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         pser = pd.Series([0, 0, 1, 1, 1, np.nan, np.nan, np.nan])
         kser = ks.from_pandas(pser)
         self.assert_eq(kser.mode(), pser.mode())
-        self.assert_eq(kser.mode(False).sort_values().values, pser.mode(False).sort_values().values)
+        if LooseVersion(pd.__version__) >= LooseVersion("0.24"):
+            # The `dropna` argument is added in pandas 0.24.
+            self.assert_eq(
+                kser.mode(False).sort_values().values, pser.mode(False).sort_values().values
+            )
 
         pser.name = "x"
         kser = ks.from_pandas(pser)
         self.assert_eq(kser.mode(), pser.mode())
-        self.assert_eq(kser.mode(False).sort_values().values, pser.mode(False).sort_values().values)
+        if LooseVersion(pd.__version__) >= LooseVersion("0.24"):
+            # The `dropna` argument is added in pandas 0.24.
+            self.assert_eq(
+                kser.mode(False).sort_values().values, pser.mode(False).sort_values().values
+            )
 
     def test_rmod(self):
         pser = pd.Series([100, None, -300, None, 500, -700], name="Koalas")


### PR DESCRIPTION
Currently, Series.mode reserves the name of Series in the result, whereas pandas Series.mode doesn't:
```
>>> kser1
x    1
y    2
Name: z, dtype: int64
>>> kser1.mode()
0    1
1    2
Name: z, dtype: int64. # Reserve name
>>> pser1 = kser1.to_pandas()
>>> pser1.mode()
0    1
1    2
dtype: int64. # Not reserve name
```

In addition, unit tests are added.