### PR TITLE
Implement (DataFrame|Series).plot.hist in plotly

### DIFF
--- a/databricks/koalas/plot/core.py
+++ b/databricks/koalas/plot/core.py
@@ -350,8 +350,8 @@ class KoalasPlotAccessor(PandasObject):
                 from databricks.koalas.plot import plotly as module
             except ImportError:
                 raise ImportError(
-                    "matplotlib is required for plotting when the "
-                    "default backend 'matplotlib' is selected."
+                    "plotly is required for plotting when the "
+                    "default backend 'plotly' is selected."
                 ) from None
 
             KoalasPlotAccessor._backends["plotly"] = module

--- a/databricks/koalas/plot/matplotlib.py
+++ b/databricks/koalas/plot/matplotlib.py
@@ -16,7 +16,7 @@
 
 from distutils.version import LooseVersion
 
-import matplotlib
+import matplotlib as mat
 import numpy as np
 import pandas as pd
 from matplotlib.axes._base import _process_plot_format
@@ -111,9 +111,7 @@ class KoalasBoxPlot(PandasBoxPlot):
             if dictionary is None:
                 dictionary = dict()
             for prop_dict in properties:
-                dictionary.setdefault(
-                    prop_dict, matplotlib.rcParams[rc_str.format(rc_name, prop_dict)]
-                )
+                dictionary.setdefault(prop_dict, mat.rcParams[rc_str.format(rc_name, prop_dict)])
             return dictionary
 
         # Common property dictionaries loading from rc
@@ -203,7 +201,7 @@ class KoalasBoxPlot(PandasBoxPlot):
         if manage_ticks is not None:
             should_manage_ticks = manage_ticks
 
-        if LooseVersion(matplotlib.__version__) < LooseVersion("3.1.0"):
+        if LooseVersion(mat.__version__) < LooseVersion("3.1.0"):
             extra_args = {"manage_xticks": should_manage_ticks}
         else:
             extra_args = {"manage_ticks": should_manage_ticks}
@@ -333,26 +331,26 @@ class KoalasBoxPlot(PandasBoxPlot):
     ):
         # Missing arguments default to rcParams.
         if whis is None:
-            whis = matplotlib.rcParams["boxplot.whiskers"]
+            whis = mat.rcParams["boxplot.whiskers"]
         if bootstrap is None:
-            bootstrap = matplotlib.rcParams["boxplot.bootstrap"]
+            bootstrap = mat.rcParams["boxplot.bootstrap"]
 
         if notch is None:
-            notch = matplotlib.rcParams["boxplot.notch"]
+            notch = mat.rcParams["boxplot.notch"]
         if vert is None:
-            vert = matplotlib.rcParams["boxplot.vertical"]
+            vert = mat.rcParams["boxplot.vertical"]
         if patch_artist is None:
-            patch_artist = matplotlib.rcParams["boxplot.patchartist"]
+            patch_artist = mat.rcParams["boxplot.patchartist"]
         if meanline is None:
-            meanline = matplotlib.rcParams["boxplot.meanline"]
+            meanline = mat.rcParams["boxplot.meanline"]
         if showmeans is None:
-            showmeans = matplotlib.rcParams["boxplot.showmeans"]
+            showmeans = mat.rcParams["boxplot.showmeans"]
         if showcaps is None:
-            showcaps = matplotlib.rcParams["boxplot.showcaps"]
+            showcaps = mat.rcParams["boxplot.showcaps"]
         if showbox is None:
-            showbox = matplotlib.rcParams["boxplot.showbox"]
+            showbox = mat.rcParams["boxplot.showbox"]
         if showfliers is None:
-            showfliers = matplotlib.rcParams["boxplot.showfliers"]
+            showfliers = mat.rcParams["boxplot.showfliers"]
 
         return dict(
             whis=whis,

--- a/databricks/koalas/plot/plotly.py
+++ b/databricks/koalas/plot/plotly.py
@@ -15,22 +15,21 @@
 #
 import pandas as pd
 
-from databricks.koalas.plot import HistogramPlotBase
+from databricks.koalas.plot import HistogramPlotBase, name_like_string
 
 
-def plot_plotly(origin_plot):
-    def plot(data, kind, **kwargs):
-        # Koalas specific plots
-        if kind == "pie":
-            return plot_pie(data, **kwargs)
-        if kind == "hist":
-            # Note that here data is a Koalas DataFrame or Series unlike other type of plots.
-            return plot_histogram(data, **kwargs)
+def plot(data, kind, **kwargs):
+    import plotly
 
-        # Other plots.
-        return origin_plot(data, kind, **kwargs)
+    # Koalas specific plots
+    if kind == "pie":
+        return plot_pie(data, **kwargs)
+    if kind == "hist":
+        # Note that here data is a Koalas DataFrame or Series unlike other type of plots.
+        return plot_histogram(data, **kwargs)
 
-    return plot
+    # Other plots.
+    return plotly.plot(data, kind, **kwargs)
 
 
 def plot_pie(data, **kwargs):
@@ -40,7 +39,6 @@ def plot_pie(data, **kwargs):
         pdf = data.to_frame()
         return express.pie(pdf, values=pdf.columns[0], names=pdf.index, **kwargs)
     elif isinstance(data, pd.DataFrame):
-        # DataFrame
         values = kwargs.pop("y", None)
         default_names = None
         if values is not None:
@@ -57,37 +55,38 @@ def plot_pie(data, **kwargs):
 
 
 def plot_histogram(data, **kwargs):
-    from plotly import express
-    from plotly.subplots import make_subplots
     import plotly.graph_objs as go
-    from databricks import koalas as ks
 
     bins = kwargs.get("bins", 10)
-    is_single_column = isinstance(data, ks.Series)
     kdf, bins = HistogramPlotBase.prepare_hist_data(data, bins)
+    assert len(bins) > 2, "the number of buckets must be higher than 2."
     output_series = HistogramPlotBase.compute_hist(kdf, bins)
+    prev = float("%.9f" % bins[0])  # to make it prettier, truncate.
+    text_bins = []
+    for b in bins[1:]:
+        norm_b = float("%.9f" % b)
+        text_bins.append("[%s, %s)" % (prev, norm_b))
+        prev = norm_b
+    text_bins[-1] = text_bins[-1][:-1] + "]"  # replace ) to ] for the last bucket.
+
     bins = 0.5 * (bins[:-1] + bins[1:])
-    if is_single_column:
-        output_series = list(output_series)
-        assert len(output_series) == 1
-        output_series = output_series[0]
-        return express.bar(
-            x=bins, y=output_series, labels={"x": str(output_series.name), "y": "count"}
+
+    output_series = list(output_series)
+    bars = []
+    for series in output_series:
+        bars.append(
+            go.Bar(
+                x=bins,
+                y=series,
+                name=name_like_string(series.name),
+                text=text_bins,
+                hovertemplate=(
+                    "variable=" + name_like_string(series.name) + "<br>value=%{text}<br>count=%{y}"
+                ),
+            )
         )
-    else:
-        output_series = list(output_series)
-        fig = make_subplots(rows=1, cols=len(output_series))
 
-        for i, series in enumerate(output_series):
-            fig.add_trace(go.Bar(x=bins, y=series, name=series.name,), row=1, col=i + 1)
-
-        for i, series in enumerate(output_series):
-            if i == 0:
-                xaxis = "xaxis"
-                yaxis = "yaxis"
-            else:
-                xaxis = "xaxis%s" % (i + 1)
-                yaxis = "yaxis%s" % (i + 1)
-            fig["layout"][xaxis]["title"] = str(series.name)
-            fig["layout"][yaxis]["title"] = "count"
-        return fig
+    fig = go.Figure(data=bars, layout=go.Layout(barmode="stack"))
+    fig["layout"]["xaxis"]["title"] = "value"
+    fig["layout"]["yaxis"]["title"] = "count"
+    return fig

--- a/databricks/koalas/plot/plotly.py
+++ b/databricks/koalas/plot/plotly.py
@@ -15,12 +15,17 @@
 #
 import pandas as pd
 
+from databricks.koalas.plot import HistogramPlotBase
+
 
 def plot_plotly(origin_plot):
     def plot(data, kind, **kwargs):
         # Koalas specific plots
         if kind == "pie":
             return plot_pie(data, **kwargs)
+        if kind == "hist":
+            # Note that here data is a Koalas DataFrame or Series unlike other type of plots.
+            return plot_histogram(data, **kwargs)
 
         # Other plots.
         return origin_plot(data, kind, **kwargs)
@@ -49,3 +54,50 @@ def plot_pie(data, **kwargs):
         )
     else:
         raise RuntimeError("Unexpected type: [%s]" % type(data))
+
+
+def plot_histogram(data, **kwargs):
+    from plotly import express
+    from plotly.subplots import make_subplots
+    import plotly.graph_objs as go
+    from databricks import koalas as ks
+
+    assert "bins" in kwargs
+    bins = kwargs["bins"]
+    data, bins = HistogramPlotBase.prepare_hist_data(data, bins)
+
+    is_single_column = False
+    if isinstance(data, ks.Series):
+        is_single_column = True
+        kdf = data.to_frame()
+    elif isinstance(data, ks.DataFrame):
+        kdf = data
+    else:
+        raise RuntimeError("Unexpected type: [%s]" % type(data))
+
+    output_series = HistogramPlotBase.compute_hist(kdf, bins)
+    bins = 0.5 * (bins[:-1] + bins[1:])
+    if is_single_column:
+        output_series = list(output_series)
+        assert len(output_series) == 1
+        output_series = output_series[0]
+        return express.bar(
+            x=bins, y=output_series, labels={"x": str(output_series.name), "y": "count"}
+        )
+    else:
+        output_series = list(output_series)
+        fig = make_subplots(rows=1, cols=len(output_series))
+
+        for i, series in enumerate(output_series):
+            fig.add_trace(go.Bar(x=bins, y=series, name=series.name,), row=1, col=i + 1)
+
+        for i, series in enumerate(output_series):
+            if i == 0:
+                xaxis = "xaxis"
+                yaxis = "yaxis"
+            else:
+                xaxis = "xaxis%s" % (i + 1)
+                yaxis = "yaxis%s" % (i + 1)
+            fig["layout"][xaxis]["title"] = str(series.name)
+            fig["layout"][yaxis]["title"] = "count"
+        return fig

--- a/databricks/koalas/plot/plotly.py
+++ b/databricks/koalas/plot/plotly.py
@@ -62,19 +62,9 @@ def plot_histogram(data, **kwargs):
     import plotly.graph_objs as go
     from databricks import koalas as ks
 
-    assert "bins" in kwargs
-    bins = kwargs["bins"]
-    data, bins = HistogramPlotBase.prepare_hist_data(data, bins)
-
-    is_single_column = False
-    if isinstance(data, ks.Series):
-        is_single_column = True
-        kdf = data.to_frame()
-    elif isinstance(data, ks.DataFrame):
-        kdf = data
-    else:
-        raise RuntimeError("Unexpected type: [%s]" % type(data))
-
+    bins = kwargs.get("bins", 10)
+    is_single_column = isinstance(data, ks.Series)
+    kdf, bins = HistogramPlotBase.prepare_hist_data(data, bins)
     output_series = HistogramPlotBase.compute_hist(kdf, bins)
     bins = 0.5 * (bins[:-1] + bins[1:])
     if is_single_column:

--- a/databricks/koalas/tests/plot/test_frame_plot.py
+++ b/databricks/koalas/tests/plot/test_frame_plot.py
@@ -81,7 +81,7 @@ class DataFramePlotTest(ReusedSQLTestCase):
         expected_histogram = np.array([5, 4, 1, 0, 0, 0, 0, 0, 0, 1])
         histogram = HistogramPlotBase.compute_hist(kdf[["a"]], bins)[0]
         self.assert_eq(pd.Series(expected_bins), pd.Series(bins))
-        self.assert_eq(pd.Series(expected_histogram, name="__a_bucket"), histogram, almost=True)
+        self.assert_eq(pd.Series(expected_histogram, name="a"), histogram, almost=True)
 
     def test_compute_hist_multi_columns(self):
         expected_bins = np.linspace(1, 50, 11)
@@ -100,7 +100,7 @@ class DataFramePlotTest(ReusedSQLTestCase):
             np.array([4, 1, 0, 0, 1, 3, 0, 0, 0, 2]),
         ]
         histograms = HistogramPlotBase.compute_hist(kdf, bins)
-        expected_names = ["__a_bucket", "__b_bucket"]
+        expected_names = ["a", "b"]
 
         for histogram, expected_histogram, expected_name in zip(
             histograms, expected_histograms, expected_names

--- a/databricks/koalas/tests/plot/test_frame_plot_plotly.py
+++ b/databricks/koalas/tests/plot/test_frame_plot_plotly.py
@@ -20,7 +20,6 @@ import pprint
 import pandas as pd
 import numpy as np
 from plotly import express
-from plotly.subplots import make_subplots
 import plotly.graph_objs as go
 
 from databricks import koalas as ks
@@ -182,23 +181,38 @@ class DataFramePlotPlotlyTest(ReusedSQLTestCase, TestUtils):
     def test_hist_plot(self):
         def check_hist_plot(kdf):
             bins = np.array([1.0, 5.9, 10.8, 15.7, 20.6, 25.5, 30.4, 35.3, 40.2, 45.1, 50.0])
-            bins = 0.5 * (bins[:-1] + bins[1:])
             data = [
                 np.array([5.0, 4.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0,]),
                 np.array([4.0, 3.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 1.0,]),
             ]
-
-            fig = make_subplots(rows=1, cols=len(data))
-            fig.add_trace(
-                go.Bar(x=bins, y=data[0], name=name_like_string(kdf.columns[0]),), row=1, col=1
-            )
-            fig.add_trace(
-                go.Bar(x=bins, y=data[1], name=name_like_string(kdf.columns[1]),), row=1, col=2
-            )
-            fig["layout"]["xaxis"]["title"] = name_like_string(kdf.columns[0])
+            prev = bins[0]
+            text_bins = []
+            for b in bins[1:]:
+                text_bins.append("[%s, %s)" % (prev, b))
+                prev = b
+            text_bins[-1] = text_bins[-1][:-1] + "]"
+            bins = 0.5 * (bins[:-1] + bins[1:])
+            name_a = name_like_string(kdf.columns[0])
+            name_b = name_like_string(kdf.columns[1])
+            bars = [
+                go.Bar(
+                    x=bins,
+                    y=data[0],
+                    name=name_a,
+                    text=text_bins,
+                    hovertemplate=("variable=" + name_a + "<br>value=%{text}<br>count=%{y}"),
+                ),
+                go.Bar(
+                    x=bins,
+                    y=data[1],
+                    name=name_b,
+                    text=text_bins,
+                    hovertemplate=("variable=" + name_b + "<br>value=%{text}<br>count=%{y}"),
+                ),
+            ]
+            fig = go.Figure(data=bars, layout=go.Layout(barmode="stack"))
+            fig["layout"]["xaxis"]["title"] = "value"
             fig["layout"]["yaxis"]["title"] = "count"
-            fig["layout"]["xaxis2"]["title"] = name_like_string(kdf.columns[1])
-            fig["layout"]["yaxis2"]["title"] = "count"
 
             self.assertEqual(
                 pprint.pformat(kdf.plot(kind="hist").to_dict()), pprint.pformat(fig.to_dict())

--- a/databricks/koalas/tests/plot/test_series_plot.py
+++ b/databricks/koalas/tests/plot/test_series_plot.py
@@ -28,7 +28,7 @@ class SeriesPlotTest(unittest.TestCase):
             self.assertEqual(ks.options.plotting.backend, plot_backend)
 
             module = KoalasPlotAccessor._get_plot_backend(plot_backend)
-            self.assertEqual(module.__name__, plot_backend)
+            self.assertEqual(module.__name__, "databricks.koalas.plot.plotly")
 
     def test_plot_backends_incorrect(self):
         fake_plot_backend = "none_plotting_module"


### PR DESCRIPTION
This PR implements `(DataFrame|Series).plot.hist` in plotly:

This can be tested via: https://mybinder.org/v2/gh/HyukjinKwon/koalas/plotly-histogram?filepath=docs%2Fsource%2Fgetting_started%2F10min.ipynb

Example:

```python
# Koalas
import databricks.koalas as ks
ks.options.plotting.backend = "plotly"
kdf = ks.DataFrame({
    'a c': [1, 2, 3, 4, 5, 6, 7, 8, 9, 15, 50],
    'b': [2, 3, 4, 5, 7, 9, 10, 15, 10, 20, 20]
})
(kdf + 100).plot.hist()

# pandas
import pandas as pd
pd.options.plotting.backend = "plotly"
pdf = pd.DataFrame({
    'a c': [1, 2, 3, 4, 5, 6, 7, 8, 9, 15, 50],
    'b': [2, 3, 4, 5, 7, 9, 10, 15, 10, 20, 20]
})
(pdf + 100).plot.hist()
```

![Screen Shot 2021-01-12 at 10 12 47 PM](https://user-images.githubusercontent.com/6477701/104318885-644e4700-5523-11eb-81bc-f56ea1dbe797.png)

![Screen Shot 2021-01-12 at 10 12 52 PM](https://user-images.githubusercontent.com/6477701/104318888-657f7400-5523-11eb-8d06-da40206b4d01.png)

 NOTE that the output is a bit different because:
 - We use Spark for histogram calculation and it's a bit different from pandas'
 - Histogram plot in plotly cannot be directly used in our case but should work around by leveraging bar charts because we don't use plotly to calculate histogram, see https://plotly.com/python/histograms/.