### PR TITLE
DataFrame.join on key column

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -7331,7 +7331,6 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         >>> join_kdf.index
         Int64Index([0, 1, 2, 3], dtype='int64')
         """
-
         if isinstance(right, ks.Series):
             common = list(self.columns.intersection([right.name]))
         else:
@@ -7342,7 +7341,6 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             )
 
         need_set_index = False
-
         if on:
             if not is_list_like(on):
                 on = [on]  # type: ignore

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -7352,10 +7352,12 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 )
 
             if set(right.index.names) != set(on):
+                # If the column `on` is not the index of `right`,
+                # use the column `on` from self as the join key
                 return self.merge(
                     right,
                     left_on=on,
-                    left_index=on is None,
+                    left_index=False,
                     right_index=True,
                     how=how,
                     suffixes=(lsuffix, rsuffix),

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -7331,6 +7331,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         >>> join_kdf.index
         Int64Index([0, 1, 2, 3], dtype='int64')
         """
+
         if isinstance(right, ks.Series):
             common = list(self.columns.intersection([right.name]))
         else:
@@ -7341,6 +7342,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             )
 
         need_set_index = False
+
         if on:
             if not is_list_like(on):
                 on = [on]  # type: ignore
@@ -7349,23 +7351,23 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                     'len(left_on) must equal the number of levels in the index of "right"'
                 )
 
-            need_set_index = len(set(on) & set(self.index.names)) == 0
-        # if need_set_index:
-        #     self = self.set_index(on)
-        # join_kdf = self.merge(
-        #     right, left_index=True, right_index=True, how=how, suffixes=(lsuffix, rsuffix)
-        # )
+            if set(right.index.names) != set(on):
+                return self.merge(
+                    right,
+                    left_on=on,
+                    left_index=on is None,
+                    right_index=True,
+                    how=how,
+                    suffixes=(lsuffix, rsuffix),
+                )
 
+            need_set_index = len(set(on) & set(self.index.names)) == 0
+        if need_set_index:
+            self = self.set_index(on)
         join_kdf = self.merge(
-            right,
-            left_on=on,
-            left_index=on is None,
-            right_index=True,
-            how=how,
-            suffixes=(lsuffix, rsuffix),
+            right, left_index=True, right_index=True, how=how, suffixes=(lsuffix, rsuffix)
         )
-        return join_kdf.reset_index(drop=True)
-        # return join_kdf.reset_index() if need_set_index else join_kdf
+        return join_kdf.reset_index() if need_set_index else join_kdf
 
     def append(
         self,

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -7350,12 +7350,22 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 )
 
             need_set_index = len(set(on) & set(self.index.names)) == 0
-        if need_set_index:
-            self = self.set_index(on)
+        # if need_set_index:
+        #     self = self.set_index(on)
+        # join_kdf = self.merge(
+        #     right, left_index=True, right_index=True, how=how, suffixes=(lsuffix, rsuffix)
+        # )
+
         join_kdf = self.merge(
-            right, left_index=True, right_index=True, how=how, suffixes=(lsuffix, rsuffix)
+            right,
+            left_on=on,
+            left_index=on is None,
+            right_index=True,
+            how=how,
+            suffixes=(lsuffix, rsuffix),
         )
-        return join_kdf.reset_index() if need_set_index else join_kdf
+        return join_kdf.reset_index(drop=True)
+        # return join_kdf.reset_index() if need_set_index else join_kdf
 
     def append(
         self,

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -2238,13 +2238,15 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         kdf1 = ks.from_pandas(pdf1)
         kdf2 = ks.from_pandas(pdf2)
 
-        join_pdf = pdf1.join(pdf2, on="B", lsuffix="_left")
-        join_pdf.sort_values(by=list(join_pdf.columns), inplace=True)
+        hows = ["left", "inner"]
+        for how in hows:
+            join_pdf = pdf1.join(pdf2, on="B", lsuffix="_left", how=how)
+            join_pdf.sort_values(by=list(join_pdf.columns), inplace=True)
 
-        join_kdf = kdf1.join(kdf2, on="B", lsuffix="_left")
-        join_kdf.sort_values(by=list(join_kdf.columns), inplace=True)
+            join_kdf = kdf1.join(kdf2, on="B", lsuffix="_left", how=how)
+            join_kdf.sort_values(by=list(join_kdf.columns), inplace=True)
 
-        self.assert_eq(join_pdf, join_kdf)
+            self.assert_eq(join_pdf, join_kdf)
 
         # check basic function
         pdf1 = pd.DataFrame(

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -2233,6 +2233,19 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(pdf.add_suffix("first_series"), kdf.add_suffix("first_series"))
 
     def test_join(self):
+        pdf1 = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+        pdf2 = pd.DataFrame({"B": [11, 12, 13], "C": [14, 15, 16]})
+        kdf1 = ks.from_pandas(pdf1)
+        kdf2 = ks.from_pandas(pdf2)
+
+        join_pdf = pdf1.join(pdf2, on="B", lsuffix="_left")
+        join_pdf.sort_values(by=list(join_pdf.columns), inplace=True)
+
+        join_kdf = kdf1.join(kdf2, on="B", lsuffix="_left")
+        join_kdf = join_kdf.sort_values(by=list(join_kdf.columns)).reset_index(drop=True)
+
+        self.assert_eq(join_pdf, join_kdf)
+        return
         # check basic function
         pdf1 = pd.DataFrame(
             {"key": ["K0", "K1", "K2", "K3"], "A": ["A0", "A1", "A2", "A3"]}, columns=["key", "A"]

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -2242,10 +2242,10 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         join_pdf.sort_values(by=list(join_pdf.columns), inplace=True)
 
         join_kdf = kdf1.join(kdf2, on="B", lsuffix="_left")
-        join_kdf = join_kdf.sort_values(by=list(join_kdf.columns)).reset_index(drop=True)
+        join_kdf.sort_values(by=list(join_kdf.columns), inplace=True)
 
         self.assert_eq(join_pdf, join_kdf)
-        return
+
         # check basic function
         pdf1 = pd.DataFrame(
             {"key": ["K0", "K1", "K2", "K3"], "A": ["A0", "A1", "A2", "A3"]}, columns=["key", "A"]


### PR DESCRIPTION
pandas support join using the on parameter when the`on` column is not the index of any sides (`self` and `right`). 

### pandas
```
>>> pdf1 = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
>>> pdf2 = pd.DataFrame({"B": [11, 12, 13], "C": [14, 15, 16]})
>>> pdf1.join(pdf2, on='B', lsuffix='_left')
   A  B_left   B   C
0  1       4 NaN NaN
1  2       5 NaN NaN
2  3       6 NaN NaN
```

### Koalas (ref #2002)
```
>>> kdf1 = ks.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
>>> kdf2 = ks.DataFrame({"B": [11, 12, 13], "C": [14, 15, 16]})
>>> kdf1.join(kdf2, on='B', lsuffix='_left')
Traceback (most recent call last):
...
  File "<string>", line 3, in raise_from
pyspark.sql.utils.AnalysisException: Reference 'B' is ambiguous, could be: right_table.B, B.;
```

We wanted to match pandas behavior in this case. 

However pandas behavior is not consistent with how join works in the SQL context, especially right join and outer join. This PR proposes for left join and inner join only.

Reference:
https://pandas.pydata.org/pandas-docs/stable/user_guide/merging.html#joining-key-columns-on-an-index