### PR TITLE
Optimize histogram calculation as a single pass

### DIFF
--- a/databricks/koalas/tests/plot/test_frame_plot_matplotlib.py
+++ b/databricks/koalas/tests/plot/test_frame_plot_matplotlib.py
@@ -24,6 +24,7 @@ import numpy as np
 
 from databricks import koalas as ks
 from databricks.koalas.config import set_option, reset_option
+from databricks.koalas.plot import KoalasHistPlot
 from databricks.koalas.testing.utils import ReusedSQLTestCase, TestUtils
 
 
@@ -404,6 +405,32 @@ class DataFramePlotMatplotlibTest(ReusedSQLTestCase, TestUtils):
         pdf1.columns = columns
         kdf1.columns = columns
         check_hist_plot(pdf1, kdf1)
+
+    def test_compute_hist(self):
+        expected_bins = np.linspace(1, 50, 11)
+        kdf = ks.DataFrame(
+            {
+                "a": [1, 2, 3, 4, 5, 6, 7, 8, 9, 15, 50],
+                "b": [50, 50, 30, 30, 30, 24, 10, 5, 4, 3, 1],
+            }
+        )
+
+        bins = KoalasHistPlot._get_bins(kdf.to_spark(), 10)
+        self.assert_eq(pd.Series(expected_bins), pd.Series(bins))
+
+        expected_histograms = [
+            np.array([5, 4, 1, 0, 0, 0, 0, 0, 0, 1]),
+            np.array([4, 1, 0, 0, 1, 3, 0, 0, 0, 2]),
+        ]
+        histograms = KoalasHistPlot._compute_hist(kdf, bins)
+        expected_names = ["__a_bucket", "__b_bucket"]
+
+        for histogram, expected_histogram, expected_name in zip(
+            histograms, expected_histograms, expected_names
+        ):
+            self.assert_eq(
+                pd.Series(expected_histogram, name=expected_name), histogram, almost=True
+            )
 
     def test_kde_plot(self):
         def moving_average(a, n=10):

--- a/databricks/koalas/tests/plot/test_series_plot_matplotlib.py
+++ b/databricks/koalas/tests/plot/test_series_plot_matplotlib.py
@@ -231,7 +231,7 @@ class SeriesPlotMatplotlibTest(ReusedSQLTestCase, TestUtils):
         bins = KoalasHistPlot._get_bins(kdf[["a"]].to_spark(), 10)
 
         expected_histogram = np.array([5, 4, 1, 0, 0, 0, 0, 0, 0, 1])
-        histogram = KoalasHistPlot._compute_hist(kdf[["a"]].to_spark(), bins)
+        histogram = next(KoalasHistPlot._compute_hist(kdf[["a"]], bins))
         self.assert_eq(pd.Series(expected_bins), pd.Series(bins))
         self.assert_eq(pd.Series(expected_histogram, name="__a_bucket"), histogram, almost=True)
 

--- a/databricks/koalas/tests/plot/test_series_plot_matplotlib.py
+++ b/databricks/koalas/tests/plot/test_series_plot_matplotlib.py
@@ -231,7 +231,7 @@ class SeriesPlotMatplotlibTest(ReusedSQLTestCase, TestUtils):
         bins = KoalasHistPlot._get_bins(kdf[["a"]].to_spark(), 10)
 
         expected_histogram = np.array([5, 4, 1, 0, 0, 0, 0, 0, 0, 1])
-        histogram = next(KoalasHistPlot._compute_hist(kdf[["a"]], bins))
+        histogram = KoalasHistPlot._compute_hist(kdf[["a"]], bins)[0]
         self.assert_eq(pd.Series(expected_bins), pd.Series(bins))
         self.assert_eq(pd.Series(expected_histogram, name="__a_bucket"), histogram, almost=True)
 


### PR DESCRIPTION
This PR optimizes histogram plot in Koalas by unioning the transformed results and making it single pass.

Previously, when the `DataFrame.plot.hist` is called, each column had to trigger each job.
Now, we can do it in single pass even for `DataFrame`s.

I also tested that it still result same:

![Screen Shot 2021-01-08 at 1 15 47 PM](https://user-images.githubusercontent.com/6477701/103973784-a68a2800-51b3-11eb-86ba-90141346434d.png)

![Screen Shot 2021-01-08 at 1 16 19 PM](https://user-images.githubusercontent.com/6477701/103973813-b99cf800-51b3-11eb-8dc9-4d6a6cc26e3c.png)

