### PR TITLE
Set upperbound xlrd<2.0.0 to fix read_excel test cases

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -31,4 +31,8 @@ pytest
 pytest-cov
 scikit-learn
 openpyxl
-xlrd
+# xlrd dropped xlsx support. pandas 0.25 added a way to continue supporting xlsx
+# by leveraging openpyxl, see also
+# https://stackoverflow.com/questions/65254535/xlrd-biffh-xlrderror-excel-xlsx-file-not-supported
+# We can remove this upperbound when our minimum pandas version is 0.25+.
+xlrd<2.0.0


### PR DESCRIPTION
The current test cases are being failed as below, 

```
E           xlrd.biffh.XLRDError: Excel xlsx file; not supported
```

https://github.com/databricks/koalas/pull/1997/checks?check_run_id=1675264925

I referred to https://stackoverflow.com/questions/65254535/xlrd-biffh-xlrderror-excel-xlsx-file-not-supported