### PR TITLE
Support NumPy 1.20.0

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -4773,8 +4773,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
     @staticmethod
     def from_records(
-        data: Union[np.array, List[tuple], dict, pd.DataFrame],
-        index: Union[str, list, np.array] = None,
+        data: Union[np.ndarray, List[tuple], dict, pd.DataFrame],
+        index: Union[str, list, np.ndarray] = None,
         exclude: list = None,
         columns: list = None,
         coerce_float: bool = False,

--- a/databricks/koalas/indexing.py
+++ b/databricks/koalas/indexing.py
@@ -1449,14 +1449,14 @@ class iLocIndexer(LocIndexerLike):
     ) -> Tuple[Optional[spark.Column], Optional[int], Optional[int]]:
         sdf = self._internal.spark_frame
 
-        if any(isinstance(key, (int, np.int, np.int64, np.int32)) and key < 0 for key in rows_sel):
+        if any(isinstance(key, (int, np.int64, np.int32)) and key < 0 for key in rows_sel):
             offset = sdf.count()
         else:
             offset = 0
 
         new_rows_sel = []
         for key in list(rows_sel):
-            if not isinstance(key, (int, np.int, np.int64, np.int32)):
+            if not isinstance(key, (int, np.int64, np.int32)):
                 raise TypeError(
                     "cannot do positional indexing with these indexers [{}] of {}".format(
                         key, type(key)

--- a/databricks/koalas/internal.py
+++ b/databricks/koalas/internal.py
@@ -824,7 +824,7 @@ class InternalFrame(object):
             for field in sdf.schema:
                 if field.nullable and pdf[field.name].isnull().all():
                     if isinstance(field.dataType, BooleanType):
-                        pdf[field.name] = pdf[field.name].astype(np.object)
+                        pdf[field.name] = pdf[field.name].astype(object)
                     elif isinstance(field.dataType, IntegralType):
                         pdf[field.name] = pdf[field.name].astype(np.float64)
                     else:

--- a/databricks/koalas/ml.py
+++ b/databricks/koalas/ml.py
@@ -76,7 +76,7 @@ def to_numeric_df(kdf: "ks.DataFrame") -> Tuple[pyspark.sql.DataFrame, List[Tupl
     """
     # TODO, it should be more robust.
     accepted_types = {
-        np.dtype(dt)
+        np.dtype(dt)  # type: ignore
         for dt in [np.int8, np.int16, np.int32, np.int64, np.float32, np.float64, np.bool_]
     }
     numeric_column_labels = [

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -979,8 +979,10 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
                     current = current.when(self.spark.column == F.lit(to_replace), value)
 
             if hasattr(arg, "__missing__"):
-                tmp_val = arg[np._NoValue]
-                del arg[np._NoValue]  # Remove in case it's set in defaultdict.
+                # Seems like mypy bug since it says `Module has no attribute "_NoValue" in mypy.
+                _NoValue = np._NoValue  # type: ignore
+                tmp_val = arg[_NoValue]
+                del arg[_NoValue]  # Remove in case it's set in defaultdict.
                 current = current.otherwise(F.lit(tmp_val))
             else:
                 current = current.otherwise(F.lit(None).cast(self.spark.data_type))

--- a/databricks/koalas/tests/test_typedef.py
+++ b/databricks/koalas/tests/test_typedef.py
@@ -55,18 +55,18 @@ class TypeHintTests(unittest.TestCase):
 
         self.assertEqual(infer_return_type(func).tpe, LongType())
 
-        def func() -> pd.Series[np.float]:
+        def func() -> pd.Series[float]:
             pass
 
         self.assertEqual(infer_return_type(func).tpe, DoubleType())
 
-        def func() -> "pd.DataFrame[np.float, str]":
+        def func() -> "pd.DataFrame[float, str]":
             pass
 
         expected = StructType([StructField("c0", DoubleType()), StructField("c1", StringType())])
         self.assertEqual(infer_return_type(func).tpe, expected)
 
-        def func() -> "pandas.DataFrame[np.float]":
+        def func() -> "pandas.DataFrame[float]":
             pass
 
         expected = StructType([StructField("c0", DoubleType())])
@@ -77,13 +77,13 @@ class TypeHintTests(unittest.TestCase):
 
         self.assertEqual(infer_return_type(func).tpe, LongType())
 
-        def func() -> pd.DataFrame[np.float, str]:
+        def func() -> pd.DataFrame[float, str]:
             pass
 
         expected = StructType([StructField("c0", DoubleType()), StructField("c1", StringType())])
         self.assertEqual(infer_return_type(func).tpe, expected)
 
-        def func() -> pd.DataFrame[np.float]:
+        def func() -> pd.DataFrame[float]:
             pass
 
         expected = StructType([StructField("c0", DoubleType())])

--- a/databricks/koalas/typedef/typehints.py
+++ b/databricks/koalas/typedef/typehints.py
@@ -110,7 +110,7 @@ def as_spark_type(tpe) -> types.DataType:
     elif tpe in (bytes, np.character, np.bytes_, np.string_):
         return types.BinaryType()
     # BooleanType
-    elif tpe in (bool, np.bool, "bool", "?"):
+    elif tpe in (bool, "bool", "?"):
         return types.BooleanType()
     # DateType
     elif tpe in (datetime.date,):
@@ -121,13 +121,13 @@ def as_spark_type(tpe) -> types.DataType:
     elif tpe in (decimal.Decimal,):
         # TODO: considering about the precision & scale for decimal type.
         return types.DecimalType(38, 18)
-    elif tpe in (float, np.float, np.float64, "float", "float64", "double"):
+    elif tpe in (float, np.float64, "float", "float64", "double"):
         return types.DoubleType()
     elif tpe in (np.float32, "float32", "f"):
         return types.FloatType()
     elif tpe in (np.int32, "int32", "i"):
         return types.IntegerType()
-    elif tpe in (int, np.int, np.int64, "int", "int64", "long"):
+    elif tpe in (int, np.int64, "int", "int64", "long"):
         return types.LongType()
     elif tpe in (np.int16, "int16", "short"):
         return types.ShortType()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@
 pandas>=0.23.2,<1.2.0
 pyarrow>=0.10
 matplotlib>=3.0.0,<3.3.0
-numpy>=1.14,<1.20.0
+numpy>=1.14
 
 # Optional dependencies in Koalas.
 mlflow>=1.0

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
     install_requires=[
         'pandas>=0.23.2,<1.2.0',
         'pyarrow>=0.10',
-        'numpy>=1.14,<1.20.0',
+        'numpy>=1.14',
         'matplotlib>=3.0.0,<3.3.0',
     ],
     author="Databricks",


### PR DESCRIPTION
The several `mypy` tests are failing on Python >= 3.7 in CI since [NumPy has been upgraded to 1.20.0.](https://github.com/numpy/numpy/releases)

Since NumPy dropped Python 3.6 from NumPy 1.20.0, only the tests run on Python >= 3.7 are affected.