### PR TITLE
Set upperbounds numpy to fix CI failure

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@
 pandas>=0.23.2,<1.2.0
 pyarrow>=0.10
 matplotlib>=3.0.0,<3.3.0
-numpy>=1.14
+numpy>=1.14,<1.20.0
 
 # Optional dependencies in Koalas.
 mlflow>=1.0

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
     install_requires=[
         'pandas>=0.23.2,<1.2.0',
         'pyarrow>=0.10',
-        'numpy>=1.14',
+        'numpy>=1.14,<1.20.0',
         'matplotlib>=3.0.0,<3.3.0',
     ],
     author="Databricks",


### PR DESCRIPTION
This PR is for quickly fix the `mypy` test failure to unblock other PRs caused by NumPy 1.20.0 release.

This upper bound should be removed again when finishing & merging #2026 