### PR TITLE
Fix as_spark_type to not support "bigint".

### DIFF
--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -346,10 +346,10 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
                 other.spark.data_type, TimestampType
             ):
                 warnings.warn(msg, UserWarning)
-                return self.astype("bigint") - other.astype("bigint")
+                return self.astype("long") - other.astype("long")
             elif isinstance(other, datetime.datetime):
                 warnings.warn(msg, UserWarning)
-                return self.astype("bigint") - F.lit(other).cast(as_spark_type("bigint"))
+                return self.astype("long") - F.lit(other).cast(as_spark_type("long"))
             else:
                 raise TypeError("datetime subtraction can only be applied to datetime series.")
         elif isinstance(self.spark.data_type, DateType):
@@ -362,10 +362,10 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
             )
             if isinstance(other, IndexOpsMixin) and isinstance(other.spark.data_type, DateType):
                 warnings.warn(msg, UserWarning)
-                return column_op(F.datediff)(self, other).astype("bigint")
+                return column_op(F.datediff)(self, other).astype("long")
             elif isinstance(other, datetime.date) and not isinstance(other, datetime.datetime):
                 warnings.warn(msg, UserWarning)
-                return column_op(F.datediff)(self, F.lit(other)).astype("bigint")
+                return column_op(F.datediff)(self, F.lit(other)).astype("long")
             else:
                 raise TypeError("date subtraction can only be applied to date series.")
         return column_op(Column.__sub__)(self, other)
@@ -467,7 +467,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
             )
             if isinstance(other, datetime.datetime):
                 warnings.warn(msg, UserWarning)
-                return -(self.astype("bigint") - F.lit(other).cast(as_spark_type("bigint")))
+                return -(self.astype("long") - F.lit(other).cast(as_spark_type("long")))
             else:
                 raise TypeError("datetime subtraction can only be applied to datetime series.")
         elif isinstance(self.spark.data_type, DateType):
@@ -480,7 +480,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
             )
             if isinstance(other, datetime.date) and not isinstance(other, datetime.datetime):
                 warnings.warn(msg, UserWarning)
-                return -column_op(F.datediff)(self, F.lit(other)).astype("bigint")
+                return -column_op(F.datediff)(self, F.lit(other)).astype("long")
             else:
                 raise TypeError("date subtraction can only be applied to date series.")
         return column_op(Column.__rsub__)(self, other)

--- a/databricks/koalas/tests/test_typedef.py
+++ b/databricks/koalas/tests/test_typedef.py
@@ -274,3 +274,6 @@ class TypeHintTests(unittest.TestCase):
 
         for numpy_or_python_type, spark_type in type_mapper.items():
             self.assertEqual(as_spark_type(numpy_or_python_type), spark_type)
+
+        with self.assertRaisesRegex(TypeError, "Type uint64 was not understood."):
+            as_spark_type(np.dtype("uint64"))

--- a/databricks/koalas/typedef/typehints.py
+++ b/databricks/koalas/typedef/typehints.py
@@ -21,7 +21,6 @@ import typing
 import datetime
 import decimal
 from inspect import getfullargspec, isclass
-import warnings
 
 import numpy as np
 import pandas as pd
@@ -102,8 +101,6 @@ def as_spark_type(tpe) -> types.DataType:
     - dictionaries of field_name -> type
     - Python3's typing system
     """
-    from databricks.koalas.utils import is_testing
-
     # TODO: Add "boolean" and "string" types.
     # ArrayType
     if tpe in (np.ndarray,):
@@ -133,16 +130,6 @@ def as_spark_type(tpe) -> types.DataType:
         return types.IntegerType()
     elif tpe in (int, np.int, np.int64, "int", "int64", "long"):
         return types.LongType()
-    elif isinstance(tpe, str) and tpe in ("bigint",):
-        msg = (
-            "A string '{}' as a dtype is deprecated. "
-            "Please use int, np.int, np.int64, 'int', 'int64', or 'long' instead.".format(tpe)
-        )
-        if is_testing():
-            raise AssertionError(msg)
-        else:
-            warnings.warn(msg, FutureWarning)
-            return types.LongType()
     elif tpe in (np.int16, "int16", "short"):
         return types.ShortType()
     # StringType

--- a/databricks/koalas/typedef/typehints.py
+++ b/databricks/koalas/typedef/typehints.py
@@ -21,6 +21,7 @@ import typing
 import datetime
 import decimal
 from inspect import getfullargspec, isclass
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -101,6 +102,8 @@ def as_spark_type(tpe) -> types.DataType:
     - dictionaries of field_name -> type
     - Python3's typing system
     """
+    from databricks.koalas.utils import is_testing
+
     # TODO: Add "boolean" and "string" types.
     # ArrayType
     if tpe in (np.ndarray,):
@@ -128,8 +131,18 @@ def as_spark_type(tpe) -> types.DataType:
         return types.FloatType()
     elif tpe in (np.int32, "int32", "i"):
         return types.IntegerType()
-    elif tpe in (int, np.int, np.int64, "int", "int64", "long", "bigint"):
+    elif tpe in (int, np.int, np.int64, "int", "int64", "long"):
         return types.LongType()
+    elif isinstance(tpe, str) and tpe in ("bigint",):
+        msg = (
+            "A string '{}' as a dtype is deprecated. "
+            "Please use int, np.int, np.int64, 'int', 'int64', or 'long' instead.".format(tpe)
+        )
+        if is_testing():
+            raise AssertionError(msg)
+        else:
+            warnings.warn(msg, FutureWarning)
+            return types.LongType()
     elif tpe in (np.int16, "int16", "short"):
         return types.ShortType()
     # StringType


### PR DESCRIPTION
Fix `as_spark_type` to not support "bigint".

The string "bigint" is not recognizable by `np.dtype` and it causes an unexpected error:

```py
>>> import numpy as np
>>> from databricks.koalas.typedef import as_spark_type
>>> as_spark_type(np.dtype("datetime64[ns]"))
Traceback (most recent call last):
...
TypeError: data type "bigint" not understood
```

Also, it doesn't work in pandas:

```py
>>> pd.Series([1, 2, 3], dtype="bigint")
Traceback (most recent call last):
...
TypeError: data type "bigint" not understood
```