### PR TITLE
Switch the default plotly backend from matplotlib to plotly

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -20,7 +20,7 @@ jobs:
             spark-version: 2.3.4
             pandas-version: 0.23.4
             pyarrow-version: 0.16.0
-          - python-version: 3.5
+          - python-version: 3.6
             spark-version: 2.3.4
             pandas-version: 0.24.2
             pyarrow-version: 0.10.0
@@ -61,6 +61,8 @@ jobs:
         # as Black only works with Python 3.6+. This is hacky but we will drop
         # Python 3.5 soon so it's fine.
         if [[ "$PYTHON_VERSION" < "3.6" ]]; then sed -i '/black/d' requirements-dev.txt; fi
+        # sphinx-plotly-directive supports Python 3.6+
+        if [[ "$PYTHON_VERSION" < "3.6" ]]; then sed -i '/sphinx-plotly-directive/d' requirements-dev.txt; fi
         pip install -r requirements-dev.txt
         pip install pandas==$PANDAS_VERSION pyarrow==$PYARROW_VERSION pyspark==$SPARK_VERSION
         # matplotlib dropped Python 3.5 support from 3.1.x; however, 3.0.3 only supports sphinx 2.x.
@@ -149,6 +151,8 @@ jobs:
         fi
         conda install -c conda-forge --yes pandas==$PANDAS_VERSION pyarrow==$PYARROW_VERSION
         sed -i -e "/pandas/d" -e "/pyarrow/d" requirements-dev.txt
+        # sphinx-plotly-directive is not available on Conda.
+        sed -i '/sphinx-plotly-directive/d' requirements-dev.txt
         conda install -c conda-forge --yes --file requirements-dev.txt
         conda list
     - name: Run tests

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -154,6 +154,7 @@ jobs:
         # sphinx-plotly-directive is not available on Conda.
         sed -i '/sphinx-plotly-directive/d' requirements-dev.txt
         conda install -c conda-forge --yes --file requirements-dev.txt
+        pip install sphinx-plotly-directive  # pip-only dependency
         conda list
     - name: Run tests
       run: |

--- a/databricks/conftest.py
+++ b/databricks/conftest.py
@@ -25,7 +25,6 @@ from distutils.version import LooseVersion
 
 import pandas as pd
 import pyarrow as pa
-import matplotlib.pyplot as plt
 from pyspark import __version__
 
 from databricks import koalas as ks
@@ -100,12 +99,6 @@ def add_db(doctest_namespace):
 def add_caplog(caplog):
     with caplog.at_level(logging.INFO, logger="databricks.koalas.usage_logger"):
         yield
-
-
-@pytest.fixture(autouse=True)
-def close_figs():
-    yield
-    plt.close("all")
 
 
 @pytest.fixture(autouse=True)

--- a/databricks/koalas/config.py
+++ b/databricks/koalas/config.py
@@ -223,11 +223,11 @@ _options = [
     Option(
         key="plotting.backend",
         doc=(
-            "Backend to use for plotting. Default is matplotlib. "
+            "Backend to use for plotting. Default is plotly. "
             "Supports any package that has a top-level `.plot` method. "
             "Known options are: [matplotlib, plotly]."
         ),
-        default="matplotlib",
+        default="plotly",
         types=str,
     ),
 ]  # type: List[Option]

--- a/databricks/koalas/plot/core.py
+++ b/databricks/koalas/plot/core.py
@@ -403,7 +403,7 @@ class KoalasPlotAccessor(PandasObject):
     Series/Frames plotting accessor and method.
 
     Uses the backend specified by the
-    option ``plotting.backend``. By default, matplotlib is used.
+    option ``plotting.backend``. By default, plotly is used.
 
     Plotting methods can also be accessed by calling the accessor as a method
     with the ``kind`` argument:
@@ -457,7 +457,7 @@ class KoalasPlotAccessor(PandasObject):
             return KoalasPlotAccessor._backends[backend]
 
         if backend == "matplotlib":
-            # Because matplotlib is an optional dependency and first-party backend,
+            # Because matplotlib is an optional dependency,
             # we need to attempt an import here to raise an ImportError if needed.
             try:
                 # test if matplotlib can be imported
@@ -527,14 +527,14 @@ class KoalasPlotAccessor(PandasObject):
 
         Returns
         -------
-        axes : :class:`matplotlib.axes.Axes` or :class:`numpy.ndarray`
-            Return an ndarray when ``subplots=True``.
-            Return an custom object when ``backend!=matplotlib``.
-
+        :class:`plotly.graph_objs.Figure`
+            Return an custom object when ``backend!=plotly``.
+            Return an ndarray when ``subplots=True`` (matplotlib-only).
 
         See Also
         --------
-        matplotlib.pyplot.plot : Plot y versus x as lines and/or markers.
+        plotly.express.line : Plot y versus x as lines and/or markers (plotly).
+        matplotlib.pyplot.plot : Plot y versus x as lines and/or markers (matplotlib).
 
         Examples
         --------
@@ -542,16 +542,14 @@ class KoalasPlotAccessor(PandasObject):
 
         For Series:
 
-        .. plot::
-            :context: close-figs
+        .. plotly::
 
             >>> s = ks.Series([1, 3, 2])
-            >>> ax = s.plot.line()
+            >>> s.plot.line()  # doctest: +SKIP
 
         For DataFrame:
 
-        .. plot::
-            :context: close-figs
+        .. plotly::
 
             The following example shows the populations for some animals
             over the years.
@@ -559,24 +557,17 @@ class KoalasPlotAccessor(PandasObject):
             >>> df = ks.DataFrame({'pig': [20, 18, 489, 675, 1776],
             ...                    'horse': [4, 25, 281, 600, 1900]},
             ...                   index=[1990, 1997, 2003, 2009, 2014])
-            >>> lines = df.plot.line()
+            >>> df.plot.line()  # doctest: +SKIP
 
-        .. plot::
-            :context: close-figs
-
-            An example with subplots, so an array of axes is returned.
-
-            >>> axes = df.plot.line(subplots=True)
-            >>> type(axes)
-            <class 'numpy.ndarray'>
-
-        .. plot::
-            :context: close-figs
+        .. plotly::
 
             The following example shows the relationship between both
             populations.
 
-            >>> lines = df.plot.line(x='pig', y='horse')
+            >>> df = ks.DataFrame({'pig': [20, 18, 489, 675, 1776],
+            ...                    'horse': [4, 25, 281, 600, 1900]},
+            ...                   index=[1990, 1997, 2003, 2009, 2014])
+            >>> df.plot.line(x='pig', y='horse')  # doctest: +SKIP
         """
         return self(kind="line", x=x, y=y, **kwargs)
 
@@ -598,10 +589,9 @@ class KoalasPlotAccessor(PandasObject):
 
         Returns
         -------
-        axes : :class:`matplotlib.axes.Axes` or :class:`numpy.ndarray`
-            Return an ndarray when ``subplots=True``.
-            Return an custom object when ``backend!=matplotlib``.
-
+        :class:`plotly.graph_objs.Figure`
+            Return an custom object when ``backend!=plotly``.
+            Return an ndarray when ``subplots=True`` (matplotlib-only).
 
         Examples
         --------
@@ -609,58 +599,17 @@ class KoalasPlotAccessor(PandasObject):
 
         For Series:
 
-        .. plot::
-            :context: close-figs
+        .. plotly::
 
             >>> s = ks.Series([1, 3, 2])
-            >>> ax = s.plot.bar()
+            >>> s.plot.bar()  # doctest: +SKIP
 
         For DataFrame:
 
-        .. plot::
-            :context: close-figs
+        .. plotly::
 
             >>> df = ks.DataFrame({'lab': ['A', 'B', 'C'], 'val': [10, 30, 20]})
-            >>> ax = df.plot.bar(x='lab', y='val', rot=0)
-
-        Plot a whole dataframe to a bar plot. Each column is assigned a
-        distinct color, and each row is nested in a group along the
-        horizontal axis.
-
-        .. plot::
-            :context: close-figs
-
-            >>> speed = [0.1, 17.5, 40, 48, 52, 69, 88]
-            >>> lifespan = [2, 8, 70, 1.5, 25, 12, 28]
-            >>> index = ['snail', 'pig', 'elephant',
-            ...          'rabbit', 'giraffe', 'coyote', 'horse']
-            >>> df = ks.DataFrame({'speed': speed,
-            ...                    'lifespan': lifespan}, index=index)
-            >>> ax = df.plot.bar(rot=0)
-
-        Instead of nesting, the figure can be split by column with
-        ``subplots=True``. In this case, a :class:`numpy.ndarray` of
-        :class:`matplotlib.axes.Axes` are returned.
-
-        .. plot::
-            :context: close-figs
-
-            >>> axes = df.plot.bar(rot=0, subplots=True)
-            >>> axes[1].legend(loc=2)  # doctest: +SKIP
-
-        Plot a single column.
-
-        .. plot::
-            :context: close-figs
-
-            >>> ax = df.plot.bar(y='speed', rot=0)
-
-        Plot only selected categories for the DataFrame.
-
-        .. plot::
-            :context: close-figs
-
-            >>> ax = df.plot.bar(x='lifespan', rot=0)
+            >>> df.plot.bar(x='lab', y='val')  # doctest: +SKIP
         """
         from databricks.koalas import DataFrame, Series
 
@@ -691,34 +640,34 @@ class KoalasPlotAccessor(PandasObject):
 
         Returns
         -------
-        :class:`matplotlib.axes.Axes` or numpy.ndarray of them
+        :class:`plotly.graph_objs.Figure`
+            Return an custom object when ``backend!=plotly``.
+            Return an ndarray when ``subplots=True`` (matplotlib-only).
 
         See Also
         --------
+        plotly.express.bar : Plot a vertical bar plot using plotly.
         matplotlib.axes.Axes.bar : Plot a vertical bar plot using matplotlib.
 
         Examples
         --------
         For Series:
 
-        .. plot::
-            :context: close-figs
+        .. plotly::
 
             >>> df = ks.DataFrame({'lab': ['A', 'B', 'C'], 'val': [10, 30, 20]})
-            >>> plot = df.val.plot.barh()
+            >>> df.val.plot.barh()  # doctest: +SKIP
 
         For DataFrame:
 
-        .. plot::
-            :context: close-figs
+        .. plotly::
 
             >>> df = ks.DataFrame({'lab': ['A', 'B', 'C'], 'val': [10, 30, 20]})
-            >>> ax = df.plot.barh(x='lab', y='val')
+            >>> df.plot.barh(x='lab', y='val')  # doctest: +SKIP
 
         Plot a whole DataFrame to a horizontal bar plot
 
-        .. plot::
-            :context: close-figs
+        .. plotly::
 
             >>> speed = [0.1, 17.5, 40, 48, 52, 69, 88]
             >>> lifespan = [2, 8, 70, 1.5, 25, 12, 28]
@@ -726,12 +675,11 @@ class KoalasPlotAccessor(PandasObject):
             ...          'rabbit', 'giraffe', 'coyote', 'horse']
             >>> df = ks.DataFrame({'speed': speed,
             ...                    'lifespan': lifespan}, index=index)
-            >>> ax = df.plot.barh()
+            >>> df.plot.barh()  # doctest: +SKIP
 
         Plot a column of the DataFrame to a horizontal bar plot
 
-        .. plot::
-            :context: close-figs
+        .. plotly::
 
             >>> speed = [0.1, 17.5, 40, 48, 52, 69, 88]
             >>> lifespan = [2, 8, 70, 1.5, 25, 12, 28]
@@ -739,12 +687,11 @@ class KoalasPlotAccessor(PandasObject):
             ...          'rabbit', 'giraffe', 'coyote', 'horse']
             >>> df = ks.DataFrame({'speed': speed,
             ...                    'lifespan': lifespan}, index=index)
-            >>> ax = df.plot.barh(y='speed')
+            >>> df.plot.barh(y='speed')  # doctest: +SKIP
 
         Plot DataFrame versus the desired column
 
-        .. plot::
-            :context: close-figs
+        .. plotly::
 
             >>> speed = [0.1, 17.5, 40, 48, 52, 69, 88]
             >>> lifespan = [2, 8, 70, 1.5, 25, 12, 28]
@@ -752,7 +699,7 @@ class KoalasPlotAccessor(PandasObject):
             ...          'rabbit', 'giraffe', 'coyote', 'horse']
             >>> df = ks.DataFrame({'speed': speed,
             ...                    'lifespan': lifespan}, index=index)
-            >>> ax = df.plot.barh(x='lifespan')
+            >>> df.plot.barh(x='lifespan')  # doctest: +SKIP
         """
         from databricks.koalas import DataFrame, Series
 
@@ -778,9 +725,9 @@ class KoalasPlotAccessor(PandasObject):
 
         Returns
         -------
-        axes : :class:`matplotlib.axes.Axes` or :class:`numpy.ndarray`
-            Return an ndarray when ``subplots=True``.
-            Return an custom object when ``backend!=matplotlib``.
+        :class:`plotly.graph_objs.Figure`
+            Return an custom object when ``backend!=plotly``.
+            Return an ndarray when ``subplots=True`` (matplotlib-only).
 
         Notes
         -----
@@ -789,7 +736,7 @@ class KoalasPlotAccessor(PandasObject):
         * Koalas computes approximate statistics - expect differences between
           pandas and Koalas boxplots, especially regarding 1st and 3rd quartiles.
         * The `whis` argument is only supported as a single number.
-        * Koalas doesn't support the following argument(s).
+        * Koalas doesn't support the following argument(s) (matplotlib-only).
 
           * `bootstrap` argument is not supported
           * `autorange` argument is not supported
@@ -801,12 +748,11 @@ class KoalasPlotAccessor(PandasObject):
 
         For Series:
 
-        .. plot::
-            :context: close-figs
+        .. plotly::
 
             >>> data = np.random.randn(25, 4)
             >>> df = ks.DataFrame(data, columns=list('ABCD'))
-            >>> ax = df['A'].plot.box()
+            >>> df['A'].plot.box()  # doctest: +SKIP
 
         This is an unsupported function for DataFrame type
         """
@@ -821,11 +767,10 @@ class KoalasPlotAccessor(PandasObject):
         """
         Draw one histogram of the DataFrame’s columns.
         A `histogram`_ is a representation of the distribution of data.
-        This function calls :meth:`matplotlib.pyplot.hist` or :meth:`plotting.backend.plot`,
+        This function calls :meth:`plotting.backend.plot`,
         on each series in the DataFrame, resulting in one histogram per column.
 
         .. _histogram: https://en.wikipedia.org/wiki/Histogram
-
 
         Parameters
         ----------
@@ -836,15 +781,13 @@ class KoalasPlotAccessor(PandasObject):
             bin. In this case, bins is returned unmodified.
         **kwds
             All other plotting keyword arguments to be passed to
-            :meth:`matplotlib.pyplot.hist`
-            Koalas.Series.plot.
+            plotting backend.
 
         Returns
         -------
-        axes : :class:`matplotlib.axes.Axes` or :class:`numpy.ndarray`
-            Return an ndarray when ``subplots=True``.
-            Return an custom object when ``backend!=matplotlib``.
-
+        :class:`plotly.graph_objs.Figure`
+            Return an custom object when ``backend!=plotly``.
+            Return an ndarray when ``subplots=True`` (matplotlib-only).
 
         Examples
         --------
@@ -852,23 +795,21 @@ class KoalasPlotAccessor(PandasObject):
 
         For Series:
 
-        .. plot::
-            :context: close-figs
+        .. plotly::
 
             >>> s = ks.Series([1, 3, 2])
-            >>> ax = s.plot.hist()
+            >>> s.plot.hist()  # doctest: +SKIP
 
         For DataFrame:
 
-        .. plot::
-            :context: close-figs
+        .. plotly::
 
             >>> df = pd.DataFrame(
             ...     np.random.randint(1, 7, 6000),
             ...     columns=['one'])
             >>> df['two'] = df['one'] + np.random.randint(1, 7, 6000)
             >>> df = ks.from_pandas(df)
-            >>> ax = df.plot.hist(bins=12, alpha=0.5)
+            >>> df.plot.hist(bins=12, alpha=0.5)  # doctest: +SKIP
         """
         return self(kind="hist", bins=bins, **kwds)
 
@@ -891,9 +832,9 @@ class KoalasPlotAccessor(PandasObject):
 
         Returns
         -------
-        axes : :class:`matplotlib.axes.Axes` or :class:`numpy.ndarray`
-            Return an ndarray when ``subplots=True``.
-            Return an custom object when ``backend!=matplotlib``.
+        :class:`plotly.graph_objs.Figure`
+            Return an custom object when ``backend!=plotly``.
+            Return an ndarray when ``subplots=True`` (matplotlib-only).
 
         Examples
         --------
@@ -901,45 +842,49 @@ class KoalasPlotAccessor(PandasObject):
         lead to over-fitting, while using a large bandwidth value may result
         in under-fitting:
 
-        .. plot::
-            :context: close-figs
+        .. plotly::
 
             >>> s = ks.Series([1, 2, 2.5, 3, 3.5, 4, 5])
-            >>> ax = s.plot.kde(bw_method=0.3)
+            >>> s.plot.kde(bw_method=0.3)  # doctest: +SKIP
 
-        .. plot::
-            :context: close-figs
+        .. plotly::
 
-            >>> ax = s.plot.kde(bw_method=3)
+            >>> s = ks.Series([1, 2, 2.5, 3, 3.5, 4, 5])
+            >>> s.plot.kde(bw_method=3)  # doctest: +SKIP
 
         The `ind` parameter determines the evaluation points for the
         plot of the estimated KDF:
 
-        .. plot::
-            :context: close-figs
+        .. plotly::
 
-            >>> ax = s.plot.kde(ind=[1, 2, 3, 4, 5], bw_method=0.3)
+            >>> s = ks.Series([1, 2, 2.5, 3, 3.5, 4, 5])
+            >>> s.plot.kde(ind=[1, 2, 3, 4, 5], bw_method=0.3)  # doctest: +SKIP
 
         For DataFrame, it works in the same way as Series:
 
-        .. plot::
-            :context: close-figs
+        .. plotly::
 
             >>> df = ks.DataFrame({
             ...     'x': [1, 2, 2.5, 3, 3.5, 4, 5],
             ...     'y': [4, 4, 4.5, 5, 5.5, 6, 6],
             ... })
-            >>> ax = df.plot.kde(bw_method=0.3)
+            >>> df.plot.kde(bw_method=0.3)  # doctest: +SKIP
 
-        .. plot::
-            :context: close-figs
+        .. plotly::
 
-            >>> ax = df.plot.kde(bw_method=3)
+            >>> df = ks.DataFrame({
+            ...     'x': [1, 2, 2.5, 3, 3.5, 4, 5],
+            ...     'y': [4, 4, 4.5, 5, 5.5, 6, 6],
+            ... })
+            >>> df.plot.kde(bw_method=3)  # doctest: +SKIP
 
-        .. plot::
-            :context: close-figs
+        .. plotly::
 
-            >>> ax = df.plot.kde(ind=[1, 2, 3, 4, 5, 6], bw_method=0.3)
+            >>> df = ks.DataFrame({
+            ...     'x': [1, 2, 2.5, 3, 3.5, 4, 5],
+            ...     'y': [4, 4, 4.5, 5, 5.5, 6, 6],
+            ... })
+            >>> df.plot.kde(ind=[1, 2, 3, 4, 5, 6], bw_method=0.3)  # doctest: +SKIP
         """
         return self(kind="kde", bw_method=bw_method, ind=ind, **kwargs)
 
@@ -950,7 +895,7 @@ class KoalasPlotAccessor(PandasObject):
         Draw a stacked area plot.
 
         An area plot displays quantitative data visually.
-        This function wraps the matplotlib area function.
+        This function wraps the plotly area function.
 
         Parameters
         ----------
@@ -967,17 +912,16 @@ class KoalasPlotAccessor(PandasObject):
 
         Returns
         -------
-        axes : :class:`matplotlib.axes.Axes` or :class:`numpy.ndarray`
-            Return an ndarray when ``subplots=True``.
-            Return an custom object when ``backend!=matplotlib``.
+        :class:`plotly.graph_objs.Figure`
+            Return an custom object when ``backend!=plotly``.
+            Return an ndarray when ``subplots=True`` (matplotlib-only).
 
         Examples
         --------
 
         For Series
 
-        .. plot::
-            :context: close-figs
+        .. plotly::
 
             >>> df = ks.DataFrame({
             ...     'sales': [3, 2, 3, 9, 10, 6],
@@ -985,12 +929,11 @@ class KoalasPlotAccessor(PandasObject):
             ...     'visits': [20, 42, 28, 62, 81, 50],
             ... }, index=pd.date_range(start='2018/01/01', end='2018/07/01',
             ...                        freq='M'))
-            >>> plot = df.sales.plot.area()
+            >>> df.sales.plot.area()  # doctest: +SKIP
 
         For DataFrame
 
-        .. plot::
-            :context: close-figs
+        .. plotly::
 
             >>> df = ks.DataFrame({
             ...     'sales': [3, 2, 3, 9, 10, 6],
@@ -998,7 +941,7 @@ class KoalasPlotAccessor(PandasObject):
             ...     'visits': [20, 42, 28, 62, 81, 50],
             ... }, index=pd.date_range(start='2018/01/01', end='2018/07/01',
             ...                        freq='M'))
-            >>> plot = df.plot.area()
+            >>> df.plot.area()  # doctest: +SKIP
         """
         from databricks.koalas import DataFrame, Series
 
@@ -1012,10 +955,8 @@ class KoalasPlotAccessor(PandasObject):
         Generate a pie plot.
 
         A pie plot is a proportional representation of the numerical data in a
-        column. This function wraps :meth:`matplotlib.pyplot.pie` for the
-        specified column. If no column reference is passed and
-        ``subplots=True`` a pie plot is drawn for each numerical column
-        independently.
+        column. This function wraps :meth:`plotly.express.pie` for the
+        specified column.
 
         Parameters
         ----------
@@ -1027,29 +968,31 @@ class KoalasPlotAccessor(PandasObject):
 
         Returns
         -------
-        matplotlib.axes.Axes or np.ndarray of them
-            A NumPy array is returned when `subplots` is True.
+        :class:`plotly.graph_objs.Figure`
+            Return an custom object when ``backend!=plotly``.
+            Return an ndarray when ``subplots=True`` (matplotlib-only).
 
         Examples
         --------
 
         For Series:
 
-        .. plot::
-            :context: close-figs
+        .. plotly::
 
             >>> df = ks.DataFrame({'mass': [0.330, 4.87, 5.97],
             ...                    'radius': [2439.7, 6051.8, 6378.1]},
             ...                   index=['Mercury', 'Venus', 'Earth'])
-            >>> plot = df.mass.plot.pie(subplots=True, figsize=(6, 3))
+            >>> df.mass.plot.pie()  # doctest: +SKIP
 
 
         For DataFrame:
 
-        .. plot::
-            :context: close-figs
+        .. plotly::
 
-            >>> plot = df.plot.pie(y='mass', figsize=(5, 5))
+            >>> df = ks.DataFrame({'mass': [0.330, 4.87, 5.97],
+            ...                    'radius': [2439.7, 6051.8, 6378.1]},
+            ...                   index=['Mercury', 'Venus', 'Earth'])
+            >>> df.plot.pie(y='mass')  # doctest: +SKIP
         """
         from databricks.koalas import DataFrame, Series
 
@@ -1096,38 +1039,38 @@ class KoalasPlotAccessor(PandasObject):
 
         Returns
         -------
-        axes : :class:`matplotlib.axes.Axes`
-            Return an custom object when ``backend!=matplotlib``.
+        :class:`plotly.graph_objs.Figure`
+            Return an custom object when ``backend!=plotly``.
+            Return an ndarray when ``subplots=True`` (matplotlib-only).
 
         See Also
         --------
+        plotly.express.scatter : Scatter plot using multiple input data
+            formats (plotly).
         matplotlib.pyplot.scatter : Scatter plot using multiple input data
-            formats.
+            formats (matplotlib).
 
         Examples
         --------
         Let's see how to draw a scatter plot using coordinates from the values
         in a DataFrame's columns.
 
-        .. plot::
-            :context: close-figs
+        .. plotly::
 
             >>> df = ks.DataFrame([[5.1, 3.5, 0], [4.9, 3.0, 0], [7.0, 3.2, 1],
             ...                    [6.4, 3.2, 1], [5.9, 3.0, 2]],
             ...                   columns=['length', 'width', 'species'])
-            >>> ax1 = df.plot.scatter(x='length',
-            ...                       y='width',
-            ...                       c='DarkBlue')
+            >>> df.plot.scatter(x='length', y='width')  # doctest: +SKIP
 
-        And now with the color determined by a column as well.
+        And now with dark scheme:
 
-        .. plot::
-            :context: close-figs
+        .. plotly::
 
-            >>> ax2 = df.plot.scatter(x='length',
-            ...                       y='width',
-            ...                       c='species',
-            ...                       colormap='viridis')
+            >>> df = ks.DataFrame([[5.1, 3.5, 0], [4.9, 3.0, 0], [7.0, 3.2, 1],
+            ...                    [6.4, 3.2, 1], [5.9, 3.0, 2]],
+            ...                   columns=['length', 'width', 'species'])
+            >>> fig = df.plot.scatter(x='length', y='width')
+            >>> fig.update_layout(template="plotly_dark")  # doctest: +SKIP
         """
         return self(kind="scatter", x=x, y=y, **kwds)
 

--- a/databricks/koalas/plot/core.py
+++ b/databricks/koalas/plot/core.py
@@ -610,6 +610,61 @@ class KoalasPlotAccessor(PandasObject):
 
             >>> df = ks.DataFrame({'lab': ['A', 'B', 'C'], 'val': [10, 30, 20]})
             >>> df.plot.bar(x='lab', y='val')  # doctest: +SKIP
+
+        Plot a whole dataframe to a bar plot. Each column is stacked with a
+        distinct color along the horizontal axis.
+
+        .. plotly::
+
+            >>> speed = [0.1, 17.5, 40, 48, 52, 69, 88]
+            >>> lifespan = [2, 8, 70, 1.5, 25, 12, 28]
+            >>> index = ['snail', 'pig', 'elephant',
+            ...          'rabbit', 'giraffe', 'coyote', 'horse']
+            >>> df = ks.DataFrame({'speed': speed,
+            ...                    'lifespan': lifespan}, index=index)
+            >>> df.plot.bar()  # doctest: +SKIP
+
+        Instead of stacking, the figure can be split by column with plotly
+        APIs.
+
+        .. plotly::
+
+            >>> from plotly.subplots import make_subplots
+            >>> speed = [0.1, 17.5, 40, 48, 52, 69, 88]
+            >>> lifespan = [2, 8, 70, 1.5, 25, 12, 28]
+            >>> index = ['snail', 'pig', 'elephant',
+            ...          'rabbit', 'giraffe', 'coyote', 'horse']
+            >>> df = ks.DataFrame({'speed': speed,
+            ...                    'lifespan': lifespan}, index=index)
+            >>> fig = (make_subplots(rows=2, cols=1)
+            ...     .add_trace(df.plot.bar(y='speed').data[0], row=1, col=1)
+            ...     .add_trace(df.plot.bar(y='speed').data[0], row=1, col=1)
+            ...     .add_trace(df.plot.bar(y='lifespan').data[0], row=2, col=1))
+            >>> fig  # doctest: +SKIP
+
+        Plot a single column.
+
+        .. plotly::
+
+            >>> speed = [0.1, 17.5, 40, 48, 52, 69, 88]
+            >>> lifespan = [2, 8, 70, 1.5, 25, 12, 28]
+            >>> index = ['snail', 'pig', 'elephant',
+            ...          'rabbit', 'giraffe', 'coyote', 'horse']
+            >>> df = ks.DataFrame({'speed': speed,
+            ...                    'lifespan': lifespan}, index=index)
+            >>> df.plot.bar(y='speed')  # doctest: +SKIP
+
+        Plot only selected categories for the DataFrame.
+
+        .. plotly::
+
+            >>> speed = [0.1, 17.5, 40, 48, 52, 69, 88]
+            >>> lifespan = [2, 8, 70, 1.5, 25, 12, 28]
+            >>> index = ['snail', 'pig', 'elephant',
+            ...          'rabbit', 'giraffe', 'coyote', 'horse']
+            >>> df = ks.DataFrame({'speed': speed,
+            ...                    'lifespan': lifespan}, index=index)
+            >>> df.plot.bar(x='lifespan')  # doctest: +SKIP
         """
         from databricks.koalas import DataFrame, Series
 

--- a/databricks/koalas/tests/plot/test_frame_plot_matplotlib.py
+++ b/databricks/koalas/tests/plot/test_frame_plot_matplotlib.py
@@ -15,6 +15,7 @@
 #
 
 import base64
+from distutils.version import LooseVersion
 from io import BytesIO
 
 import matplotlib
@@ -36,11 +37,17 @@ class DataFramePlotMatplotlibTest(ReusedSQLTestCase, TestUtils):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        if LooseVersion(pd.__version__) >= LooseVersion("0.25"):
+            pd.set_option("plotting.backend", "matplotlib")
+        set_option("plotting.backend", "matplotlib")
         set_option("plotting.max_rows", 2000)
         set_option("plotting.sample_ratio", None)
 
     @classmethod
     def tearDownClass(cls):
+        if LooseVersion(pd.__version__) >= LooseVersion("0.25"):
+            pd.reset_option("plotting.backend")
+        reset_option("plotting.backend")
         reset_option("plotting.max_rows")
         reset_option("plotting.sample_ratio")
         super().tearDownClass()

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -14,19 +14,13 @@
 # limitations under the License.
 #
 
-import base64
 import unittest
 from collections import defaultdict
 from distutils.version import LooseVersion
 import inspect
-from io import BytesIO
 from itertools import product
 from datetime import datetime, timedelta
 
-import matplotlib
-
-matplotlib.use("agg")
-from matplotlib import pyplot as plt
 import numpy as np
 import pandas as pd
 import pyspark
@@ -1243,28 +1237,6 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         )
         kser = ks.from_pandas(pser)
         self.assert_eq(pser.add_suffix("_item"), kser.add_suffix("_item"))
-
-    def test_hist(self):
-        pdf = pd.DataFrame(
-            {"a": [1, 2, 3, 4, 5, 6, 7, 8, 9, 15, 50],}, index=[0, 1, 3, 5, 6, 8, 9, 9, 9, 10, 10]
-        )
-
-        kdf = ks.from_pandas(pdf)
-
-        def plot_to_base64(ax):
-            bytes_data = BytesIO()
-            ax.figure.savefig(bytes_data, format="png")
-            bytes_data.seek(0)
-            b64_data = base64.b64encode(bytes_data.read())
-            plt.close(ax.figure)
-            return b64_data
-
-        _, ax1 = plt.subplots(1, 1)
-        # Using plot.hist() because pandas changes ticks props when called hist()
-        ax1 = pdf["a"].plot.hist()
-        _, ax2 = plt.subplots(1, 1)
-        ax2 = kdf["a"].hist()
-        self.assert_eq(plot_to_base64(ax1), plot_to_base64(ax2))
 
     def test_cummin(self):
         pser = pd.Series([1.0, None, 0.0, 4.0, 9.0])

--- a/dev/gendoc.py
+++ b/dev/gendoc.py
@@ -215,7 +215,7 @@ def download_pandoc_if_needed(path):
         if not os.path.isfile(filename) or not os.path.isfile("pandoc"):
             def download_pandoc():
                 try:
-                    return pandoc_download.download_pandoc(targetfolder=path, version="latest")
+                    return pandoc_download.download_pandoc(targetfolder=path, version="1.19.1")
                 except Exception as e:
                     if os.path.isfile(filename):
                         os.remove(filename)

--- a/dev/lint-python
+++ b/dev/lint-python
@@ -217,6 +217,14 @@ function sphinx_test {
         return
     fi
 
+    # TODO: Remove this and enable the Sphinx build with Conda in CI
+    PYTHON_HAS_THEME=$("$PYTHON_EXECUTABLE" -c 'import importlib.util; print(importlib.util.find_spec("sphinx_plotly_directive") is not None)')
+    if [[ "$PYTHON_HAS_THEME" == "False" ]]; then
+        echo "$PYTHON_EXECUTABLE does not have sphinx-plotly-directive installed. Skipping Sphinx build for now."
+        echo
+        return
+    fi
+
     echo "starting $SPHINX_BUILD tests..."
     pushd docs &> /dev/null
     make clean &> /dev/null

--- a/dev/lint-python
+++ b/dev/lint-python
@@ -217,7 +217,6 @@ function sphinx_test {
         return
     fi
 
-    # TODO: Remove this and enable the Sphinx build with Conda in CI
     PYTHON_HAS_THEME=$("$PYTHON_EXECUTABLE" -c 'import importlib.util; print(importlib.util.find_spec("sphinx_plotly_directive") is not None)')
     if [[ "$PYTHON_HAS_THEME" == "False" ]]; then
         echo "$PYTHON_EXECUTABLE does not have sphinx-plotly-directive installed. Skipping Sphinx build for now."

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -81,18 +81,17 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.viewcode',
     'numpydoc',  # handle NumPy documentation formatted docstrings. Needs to install
-    'matplotlib.sphinxext.plot_directive',  # For visualize plot result
+    'sphinx_plotly_directive',  # For visualize plot result
     'nbsphinx',  # Converts Jupyter Notebook to reStructuredText files for Sphinx.
     # For ipython directive in reStructuredText files.
     'IPython.sphinxext.ipython_console_highlighting',
 ]
 
-# matplotlib plot directive
-plot_include_source = True
-plot_formats = [("png", 90)]
-plot_html_show_formats = False
-plot_html_show_source_link = False
-plot_pre_code = """import numpy as np
+# plotly plot directive
+plotly_include_source = True
+plotly_html_show_formats = False
+plotly_html_show_source_link = False
+plotly_pre_code = """import numpy as np
 import pandas as pd
 import databricks.koalas as ks"""
 

--- a/docs/source/development/contributing.rst
+++ b/docs/source/development/contributing.rst
@@ -56,7 +56,7 @@ If you are using Conda, the Koalas installation and development environment are 
     conda create --name koalas-dev-env python=3.6
     conda activate koalas-dev-env
     conda install -c conda-forge pyspark=2.4
-    conda install -c conda-forge --yes --file requirements-dev.txt
+    pip install -r requirements-dev.txt
     pip install -e .  # installs koalas from current checkout
 
 Once setup, make sure you switch to `koalas-dev-env` before development:

--- a/docs/source/user_guide/options.rst
+++ b/docs/source/user_guide/options.rst
@@ -268,7 +268,7 @@ plotting.sample_ratio           None           'plotting.sample_ratio' sets the 
                                                that will be plotted for sample-based plots such as
                                                `plot.line` and `plot.area`. This option defaults to
                                                'plotting.max_rows' option.
-plotting.backend                'matplotlib'   Backend to use for plotting. Default is matplotlib.
+plotting.backend                'plotly'       Backend to use for plotting. Default is plotly.
                                                Supports any package that has a top-level `.plot`
                                                method. Some options are: [matplotlib, plotly,
                                                pandas_bokeh, pandas_altair].

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -37,3 +37,7 @@ openpyxl
 # https://stackoverflow.com/questions/65254535/xlrd-biffh-xlrderror-excel-xlsx-file-not-supported
 # We can remove this upperbound when our minimum pandas version is 0.25+.
 xlrd<2.0.0
+
+# PIP only dependency. It's required for documentation build only.
+# It's placed last so all other dependencies can be installed when deverlopers use this file on Conda.
+sphinx-plotly-directive

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -38,6 +38,5 @@ openpyxl
 # We can remove this upperbound when our minimum pandas version is 0.25+.
 xlrd<2.0.0
 
-# PIP only dependency. It's required for documentation build only.
-# It's placed last so all other dependencies can be installed when deverlopers use this file on Conda.
+# PIP only dependency
 sphinx-plotly-directive


### PR DESCRIPTION
This PR proposes to switch the default plotly backend from matplotlib to plotly.

Resolves #1933