### PR TITLE
Reuse as_spark_type in infer_pd_series_spark_type.

### DIFF
--- a/databricks/koalas/extensions.py
+++ b/databricks/koalas/extensions.py
@@ -104,9 +104,9 @@ def _register_accessor(name, cls):
 
     def decorator(accessor):
         if hasattr(cls, name):
-            msg = "registration of accessor {0} under name {1} for type {2} is overriding \
-                a preexisting attribute with the same name.".format(
-                accessor, name, cls
+            msg = (
+                "registration of accessor {0} under name '{1}' for type {2} is overriding "
+                "a preexisting attribute with the same name.".format(accessor, name, cls.__name__)
             )
 
             warnings.warn(

--- a/databricks/koalas/tests/test_extension.py
+++ b/databricks/koalas/tests/test_extension.py
@@ -115,7 +115,7 @@ class ExtensionTest(ReusedSQLTestCase):
     def test_overwrite_warns(self):
         mean = ks.Series.mean
         try:
-            with assert_produces_warning(UserWarning) as w:
+            with assert_produces_warning(UserWarning, raise_on_extra_warnings=False) as w:
                 register_series_accessor("mean")(CustomAccessor)
                 s = ks.Series([1, 2])
                 assert s.mean.prop == "item"

--- a/databricks/koalas/typedef/typehints.py
+++ b/databricks/koalas/typedef/typehints.py
@@ -24,7 +24,6 @@ from inspect import getfullargspec, isclass
 
 import numpy as np
 import pandas as pd
-from pandas.api.types import is_datetime64_dtype, is_datetime64tz_dtype
 import pyarrow as pa
 import pyspark.sql.types as types
 

--- a/databricks/koalas/typedef/typehints.py
+++ b/databricks/koalas/typedef/typehints.py
@@ -166,10 +166,8 @@ def infer_pd_series_spark_type(s: pd.Series) -> types.DataType:
             return s[0].__UDT__
         else:
             return from_arrow_type(pa.Array.from_pandas(s).type)
-    elif is_datetime64_dtype(dt) or is_datetime64tz_dtype(dt):
-        return types.TimestampType()
     else:
-        return from_arrow_type(pa.from_numpy_dtype(dt))
+        return as_spark_type(dt)
 
 
 def infer_return_type(f) -> typing.Union[SeriesType, DataFrameType, ScalarType, UnknownType]:


### PR DESCRIPTION
Now that `as_spark_type` is good enough for Koalas, we should reuse it in `infer_pd_series_spark_type` to avoid inconsistency.