### PR TITLE
Preserve index for statistical functions with axis==1.

### DIFF
--- a/databricks/koalas/tests/test_stats.py
+++ b/databricks/koalas/tests/test_stats.py
@@ -163,7 +163,8 @@ class StatsTest(ReusedSQLTestCase, SQLTestUtils):
                     "B": [1.0, -2, 3, -4, 5] * 300,
                     "C": [-6.0, -7, -8, -9, 10] * 300,
                     "D": [True, False, True, False, False] * 300,
-                }
+                },
+                index=range(10, 15001, 10),
             )
             kdf = ks.from_pandas(pdf)
             self.assert_eq(kdf.count(axis=1), pdf.count(axis=1))


### PR DESCRIPTION
Preserves `index` for statistical functions with `axis==1`.

```py
>>> kdf = ks.DataFrame(
...     {
...         "A": [1, -2, 3, -4, 5],
...         "B": [1.0, -2, 3, -4, 5],
...         "C": [-6.0, -7, -8, -9, 10],
...         "D": [True, False, True, False, False],
...     },
...     index=[10, 20, 30, 40, 50]
... )
>>> kdf.count(axis=1)
10    4
20    4
30    4
40    4
50    4
dtype: int64
```

whereas:

```py
>>> ks.set_option("compute.shortcut_limit", 2)
>>> kdf.count(axis=1)
0    4
1    4
2    4
3    4
4    4
dtype: int64
```

After:

```py
>>> ks.set_option("compute.shortcut_limit", 2)
>>> kdf.count(axis=1)
10    4
20    4
30    4
40    4
50    4
dtype: int64
```