### PR TITLE
Implemented ks.read_orc

### DIFF
--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -2600,7 +2600,12 @@ def broadcast(obj) -> DataFrame:
     return DataFrame(obj._internal.with_new_sdf(F.broadcast(obj._internal.spark_frame)))
 
 
-def read_orc(path, columns: Optional[List[str]] = None, **options) -> "DataFrame":
+def read_orc(
+    path,
+    columns: Optional[List[str]] = None,
+    index_col: Optional[Union[str, List[str]]] = None,
+    **options
+) -> "DataFrame":
     """
     Load an ORC object from the file path, returning a DataFrame.
 
@@ -2610,6 +2615,8 @@ def read_orc(path, columns: Optional[List[str]] = None, **options) -> "DataFrame
         The path string storing the ORC file to be read.
     columns : list, default None
         If not None, only these columns will be read from the file.
+    index_col : str or list of str, optional, default: None
+        Index column of table in Spark.
     options : dict
         All other options passed directly into Spark's data source.
 
@@ -2624,7 +2631,7 @@ def read_orc(path, columns: Optional[List[str]] = None, **options) -> "DataFrame
     if "options" in options and isinstance(options.get("options"), dict) and len(options) == 1:
         options = options.get("options")  # type: ignore
 
-    kdf = read_spark_io(path, format="orc", **options)
+    kdf = read_spark_io(path, format="orc", index_col=index_col, **options)
 
     if columns is not None:
         kdf_columns = kdf.columns

--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -97,6 +97,7 @@ __all__ = [
     "merge",
     "to_numeric",
     "broadcast",
+    "read_orc",
 ]
 
 
@@ -2597,6 +2598,45 @@ def broadcast(obj) -> DataFrame:
     if not isinstance(obj, DataFrame):
         raise ValueError("Invalid type : expected DataFrame got {}".format(type(obj).__name__))
     return DataFrame(obj._internal.with_new_sdf(F.broadcast(obj._internal.spark_frame)))
+
+
+def read_orc(path, columns: Optional[List[str]] = None, **options) -> "DataFrame":
+    """
+    Load an ORC object from the file path, returning a DataFrame.
+
+    Parameters
+    ----------
+    path : str
+        The path string storing the ORC file to be read.
+    columns : list, default None
+        If not None, only these columns will be read from the file.
+    options : dict
+        All other options passed directly into Spark's data source.
+
+    Returns
+    -------
+    DataFrame
+
+    Examples
+    --------
+    >>> ks.read_orc('data.orc')  # doctest: +SKIP
+    """
+    if "options" in options and isinstance(options.get("options"), dict) and len(options) == 1:
+        options = options.get("options")  # type: ignore
+
+    kdf = read_spark_io(path, format="orc", **options)
+
+    if columns is not None:
+        kdf_columns = kdf.columns
+        new_columns = list()
+        for column in list(columns):
+            if column in kdf_columns:
+                new_columns.append(column)
+            else:
+                raise ValueError("Unknown column name '{}'".format(column))
+        kdf = kdf[new_columns]
+
+    return kdf
 
 
 def _get_index_map(

--- a/databricks/koalas/tests/test_dataframe_spark_io.py
+++ b/databricks/koalas/tests/test_dataframe_spark_io.py
@@ -16,6 +16,8 @@
 
 from distutils.version import LooseVersion
 import unittest
+import glob
+import os
 
 import numpy as np
 import pandas as pd
@@ -375,3 +377,38 @@ class DataFrameSparkIOTest(ReusedSQLTestCase, TestUtils):
                     )
             else:
                 self.assertRaises(ValueError, lambda: ks.read_excel(tmp))
+
+    def test_read_orc(self):
+        with self.temp_dir() as tmp:
+            path = "{}/file1.orc".format(tmp)
+            data = self.test_pdf
+            self.spark.createDataFrame(data, "i32 int, i64 long, f double, bhello string").coalesce(
+                1
+            ).write.orc(path, mode="overwrite")
+
+            # `spark.write.orc` create a directory contains distributed orc files.
+            # But pandas only can read from file, not directory. Therefore, we need orc file path.
+            orc_file_path = glob.glob(os.path.join(path, "*.orc"))[0]
+
+            if LooseVersion(pd.__version__) >= LooseVersion("1.0.0"):
+                expected = pd.read_orc(orc_file_path)
+            else:
+                expected = data.reset_index()[data.columns]
+            actual = ks.read_orc(path)
+            self.assertPandasEqual(expected, actual.to_pandas())
+
+            # columns
+            columns = ["i32", "i64"]
+            if LooseVersion(pd.__version__) >= LooseVersion("1.0.0"):
+                expected = pd.read_orc(orc_file_path, columns=columns)
+            else:
+                expected = data.reset_index()[columns]
+            actual = ks.read_orc(path, columns=columns)
+            self.assertPandasEqual(expected, actual.to_pandas())
+
+            msg = "Unknown column name 'i'"
+            with self.assertRaises(ValueError, msg=msg):
+                ks.read_orc(path, columns="i32")
+            msg = "Unknown column name 'i34'"
+            with self.assertRaises(ValueError, msg=msg):
+                ks.read_orc(path, columns=["i34", "i64"])

--- a/databricks/koalas/tests/test_dataframe_spark_io.py
+++ b/databricks/koalas/tests/test_dataframe_spark_io.py
@@ -406,6 +406,26 @@ class DataFrameSparkIOTest(ReusedSQLTestCase, TestUtils):
             actual = ks.read_orc(path, columns=columns)
             self.assertPandasEqual(expected, actual.to_pandas())
 
+            # index_col
+            kdf = ks.from_pandas(data)
+            expected = kdf.set_index("i32")
+            actual = ks.read_orc(path, index_col="i32")
+            self.assert_eq(actual, expected)
+
+            expected = kdf.set_index(["i32", "f"])
+            actual = ks.read_orc(path, index_col=["i32", "f"])
+            self.assert_eq(actual, expected)
+
+            # index_col with columns
+            kdf = ks.from_pandas(data)
+            expected = kdf.set_index("i32")[["i64", "bhello"]]
+            actual = ks.read_orc(path, index_col=["i32"], columns=["i64", "bhello"])
+            self.assert_eq(actual, expected)
+
+            expected = kdf.set_index(["i32", "f"])[["bhello", "i64"]]
+            actual = ks.read_orc(path, index_col=["i32", "f"], columns=["bhello", "i64"])
+            self.assert_eq(actual, expected)
+
             msg = "Unknown column name 'i'"
             with self.assertRaises(ValueError, msg=msg):
                 ks.read_orc(path, columns="i32")

--- a/databricks/koalas/tests/test_dataframe_spark_io.py
+++ b/databricks/koalas/tests/test_dataframe_spark_io.py
@@ -408,21 +408,21 @@ class DataFrameSparkIOTest(ReusedSQLTestCase, TestUtils):
 
             # index_col
             kdf = ks.from_pandas(data)
-            expected = kdf.set_index("i32")
+            expected = data.set_index("i32")
             actual = ks.read_orc(path, index_col="i32")
             self.assert_eq(actual, expected)
 
-            expected = kdf.set_index(["i32", "f"])
+            expected = data.set_index(["i32", "f"])
             actual = ks.read_orc(path, index_col=["i32", "f"])
             self.assert_eq(actual, expected)
 
             # index_col with columns
             kdf = ks.from_pandas(data)
-            expected = kdf.set_index("i32")[["i64", "bhello"]]
+            expected = data.set_index("i32")[["i64", "bhello"]]
             actual = ks.read_orc(path, index_col=["i32"], columns=["i64", "bhello"])
             self.assert_eq(actual, expected)
 
-            expected = kdf.set_index(["i32", "f"])[["bhello", "i64"]]
+            expected = data.set_index(["i32", "f"])[["bhello", "i64"]]
             actual = ks.read_orc(path, index_col=["i32", "f"], columns=["bhello", "i64"])
             self.assert_eq(actual, expected)
 

--- a/docs/source/reference/io.rst
+++ b/docs/source/reference/io.rst
@@ -37,6 +37,13 @@ Parquet
    read_parquet
    DataFrame.to_parquet
 
+ORC
+-------
+.. autosummary::
+   :toctree: api/
+
+   read_orc
+
 Generic Spark I/O
 -----------------
 .. autosummary::


### PR DESCRIPTION
This PR proposes `ks.read_orc` to support creating `DataFrame` from ORC file.

https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_orc.html#pandas.read_orc

```python
>>> ks.read_orc("example.orc")
   i32  i64    f  bhello
0    0    0  0.0  people

>>> pd.read_orc("example.orc")
   i32  i64    f  bhello
0    0    0  0.0  people

# with columns
>>> ks.read_orc("example.orc", columns=["i32", "f"])
   i32    f
0    0  0.0

>>> pd.read_orc("example.orc", columns=["i32", "f"])
   i32    f
0    0  0.0
>>>
```