### PR TITLE
Implement (DataFrame|Series).plot.kde with Plotly

### DIFF
--- a/databricks/koalas/plot/core.py
+++ b/databricks/koalas/plot/core.py
@@ -99,7 +99,7 @@ class SampledPlotBase:
 class HistogramPlotBase:
     @staticmethod
     def prepare_hist_data(data, bins):
-        # TODO: this logic is same with KdePlot. Might have to deduplicate it.
+        # TODO: this logic is similar with KdePlotBase. Might have to deduplicate it.
         from databricks.koalas.series import Series
 
         if isinstance(data, Series):
@@ -341,7 +341,7 @@ class BoxPlotBase:
 class KdePlotBase:
     @staticmethod
     def prepare_kde_data(data):
-        # TODO: this logic is same with KdePlot. Might have to deduplicate it.
+        # TODO: this logic is similar with HistogramPlotBase. Might have to deduplicate it.
         from databricks.koalas.series import Series
 
         if isinstance(data, Series):

--- a/databricks/koalas/plot/matplotlib.py
+++ b/databricks/koalas/plot/matplotlib.py
@@ -464,23 +464,7 @@ class KoalasScatterPlot(PandasScatterPlot, TopNPlotBase):
 
 class KoalasKdePlot(PandasKdePlot, KdePlotBase):
     def _compute_plot_data(self):
-        from databricks.koalas.series import Series
-
-        data = self.data
-        if isinstance(data, Series):
-            data = data.to_frame()
-
-        numeric_data = data.select_dtypes(
-            include=["byte", "decimal", "integer", "float", "long", "double", np.datetime64]
-        )
-
-        # no empty frames or series allowed
-        if len(numeric_data.columns) == 0:
-            raise TypeError(
-                "Empty {0!r}: no numeric data to " "plot".format(numeric_data.__class__.__name__)
-            )
-
-        self.data = numeric_data
+        self.data = KdePlotBase.prepare_kde_data(self.data)
 
     def _make_plot(self):
         # 'num_colors' requires to calculate `shape` which has to count all.

--- a/databricks/koalas/tests/plot/test_frame_plot_plotly.py
+++ b/databricks/koalas/tests/plot/test_frame_plot_plotly.py
@@ -224,3 +224,31 @@ class DataFramePlotPlotlyTest(ReusedSQLTestCase, TestUtils):
         columns = pd.MultiIndex.from_tuples([("x", "y"), ("y", "z")])
         kdf1.columns = columns
         check_hist_plot(kdf1)
+
+    def test_kde_plot(self):
+        kdf = ks.DataFrame({"a": [1, 2, 3, 4, 5], "b": [1, 3, 5, 7, 9], "c": [2, 4, 6, 8, 10]})
+
+        pdf = pd.DataFrame(
+            {
+                "Density": [
+                    0.03515491,
+                    0.06834979,
+                    0.00663503,
+                    0.02372059,
+                    0.06834979,
+                    0.01806934,
+                    0.01806934,
+                    0.06834979,
+                    0.02372059,
+                ],
+                "names": ["a", "a", "a", "b", "b", "b", "c", "c", "c"],
+                "index": [-3.5, 5.5, 14.5, -3.5, 5.5, 14.5, -3.5, 5.5, 14.5],
+            }
+        )
+
+        actual = kdf.plot.kde(bw_method=5, ind=3)
+
+        expected = express.line(pdf, x="index", y="Density", color="names")
+        expected["layout"]["xaxis"]["title"] = None
+
+        self.assertEqual(pprint.pformat(actual.to_dict()), pprint.pformat(expected.to_dict()))

--- a/databricks/koalas/tests/plot/test_series_plot_plotly.py
+++ b/databricks/koalas/tests/plot/test_series_plot_plotly.py
@@ -206,3 +206,20 @@ class SeriesPlotPlotlyTest(ReusedSQLTestCase, TestUtils):
         with self.assertRaisesRegex(ValueError, "does not support"):
             self.kdf1.a.plot.box(notched=True)
         self.kdf1.a.plot.box(hovertext="abc")  # other arguments should not throw an exception
+
+    def test_kde_plot(self):
+        kdf = ks.DataFrame({"a": [1, 2, 3, 4, 5]})
+        pdf = pd.DataFrame(
+            {
+                "Density": [0.05709372, 0.07670272, 0.05709372],
+                "names": ["a", "a", "a"],
+                "index": [-1.0, 3.0, 7.0],
+            }
+        )
+
+        actual = kdf.a.plot.kde(bw_method=5, ind=3)
+
+        expected = express.line(pdf, x="index", y="Density")
+        expected["layout"]["xaxis"]["title"] = None
+
+        self.assertEqual(pprint.pformat(actual.to_dict()), pprint.pformat(expected.to_dict()))


### PR DESCRIPTION
This PR implements (DataFrame|Series).plot.kde with Plotly:

Can be tested here:

http://mybinder.org/v2/gh/hyukjinkwon/koalas/plotly-kde?filepath=docs%2Fsource%2Fgetting_started%2F10min.ipynb

**matplotlib**:

```python
import databricks.koalas as ks
ks.options.plotting.backend = "matplotlib"
kdf = ks.DataFrame({
    'a': [1, 2, 2.5, 3, 3.5, 4, 5],
    'b': [1, 2, 3, 4, 5, 6, 7],
    'c': [0.5, 1, 1.5, 2, 2.5, 3, 3.5]})
kdf.plot.kde(bw_method=3).figure.savefig("fig1_mat.png")
kdf.a.plot.kde(bw_method=3).figure.savefig("fig2_mat.png")
```

![fig1_mat](https://user-images.githubusercontent.com/6477701/106457742-beaf4780-64d2-11eb-9f61-7c96de1a6edf.png)
![fig2_mat](https://user-images.githubusercontent.com/6477701/106457746-bfe07480-64d2-11eb-951b-bd51fe58ce0f.png)

**plotly**

```python
import databricks.koalas as ks
ks.options.plotting.backend = "plotly"
kdf = ks.DataFrame({
    'a': [1, 2, 2.5, 3, 3.5, 4, 5],
    'b': [1, 2, 3, 4, 5, 6, 7],
    'c': [0.5, 1, 1.5, 2, 2.5, 3, 3.5]})
kdf.plot.kde(bw_method=3).write_image("fig1.png")
kdf.a.plot.kde(bw_method=3).write_image("fig2.png")
```

![fig1](https://user-images.githubusercontent.com/6477701/106457713-b6570c80-64d2-11eb-9eaf-afffa16a923a.png)
![fig2](https://user-images.githubusercontent.com/6477701/106457720-b6efa300-64d2-11eb-8874-1b275ba3b153.png)
