### PR TITLE
Use iloc to make sure it retrieves the first element.

### DIFF
--- a/databricks/koalas/typedef/typehints.py
+++ b/databricks/koalas/typedef/typehints.py
@@ -163,8 +163,8 @@ def infer_pd_series_spark_type(s: pd.Series) -> types.DataType:
     if dt == np.dtype("object"):
         if len(s) == 0 or s.isnull().all():
             return types.NullType()
-        elif hasattr(s[0], "__UDT__"):
-            return s[0].__UDT__
+        elif hasattr(s.iloc[0], "__UDT__"):
+            return s.iloc[0].__UDT__
         else:
             return from_arrow_type(pa.Array.from_pandas(s).type)
     else:


### PR DESCRIPTION
Use `iloc` in `infer_pd_series_spark_type` to make sure it retrieves the first element.

Before:

```py
>>> infer_pd_series_spark_type(pd.Series(['a','b','c'], index=[10,20,30]))
Traceback (most recent call last):
...
KeyError: 0
```

After:

```py
>>> infer_pd_series_spark_type(pd.Series(['a','b','c'], index=[10,20,30]))
StringType
```

Note that currently the function in only called from `InternalFrame.from_pandas` which always resets index before calling it.