### PR TITLE
Supports list-like Python objects for Series comparison.

### DIFF
--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -658,6 +658,11 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         d    False
         Name: b, dtype: bool
         """
+        return self == other
+
+    equals = eq
+
+    def __eq__(self, other):
         if isinstance(other, (list, tuple)):
             if len(self) == len(other):
                 other = ks.Series(other)
@@ -666,9 +671,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         # pandas always returns False for all items with dict and set.
         elif isinstance(other, (dict, set)):
             return self != self
-        return self == other
-
-    equals = eq
+        return IndexOpsMixin.__eq__(self, other)
 
     def gt(self, other) -> "Series":
         """

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -658,6 +658,14 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         d    False
         Name: b, dtype: bool
         """
+        if isinstance(other, (list, tuple)):
+            if len(self) == len(other):
+                other = ks.Series(other)
+            else:
+                raise ValueError("Lengths must be equal")
+        # pandas always returns False for all items with dict and set.
+        elif isinstance(other, (dict, set)):
+            return self != self
         return self == other
 
     equals = eq

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -658,6 +658,13 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         d    False
         Name: b, dtype: bool
         """
+        # pandas won't keep the name with `eq` when other is list of tuple,
+        # whereas `__eq__` always keeps the name.
+        if isinstance(other, (list, tuple)):
+            if len(self) == len(other):
+                other = ks.Series(other)
+            else:
+                raise ValueError("Lengths must be equal")
         return self == other
 
     equals = eq
@@ -665,7 +672,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
     def __eq__(self, other):
         if isinstance(other, (list, tuple)):
             if len(self) == len(other):
-                other = ks.Series(other)
+                other = ks.Series(other, name=self.name)
             else:
                 raise ValueError("Lengths must be equal")
         # pandas always returns False for all items with dict and set.

--- a/databricks/koalas/tests/test_ops_on_diff_frames.py
+++ b/databricks/koalas/tests/test_ops_on_diff_frames.py
@@ -1378,19 +1378,23 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
         pandas_other = pd.Series([np.nan, 1, 3, 4, np.nan, 6], name="x")
         koalas_other = ks.from_pandas(pandas_other)
         self.assert_eq(pser.eq(pandas_other), kser.eq(koalas_other).sort_index())
+        self.assert_eq(pser == pandas_other, (kser == koalas_other).sort_index())
 
         # other = Index
         pandas_other = pd.Index([np.nan, 1, 3, 4, np.nan, 6], name="x")
         koalas_other = ks.from_pandas(pandas_other)
         self.assert_eq(pser.eq(pandas_other), kser.eq(koalas_other).sort_index())
+        self.assert_eq(pser == pandas_other, (kser == koalas_other).sort_index())
 
         # other = list
         other = [np.nan, 1, 3, 4, np.nan, 6]
         self.assert_eq(pser.eq(other), kser.eq(other).sort_index())
+        self.assert_eq(pser == other, (kser == other).sort_index())
 
         # other = tuple
         other = (np.nan, 1, 3, 4, np.nan, 6)
         self.assert_eq(pser.eq(other), kser.eq(other).sort_index())
+        self.assert_eq(pser == other, (kser == other).sort_index())
 
 
 class OpsOnDiffFramesDisabledTest(ReusedSQLTestCase, SQLTestUtils):
@@ -1547,3 +1551,5 @@ class OpsOnDiffFramesDisabledTest(ReusedSQLTestCase, SQLTestUtils):
         for other in others:
             with self.assertRaisesRegex(ValueError, "Cannot combine the series or dataframe"):
                 kser.eq(other)
+            with self.assertRaisesRegex(ValueError, "Cannot combine the series or dataframe"):
+                kser == other

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -2646,21 +2646,28 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
 
         # other = Series
         self.assert_eq(pser.eq(pser), kser.eq(kser))
+        self.assert_eq(pser == pser, kser == kser)
 
         # other = dict
         other = {1: None, 2: None, 3: None, 4: None, np.nan: None, 6: None}
         self.assert_eq(pser.eq(other), kser.eq(other))
+        self.assert_eq(pser == other, kser == other)
 
         # other = set
         other = {1, 2, 3, 4, np.nan, 6}
         self.assert_eq(pser.eq(other), kser.eq(other))
+        self.assert_eq(pser == other, kser == other)
 
         # other = list with the different length
         other = [np.nan, 1, 3, 4, np.nan]
         with self.assertRaisesRegex(ValueError, "Lengths must be equal"):
-            self.assert_eq(pser.eq(other), kser.eq(other))
+            kser.eq(other)
+        with self.assertRaisesRegex(ValueError, "Lengths must be equal"):
+            kser == other
 
         # other = tuple with the different length
         other = (np.nan, 1, 3, 4, np.nan)
         with self.assertRaisesRegex(ValueError, "Lengths must be equal"):
-            self.assert_eq(pser.eq(other), kser.eq(other))
+            kser.eq(other)
+        with self.assertRaisesRegex(ValueError, "Lengths must be equal"):
+            kser == other

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -2639,3 +2639,28 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
             # Test `inplace=True`
             kser.backfill(inplace=True)
             self.assert_eq(expected, kser)
+
+    def test_eq(self):
+        pser = pd.Series([1, 2, 3, 4, 5, 6], name="x")
+        kser = ks.from_pandas(pser)
+
+        # other = Series
+        self.assert_eq(pser.eq(pser), kser.eq(kser))
+
+        # other = dict
+        other = {1: None, 2: None, 3: None, 4: None, np.nan: None, 6: None}
+        self.assert_eq(pser.eq(other), kser.eq(other))
+
+        # other = set
+        other = {1, 2, 3, 4, np.nan, 6}
+        self.assert_eq(pser.eq(other), kser.eq(other))
+
+        # other = list with the different length
+        other = [np.nan, 1, 3, 4, np.nan]
+        with self.assertRaisesRegex(ValueError, "Lengths must be equal"):
+            self.assert_eq(pser.eq(other), kser.eq(other))
+
+        # other = tuple with the different length
+        other = (np.nan, 1, 3, 4, np.nan)
+        with self.assertRaisesRegex(ValueError, "Lengths must be equal"):
+            self.assert_eq(pser.eq(other), kser.eq(other))


### PR DESCRIPTION
Currently Series doesn't support the comparison to list-like Python objects such as `list`, `tuple`, `dict`, `set`.

```python
>>> kser
0    1
1    2
2    3
dtype: int64

>>> kser == [3, 2, 1]
Traceback (most recent call last):
...
    raise Py4JJavaError(
py4j.protocol.Py4JJavaError: An error occurred while calling o77.equalTo.
...
```

This PR proposes supporting them as well for Series comparison.

```python
>>> kser
0    1
1    2
2    3
dtype: int64

>>> kser == [3, 2, 1]
0    False
1     True
2    False
dtype: bool
```

This should resolve #2018 