### PR TITLE
Implemented DataFrame.to_orc

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -4539,6 +4539,81 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         builder._set_opts(compression=compression)
         builder.options(**options).format("parquet").save(path)
 
+    def to_orc(
+        self,
+        path: str,
+        mode: str = "overwrite",
+        partition_cols: Optional[Union[str, List[str]]] = None,
+        compression: Optional[str] = None,
+        index_col: Optional[Union[str, List[str]]] = None,
+        **options
+    ) -> None:
+        """
+        Write the DataFrame out as a ORC file or directory.
+
+        Parameters
+        ----------
+        path : str, required
+            Path to write to.
+        mode : str {'append', 'overwrite', 'ignore', 'error', 'errorifexists'},
+            default 'overwrite'. Specifies the behavior of the save operation when the
+            destination exists already.
+
+            - 'append': Append the new data to existing data.
+            - 'overwrite': Overwrite existing data.
+            - 'ignore': Silently ignore this operation if data already exists.
+            - 'error' or 'errorifexists': Throw an exception if data already exists.
+
+        partition_cols : str or list of str, optional, default None
+            Names of partitioning columns
+        compression : str {'none', 'uncompressed', 'snappy', 'gzip', 'lzo', 'brotli', 'lz4', 'zstd'}
+            Compression codec to use when saving to file. If None is set, it uses the
+            value specified in `spark.sql.parquet.compression.codec`.
+        index_col: str or list of str, optional, default: None
+            Column names to be used in Spark to represent Koalas' index. The index name
+            in Koalas is ignored. By default, the index is always lost.
+        options : dict
+            All other options passed directly into Spark's data source.
+
+        See Also
+        --------
+        read_orc
+        DataFrame.to_delta
+        DataFrame.to_parquet
+        DataFrame.to_table
+        DataFrame.to_spark_io
+
+        Examples
+        --------
+        >>> df = ks.DataFrame(dict(
+        ...    date=list(pd.date_range('2012-1-1 12:00:00', periods=3, freq='M')),
+        ...    country=['KR', 'US', 'JP'],
+        ...    code=[1, 2 ,3]), columns=['date', 'country', 'code'])
+        >>> df
+                         date country  code
+        0 2012-01-31 12:00:00      KR     1
+        1 2012-02-29 12:00:00      US     2
+        2 2012-03-31 12:00:00      JP     3
+
+        >>> df.to_orc('%s/to_orc/foo.orc' % path, partition_cols='date')
+
+        >>> df.to_orc(
+        ...     '%s/to_orc/foo.orc' % path,
+        ...     mode = 'overwrite',
+        ...     partition_cols=['date', 'country'])
+        """
+        if "options" in options and isinstance(options.get("options"), dict) and len(options) == 1:
+            options = options.get("options")  # type: ignore
+
+        self.to_spark_io(
+            path=path,
+            mode=mode,
+            format="orc",
+            partition_cols=partition_cols,
+            index_col=index_col,
+            **options,
+        )
+
     def to_spark_io(
         self,
         path: Optional[str] = None,

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -4459,7 +4459,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         if "options" in options and isinstance(options.get("options"), dict) and len(options) == 1:
             options = options.get("options")  # type: ignore
 
-        self.to_spark_io(
+        self.spark.to_spark_io(
             path=path,
             mode=mode,
             format="delta",
@@ -4544,7 +4544,6 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         path: str,
         mode: str = "overwrite",
         partition_cols: Optional[Union[str, List[str]]] = None,
-        compression: Optional[str] = None,
         index_col: Optional[Union[str, List[str]]] = None,
         **options
     ) -> None:
@@ -4566,9 +4565,6 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         partition_cols : str or list of str, optional, default None
             Names of partitioning columns
-        compression : str {'none', 'uncompressed', 'snappy', 'gzip', 'lzo', 'brotli', 'lz4', 'zstd'}
-            Compression codec to use when saving to file. If None is set, it uses the
-            value specified in `spark.sql.parquet.compression.codec`.
         index_col: str or list of str, optional, default: None
             Column names to be used in Spark to represent Koalas' index. The index name
             in Koalas is ignored. By default, the index is always lost.
@@ -4605,7 +4601,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         if "options" in options and isinstance(options.get("options"), dict) and len(options) == 1:
             options = options.get("options")  # type: ignore
 
-        self.to_spark_io(
+        self.spark.to_spark_io(
             path=path,
             mode=mode,
             format="orc",

--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -2626,7 +2626,19 @@ def read_orc(
 
     Examples
     --------
-    >>> ks.read_orc('data.orc')  # doctest: +SKIP
+    >>> ks.range(1).to_orc('%s/read_spark_io/data.orc' % path)
+    >>> ks.read_orc('%s/read_spark_io/data.orc' % path, columns=['id'])
+       id
+    0   0
+
+    You can preserve the index in the roundtrip as below.
+
+    >>> ks.range(1).to_orc('%s/read_spark_io/data.orc' % path, index_col="index")
+    >>> ks.read_orc('%s/read_spark_io/data.orc' % path, columns=['id'], index_col="index")
+    ... # doctest: +NORMALIZE_WHITESPACE
+           id
+    index
+    0       0
     """
     if "options" in options and isinstance(options.get("options"), dict) and len(options) == 1:
         options = options.get("options")  # type: ignore

--- a/databricks/koalas/tests/test_dataframe_spark_io.py
+++ b/databricks/koalas/tests/test_dataframe_spark_io.py
@@ -407,7 +407,6 @@ class DataFrameSparkIOTest(ReusedSQLTestCase, TestUtils):
             self.assertPandasEqual(expected, actual.to_pandas())
 
             # index_col
-            kdf = ks.from_pandas(data)
             expected = data.set_index("i32")
             actual = ks.read_orc(path, index_col="i32")
             self.assert_eq(actual, expected)
@@ -417,7 +416,6 @@ class DataFrameSparkIOTest(ReusedSQLTestCase, TestUtils):
             self.assert_eq(actual, expected)
 
             # index_col with columns
-            kdf = ks.from_pandas(data)
             expected = data.set_index("i32")[["i64", "bhello"]]
             actual = ks.read_orc(path, index_col=["i32"], columns=["i64", "bhello"])
             self.assert_eq(actual, expected)

--- a/docs/source/reference/io.rst
+++ b/docs/source/reference/io.rst
@@ -43,6 +43,7 @@ ORC
    :toctree: api/
 
    read_orc
+   DataFrame.to_orc
 
 Generic Spark I/O
 -----------------


### PR DESCRIPTION
This PR proposes `DataFrame.to_orc` to write the ORC file.

pandas doesn't support this, but we do provide it for convenience, though.