### PR TITLE
Add Int64Index, Float64Index, DatetimeIndex.

### DIFF
--- a/databricks/koalas/__init__.py
+++ b/databricks/koalas/__init__.py
@@ -86,7 +86,10 @@ if (
     os.environ["PYARROW_IGNORE_TIMEZONE"] = "1"
 
 from databricks.koalas.frame import DataFrame
-from databricks.koalas.indexes import Index, MultiIndex
+from databricks.koalas.indexes.base import Index
+from databricks.koalas.indexes.datetimes import DatetimeIndex
+from databricks.koalas.indexes.multi import MultiIndex
+from databricks.koalas.indexes.numeric import Float64Index, Int64Index
 from databricks.koalas.series import Series
 from databricks.koalas.groupby import NamedAgg
 
@@ -100,6 +103,9 @@ __all__ = [  # noqa: F405
     "Series",
     "Index",
     "MultiIndex",
+    "Int64Index",
+    "Float64Index",
+    "DatetimeIndex",
     "sql",
     "range",
     "concat",

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -3238,12 +3238,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         --------
         Index
         """
-        from databricks.koalas.indexes import Index, MultiIndex
+        from databricks.koalas.indexes.base import Index
 
-        if self._internal.index_level == 1:
-            return Index(self)
-        else:
-            return MultiIndex(self)
+        return Index(self)
 
     @property
     def empty(self) -> bool:

--- a/databricks/koalas/indexes/__init__.py
+++ b/databricks/koalas/indexes/__init__.py
@@ -1,0 +1,19 @@
+#
+# Copyright (C) 2019 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from databricks.koalas.indexes.base import Index  # noqa: F401
+from databricks.koalas.indexes.datetimes import DatetimeIndex  # noqa: F401
+from databricks.koalas.indexes.multi import MultiIndex  # noqa: F401
+from databricks.koalas.indexes.numeric import Float64Index, Int64Index  # noqa: F401

--- a/databricks/koalas/indexes/base.py
+++ b/databricks/koalas/indexes/base.py
@@ -2364,7 +2364,7 @@ class Index(IndexOpsMixin):
                 return property_or_func.fget(self)  # type: ignore
             else:
                 return partial(property_or_func, self)
-        raise AttributeError("'{}}' object has no attribute '{}'".format(type(self).__name__, item))
+        raise AttributeError("'{}' object has no attribute '{}'".format(type(self).__name__, item))
 
     def __repr__(self):
         max_display_count = get_option("display.max_rows")

--- a/databricks/koalas/indexes/base.py
+++ b/databricks/koalas/indexes/base.py
@@ -2364,7 +2364,7 @@ class Index(IndexOpsMixin):
                 return property_or_func.fget(self)  # type: ignore
             else:
                 return partial(property_or_func, self)
-        raise AttributeError("'Index' object has no attribute '{}'".format(item))
+        raise AttributeError("'{}}' object has no attribute '{}'".format(type(self).__name__, item))
 
     def __repr__(self):
         max_display_count = get_option("display.max_rows")

--- a/databricks/koalas/indexes/base.py
+++ b/databricks/koalas/indexes/base.py
@@ -14,12 +14,8 @@
 # limitations under the License.
 #
 
-"""
-Wrappers for Indexes to behave similar to pandas Index, MultiIndex.
-"""
-from distutils.version import LooseVersion
 from functools import partial
-from typing import Any, List, Optional, Tuple, Union, cast
+from typing import Any, List, Optional, Tuple, Union
 import warnings
 
 import pandas as pd
@@ -39,22 +35,18 @@ from pandas.io.formats.printing import pprint_thing
 from pandas.api.types import is_hashable
 from pandas._libs import lib
 
-import pyspark
 from pyspark import sql as spark
-from pyspark.sql import functions as F, Window
-from pyspark.sql.types import TimestampType, IntegralType, DataType
+from pyspark.sql import functions as F
+from pyspark.sql.types import DataType, FractionalType, IntegralType, TimestampType
 
 from databricks import koalas as ks  # For running doctests and reference resolution in PyCharm.
 from databricks.koalas.config import get_option, option_context
-from databricks.koalas.exceptions import PandasNotImplementedError
 from databricks.koalas.base import IndexOpsMixin
 from databricks.koalas.frame import DataFrame
-from databricks.koalas.missing.indexes import MissingPandasLikeIndex, MissingPandasLikeMultiIndex
+from databricks.koalas.missing.indexes import MissingPandasLikeIndex
 from databricks.koalas.series import Series, first_series
 from databricks.koalas.spark.accessors import SparkIndexMethods
 from databricks.koalas.utils import (
-    compare_disallow_null,
-    default_session,
     is_name_like_tuple,
     is_name_like_value,
     name_like_string,
@@ -67,7 +59,6 @@ from databricks.koalas.utils import (
 from databricks.koalas.internal import (
     InternalFrame,
     DEFAULT_SERIES_NAME,
-    NATURAL_ORDER_COLUMN_NAME,
     SPARK_DEFAULT_INDEX_NAME,
     SPARK_INDEX_NAME_FORMAT,
 )
@@ -112,6 +103,10 @@ class Index(IndexOpsMixin):
     """
 
     def __new__(cls, data: Union[DataFrame, list], dtype=None, name=None, names=None):
+        from databricks.koalas.indexes.datetimes import DatetimeIndex
+        from databricks.koalas.indexes.multi import MultiIndex
+        from databricks.koalas.indexes.numeric import Float64Index, Int64Index
+
         assert data is not None
 
         if isinstance(data, DataFrame):
@@ -127,7 +122,22 @@ class Index(IndexOpsMixin):
             index = pd.Index(data=data, dtype=dtype, name=name)
             data = DataFrame(index=index)
 
-        instance = object.__new__(cls)
+        if data._internal.index_level > 1:
+            instance = object.__new__(MultiIndex)
+        elif isinstance(
+            data._internal.spark_type_for(data._internal.index_spark_columns[0]), IntegralType
+        ):
+            instance = object.__new__(Int64Index)
+        elif isinstance(
+            data._internal.spark_type_for(data._internal.index_spark_columns[0]), FractionalType
+        ):
+            instance = object.__new__(Float64Index)
+        elif isinstance(
+            data._internal.spark_type_for(data._internal.index_spark_columns[0]), TimestampType
+        ):
+            instance = object.__new__(DatetimeIndex)
+        else:
+            instance = object.__new__(Index)
 
         instance._anchor = data
         return instance
@@ -278,6 +288,8 @@ class Index(IndexOpsMixin):
         >>> midx.identical(idx)
         False
         """
+        from databricks.koalas.indexes.multi import MultiIndex
+
         self_name = self.names if isinstance(self, MultiIndex) else self.name
         other_name = other.names if isinstance(other, MultiIndex) else other.name
 
@@ -1659,6 +1671,8 @@ class Index(IndexOpsMixin):
                     ('b', 'y')],
                    )
         """
+        from databricks.koalas.indexes.multi import MultiIndex
+
         if type(self) is not type(other):
             raise NotImplementedError(
                 "append() between Index & MultiIndex currently is not supported"
@@ -1819,6 +1833,8 @@ class Index(IndexOpsMixin):
                     ('b', 'y')],
                    names=['species', 'year'])
         """
+        from databricks.koalas.indexes.multi import MultiIndex
+
         if isinstance(self, MultiIndex):
             if level is not None:
                 self_names = self.names
@@ -1862,6 +1878,8 @@ class Index(IndexOpsMixin):
                     ('c', 'z', 3)],
                    )
         """
+        from databricks.koalas.indexes.multi import MultiIndex
+
         if not is_list_like(other):
             raise TypeError("Input must be Index or array-like")
         if not isinstance(sort, (type(None), type(True))):
@@ -2087,6 +2105,8 @@ class Index(IndexOpsMixin):
                     ('x', 'f')],
                    )
         """
+        from databricks.koalas.indexes.multi import MultiIndex
+
         sort = True if sort is None else sort
         sort = validate_bool_kwarg(sort, "sort")
         if type(self) is not type(other):
@@ -2180,6 +2200,8 @@ class Index(IndexOpsMixin):
         >>> idx1.intersection(idx2).sort_values()
         Int64Index([3, 4], dtype='int64')
         """
+        from databricks.koalas.indexes.multi import MultiIndex
+
         if isinstance(other, DataFrame):
             raise ValueError("Index data must be 1-dimensional")
         elif isinstance(other, MultiIndex):
@@ -2370,1060 +2392,3 @@ class Index(IndexOpsMixin):
             "The truth value of a {0} is ambiguous. "
             "Use a.empty, a.bool(), a.item(), a.any() or a.all().".format(self.__class__.__name__)
         )
-
-
-class MultiIndex(Index):
-    """
-    Koalas MultiIndex that corresponds to pandas MultiIndex logically. This might hold Spark Column
-    internally.
-
-    :ivar _kdf: The parent dataframe
-    :type _kdf: DataFrame
-    :ivar _scol: Spark Column instance
-    :type _scol: pyspark.Column
-
-    See Also
-    --------
-    Index : A single-level Index.
-
-    Examples
-    --------
-    >>> ks.DataFrame({'a': ['a', 'b', 'c']}, index=[[1, 2, 3], [4, 5, 6]]).index  # doctest: +SKIP
-    MultiIndex([(1, 4),
-                (2, 5),
-                (3, 6)],
-               )
-
-    >>> ks.DataFrame({'a': [1, 2, 3]}, index=[list('abc'), list('def')]).index  # doctest: +SKIP
-    MultiIndex([('a', 'd'),
-                ('b', 'e'),
-                ('c', 'f')],
-               )
-    """
-
-    def __new__(cls, kdf: DataFrame):
-        assert kdf._internal.index_level > 1
-
-        return super().__new__(cls, data=kdf)
-
-    @property
-    def _internal(self):
-        internal = self._kdf._internal
-        scol = F.struct(internal.index_spark_columns)
-        return internal.copy(
-            column_labels=[None], data_spark_columns=[scol], column_label_names=None
-        )
-
-    @property
-    def _column_label(self):
-        return None
-
-    def __abs__(self):
-        raise TypeError("TypeError: cannot perform __abs__ with this index type: MultiIndex")
-
-    def _with_new_scol(self, scol: spark.Column):
-        raise NotImplementedError("Not supported for type MultiIndex")
-
-    def _align_and_column_op(self, f, *args) -> "Index":
-        raise NotImplementedError("Not supported for type MultiIndex")
-
-    def any(self, *args, **kwargs) -> None:
-        raise TypeError("cannot perform any with this index type: MultiIndex")
-
-    def all(self, *args, **kwargs) -> None:
-        raise TypeError("cannot perform all with this index type: MultiIndex")
-
-    @staticmethod
-    def from_tuples(tuples, sortorder=None, names=None) -> "MultiIndex":
-        """
-        Convert list of tuples to MultiIndex.
-
-        Parameters
-        ----------
-        tuples : list / sequence of tuple-likes
-            Each tuple is the index of one row/column.
-        sortorder : int or None
-            Level of sortedness (must be lexicographically sorted by that level).
-        names : list / sequence of str, optional
-            Names for the levels in the index.
-
-        Returns
-        -------
-        index : MultiIndex
-
-        Examples
-        --------
-
-        >>> tuples = [(1, 'red'), (1, 'blue'),
-        ...           (2, 'red'), (2, 'blue')]
-        >>> ks.MultiIndex.from_tuples(tuples, names=('number', 'color'))  # doctest: +SKIP
-        MultiIndex([(1,  'red'),
-                    (1, 'blue'),
-                    (2,  'red'),
-                    (2, 'blue')],
-                   names=['number', 'color'])
-        """
-        return cast(
-            MultiIndex,
-            DataFrame(
-                index=pd.MultiIndex.from_tuples(tuples=tuples, sortorder=sortorder, names=names)
-            ).index,
-        )
-
-    @staticmethod
-    def from_arrays(arrays, sortorder=None, names=None) -> "MultiIndex":
-        """
-        Convert arrays to MultiIndex.
-
-        Parameters
-        ----------
-        arrays: list / sequence of array-likes
-            Each array-like gives one level’s value for each data point. len(arrays)
-            is the number of levels.
-        sortorder: int or None
-            Level of sortedness (must be lexicographically sorted by that level).
-        names: list / sequence of str, optional
-            Names for the levels in the index.
-
-        Returns
-        -------
-        index: MultiIndex
-
-        Examples
-        --------
-
-        >>> arrays = [[1, 1, 2, 2], ['red', 'blue', 'red', 'blue']]
-        >>> ks.MultiIndex.from_arrays(arrays, names=('number', 'color'))  # doctest: +SKIP
-        MultiIndex([(1,  'red'),
-                    (1, 'blue'),
-                    (2,  'red'),
-                    (2, 'blue')],
-                   names=['number', 'color'])
-        """
-        return cast(
-            MultiIndex,
-            DataFrame(
-                index=pd.MultiIndex.from_arrays(arrays=arrays, sortorder=sortorder, names=names)
-            ).index,
-        )
-
-    @staticmethod
-    def from_product(iterables, sortorder=None, names=None) -> "MultiIndex":
-        """
-        Make a MultiIndex from the cartesian product of multiple iterables.
-
-        Parameters
-        ----------
-        iterables : list / sequence of iterables
-            Each iterable has unique labels for each level of the index.
-        sortorder : int or None
-            Level of sortedness (must be lexicographically sorted by that
-            level).
-        names : list / sequence of str, optional
-            Names for the levels in the index.
-
-        Returns
-        -------
-        index : MultiIndex
-
-        See Also
-        --------
-        MultiIndex.from_arrays : Convert list of arrays to MultiIndex.
-        MultiIndex.from_tuples : Convert list of tuples to MultiIndex.
-
-        Examples
-        --------
-        >>> numbers = [0, 1, 2]
-        >>> colors = ['green', 'purple']
-        >>> ks.MultiIndex.from_product([numbers, colors],
-        ...                            names=['number', 'color'])  # doctest: +SKIP
-        MultiIndex([(0,  'green'),
-                    (0, 'purple'),
-                    (1,  'green'),
-                    (1, 'purple'),
-                    (2,  'green'),
-                    (2, 'purple')],
-                   names=['number', 'color'])
-        """
-        return cast(
-            MultiIndex,
-            DataFrame(
-                index=pd.MultiIndex.from_product(
-                    iterables=iterables, sortorder=sortorder, names=names
-                )
-            ).index,
-        )
-
-    @staticmethod
-    def from_frame(df, names=None) -> "MultiIndex":
-        """
-        Make a MultiIndex from a DataFrame.
-
-        Parameters
-        ----------
-        df : DataFrame
-            DataFrame to be converted to MultiIndex.
-        names : list-like, optional
-            If no names are provided, use the column names, or tuple of column
-            names if the columns is a MultiIndex. If a sequence, overwrite
-            names with the given sequence.
-
-        Returns
-        -------
-        MultiIndex
-            The MultiIndex representation of the given DataFrame.
-
-        See Also
-        --------
-        MultiIndex.from_arrays : Convert list of arrays to MultiIndex.
-        MultiIndex.from_tuples : Convert list of tuples to MultiIndex.
-        MultiIndex.from_product : Make a MultiIndex from cartesian product
-                                  of iterables.
-
-        Examples
-        --------
-        >>> df = ks.DataFrame([['HI', 'Temp'], ['HI', 'Precip'],
-        ...                    ['NJ', 'Temp'], ['NJ', 'Precip']],
-        ...                   columns=['a', 'b'])
-        >>> df  # doctest: +SKIP
-              a       b
-        0    HI    Temp
-        1    HI  Precip
-        2    NJ    Temp
-        3    NJ  Precip
-
-        >>> ks.MultiIndex.from_frame(df)  # doctest: +SKIP
-        MultiIndex([('HI',   'Temp'),
-                    ('HI', 'Precip'),
-                    ('NJ',   'Temp'),
-                    ('NJ', 'Precip')],
-                   names=['a', 'b'])
-
-        Using explicit names, instead of the column names
-
-        >>> ks.MultiIndex.from_frame(df, names=['state', 'observation'])  # doctest: +SKIP
-        MultiIndex([('HI',   'Temp'),
-                    ('HI', 'Precip'),
-                    ('NJ',   'Temp'),
-                    ('NJ', 'Precip')],
-                   names=['state', 'observation'])
-        """
-        if not isinstance(df, DataFrame):
-            raise TypeError("Input must be a DataFrame")
-        sdf = df.to_spark()
-
-        if names is None:
-            names = df._internal.column_labels
-        elif not is_list_like(names):
-            raise ValueError("Names should be list-like for a MultiIndex")
-        else:
-            names = [name if is_name_like_tuple(name) else (name,) for name in names]
-
-        internal = InternalFrame(
-            spark_frame=sdf,
-            index_spark_columns=[scol_for(sdf, col) for col in sdf.columns],
-            index_names=names,
-        )
-        return cast(MultiIndex, DataFrame(internal).index)
-
-    @property
-    def name(self) -> str:
-        raise PandasNotImplementedError(class_name="pd.MultiIndex", property_name="name")
-
-    @name.setter
-    def name(self, name: str) -> None:
-        raise PandasNotImplementedError(class_name="pd.MultiIndex", property_name="name")
-
-    def _verify_for_rename(self, name):
-        if is_list_like(name):
-            if self._internal.index_level != len(name):
-                raise ValueError(
-                    "Length of new names must be {}, got {}".format(
-                        self._internal.index_level, len(name)
-                    )
-                )
-            if any(not is_hashable(n) for n in name):
-                raise TypeError("MultiIndex.name must be a hashable type")
-            return [n if is_name_like_tuple(n) else (n,) for n in name]
-        else:
-            raise TypeError("Must pass list-like as `names`.")
-
-    def swaplevel(self, i=-2, j=-1) -> "MultiIndex":
-        """
-        Swap level i with level j.
-        Calling this method does not change the ordering of the values.
-
-        Parameters
-        ----------
-        i : int, str, default -2
-            First level of index to be swapped. Can pass level name as string.
-            Type of parameters can be mixed.
-        j : int, str, default -1
-            Second level of index to be swapped. Can pass level name as string.
-            Type of parameters can be mixed.
-
-        Returns
-        -------
-        MultiIndex
-            A new MultiIndex.
-
-        Examples
-        --------
-        >>> midx = ks.MultiIndex.from_arrays([['a', 'b'], [1, 2]], names = ['word', 'number'])
-        >>> midx  # doctest: +SKIP
-        MultiIndex([('a', 1),
-                    ('b', 2)],
-                   names=['word', 'number'])
-
-        >>> midx.swaplevel(0, 1)  # doctest: +SKIP
-        MultiIndex([(1, 'a'),
-                    (2, 'b')],
-                   names=['number', 'word'])
-
-        >>> midx.swaplevel('number', 'word')  # doctest: +SKIP
-        MultiIndex([(1, 'a'),
-                    (2, 'b')],
-                   names=['number', 'word'])
-        """
-        for index in (i, j):
-            if not isinstance(index, int) and index not in self.names:
-                raise KeyError("Level %s not found" % index)
-
-        i = i if isinstance(i, int) else self.names.index(i)
-        j = j if isinstance(j, int) else self.names.index(j)
-
-        for index in (i, j):
-            if index >= len(self.names) or index < -len(self.names):
-                raise IndexError(
-                    "Too many levels: Index has only %s levels, "
-                    "%s is not a valid level number" % (len(self.names), index)
-                )
-
-        index_map = list(zip(self._internal.index_spark_columns, self._internal.index_names))
-        index_map[i], index_map[j], = index_map[j], index_map[i]
-        index_spark_columns, index_names = zip(*index_map)
-        internal = self._internal.copy(
-            index_spark_columns=list(index_spark_columns),
-            index_names=list(index_names),
-            column_labels=[],
-            data_spark_columns=[],
-        )
-        return cast(MultiIndex, DataFrame(internal).index)
-
-    @property
-    def levshape(self) -> Tuple[int, ...]:
-        """
-        A tuple with the length of each level.
-
-        Examples
-        --------
-        >>> midx = ks.MultiIndex.from_tuples([('a', 'x'), ('b', 'y'), ('c', 'z')])
-        >>> midx  # doctest: +SKIP
-        MultiIndex([('a', 'x'),
-                    ('b', 'y'),
-                    ('c', 'z')],
-                   )
-
-        >>> midx.levshape
-        (3, 3)
-        """
-        result = self._internal.spark_frame.agg(
-            *(F.countDistinct(c) for c in self._internal.index_spark_columns)
-        ).collect()[0]
-        return tuple(result)
-
-    @staticmethod
-    def _comparator_for_monotonic_increasing(data_type):
-        return compare_disallow_null
-
-    def _is_monotonic(self, order):
-        if order == "increasing":
-            return self._is_monotonic_increasing().all()
-        else:
-            return self._is_monotonic_decreasing().all()
-
-    def _is_monotonic_increasing(self):
-        scol = self.spark.column
-        window = Window.orderBy(NATURAL_ORDER_COLUMN_NAME).rowsBetween(-1, -1)
-        prev = F.lag(scol, 1).over(window)
-
-        cond = F.lit(True)
-        has_not_null = F.lit(True)
-        for field in self.spark.data_type[::-1]:
-            left = scol.getField(field.name)
-            right = prev.getField(field.name)
-            compare = MultiIndex._comparator_for_monotonic_increasing(field.dataType)
-            # Since pandas 1.1.4, null value is not allowed at any levels of MultiIndex.
-            # Therefore, we should check `has_not_null` over the all levels.
-            has_not_null = has_not_null & left.isNotNull()
-            cond = F.when(left.eqNullSafe(right), cond).otherwise(
-                compare(left, right, spark.Column.__gt__)
-            )
-
-        cond = has_not_null & (prev.isNull() | cond)
-
-        cond_name = verify_temp_column_name(
-            self._internal.spark_frame.select(self._internal.index_spark_columns),
-            "__is_monotonic_increasing_cond__",
-        )
-
-        sdf = self._internal.spark_frame.select(
-            self._internal.index_spark_columns + [cond.alias(cond_name)]
-        )
-
-        internal = InternalFrame(
-            spark_frame=sdf,
-            index_spark_columns=[
-                scol_for(sdf, col) for col in self._internal.index_spark_column_names
-            ],
-            index_names=self._internal.index_names,
-        )
-
-        return first_series(DataFrame(internal))
-
-    @staticmethod
-    def _comparator_for_monotonic_decreasing(data_type):
-        return compare_disallow_null
-
-    def _is_monotonic_decreasing(self):
-        scol = self.spark.column
-        window = Window.orderBy(NATURAL_ORDER_COLUMN_NAME).rowsBetween(-1, -1)
-        prev = F.lag(scol, 1).over(window)
-
-        cond = F.lit(True)
-        has_not_null = F.lit(True)
-        for field in self.spark.data_type[::-1]:
-            left = scol.getField(field.name)
-            right = prev.getField(field.name)
-            compare = MultiIndex._comparator_for_monotonic_decreasing(field.dataType)
-            # Since pandas 1.1.4, null value is not allowed at any levels of MultiIndex.
-            # Therefore, we should check `has_not_null` over the all levels.
-            has_not_null = has_not_null & left.isNotNull()
-            cond = F.when(left.eqNullSafe(right), cond).otherwise(
-                compare(left, right, spark.Column.__lt__)
-            )
-
-        cond = has_not_null & (prev.isNull() | cond)
-
-        cond_name = verify_temp_column_name(
-            self._internal.spark_frame.select(self._internal.index_spark_columns),
-            "__is_monotonic_decreasing_cond__",
-        )
-
-        sdf = self._internal.spark_frame.select(
-            self._internal.index_spark_columns + [cond.alias(cond_name)]
-        )
-
-        internal = InternalFrame(
-            spark_frame=sdf,
-            index_spark_columns=[
-                scol_for(sdf, col) for col in self._internal.index_spark_column_names
-            ],
-            index_names=self._internal.index_names,
-        )
-
-        return first_series(DataFrame(internal))
-
-    def to_frame(self, index=True, name=None) -> DataFrame:
-        """
-        Create a DataFrame with the levels of the MultiIndex as columns.
-        Column ordering is determined by the DataFrame constructor with data as
-        a dict.
-
-        Parameters
-        ----------
-        index : boolean, default True
-            Set the index of the returned DataFrame as the original MultiIndex.
-        name : list / sequence of strings, optional
-            The passed names should substitute index level names.
-
-        Returns
-        -------
-        DataFrame : a DataFrame containing the original MultiIndex data.
-
-        See Also
-        --------
-        DataFrame
-
-        Examples
-        --------
-        >>> tuples = [(1, 'red'), (1, 'blue'),
-        ...           (2, 'red'), (2, 'blue')]
-        >>> idx = ks.MultiIndex.from_tuples(tuples, names=('number', 'color'))
-        >>> idx  # doctest: +SKIP
-        MultiIndex([(1,  'red'),
-                    (1, 'blue'),
-                    (2,  'red'),
-                    (2, 'blue')],
-                   names=['number', 'color'])
-        >>> idx.to_frame()  # doctest: +NORMALIZE_WHITESPACE
-                      number color
-        number color
-        1      red         1   red
-               blue        1  blue
-        2      red         2   red
-               blue        2  blue
-
-        By default, the original Index is reused. To enforce a new Index:
-
-        >>> idx.to_frame(index=False)
-           number color
-        0       1   red
-        1       1  blue
-        2       2   red
-        3       2  blue
-
-        To override the name of the resulting column, specify `name`:
-
-        >>> idx.to_frame(name=['n', 'c'])  # doctest: +NORMALIZE_WHITESPACE
-                      n     c
-        number color
-        1      red    1   red
-               blue   1  blue
-        2      red    2   red
-               blue   2  blue
-        """
-        if name is None:
-            name = [
-                name if name is not None else (i,)
-                for i, name in enumerate(self._internal.index_names)
-            ]
-        elif is_list_like(name):
-            if len(name) != self._internal.index_level:
-                raise ValueError("'name' should have same length as number of levels on index.")
-            name = [n if is_name_like_tuple(n) else (n,) for n in name]
-        else:
-            raise TypeError("'name' must be a list / sequence of column names.")
-
-        return self._to_frame(index=index, names=name)
-
-    def to_pandas(self) -> pd.MultiIndex:
-        """
-        Return a pandas MultiIndex.
-
-        .. note:: This method should only be used if the resulting pandas object is expected
-                  to be small, as all the data is loaded into the driver's memory.
-
-        Examples
-        --------
-        >>> df = ks.DataFrame([(.2, .3), (.0, .6), (.6, .0), (.2, .1)],
-        ...                   columns=['dogs', 'cats'],
-        ...                   index=[list('abcd'), list('efgh')])
-        >>> df['dogs'].index.to_pandas()  # doctest: +SKIP
-        MultiIndex([('a', 'e'),
-                    ('b', 'f'),
-                    ('c', 'g'),
-                    ('d', 'h')],
-                   )
-        """
-        # TODO: We might need to handle internal state change.
-        # So far, we don't have any functions to change the internal state of MultiIndex except for
-        # series-like operations. In that case, it creates new Index object instead of MultiIndex.
-        return super().to_pandas()
-
-    def toPandas(self) -> pd.MultiIndex:
-        warnings.warn(
-            "MultiIndex.toPandas is deprecated as of MultiIndex.to_pandas. "
-            "Please use the API instead.",
-            FutureWarning,
-        )
-        return self.to_pandas()
-
-    toPandas.__doc__ = to_pandas.__doc__
-
-    def nunique(self, dropna=True) -> None:  # type: ignore
-        raise NotImplementedError("nunique is not defined for MultiIndex")
-
-    # TODO: add 'name' parameter after pd.MultiIndex.name is implemented
-    def copy(self, deep=None) -> "MultiIndex":  # type: ignore
-        """
-        Make a copy of this object.
-
-        Parameters
-        ----------
-        deep : None
-            this parameter is not supported but just dummy parameter to match pandas.
-
-        Examples
-        --------
-        >>> df = ks.DataFrame([(.2, .3), (.0, .6), (.6, .0), (.2, .1)],
-        ...                   columns=['dogs', 'cats'],
-        ...                   index=[list('abcd'), list('efgh')])
-        >>> df['dogs'].index  # doctest: +SKIP
-        MultiIndex([('a', 'e'),
-                    ('b', 'f'),
-                    ('c', 'g'),
-                    ('d', 'h')],
-                   )
-
-        Copy index
-
-        >>> df.index.copy()  # doctest: +SKIP
-        MultiIndex([('a', 'e'),
-                    ('b', 'f'),
-                    ('c', 'g'),
-                    ('d', 'h')],
-                   )
-        """
-        return super().copy(deep=deep)  # type: ignore
-
-    def symmetric_difference(self, other, result_name=None, sort=None) -> "MultiIndex":
-        """
-        Compute the symmetric difference of two MultiIndex objects.
-
-        Parameters
-        ----------
-        other : Index or array-like
-        result_name : list
-        sort : True or None, default None
-            Whether to sort the resulting index.
-            * True : Attempt to sort the result.
-            * None : Do not sort the result.
-
-        Returns
-        -------
-        symmetric_difference : MiltiIndex
-
-        Notes
-        -----
-        ``symmetric_difference`` contains elements that appear in either
-        ``idx1`` or ``idx2`` but not both. Equivalent to the Index created by
-        ``idx1.difference(idx2) | idx2.difference(idx1)`` with duplicates
-        dropped.
-
-        Examples
-        --------
-        >>> midx1 = pd.MultiIndex([['lama', 'cow', 'falcon'],
-        ...                        ['speed', 'weight', 'length']],
-        ...                       [[0, 0, 0, 1, 1, 1, 2, 2, 2],
-        ...                        [0, 0, 0, 0, 1, 2, 0, 1, 2]])
-        >>> midx2 = pd.MultiIndex([['koalas', 'cow', 'falcon'],
-        ...                        ['speed', 'weight', 'length']],
-        ...                       [[0, 0, 0, 1, 1, 1, 2, 2, 2],
-        ...                        [0, 0, 0, 0, 1, 2, 0, 1, 2]])
-        >>> s1 = ks.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3],
-        ...                index=midx1)
-        >>> s2 = ks.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3],
-        ...              index=midx2)
-
-        >>> s1.index.symmetric_difference(s2.index)  # doctest: +SKIP
-        MultiIndex([('koalas', 'speed'),
-                    (  'lama', 'speed')],
-                   )
-
-        You can set names of result Index.
-
-        >>> s1.index.symmetric_difference(s2.index, result_name=['a', 'b'])  # doctest: +SKIP
-        MultiIndex([('koalas', 'speed'),
-                    (  'lama', 'speed')],
-                   names=['a', 'b'])
-
-        You can set sort to `True`, if you want to sort the resulting index.
-
-        >>> s1.index.symmetric_difference(s2.index, sort=True)  # doctest: +SKIP
-        MultiIndex([('koalas', 'speed'),
-                    (  'lama', 'speed')],
-                   )
-
-        You can also use the ``^`` operator:
-
-        >>> s1.index ^ s2.index  # doctest: +SKIP
-        MultiIndex([('koalas', 'speed'),
-                    (  'lama', 'speed')],
-                   )
-        """
-        if type(self) != type(other):
-            raise NotImplementedError(
-                "Doesn't support symmetric_difference between Index & MultiIndex for now"
-            )
-
-        sdf_self = self._kdf._internal.spark_frame.select(self._internal.index_spark_columns)
-        sdf_other = other._kdf._internal.spark_frame.select(other._internal.index_spark_columns)
-
-        sdf_symdiff = sdf_self.union(sdf_other).subtract(sdf_self.intersect(sdf_other))
-
-        if sort:
-            sdf_symdiff = sdf_symdiff.sort(self._internal.index_spark_columns)
-
-        internal = InternalFrame(
-            spark_frame=sdf_symdiff,
-            index_spark_columns=[
-                scol_for(sdf_symdiff, col) for col in self._internal.index_spark_column_names
-            ],
-            index_names=self._internal.index_names,
-        )
-        result = MultiIndex(DataFrame(internal))
-
-        if result_name:
-            result.names = result_name
-
-        return result
-
-    # TODO: ADD error parameter
-    def drop(self, codes, level=None) -> "MultiIndex":
-        """
-        Make new MultiIndex with passed list of labels deleted
-
-        Parameters
-        ----------
-        codes : array-like
-            Must be a list of tuples
-        level : int or level name, default None
-
-        Returns
-        -------
-        dropped : MultiIndex
-
-        Examples
-        --------
-        >>> index = ks.MultiIndex.from_tuples([('a', 'x'), ('b', 'y'), ('c', 'z')])
-        >>> index # doctest: +SKIP
-        MultiIndex([('a', 'x'),
-                    ('b', 'y'),
-                    ('c', 'z')],
-                   )
-
-        >>> index.drop(['a']) # doctest: +SKIP
-        MultiIndex([('b', 'y'),
-                    ('c', 'z')],
-                   )
-
-        >>> index.drop(['x', 'y'], level=1) # doctest: +SKIP
-        MultiIndex([('c', 'z')],
-                   )
-        """
-        internal = self._internal.resolved_copy
-        sdf = internal.spark_frame
-        index_scols = internal.index_spark_columns
-        if level is None:
-            scol = index_scols[0]
-        elif isinstance(level, int):
-            scol = index_scols[level]
-        else:
-            scol = None
-            for index_spark_column, index_name in zip(
-                internal.index_spark_columns, internal.index_names
-            ):
-                if not isinstance(level, tuple):
-                    level = (level,)
-                if level == index_name:
-                    if scol is not None:
-                        raise ValueError(
-                            "The name {} occurs multiple times, use a level number".format(
-                                name_like_string(level)
-                            )
-                        )
-                    scol = index_spark_column
-            if scol is None:
-                raise KeyError("Level {} not found".format(name_like_string(level)))
-        sdf = sdf[~scol.isin(codes)]
-
-        return MultiIndex(
-            DataFrame(
-                InternalFrame(
-                    spark_frame=sdf,
-                    index_spark_columns=[
-                        scol_for(sdf, col) for col in internal.index_spark_column_names
-                    ],
-                    index_names=internal.index_names,
-                    column_labels=[],
-                    data_spark_columns=[],
-                )
-            )
-        )
-
-    def value_counts(
-        self, normalize=False, sort=True, ascending=False, bins=None, dropna=True
-    ) -> Series:
-        if (
-            LooseVersion(pyspark.__version__) < LooseVersion("2.4")
-            and default_session().conf.get("spark.sql.execution.arrow.enabled") == "true"
-            and isinstance(self, MultiIndex)
-        ):
-            raise RuntimeError(
-                "if you're using pyspark < 2.4, set conf "
-                "'spark.sql.execution.arrow.enabled' to 'false' "
-                "for using this function with MultiIndex"
-            )
-        return super().value_counts(
-            normalize=normalize, sort=sort, ascending=ascending, bins=bins, dropna=dropna
-        )
-
-    value_counts.__doc__ = IndexOpsMixin.value_counts.__doc__
-
-    def argmax(self) -> None:
-        raise TypeError("reduction operation 'argmax' not allowed for this dtype")
-
-    def argmin(self) -> None:
-        raise TypeError("reduction operation 'argmin' not allowed for this dtype")
-
-    def asof(self, label) -> None:
-        raise NotImplementedError(
-            "only the default get_loc method is currently supported for MultiIndex"
-        )
-
-    @property
-    def is_all_dates(self) -> bool:
-        """
-        is_all_dates always returns False for MultiIndex
-
-        Examples
-        --------
-        >>> from datetime import datetime
-
-        >>> idx = ks.MultiIndex.from_tuples(
-        ...     [(datetime(2019, 1, 1, 0, 0, 0), datetime(2019, 1, 1, 0, 0, 0)),
-        ...      (datetime(2019, 1, 1, 0, 0, 0), datetime(2019, 1, 1, 0, 0, 0))])
-        >>> idx  # doctest: +SKIP
-        MultiIndex([('2019-01-01', '2019-01-01'),
-                    ('2019-01-01', '2019-01-01')],
-                   )
-
-        >>> idx.is_all_dates
-        False
-        """
-        return False
-
-    def __getattr__(self, item: str) -> Any:
-        if hasattr(MissingPandasLikeMultiIndex, item):
-            property_or_func = getattr(MissingPandasLikeMultiIndex, item)
-            if isinstance(property_or_func, property):
-                return property_or_func.fget(self)  # type: ignore
-            else:
-                return partial(property_or_func, self)
-        raise AttributeError("'MultiIndex' object has no attribute '{}'".format(item))
-
-    def _get_level_number(self, level) -> Optional[int]:
-        """
-        Return the level number if a valid level is given.
-        """
-        count = self.names.count(level)
-        if (count > 1) and not isinstance(level, int):
-            raise ValueError("The name %s occurs multiple times, use a level number" % level)
-        if level in self.names:
-            level = self.names.index(level)
-        elif isinstance(level, int):
-            nlevels = self.nlevels
-            if level >= nlevels:
-                raise IndexError(
-                    "Too many levels: Index has only %d "
-                    "levels, %d is not a valid level number" % (nlevels, level)
-                )
-            if level < 0:
-                if (level + nlevels) < 0:
-                    raise IndexError(
-                        "Too many levels: Index has only %d levels, "
-                        "not %d" % (nlevels, level + 1)
-                    )
-                level = level + nlevels
-        else:
-            raise KeyError("Level %s not found" % str(level))
-            return None
-
-        return level
-
-    def get_level_values(self, level) -> Index:
-        """
-        Return vector of label values for requested level,
-        equal to the length of the index.
-
-        Parameters
-        ----------
-        level : int or str
-            ``level`` is either the integer position of the level in the
-            MultiIndex, or the name of the level.
-
-        Returns
-        -------
-        values : Index
-            Values is a level of this MultiIndex converted to
-            a single :class:`Index` (or subclass thereof).
-
-        Examples
-        --------
-
-        Create a MultiIndex:
-
-        >>> mi = ks.MultiIndex.from_tuples([('x', 'a'), ('x', 'b'), ('y', 'a')])
-        >>> mi.names = ['level_1', 'level_2']
-
-        Get level values by supplying level as either integer or name:
-
-        >>> mi.get_level_values(0)
-        Index(['x', 'x', 'y'], dtype='object', name='level_1')
-
-        >>> mi.get_level_values('level_2')
-        Index(['a', 'b', 'a'], dtype='object', name='level_2')
-        """
-        level = self._get_level_number(level)
-        index_scol = self._internal.index_spark_columns[level]
-        index_name = self._internal.index_names[level]
-        internal = self._internal.copy(
-            index_spark_columns=[index_scol],
-            index_names=[index_name],
-            column_labels=[],
-            data_spark_columns=[],
-        )
-        return DataFrame(internal).index
-
-    def insert(self, loc: int, item) -> Index:
-        """
-        Make new MultiIndex inserting new item at location.
-
-        Follows Python list.append semantics for negative values.
-
-        Parameters
-        ----------
-        loc : int
-        item : object
-
-        Returns
-        -------
-        new_index : MultiIndex
-
-        Examples
-        --------
-        >>> kmidx = ks.MultiIndex.from_tuples([("a", "x"), ("b", "y"), ("c", "z")])
-        >>> kmidx.insert(3, ("h", "j"))  # doctest: +SKIP
-        MultiIndex([('a', 'x'),
-                    ('b', 'y'),
-                    ('c', 'z'),
-                    ('h', 'j')],
-                   )
-
-        For negative values
-
-        >>> kmidx.insert(-2, ("h", "j"))  # doctest: +SKIP
-        MultiIndex([('a', 'x'),
-                    ('h', 'j'),
-                    ('b', 'y'),
-                    ('c', 'z')],
-                   )
-        """
-        length = len(self)
-        if loc < 0:
-            loc = loc + length
-            if loc < 0:
-                raise IndexError(
-                    "index {} is out of bounds for axis 0 with size {}".format(
-                        (loc - length), length
-                    )
-                )
-        else:
-            if loc > length:
-                raise IndexError(
-                    "index {} is out of bounds for axis 0 with size {}".format(loc, length)
-                )
-
-        index_name = self._internal.index_spark_column_names
-        sdf_before = self.to_frame(name=index_name)[:loc].to_spark()
-        sdf_middle = Index([item]).to_frame(name=index_name).to_spark()
-        sdf_after = self.to_frame(name=index_name)[loc:].to_spark()
-        sdf = sdf_before.union(sdf_middle).union(sdf_after)
-
-        internal = InternalFrame(
-            spark_frame=sdf,
-            index_spark_columns=[
-                scol_for(sdf, col) for col in self._internal.index_spark_column_names
-            ],
-            index_names=self._internal.index_names,
-        )
-        return DataFrame(internal).index
-
-    def item(self) -> Tuple[Scalar, ...]:
-        """
-        Return the first element of the underlying data as a python tuple.
-
-        Returns
-        -------
-        tuple
-            The first element of MultiIndex.
-
-        Raises
-        ------
-        ValueError
-            If the data is not length-1.
-
-        Examples
-        --------
-        >>> kmidx = ks.MultiIndex.from_tuples([('a', 'x')])
-        >>> kmidx.item()
-        ('a', 'x')
-        """
-        return self._kdf.head(2)._to_internal_pandas().index.item()
-
-    def intersection(self, other) -> "MultiIndex":
-        """
-        Form the intersection of two Index objects.
-
-        This returns a new Index with elements common to the index and `other`.
-
-        Parameters
-        ----------
-        other : Index or array-like
-
-        Returns
-        -------
-        intersection : MultiIndex
-
-        Examples
-        --------
-        >>> midx1 = ks.MultiIndex.from_tuples([("a", "x"), ("b", "y"), ("c", "z")])
-        >>> midx2 = ks.MultiIndex.from_tuples([("c", "z"), ("d", "w")])
-        >>> midx1.intersection(midx2).sort_values()  # doctest: +SKIP
-        MultiIndex([('c', 'z')],
-                   )
-        """
-        if isinstance(other, Series) or not is_list_like(other):
-            raise TypeError("other must be a MultiIndex or a list of tuples")
-        elif isinstance(other, DataFrame):
-            raise ValueError("Index data must be 1-dimensional")
-        elif isinstance(other, MultiIndex):
-            spark_frame_other = other.to_frame().to_spark()
-            keep_name = self.names == other.names
-        elif isinstance(other, Index):
-            # Always returns an empty MultiIndex if `other` is Index.
-            return self.to_frame().head(0).index  # type: ignore
-        elif not all(isinstance(item, tuple) for item in other):
-            raise TypeError("other must be a MultiIndex or a list of tuples")
-        else:
-            other = MultiIndex.from_tuples(list(other))
-            spark_frame_other = other.to_frame().to_spark()
-            keep_name = True
-
-        default_name = [SPARK_INDEX_NAME_FORMAT(i) for i in range(self.nlevels)]
-        spark_frame_self = self.to_frame(name=default_name).to_spark()
-        spark_frame_intersected = spark_frame_self.intersect(spark_frame_other)
-        if keep_name:
-            index_names = self._internal.index_names
-        else:
-            index_names = None
-        internal = InternalFrame(
-            spark_frame=spark_frame_intersected,
-            index_spark_columns=[scol_for(spark_frame_intersected, col) for col in default_name],
-            index_names=index_names,
-        )
-        return cast(MultiIndex, DataFrame(internal).index)
-
-    @property
-    def hasnans(self):
-        raise NotImplementedError("hasnans is not defined for MultiIndex")
-
-    @property
-    def inferred_type(self) -> str:
-        """
-        Return a string of the type inferred from the values.
-        """
-        # Always returns "mixed" for MultiIndex
-        return "mixed"
-
-    @property
-    def asi8(self) -> None:
-        """
-        Integer representation of the values.
-        """
-        # Always returns None for MultiIndex
-        return None
-
-    def __iter__(self):
-        return MissingPandasLikeMultiIndex.__iter__(self)

--- a/databricks/koalas/indexes/base.py
+++ b/databricks/koalas/indexes/base.py
@@ -109,10 +109,7 @@ class Index(IndexOpsMixin):
 
         assert data is not None
 
-        if isinstance(data, DataFrame):
-            assert dtype is None
-            assert name is None
-        else:
+        if not isinstance(data, DataFrame):
             if isinstance(data, list) and all([isinstance(item, tuple) for item in data]):
                 return MultiIndex.from_tuples(data, names=names)
 
@@ -120,7 +117,10 @@ class Index(IndexOpsMixin):
                 raise TypeError("Index.name must be a hashable type")
 
             index = pd.Index(data=data, dtype=dtype, name=name)
-            data = DataFrame(index=index)
+            return DataFrame(index=index).index
+
+        assert dtype is None
+        assert name is None
 
         if data._internal.index_level > 1:
             instance = object.__new__(MultiIndex)

--- a/databricks/koalas/indexes/datetimes.py
+++ b/databricks/koalas/indexes/datetimes.py
@@ -1,0 +1,33 @@
+#
+# Copyright (C) 2019 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from databricks.koalas.indexes.base import Index
+
+
+class DatetimeIndex(Index):
+    """
+    Immutable ndarray-like of datetime64 data.
+
+    Represented internally as int64, and which can be boxed to Timestamp objects
+    that are subclasses of datetime and carry metadata.
+
+    See Also
+    --------
+    Index : The base pandas Index type.
+    to_datetime : Convert argument to datetime.
+    """
+
+    pass

--- a/databricks/koalas/indexes/datetimes.py
+++ b/databricks/koalas/indexes/datetimes.py
@@ -13,8 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from functools import partial
+from typing import Any
 
 from databricks.koalas.indexes.base import Index
+from databricks.koalas.missing.indexes import MissingPandasLikeDatetimeIndex
 
 
 class DatetimeIndex(Index):
@@ -30,4 +33,11 @@ class DatetimeIndex(Index):
     to_datetime : Convert argument to datetime.
     """
 
-    pass
+    def __getattr__(self, item: str) -> Any:
+        if hasattr(MissingPandasLikeDatetimeIndex, item):
+            property_or_func = getattr(MissingPandasLikeDatetimeIndex, item)
+            if isinstance(property_or_func, property):
+                return property_or_func.fget(self)  # type: ignore
+            else:
+                return partial(property_or_func, self)
+        raise AttributeError("'DatetimeIndex' object has no attribute '{}'".format(item))

--- a/databricks/koalas/indexes/multi.py
+++ b/databricks/koalas/indexes/multi.py
@@ -1,0 +1,1108 @@
+#
+# Copyright (C) 2019 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from distutils.version import LooseVersion
+from functools import partial
+from typing import Any, Optional, Tuple, cast
+import warnings
+
+import pandas as pd
+from pandas.api.types import is_list_like
+from pandas.api.types import is_hashable
+
+import pyspark
+from pyspark import sql as spark
+from pyspark.sql import functions as F, Window
+
+# For running doctests and reference resolution in PyCharm.
+from databricks import koalas as ks  # noqa: F401
+from databricks.koalas.exceptions import PandasNotImplementedError
+from databricks.koalas.base import IndexOpsMixin
+from databricks.koalas.frame import DataFrame
+from databricks.koalas.indexes.base import Index
+from databricks.koalas.missing.indexes import MissingPandasLikeMultiIndex
+from databricks.koalas.series import Series, first_series
+from databricks.koalas.utils import (
+    compare_disallow_null,
+    default_session,
+    is_name_like_tuple,
+    name_like_string,
+    scol_for,
+    verify_temp_column_name,
+)
+from databricks.koalas.internal import (
+    InternalFrame,
+    NATURAL_ORDER_COLUMN_NAME,
+    SPARK_INDEX_NAME_FORMAT,
+)
+from databricks.koalas.typedef import Scalar
+
+
+class MultiIndex(Index):
+    """
+    Koalas MultiIndex that corresponds to pandas MultiIndex logically. This might hold Spark Column
+    internally.
+
+    :ivar _kdf: The parent dataframe
+    :type _kdf: DataFrame
+    :ivar _scol: Spark Column instance
+    :type _scol: pyspark.Column
+
+    See Also
+    --------
+    Index : A single-level Index.
+
+    Examples
+    --------
+    >>> ks.DataFrame({'a': ['a', 'b', 'c']}, index=[[1, 2, 3], [4, 5, 6]]).index  # doctest: +SKIP
+    MultiIndex([(1, 4),
+                (2, 5),
+                (3, 6)],
+               )
+
+    >>> ks.DataFrame({'a': [1, 2, 3]}, index=[list('abc'), list('def')]).index  # doctest: +SKIP
+    MultiIndex([('a', 'd'),
+                ('b', 'e'),
+                ('c', 'f')],
+               )
+    """
+
+    def __new__(cls, kdf: DataFrame):
+        assert kdf._internal.index_level > 1
+
+        return super().__new__(cls, data=kdf)
+
+    @property
+    def _internal(self):
+        internal = self._kdf._internal
+        scol = F.struct(internal.index_spark_columns)
+        return internal.copy(
+            column_labels=[None], data_spark_columns=[scol], column_label_names=None
+        )
+
+    @property
+    def _column_label(self):
+        return None
+
+    def __abs__(self):
+        raise TypeError("TypeError: cannot perform __abs__ with this index type: MultiIndex")
+
+    def _with_new_scol(self, scol: spark.Column):
+        raise NotImplementedError("Not supported for type MultiIndex")
+
+    def _align_and_column_op(self, f, *args) -> Index:
+        raise NotImplementedError("Not supported for type MultiIndex")
+
+    def any(self, *args, **kwargs) -> None:
+        raise TypeError("cannot perform any with this index type: MultiIndex")
+
+    def all(self, *args, **kwargs) -> None:
+        raise TypeError("cannot perform all with this index type: MultiIndex")
+
+    @staticmethod
+    def from_tuples(tuples, sortorder=None, names=None) -> "MultiIndex":
+        """
+        Convert list of tuples to MultiIndex.
+
+        Parameters
+        ----------
+        tuples : list / sequence of tuple-likes
+            Each tuple is the index of one row/column.
+        sortorder : int or None
+            Level of sortedness (must be lexicographically sorted by that level).
+        names : list / sequence of str, optional
+            Names for the levels in the index.
+
+        Returns
+        -------
+        index : MultiIndex
+
+        Examples
+        --------
+
+        >>> tuples = [(1, 'red'), (1, 'blue'),
+        ...           (2, 'red'), (2, 'blue')]
+        >>> ks.MultiIndex.from_tuples(tuples, names=('number', 'color'))  # doctest: +SKIP
+        MultiIndex([(1,  'red'),
+                    (1, 'blue'),
+                    (2,  'red'),
+                    (2, 'blue')],
+                   names=['number', 'color'])
+        """
+        return cast(
+            MultiIndex,
+            DataFrame(
+                index=pd.MultiIndex.from_tuples(tuples=tuples, sortorder=sortorder, names=names)
+            ).index,
+        )
+
+    @staticmethod
+    def from_arrays(arrays, sortorder=None, names=None) -> "MultiIndex":
+        """
+        Convert arrays to MultiIndex.
+
+        Parameters
+        ----------
+        arrays: list / sequence of array-likes
+            Each array-like gives one level’s value for each data point. len(arrays)
+            is the number of levels.
+        sortorder: int or None
+            Level of sortedness (must be lexicographically sorted by that level).
+        names: list / sequence of str, optional
+            Names for the levels in the index.
+
+        Returns
+        -------
+        index: MultiIndex
+
+        Examples
+        --------
+
+        >>> arrays = [[1, 1, 2, 2], ['red', 'blue', 'red', 'blue']]
+        >>> ks.MultiIndex.from_arrays(arrays, names=('number', 'color'))  # doctest: +SKIP
+        MultiIndex([(1,  'red'),
+                    (1, 'blue'),
+                    (2,  'red'),
+                    (2, 'blue')],
+                   names=['number', 'color'])
+        """
+        return cast(
+            MultiIndex,
+            DataFrame(
+                index=pd.MultiIndex.from_arrays(arrays=arrays, sortorder=sortorder, names=names)
+            ).index,
+        )
+
+    @staticmethod
+    def from_product(iterables, sortorder=None, names=None) -> "MultiIndex":
+        """
+        Make a MultiIndex from the cartesian product of multiple iterables.
+
+        Parameters
+        ----------
+        iterables : list / sequence of iterables
+            Each iterable has unique labels for each level of the index.
+        sortorder : int or None
+            Level of sortedness (must be lexicographically sorted by that
+            level).
+        names : list / sequence of str, optional
+            Names for the levels in the index.
+
+        Returns
+        -------
+        index : MultiIndex
+
+        See Also
+        --------
+        MultiIndex.from_arrays : Convert list of arrays to MultiIndex.
+        MultiIndex.from_tuples : Convert list of tuples to MultiIndex.
+
+        Examples
+        --------
+        >>> numbers = [0, 1, 2]
+        >>> colors = ['green', 'purple']
+        >>> ks.MultiIndex.from_product([numbers, colors],
+        ...                            names=['number', 'color'])  # doctest: +SKIP
+        MultiIndex([(0,  'green'),
+                    (0, 'purple'),
+                    (1,  'green'),
+                    (1, 'purple'),
+                    (2,  'green'),
+                    (2, 'purple')],
+                   names=['number', 'color'])
+        """
+        return cast(
+            MultiIndex,
+            DataFrame(
+                index=pd.MultiIndex.from_product(
+                    iterables=iterables, sortorder=sortorder, names=names
+                )
+            ).index,
+        )
+
+    @staticmethod
+    def from_frame(df, names=None) -> "MultiIndex":
+        """
+        Make a MultiIndex from a DataFrame.
+
+        Parameters
+        ----------
+        df : DataFrame
+            DataFrame to be converted to MultiIndex.
+        names : list-like, optional
+            If no names are provided, use the column names, or tuple of column
+            names if the columns is a MultiIndex. If a sequence, overwrite
+            names with the given sequence.
+
+        Returns
+        -------
+        MultiIndex
+            The MultiIndex representation of the given DataFrame.
+
+        See Also
+        --------
+        MultiIndex.from_arrays : Convert list of arrays to MultiIndex.
+        MultiIndex.from_tuples : Convert list of tuples to MultiIndex.
+        MultiIndex.from_product : Make a MultiIndex from cartesian product
+                                  of iterables.
+
+        Examples
+        --------
+        >>> df = ks.DataFrame([['HI', 'Temp'], ['HI', 'Precip'],
+        ...                    ['NJ', 'Temp'], ['NJ', 'Precip']],
+        ...                   columns=['a', 'b'])
+        >>> df  # doctest: +SKIP
+              a       b
+        0    HI    Temp
+        1    HI  Precip
+        2    NJ    Temp
+        3    NJ  Precip
+
+        >>> ks.MultiIndex.from_frame(df)  # doctest: +SKIP
+        MultiIndex([('HI',   'Temp'),
+                    ('HI', 'Precip'),
+                    ('NJ',   'Temp'),
+                    ('NJ', 'Precip')],
+                   names=['a', 'b'])
+
+        Using explicit names, instead of the column names
+
+        >>> ks.MultiIndex.from_frame(df, names=['state', 'observation'])  # doctest: +SKIP
+        MultiIndex([('HI',   'Temp'),
+                    ('HI', 'Precip'),
+                    ('NJ',   'Temp'),
+                    ('NJ', 'Precip')],
+                   names=['state', 'observation'])
+        """
+        if not isinstance(df, DataFrame):
+            raise TypeError("Input must be a DataFrame")
+        sdf = df.to_spark()
+
+        if names is None:
+            names = df._internal.column_labels
+        elif not is_list_like(names):
+            raise ValueError("Names should be list-like for a MultiIndex")
+        else:
+            names = [name if is_name_like_tuple(name) else (name,) for name in names]
+
+        internal = InternalFrame(
+            spark_frame=sdf,
+            index_spark_columns=[scol_for(sdf, col) for col in sdf.columns],
+            index_names=names,
+        )
+        return cast(MultiIndex, DataFrame(internal).index)
+
+    @property
+    def name(self) -> str:
+        raise PandasNotImplementedError(class_name="pd.MultiIndex", property_name="name")
+
+    @name.setter
+    def name(self, name: str) -> None:
+        raise PandasNotImplementedError(class_name="pd.MultiIndex", property_name="name")
+
+    def _verify_for_rename(self, name):
+        if is_list_like(name):
+            if self._internal.index_level != len(name):
+                raise ValueError(
+                    "Length of new names must be {}, got {}".format(
+                        self._internal.index_level, len(name)
+                    )
+                )
+            if any(not is_hashable(n) for n in name):
+                raise TypeError("MultiIndex.name must be a hashable type")
+            return [n if is_name_like_tuple(n) else (n,) for n in name]
+        else:
+            raise TypeError("Must pass list-like as `names`.")
+
+    def swaplevel(self, i=-2, j=-1) -> "MultiIndex":
+        """
+        Swap level i with level j.
+        Calling this method does not change the ordering of the values.
+
+        Parameters
+        ----------
+        i : int, str, default -2
+            First level of index to be swapped. Can pass level name as string.
+            Type of parameters can be mixed.
+        j : int, str, default -1
+            Second level of index to be swapped. Can pass level name as string.
+            Type of parameters can be mixed.
+
+        Returns
+        -------
+        MultiIndex
+            A new MultiIndex.
+
+        Examples
+        --------
+        >>> midx = ks.MultiIndex.from_arrays([['a', 'b'], [1, 2]], names = ['word', 'number'])
+        >>> midx  # doctest: +SKIP
+        MultiIndex([('a', 1),
+                    ('b', 2)],
+                   names=['word', 'number'])
+
+        >>> midx.swaplevel(0, 1)  # doctest: +SKIP
+        MultiIndex([(1, 'a'),
+                    (2, 'b')],
+                   names=['number', 'word'])
+
+        >>> midx.swaplevel('number', 'word')  # doctest: +SKIP
+        MultiIndex([(1, 'a'),
+                    (2, 'b')],
+                   names=['number', 'word'])
+        """
+        for index in (i, j):
+            if not isinstance(index, int) and index not in self.names:
+                raise KeyError("Level %s not found" % index)
+
+        i = i if isinstance(i, int) else self.names.index(i)
+        j = j if isinstance(j, int) else self.names.index(j)
+
+        for index in (i, j):
+            if index >= len(self.names) or index < -len(self.names):
+                raise IndexError(
+                    "Too many levels: Index has only %s levels, "
+                    "%s is not a valid level number" % (len(self.names), index)
+                )
+
+        index_map = list(zip(self._internal.index_spark_columns, self._internal.index_names))
+        index_map[i], index_map[j], = index_map[j], index_map[i]
+        index_spark_columns, index_names = zip(*index_map)
+        internal = self._internal.copy(
+            index_spark_columns=list(index_spark_columns),
+            index_names=list(index_names),
+            column_labels=[],
+            data_spark_columns=[],
+        )
+        return cast(MultiIndex, DataFrame(internal).index)
+
+    @property
+    def levshape(self) -> Tuple[int, ...]:
+        """
+        A tuple with the length of each level.
+
+        Examples
+        --------
+        >>> midx = ks.MultiIndex.from_tuples([('a', 'x'), ('b', 'y'), ('c', 'z')])
+        >>> midx  # doctest: +SKIP
+        MultiIndex([('a', 'x'),
+                    ('b', 'y'),
+                    ('c', 'z')],
+                   )
+
+        >>> midx.levshape
+        (3, 3)
+        """
+        result = self._internal.spark_frame.agg(
+            *(F.countDistinct(c) for c in self._internal.index_spark_columns)
+        ).collect()[0]
+        return tuple(result)
+
+    @staticmethod
+    def _comparator_for_monotonic_increasing(data_type):
+        return compare_disallow_null
+
+    def _is_monotonic(self, order):
+        if order == "increasing":
+            return self._is_monotonic_increasing().all()
+        else:
+            return self._is_monotonic_decreasing().all()
+
+    def _is_monotonic_increasing(self):
+        scol = self.spark.column
+        window = Window.orderBy(NATURAL_ORDER_COLUMN_NAME).rowsBetween(-1, -1)
+        prev = F.lag(scol, 1).over(window)
+
+        cond = F.lit(True)
+        has_not_null = F.lit(True)
+        for field in self.spark.data_type[::-1]:
+            left = scol.getField(field.name)
+            right = prev.getField(field.name)
+            compare = MultiIndex._comparator_for_monotonic_increasing(field.dataType)
+            # Since pandas 1.1.4, null value is not allowed at any levels of MultiIndex.
+            # Therefore, we should check `has_not_null` over the all levels.
+            has_not_null = has_not_null & left.isNotNull()
+            cond = F.when(left.eqNullSafe(right), cond).otherwise(
+                compare(left, right, spark.Column.__gt__)
+            )
+
+        cond = has_not_null & (prev.isNull() | cond)
+
+        cond_name = verify_temp_column_name(
+            self._internal.spark_frame.select(self._internal.index_spark_columns),
+            "__is_monotonic_increasing_cond__",
+        )
+
+        sdf = self._internal.spark_frame.select(
+            self._internal.index_spark_columns + [cond.alias(cond_name)]
+        )
+
+        internal = InternalFrame(
+            spark_frame=sdf,
+            index_spark_columns=[
+                scol_for(sdf, col) for col in self._internal.index_spark_column_names
+            ],
+            index_names=self._internal.index_names,
+        )
+
+        return first_series(DataFrame(internal))
+
+    @staticmethod
+    def _comparator_for_monotonic_decreasing(data_type):
+        return compare_disallow_null
+
+    def _is_monotonic_decreasing(self):
+        scol = self.spark.column
+        window = Window.orderBy(NATURAL_ORDER_COLUMN_NAME).rowsBetween(-1, -1)
+        prev = F.lag(scol, 1).over(window)
+
+        cond = F.lit(True)
+        has_not_null = F.lit(True)
+        for field in self.spark.data_type[::-1]:
+            left = scol.getField(field.name)
+            right = prev.getField(field.name)
+            compare = MultiIndex._comparator_for_monotonic_decreasing(field.dataType)
+            # Since pandas 1.1.4, null value is not allowed at any levels of MultiIndex.
+            # Therefore, we should check `has_not_null` over the all levels.
+            has_not_null = has_not_null & left.isNotNull()
+            cond = F.when(left.eqNullSafe(right), cond).otherwise(
+                compare(left, right, spark.Column.__lt__)
+            )
+
+        cond = has_not_null & (prev.isNull() | cond)
+
+        cond_name = verify_temp_column_name(
+            self._internal.spark_frame.select(self._internal.index_spark_columns),
+            "__is_monotonic_decreasing_cond__",
+        )
+
+        sdf = self._internal.spark_frame.select(
+            self._internal.index_spark_columns + [cond.alias(cond_name)]
+        )
+
+        internal = InternalFrame(
+            spark_frame=sdf,
+            index_spark_columns=[
+                scol_for(sdf, col) for col in self._internal.index_spark_column_names
+            ],
+            index_names=self._internal.index_names,
+        )
+
+        return first_series(DataFrame(internal))
+
+    def to_frame(self, index=True, name=None) -> DataFrame:
+        """
+        Create a DataFrame with the levels of the MultiIndex as columns.
+        Column ordering is determined by the DataFrame constructor with data as
+        a dict.
+
+        Parameters
+        ----------
+        index : boolean, default True
+            Set the index of the returned DataFrame as the original MultiIndex.
+        name : list / sequence of strings, optional
+            The passed names should substitute index level names.
+
+        Returns
+        -------
+        DataFrame : a DataFrame containing the original MultiIndex data.
+
+        See Also
+        --------
+        DataFrame
+
+        Examples
+        --------
+        >>> tuples = [(1, 'red'), (1, 'blue'),
+        ...           (2, 'red'), (2, 'blue')]
+        >>> idx = ks.MultiIndex.from_tuples(tuples, names=('number', 'color'))
+        >>> idx  # doctest: +SKIP
+        MultiIndex([(1,  'red'),
+                    (1, 'blue'),
+                    (2,  'red'),
+                    (2, 'blue')],
+                   names=['number', 'color'])
+        >>> idx.to_frame()  # doctest: +NORMALIZE_WHITESPACE
+                      number color
+        number color
+        1      red         1   red
+               blue        1  blue
+        2      red         2   red
+               blue        2  blue
+
+        By default, the original Index is reused. To enforce a new Index:
+
+        >>> idx.to_frame(index=False)
+           number color
+        0       1   red
+        1       1  blue
+        2       2   red
+        3       2  blue
+
+        To override the name of the resulting column, specify `name`:
+
+        >>> idx.to_frame(name=['n', 'c'])  # doctest: +NORMALIZE_WHITESPACE
+                      n     c
+        number color
+        1      red    1   red
+               blue   1  blue
+        2      red    2   red
+               blue   2  blue
+        """
+        if name is None:
+            name = [
+                name if name is not None else (i,)
+                for i, name in enumerate(self._internal.index_names)
+            ]
+        elif is_list_like(name):
+            if len(name) != self._internal.index_level:
+                raise ValueError("'name' should have same length as number of levels on index.")
+            name = [n if is_name_like_tuple(n) else (n,) for n in name]
+        else:
+            raise TypeError("'name' must be a list / sequence of column names.")
+
+        return self._to_frame(index=index, names=name)
+
+    def to_pandas(self) -> pd.MultiIndex:
+        """
+        Return a pandas MultiIndex.
+
+        .. note:: This method should only be used if the resulting pandas object is expected
+                  to be small, as all the data is loaded into the driver's memory.
+
+        Examples
+        --------
+        >>> df = ks.DataFrame([(.2, .3), (.0, .6), (.6, .0), (.2, .1)],
+        ...                   columns=['dogs', 'cats'],
+        ...                   index=[list('abcd'), list('efgh')])
+        >>> df['dogs'].index.to_pandas()  # doctest: +SKIP
+        MultiIndex([('a', 'e'),
+                    ('b', 'f'),
+                    ('c', 'g'),
+                    ('d', 'h')],
+                   )
+        """
+        # TODO: We might need to handle internal state change.
+        # So far, we don't have any functions to change the internal state of MultiIndex except for
+        # series-like operations. In that case, it creates new Index object instead of MultiIndex.
+        return super().to_pandas()
+
+    def toPandas(self) -> pd.MultiIndex:
+        warnings.warn(
+            "MultiIndex.toPandas is deprecated as of MultiIndex.to_pandas. "
+            "Please use the API instead.",
+            FutureWarning,
+        )
+        return self.to_pandas()
+
+    toPandas.__doc__ = to_pandas.__doc__
+
+    def nunique(self, dropna=True) -> None:  # type: ignore
+        raise NotImplementedError("nunique is not defined for MultiIndex")
+
+    # TODO: add 'name' parameter after pd.MultiIndex.name is implemented
+    def copy(self, deep=None) -> "MultiIndex":  # type: ignore
+        """
+        Make a copy of this object.
+
+        Parameters
+        ----------
+        deep : None
+            this parameter is not supported but just dummy parameter to match pandas.
+
+        Examples
+        --------
+        >>> df = ks.DataFrame([(.2, .3), (.0, .6), (.6, .0), (.2, .1)],
+        ...                   columns=['dogs', 'cats'],
+        ...                   index=[list('abcd'), list('efgh')])
+        >>> df['dogs'].index  # doctest: +SKIP
+        MultiIndex([('a', 'e'),
+                    ('b', 'f'),
+                    ('c', 'g'),
+                    ('d', 'h')],
+                   )
+
+        Copy index
+
+        >>> df.index.copy()  # doctest: +SKIP
+        MultiIndex([('a', 'e'),
+                    ('b', 'f'),
+                    ('c', 'g'),
+                    ('d', 'h')],
+                   )
+        """
+        return super().copy(deep=deep)  # type: ignore
+
+    def symmetric_difference(self, other, result_name=None, sort=None) -> "MultiIndex":
+        """
+        Compute the symmetric difference of two MultiIndex objects.
+
+        Parameters
+        ----------
+        other : Index or array-like
+        result_name : list
+        sort : True or None, default None
+            Whether to sort the resulting index.
+            * True : Attempt to sort the result.
+            * None : Do not sort the result.
+
+        Returns
+        -------
+        symmetric_difference : MiltiIndex
+
+        Notes
+        -----
+        ``symmetric_difference`` contains elements that appear in either
+        ``idx1`` or ``idx2`` but not both. Equivalent to the Index created by
+        ``idx1.difference(idx2) | idx2.difference(idx1)`` with duplicates
+        dropped.
+
+        Examples
+        --------
+        >>> midx1 = pd.MultiIndex([['lama', 'cow', 'falcon'],
+        ...                        ['speed', 'weight', 'length']],
+        ...                       [[0, 0, 0, 1, 1, 1, 2, 2, 2],
+        ...                        [0, 0, 0, 0, 1, 2, 0, 1, 2]])
+        >>> midx2 = pd.MultiIndex([['koalas', 'cow', 'falcon'],
+        ...                        ['speed', 'weight', 'length']],
+        ...                       [[0, 0, 0, 1, 1, 1, 2, 2, 2],
+        ...                        [0, 0, 0, 0, 1, 2, 0, 1, 2]])
+        >>> s1 = ks.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3],
+        ...                index=midx1)
+        >>> s2 = ks.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3],
+        ...              index=midx2)
+
+        >>> s1.index.symmetric_difference(s2.index)  # doctest: +SKIP
+        MultiIndex([('koalas', 'speed'),
+                    (  'lama', 'speed')],
+                   )
+
+        You can set names of result Index.
+
+        >>> s1.index.symmetric_difference(s2.index, result_name=['a', 'b'])  # doctest: +SKIP
+        MultiIndex([('koalas', 'speed'),
+                    (  'lama', 'speed')],
+                   names=['a', 'b'])
+
+        You can set sort to `True`, if you want to sort the resulting index.
+
+        >>> s1.index.symmetric_difference(s2.index, sort=True)  # doctest: +SKIP
+        MultiIndex([('koalas', 'speed'),
+                    (  'lama', 'speed')],
+                   )
+
+        You can also use the ``^`` operator:
+
+        >>> s1.index ^ s2.index  # doctest: +SKIP
+        MultiIndex([('koalas', 'speed'),
+                    (  'lama', 'speed')],
+                   )
+        """
+        if type(self) != type(other):
+            raise NotImplementedError(
+                "Doesn't support symmetric_difference between Index & MultiIndex for now"
+            )
+
+        sdf_self = self._kdf._internal.spark_frame.select(self._internal.index_spark_columns)
+        sdf_other = other._kdf._internal.spark_frame.select(other._internal.index_spark_columns)
+
+        sdf_symdiff = sdf_self.union(sdf_other).subtract(sdf_self.intersect(sdf_other))
+
+        if sort:
+            sdf_symdiff = sdf_symdiff.sort(self._internal.index_spark_columns)
+
+        internal = InternalFrame(
+            spark_frame=sdf_symdiff,
+            index_spark_columns=[
+                scol_for(sdf_symdiff, col) for col in self._internal.index_spark_column_names
+            ],
+            index_names=self._internal.index_names,
+        )
+        result = MultiIndex(DataFrame(internal))
+
+        if result_name:
+            result.names = result_name
+
+        return result
+
+    # TODO: ADD error parameter
+    def drop(self, codes, level=None) -> "MultiIndex":
+        """
+        Make new MultiIndex with passed list of labels deleted
+
+        Parameters
+        ----------
+        codes : array-like
+            Must be a list of tuples
+        level : int or level name, default None
+
+        Returns
+        -------
+        dropped : MultiIndex
+
+        Examples
+        --------
+        >>> index = ks.MultiIndex.from_tuples([('a', 'x'), ('b', 'y'), ('c', 'z')])
+        >>> index # doctest: +SKIP
+        MultiIndex([('a', 'x'),
+                    ('b', 'y'),
+                    ('c', 'z')],
+                   )
+
+        >>> index.drop(['a']) # doctest: +SKIP
+        MultiIndex([('b', 'y'),
+                    ('c', 'z')],
+                   )
+
+        >>> index.drop(['x', 'y'], level=1) # doctest: +SKIP
+        MultiIndex([('c', 'z')],
+                   )
+        """
+        internal = self._internal.resolved_copy
+        sdf = internal.spark_frame
+        index_scols = internal.index_spark_columns
+        if level is None:
+            scol = index_scols[0]
+        elif isinstance(level, int):
+            scol = index_scols[level]
+        else:
+            scol = None
+            for index_spark_column, index_name in zip(
+                internal.index_spark_columns, internal.index_names
+            ):
+                if not isinstance(level, tuple):
+                    level = (level,)
+                if level == index_name:
+                    if scol is not None:
+                        raise ValueError(
+                            "The name {} occurs multiple times, use a level number".format(
+                                name_like_string(level)
+                            )
+                        )
+                    scol = index_spark_column
+            if scol is None:
+                raise KeyError("Level {} not found".format(name_like_string(level)))
+        sdf = sdf[~scol.isin(codes)]
+
+        return MultiIndex(
+            DataFrame(
+                InternalFrame(
+                    spark_frame=sdf,
+                    index_spark_columns=[
+                        scol_for(sdf, col) for col in internal.index_spark_column_names
+                    ],
+                    index_names=internal.index_names,
+                    column_labels=[],
+                    data_spark_columns=[],
+                )
+            )
+        )
+
+    def value_counts(
+        self, normalize=False, sort=True, ascending=False, bins=None, dropna=True
+    ) -> Series:
+        if (
+            LooseVersion(pyspark.__version__) < LooseVersion("2.4")
+            and default_session().conf.get("spark.sql.execution.arrow.enabled") == "true"
+            and isinstance(self, MultiIndex)
+        ):
+            raise RuntimeError(
+                "if you're using pyspark < 2.4, set conf "
+                "'spark.sql.execution.arrow.enabled' to 'false' "
+                "for using this function with MultiIndex"
+            )
+        return super().value_counts(
+            normalize=normalize, sort=sort, ascending=ascending, bins=bins, dropna=dropna
+        )
+
+    value_counts.__doc__ = IndexOpsMixin.value_counts.__doc__
+
+    def argmax(self) -> None:
+        raise TypeError("reduction operation 'argmax' not allowed for this dtype")
+
+    def argmin(self) -> None:
+        raise TypeError("reduction operation 'argmin' not allowed for this dtype")
+
+    def asof(self, label) -> None:
+        raise NotImplementedError(
+            "only the default get_loc method is currently supported for MultiIndex"
+        )
+
+    @property
+    def is_all_dates(self) -> bool:
+        """
+        is_all_dates always returns False for MultiIndex
+
+        Examples
+        --------
+        >>> from datetime import datetime
+
+        >>> idx = ks.MultiIndex.from_tuples(
+        ...     [(datetime(2019, 1, 1, 0, 0, 0), datetime(2019, 1, 1, 0, 0, 0)),
+        ...      (datetime(2019, 1, 1, 0, 0, 0), datetime(2019, 1, 1, 0, 0, 0))])
+        >>> idx  # doctest: +SKIP
+        MultiIndex([('2019-01-01', '2019-01-01'),
+                    ('2019-01-01', '2019-01-01')],
+                   )
+
+        >>> idx.is_all_dates
+        False
+        """
+        return False
+
+    def __getattr__(self, item: str) -> Any:
+        if hasattr(MissingPandasLikeMultiIndex, item):
+            property_or_func = getattr(MissingPandasLikeMultiIndex, item)
+            if isinstance(property_or_func, property):
+                return property_or_func.fget(self)  # type: ignore
+            else:
+                return partial(property_or_func, self)
+        raise AttributeError("'MultiIndex' object has no attribute '{}'".format(item))
+
+    def _get_level_number(self, level) -> Optional[int]:
+        """
+        Return the level number if a valid level is given.
+        """
+        count = self.names.count(level)
+        if (count > 1) and not isinstance(level, int):
+            raise ValueError("The name %s occurs multiple times, use a level number" % level)
+        if level in self.names:
+            level = self.names.index(level)
+        elif isinstance(level, int):
+            nlevels = self.nlevels
+            if level >= nlevels:
+                raise IndexError(
+                    "Too many levels: Index has only %d "
+                    "levels, %d is not a valid level number" % (nlevels, level)
+                )
+            if level < 0:
+                if (level + nlevels) < 0:
+                    raise IndexError(
+                        "Too many levels: Index has only %d levels, "
+                        "not %d" % (nlevels, level + 1)
+                    )
+                level = level + nlevels
+        else:
+            raise KeyError("Level %s not found" % str(level))
+            return None
+
+        return level
+
+    def get_level_values(self, level) -> Index:
+        """
+        Return vector of label values for requested level,
+        equal to the length of the index.
+
+        Parameters
+        ----------
+        level : int or str
+            ``level`` is either the integer position of the level in the
+            MultiIndex, or the name of the level.
+
+        Returns
+        -------
+        values : Index
+            Values is a level of this MultiIndex converted to
+            a single :class:`Index` (or subclass thereof).
+
+        Examples
+        --------
+
+        Create a MultiIndex:
+
+        >>> mi = ks.MultiIndex.from_tuples([('x', 'a'), ('x', 'b'), ('y', 'a')])
+        >>> mi.names = ['level_1', 'level_2']
+
+        Get level values by supplying level as either integer or name:
+
+        >>> mi.get_level_values(0)
+        Index(['x', 'x', 'y'], dtype='object', name='level_1')
+
+        >>> mi.get_level_values('level_2')
+        Index(['a', 'b', 'a'], dtype='object', name='level_2')
+        """
+        level = self._get_level_number(level)
+        index_scol = self._internal.index_spark_columns[level]
+        index_name = self._internal.index_names[level]
+        internal = self._internal.copy(
+            index_spark_columns=[index_scol],
+            index_names=[index_name],
+            column_labels=[],
+            data_spark_columns=[],
+        )
+        return DataFrame(internal).index
+
+    def insert(self, loc: int, item) -> Index:
+        """
+        Make new MultiIndex inserting new item at location.
+
+        Follows Python list.append semantics for negative values.
+
+        Parameters
+        ----------
+        loc : int
+        item : object
+
+        Returns
+        -------
+        new_index : MultiIndex
+
+        Examples
+        --------
+        >>> kmidx = ks.MultiIndex.from_tuples([("a", "x"), ("b", "y"), ("c", "z")])
+        >>> kmidx.insert(3, ("h", "j"))  # doctest: +SKIP
+        MultiIndex([('a', 'x'),
+                    ('b', 'y'),
+                    ('c', 'z'),
+                    ('h', 'j')],
+                   )
+
+        For negative values
+
+        >>> kmidx.insert(-2, ("h", "j"))  # doctest: +SKIP
+        MultiIndex([('a', 'x'),
+                    ('h', 'j'),
+                    ('b', 'y'),
+                    ('c', 'z')],
+                   )
+        """
+        length = len(self)
+        if loc < 0:
+            loc = loc + length
+            if loc < 0:
+                raise IndexError(
+                    "index {} is out of bounds for axis 0 with size {}".format(
+                        (loc - length), length
+                    )
+                )
+        else:
+            if loc > length:
+                raise IndexError(
+                    "index {} is out of bounds for axis 0 with size {}".format(loc, length)
+                )
+
+        index_name = self._internal.index_spark_column_names
+        sdf_before = self.to_frame(name=index_name)[:loc].to_spark()
+        sdf_middle = Index([item]).to_frame(name=index_name).to_spark()
+        sdf_after = self.to_frame(name=index_name)[loc:].to_spark()
+        sdf = sdf_before.union(sdf_middle).union(sdf_after)
+
+        internal = InternalFrame(
+            spark_frame=sdf,
+            index_spark_columns=[
+                scol_for(sdf, col) for col in self._internal.index_spark_column_names
+            ],
+            index_names=self._internal.index_names,
+        )
+        return DataFrame(internal).index
+
+    def item(self) -> Tuple[Scalar, ...]:
+        """
+        Return the first element of the underlying data as a python tuple.
+
+        Returns
+        -------
+        tuple
+            The first element of MultiIndex.
+
+        Raises
+        ------
+        ValueError
+            If the data is not length-1.
+
+        Examples
+        --------
+        >>> kmidx = ks.MultiIndex.from_tuples([('a', 'x')])
+        >>> kmidx.item()
+        ('a', 'x')
+        """
+        return self._kdf.head(2)._to_internal_pandas().index.item()
+
+    def intersection(self, other) -> "MultiIndex":
+        """
+        Form the intersection of two Index objects.
+
+        This returns a new Index with elements common to the index and `other`.
+
+        Parameters
+        ----------
+        other : Index or array-like
+
+        Returns
+        -------
+        intersection : MultiIndex
+
+        Examples
+        --------
+        >>> midx1 = ks.MultiIndex.from_tuples([("a", "x"), ("b", "y"), ("c", "z")])
+        >>> midx2 = ks.MultiIndex.from_tuples([("c", "z"), ("d", "w")])
+        >>> midx1.intersection(midx2).sort_values()  # doctest: +SKIP
+        MultiIndex([('c', 'z')],
+                   )
+        """
+        if isinstance(other, Series) or not is_list_like(other):
+            raise TypeError("other must be a MultiIndex or a list of tuples")
+        elif isinstance(other, DataFrame):
+            raise ValueError("Index data must be 1-dimensional")
+        elif isinstance(other, MultiIndex):
+            spark_frame_other = other.to_frame().to_spark()
+            keep_name = self.names == other.names
+        elif isinstance(other, Index):
+            # Always returns an empty MultiIndex if `other` is Index.
+            return self.to_frame().head(0).index  # type: ignore
+        elif not all(isinstance(item, tuple) for item in other):
+            raise TypeError("other must be a MultiIndex or a list of tuples")
+        else:
+            other = MultiIndex.from_tuples(list(other))
+            spark_frame_other = other.to_frame().to_spark()
+            keep_name = True
+
+        default_name = [SPARK_INDEX_NAME_FORMAT(i) for i in range(self.nlevels)]
+        spark_frame_self = self.to_frame(name=default_name).to_spark()
+        spark_frame_intersected = spark_frame_self.intersect(spark_frame_other)
+        if keep_name:
+            index_names = self._internal.index_names
+        else:
+            index_names = None
+        internal = InternalFrame(
+            spark_frame=spark_frame_intersected,
+            index_spark_columns=[scol_for(spark_frame_intersected, col) for col in default_name],
+            index_names=index_names,
+        )
+        return cast(MultiIndex, DataFrame(internal).index)
+
+    @property
+    def hasnans(self):
+        raise NotImplementedError("hasnans is not defined for MultiIndex")
+
+    @property
+    def inferred_type(self) -> str:
+        """
+        Return a string of the type inferred from the values.
+        """
+        # Always returns "mixed" for MultiIndex
+        return "mixed"
+
+    @property
+    def asi8(self) -> None:
+        """
+        Integer representation of the values.
+        """
+        # Always returns None for MultiIndex
+        return None
+
+    def __iter__(self):
+        return MissingPandasLikeMultiIndex.__iter__(self)

--- a/databricks/koalas/indexes/numeric.py
+++ b/databricks/koalas/indexes/numeric.py
@@ -1,0 +1,70 @@
+#
+# Copyright (C) 2019 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from databricks.koalas.indexes.base import Index
+
+
+class NumericIndex(Index):
+    """
+    Provide numeric type operations.
+    This is an abstract class.
+    """
+
+    pass
+
+
+class IntegerIndex(NumericIndex):
+    """
+    This is an abstract class for Int64Index.
+    """
+
+    pass
+
+
+class Int64Index(IntegerIndex):
+    """
+    Immutable sequence used for indexing and alignment. The basic object
+    storing axis labels for all pandas objects. Int64Index is a special case
+    of `Index` with purely integer labels.
+
+    See Also
+    --------
+    Index : The base pandas Index type.
+
+    Notes
+    -----
+    An Index instance can **only** contain hashable objects.
+    """
+
+    pass
+
+
+class Float64Index(NumericIndex):
+    """
+    Immutable sequence used for indexing and alignment. The basic object
+    storing axis labels for all pandas objects. Float64Index is a special case
+    of `Index` with purely float labels.
+
+    See Also
+    --------
+    Index : The base pandas Index type.
+
+    Notes
+    -----
+    An Index instance can **only** contain hashable objects.
+    """
+
+    pass

--- a/databricks/koalas/missing/indexes.py
+++ b/databricks/koalas/missing/indexes.py
@@ -20,15 +20,21 @@ import pandas as pd
 from databricks.koalas.missing import unsupported_function, unsupported_property, common
 
 
-def _unsupported_function(method_name, deprecated=False, reason=""):
+def _unsupported_function(method_name, deprecated=False, reason="", cls="Index"):
     return unsupported_function(
-        class_name="pd.Index", method_name=method_name, deprecated=deprecated, reason=reason
+        class_name="pd.{}".format(cls),
+        method_name=method_name,
+        deprecated=deprecated,
+        reason=reason,
     )
 
 
-def _unsupported_property(property_name, deprecated=False, reason=""):
+def _unsupported_property(property_name, deprecated=False, reason="", cls="Index"):
     return unsupported_property(
-        class_name="pd.Index", property_name=property_name, deprecated=deprecated, reason=reason
+        class_name="pd.{}".format(cls),
+        property_name=property_name,
+        deprecated=deprecated,
+        reason=reason,
     )
 
 
@@ -89,6 +95,58 @@ class MissingPandasLikeIndex(object):
         get_duplicates = _unsupported_function("get_duplicates", deprecated=True)
         summary = _unsupported_function("summary", deprecated=True)
         contains = _unsupported_function("contains", deprecated=True)
+
+
+class MissingPandasLikeDatetimeIndex(MissingPandasLikeIndex):
+
+    # Properties
+    year = _unsupported_property("year", cls="DatetimeIndex")
+    month = _unsupported_property("month", cls="DatetimeIndex")
+    day = _unsupported_property("day", cls="DatetimeIndex")
+    hour = _unsupported_property("hour", cls="DatetimeIndex")
+    minute = _unsupported_property("minute", cls="DatetimeIndex")
+    second = _unsupported_property("second", cls="DatetimeIndex")
+    microsecond = _unsupported_property("microsecond", cls="DatetimeIndex")
+    nanosecond = _unsupported_property("nanosecond", cls="DatetimeIndex")
+    date = _unsupported_property("date", cls="DatetimeIndex")
+    time = _unsupported_property("time", cls="DatetimeIndex")
+    timetz = _unsupported_property("timetz", cls="DatetimeIndex")
+    dayofyear = _unsupported_property("dayofyear", cls="DatetimeIndex")
+    day_of_year = _unsupported_property("day_of_year", cls="DatetimeIndex")
+    weekofyear = _unsupported_property("weekofyear", cls="DatetimeIndex")
+    week = _unsupported_property("week", cls="DatetimeIndex")
+    dayofweek = _unsupported_property("dayofweek", cls="DatetimeIndex")
+    day_of_week = _unsupported_property("day_of_week", cls="DatetimeIndex")
+    weekday = _unsupported_property("weekday", cls="DatetimeIndex")
+    quarter = _unsupported_property("quarter", cls="DatetimeIndex")
+    tz = _unsupported_property("tz", cls="DatetimeIndex")
+    freq = _unsupported_property("freq", cls="DatetimeIndex")
+    freqstr = _unsupported_property("freqstr", cls="DatetimeIndex")
+    is_month_start = _unsupported_property("is_month_start", cls="DatetimeIndex")
+    is_month_end = _unsupported_property("is_month_end", cls="DatetimeIndex")
+    is_quarter_start = _unsupported_property("is_quarter_start", cls="DatetimeIndex")
+    is_quarter_end = _unsupported_property("is_quarter_end", cls="DatetimeIndex")
+    is_year_start = _unsupported_property("is_year_start", cls="DatetimeIndex")
+    is_year_end = _unsupported_property("is_year_end", cls="DatetimeIndex")
+    is_leap_year = _unsupported_property("is_leap_year", cls="DatetimeIndex")
+    inferred_freq = _unsupported_property("inferred_freq", cls="DatetimeIndex")
+
+    # Functions
+    normalize = _unsupported_function("normalize", cls="DatetimeIndex")
+    strftime = _unsupported_function("strftime", cls="DatetimeIndex")
+    snap = _unsupported_function("snap", cls="DatetimeIndex")
+    tz_convert = _unsupported_function("tz_convert", cls="DatetimeIndex")
+    tz_localize = _unsupported_function("tz_localize", cls="DatetimeIndex")
+    round = _unsupported_function("round", cls="DatetimeIndex")
+    floor = _unsupported_function("floor", cls="DatetimeIndex")
+    ceil = _unsupported_function("ceil", cls="DatetimeIndex")
+    to_period = _unsupported_function("to_period", cls="DatetimeIndex")
+    to_perioddelta = _unsupported_function("to_perioddelta", cls="DatetimeIndex")
+    to_pydatetime = _unsupported_function("to_pydatetime", cls="DatetimeIndex")
+    month_name = _unsupported_function("month_name", cls="DatetimeIndex")
+    day_name = _unsupported_function("day_name", cls="DatetimeIndex")
+    mean = _unsupported_function("mean", cls="DatetimeIndex")
+    std = _unsupported_function("std", cls="DatetimeIndex")
 
 
 class MissingPandasLikeMultiIndex(object):

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -43,6 +43,12 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
 
     def test_index(self):
         for pdf in [
+            pd.DataFrame(np.random.randn(10, 5), index=np.random.randint(100, size=10)),
+            pd.DataFrame(
+                np.random.randn(10, 5), index=np.random.randint(100, size=10).astype(np.int32)
+            ),
+            pd.DataFrame(np.random.randn(10, 5), index=np.random.randn(10)),
+            pd.DataFrame(np.random.randn(10, 5), index=np.random.randn(10).astype(np.float32)),
             pd.DataFrame(np.random.randn(10, 5), index=list("abcdefghij")),
             pd.DataFrame(
                 np.random.randn(10, 5), index=pd.date_range("2011-01-01", freq="D", periods=10)
@@ -51,6 +57,7 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         ]:
             kdf = ks.from_pandas(pdf)
             self.assert_eq(kdf.index, pdf.index)
+            self.assert_eq(type(kdf.index).__name__, type(pdf.index).__name__)
 
     def test_index_getattr(self):
         kidx = self.kdf.index

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -67,9 +67,11 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         kidx = self.kdf.index
         item = "databricks"
 
-        expected_error_message = "'Index' object has no attribute '{}'".format(item)
+        expected_error_message = "'.*Index' object has no attribute '{}'".format(item)
         with self.assertRaisesRegex(AttributeError, expected_error_message):
             kidx.__getattr__(item)
+        with self.assertRaisesRegex(AttributeError, expected_error_message):
+            ks.from_pandas(pd.date_range("2011-01-01", freq="D", periods=10)).__getattr__(item)
 
     def test_multi_index_getattr(self):
         arrays = [[1, 1, 2, 2], ["red", "blue", "red", "blue"]]

--- a/databricks/koalas/usage_logging/__init__.py
+++ b/databricks/koalas/usage_logging/__init__.py
@@ -29,7 +29,10 @@ from databricks.koalas.accessors import KoalasFrameMethods
 from databricks.koalas.frame import DataFrame
 from databricks.koalas.datetimes import DatetimeMethods
 from databricks.koalas.groupby import DataFrameGroupBy, SeriesGroupBy
-from databricks.koalas.indexes import Index, MultiIndex
+from databricks.koalas.indexes.base import Index
+from databricks.koalas.indexes.datetimes import DatetimeIndex
+from databricks.koalas.indexes.multi import MultiIndex
+from databricks.koalas.indexes.numeric import Float64Index, Int64Index
 from databricks.koalas.missing.frame import _MissingPandasLikeDataFrame
 from databricks.koalas.missing.groupby import (
     MissingPandasLikeDataFrameGroupBy,
@@ -78,6 +81,9 @@ def attach(logger_module: Union[str, ModuleType]) -> None:
         Series,
         Index,
         MultiIndex,
+        Int64Index,
+        Float64Index,
+        DatetimeIndex,
         DataFrameGroupBy,
         SeriesGroupBy,
         DatetimeMethods,

--- a/databricks/koalas/usage_logging/__init__.py
+++ b/databricks/koalas/usage_logging/__init__.py
@@ -38,7 +38,11 @@ from databricks.koalas.missing.groupby import (
     MissingPandasLikeDataFrameGroupBy,
     MissingPandasLikeSeriesGroupBy,
 )
-from databricks.koalas.missing.indexes import MissingPandasLikeIndex, MissingPandasLikeMultiIndex
+from databricks.koalas.missing.indexes import (
+    MissingPandasLikeDatetimeIndex,
+    MissingPandasLikeIndex,
+    MissingPandasLikeMultiIndex,
+)
 from databricks.koalas.missing.series import MissingPandasLikeSeries
 from databricks.koalas.missing.window import (
     MissingPandasLikeExpanding,
@@ -149,6 +153,7 @@ def attach(logger_module: Union[str, ModuleType]) -> None:
         (pd.Series, MissingPandasLikeSeries),
         (pd.Index, MissingPandasLikeIndex),
         (pd.MultiIndex, MissingPandasLikeMultiIndex),
+        (pd.DatetimeIndex, MissingPandasLikeDatetimeIndex),
         (pd.core.groupby.DataFrameGroupBy, MissingPandasLikeDataFrameGroupBy),
         (pd.core.groupby.SeriesGroupBy, MissingPandasLikeSeriesGroupBy),
         (pd.core.window.Expanding, MissingPandasLikeExpanding),

--- a/docs/source/reference/indexing.rst
+++ b/docs/source/reference/indexing.rst
@@ -153,6 +153,16 @@ Selecting
    Index.asof
    Index.isin
 
+.. _api.numeric:
+
+Numeric Index
+-------------
+.. autosummary::
+   :toctree: api/
+
+   Int64Index
+   Float64Index
+
 .. _api.multiindex:
 
 MultiIndex
@@ -274,3 +284,12 @@ MultiIndex Sorting
    :toctree: api/
 
    MultiIndex.sort_values
+
+.. _api.datetimes:
+
+DatatimeIndex
+-------------
+.. autosummary::
+   :toctree: api/
+
+   DatetimeIndex

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
     packages=[
         'databricks',
         'databricks.koalas',
+        'databricks.koalas.indexes',
         'databricks.koalas.missing',
         'databricks.koalas.plot',
         'databricks.koalas.spark',


### PR DESCRIPTION
Adds `Int64Index`, `Float64Index`, and `DatetimeIndex` as a placeholder.
We should still add specific attributes and methods in the following PRs.

Before:

```py
>>> kdf = ks.DataFrame([1,2,3])
>>> type(kdf.index)
<class 'databricks.koalas.indexes.Index'>
```

After:

```py
>>> type(kdf.index)
<class 'databricks.koalas.indexes.numeric.Int64Index'>
```