### PR TITLE
Add basic extension dtypes support.

### DIFF
--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -244,7 +244,6 @@ def column_op(f):
             # Same DataFrame anchors
             args = [arg.spark.column if isinstance(arg, IndexOpsMixin) else arg for arg in args]
             scol = f(self.spark.column, *args)
-            scol = booleanize_null(self.spark.column, scol, f)
 
             spark_type = self._internal.spark_frame.select(scol).schema[0].dataType
             use_extension_dtypes = any(
@@ -253,6 +252,9 @@ def column_op(f):
             dtype = spark_type_to_pandas_dtype(
                 spark_type, use_extension_dtypes=use_extension_dtypes
             )
+
+            if not isinstance(dtype, extension_dtypes):
+                scol = booleanize_null(self.spark.column, scol, f)
 
             if isinstance(self, Series) or not any(isinstance(col, Series) for col in cols):
                 index_ops = self._with_new_scol(scol, dtype=dtype)

--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -50,7 +50,7 @@ from databricks.koalas.internal import (
 )
 from databricks.koalas.spark import functions as SF
 from databricks.koalas.spark.accessors import SparkIndexOpsMethods
-from databricks.koalas.typedef import as_spark_type, spark_type_to_pandas_dtype
+from databricks.koalas.typedef import as_spark_type
 from databricks.koalas.utils import (
     combine_frames,
     same_anchor,
@@ -281,7 +281,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def _with_new_scol(self, scol: spark.Column):
+    def _with_new_scol(self, scol: spark.Column, *, dtype=None):
         pass
 
     @property
@@ -630,7 +630,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
         >>> s.rename("a").to_frame().set_index("a").index.dtype
         dtype('<M8[ns]')
         """
-        return spark_type_to_pandas_dtype(self.spark.data_type)
+        return self._internal.data_dtypes[0]
 
     @property
     def empty(self) -> bool:
@@ -989,7 +989,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
             )
         else:
             scol = self.spark.column.cast(spark_type)
-        return self._with_new_scol(scol)
+        return self._with_new_scol(scol, dtype=dtype)
 
     def isin(self, values) -> Union["Series", "Index"]:
         """

--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -51,7 +51,12 @@ from databricks.koalas.internal import (
 )
 from databricks.koalas.spark import functions as SF
 from databricks.koalas.spark.accessors import SparkIndexOpsMethods
-from databricks.koalas.typedef import as_spark_type, extension_dtypes, spark_type_to_pandas_dtype
+from databricks.koalas.typedef import (
+    Dtype,
+    as_spark_type,
+    extension_dtypes,
+    spark_type_to_pandas_dtype,
+)
 from databricks.koalas.utils import (
     combine_frames,
     same_anchor,
@@ -619,7 +624,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
             raise NotImplementedError("Koalas objects currently do not support %s." % ufunc)
 
     @property
-    def dtype(self) -> np.dtype:
+    def dtype(self) -> Dtype:
         """Return the dtype object of the underlying data.
 
         Examples
@@ -942,7 +947,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
         """
         return 1
 
-    def astype(self, dtype) -> Union["Index", "Series"]:
+    def astype(self, dtype: Union[str, type, Dtype]) -> Union["Index", "Series"]:
         """
         Cast a Koalas object to a specified dtype ``dtype``.
 

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -5504,7 +5504,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             sdf = self._internal.resolved_copy.spark_frame
             if get_option("compute.ordered_head"):
                 sdf = sdf.orderBy(NATURAL_ORDER_COLUMN_NAME)
-            return DataFrame(self._internal.with_new_sdf(sdf.limit(n)))
+            return DataFrame(self._internal.with_new_sdf(sdf.limit(n), preserve_dtypes=True))
 
     def pivot_table(
         self, values=None, index=None, columns=None, aggfunc="mean", fill_value=None

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -795,7 +795,7 @@ class DataFrame(Frame, Generic[T]):
                             .alias(name_like_string(label))
                         )
                         column_labels.append(label)
-                internal = self._internal.with_new_columns(applied, column_labels)
+                internal = self._internal.with_new_columns(applied, column_labels=column_labels)
                 return DataFrame(internal)
         else:
             return self._apply_series_op(lambda kser: getattr(kser, op)(other))
@@ -5958,17 +5958,12 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         else:
             column_label_names = None
 
-        data_columns = [name_like_string(label) for label in column_labels]
-        data_spark_columns = [
-            self._internal.spark_column_for(label).alias(name)
-            for label, name in zip(self._internal.column_labels, data_columns)
+        ksers = [
+            self._kser_for(label).rename(name)
+            for label, name in zip(self._internal.column_labels, column_labels)
         ]
         self._update_internal_frame(
-            self._internal.with_new_columns(
-                data_spark_columns,
-                column_labels=column_labels,
-                column_label_names=column_label_names,
-            )
+            self._internal.with_new_columns(ksers, column_label_names=column_label_names)
         )
 
     @property

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -6429,7 +6429,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         }
         by = [mapper[(asc, na_position)](scol) for scol, asc in zip(by, ascending)]
         sdf = self._internal.resolved_copy.spark_frame.sort(*(by + [NATURAL_ORDER_COLUMN_NAME]))
-        kdf = DataFrame(self._internal.with_new_sdf(sdf))  # type: ks.DataFrame
+        kdf = DataFrame(
+            self._internal.with_new_sdf(sdf, preserve_dtypes=True)
+        )  # type: ks.DataFrame
         if inplace:
             self._update_internal_frame(kdf._internal)
             return None

--- a/databricks/koalas/indexes/base.py
+++ b/databricks/koalas/indexes/base.py
@@ -159,7 +159,7 @@ class Index(IndexOpsMixin):
     def _column_label(self):
         return self._kdf._internal.index_names[0]
 
-    def _with_new_scol(self, scol: spark.Column) -> "Index":
+    def _with_new_scol(self, scol: spark.Column, *, dtype=None) -> "Index":
         """
         Copy Koalas Index with the new Spark Column.
 
@@ -168,8 +168,10 @@ class Index(IndexOpsMixin):
         """
         internal = self._internal.copy(
             index_spark_columns=[scol.alias(SPARK_DEFAULT_INDEX_NAME)],
+            index_dtypes=(None if dtype is None else [dtype]),
             column_labels=[],
             data_spark_columns=[],
+            data_dtypes=[],
         )
         return DataFrame(internal).index
 

--- a/databricks/koalas/indexes/base.py
+++ b/databricks/koalas/indexes/base.py
@@ -168,7 +168,7 @@ class Index(IndexOpsMixin):
         """
         internal = self._internal.copy(
             index_spark_columns=[scol.alias(SPARK_DEFAULT_INDEX_NAME)],
-            index_dtypes=(None if dtype is None else [dtype]),
+            index_dtypes=[dtype],
             column_labels=[],
             data_spark_columns=[],
             data_dtypes=[],

--- a/databricks/koalas/indexes/multi.py
+++ b/databricks/koalas/indexes/multi.py
@@ -100,7 +100,7 @@ class MultiIndex(Index):
     def __abs__(self):
         raise TypeError("TypeError: cannot perform __abs__ with this index type: MultiIndex")
 
-    def _with_new_scol(self, scol: spark.Column):
+    def _with_new_scol(self, scol: spark.Column, *, dtype=None):
         raise NotImplementedError("Not supported for type MultiIndex")
 
     def _align_and_column_op(self, f, *args) -> Index:

--- a/databricks/koalas/indexing.py
+++ b/databricks/koalas/indexing.py
@@ -36,7 +36,7 @@ from databricks.koalas.internal import (
     SPARK_DEFAULT_SERIES_NAME,
 )
 from databricks.koalas.exceptions import SparkPandasIndexingError, SparkPandasNotImplementedError
-from databricks.koalas.typedef import Scalar
+from databricks.koalas.typedef.typehints import Scalar, extension_dtypes, spark_type_to_pandas_dtype
 from databricks.koalas.utils import (
     is_name_like_tuple,
     is_name_like_value,
@@ -272,7 +272,7 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
 
     def _select_cols(
         self, cols_sel: Any, missing_keys: Optional[List[Tuple]] = None
-    ) -> Tuple[List[Tuple], Optional[List[spark.Column]], bool, Optional[Tuple]]:
+    ) -> Tuple[List[Tuple], Optional[List[spark.Column]], Any, bool, Optional[Tuple]]:
         """
         Dispatch the logic for select columns to more specific methods by `cols_sel` argument types.
 
@@ -282,10 +282,11 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
 
         Returns
         -------
-        Tuple of list of column label, list of Spark columns, bool:
+        Tuple of list of column label, list of Spark columns, list of dtypes, bool:
 
             * The column labels selected.
             * The Spark columns selected.
+            * The dtypes selected.
             * The boolean value whether Series should be returned or not.
             * The Series name if needed.
         """
@@ -294,7 +295,8 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
         if cols_sel is None:
             column_labels = self._internal.column_labels
             data_spark_columns = self._internal.data_spark_columns
-            return column_labels, data_spark_columns, False, None
+            data_dtypes = self._internal.data_dtypes
+            return column_labels, data_spark_columns, data_dtypes, False, None
         elif isinstance(cols_sel, Series):
             return self._select_cols_by_series(cols_sel, missing_keys)
         elif isinstance(cols_sel, spark.Column):
@@ -304,7 +306,8 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
                 # If slice is None - select everything, so nothing to do
                 column_labels = self._internal.column_labels
                 data_spark_columns = self._internal.data_spark_columns
-                return column_labels, data_spark_columns, False, None
+                data_dtypes = self._internal.data_dtypes
+                return column_labels, data_spark_columns, data_dtypes, False, None
             return self._select_cols_by_slice(cols_sel, missing_keys)
         elif isinstance(cols_sel, tuple):
             return self._select_cols_else(cols_sel, missing_keys)
@@ -355,35 +358,35 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
     @abstractmethod
     def _select_cols_by_series(
         self, cols_sel: "Series", missing_keys: Optional[List[Tuple]]
-    ) -> Tuple[List[Tuple], Optional[List[spark.Column]], bool, Optional[Tuple]]:
+    ) -> Tuple[List[Tuple], Optional[List[spark.Column]], Any, bool, Optional[Tuple]]:
         """ Select columns by `Series` type key. """
         pass
 
     @abstractmethod
     def _select_cols_by_spark_column(
         self, cols_sel: spark.Column, missing_keys: Optional[List[Tuple]]
-    ) -> Tuple[List[Tuple], Optional[List[spark.Column]], bool, Optional[Tuple]]:
+    ) -> Tuple[List[Tuple], Optional[List[spark.Column]], Any, bool, Optional[Tuple]]:
         """ Select columns by Spark `Column` type key. """
         pass
 
     @abstractmethod
     def _select_cols_by_slice(
         self, cols_sel: slice, missing_keys: Optional[List[Tuple]]
-    ) -> Tuple[List[Tuple], Optional[List[spark.Column]], bool, Optional[Tuple]]:
+    ) -> Tuple[List[Tuple], Optional[List[spark.Column]], Any, bool, Optional[Tuple]]:
         """ Select columns by `slice` type key. """
         pass
 
     @abstractmethod
     def _select_cols_by_iterable(
         self, cols_sel: Iterable, missing_keys: Optional[List[Tuple]]
-    ) -> Tuple[List[Tuple], Optional[List[spark.Column]], bool, Optional[Tuple]]:
+    ) -> Tuple[List[Tuple], Optional[List[spark.Column]], Any, bool, Optional[Tuple]]:
         """ Select columns by `Iterable` type key. """
         pass
 
     @abstractmethod
     def _select_cols_else(
         self, cols_sel: Any, missing_keys: Optional[List[Tuple]]
-    ) -> Tuple[List[Tuple], Optional[List[spark.Column]], bool, Optional[Tuple]]:
+    ) -> Tuple[List[Tuple], Optional[List[spark.Column]], Any, bool, Optional[Tuple]]:
         """ Select columns by other type key. """
         pass
 
@@ -406,6 +409,7 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
             column_label = self._kdf_or_kser._column_label
             column_labels = [column_label]
             data_spark_columns = [self._internal.spark_column_for(column_label)]
+            data_dtypes = [self._internal.dtype_for(column_label)]
             returns_series = True
             series_name = self._kdf_or_kser.name
         else:
@@ -426,9 +430,13 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
                 return type(self)(kdf)[kdf[temp_col], cols_sel][list(self._kdf_or_kser.columns)]
 
             cond, limit, remaining_index = self._select_rows(rows_sel)
-            column_labels, data_spark_columns, returns_series, series_name = self._select_cols(
-                cols_sel
-            )
+            (
+                column_labels,
+                data_spark_columns,
+                data_dtypes,
+                returns_series,
+                series_name,
+            ) = self._select_cols(cols_sel)
 
             if cond is None and limit is None and returns_series:
                 kser = self._kdf_or_kser._kser_for(column_labels[0])
@@ -439,9 +447,11 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
         if remaining_index is not None:
             index_spark_columns = self._internal.index_spark_columns[-remaining_index:]
             index_names = self._internal.index_names[-remaining_index:]
+            index_dtypes = self._internal.index_dtypes[-remaining_index:]
         else:
             index_spark_columns = self._internal.index_spark_columns
             index_names = self._internal.index_names
+            index_dtypes = self._internal.index_dtypes
 
         if len(column_labels) > 0:
             column_labels = column_labels.copy()
@@ -491,8 +501,10 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
             spark_frame=sdf,
             index_spark_columns=index_spark_columns,
             index_names=index_names,
+            index_dtypes=index_dtypes,
             column_labels=column_labels,
             data_spark_columns=data_spark_columns,
+            data_dtypes=data_dtypes,
             column_label_names=column_label_names,
         )
         kdf = DataFrame(internal)
@@ -649,7 +661,7 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
 
             cond, limit, remaining_index = self._select_rows(rows_sel)
             missing_keys = []
-            _, data_spark_columns, _, _ = self._select_cols(cols_sel, missing_keys=missing_keys)
+            _, data_spark_columns, _, _, _ = self._select_cols(cols_sel, missing_keys=missing_keys)
 
             if cond is None:
                 cond = F.lit(True)
@@ -667,14 +679,22 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
                 value = F.lit(value)
 
             new_data_spark_columns = []
-            for new_scol, spark_column_name in zip(
-                self._internal.data_spark_columns, self._internal.data_spark_column_names
+            new_dtypes = []
+            for new_scol, spark_column_name, new_dtype in zip(
+                self._internal.data_spark_columns,
+                self._internal.data_spark_column_names,
+                self._internal.data_dtypes,
             ):
                 for scol in data_spark_columns:
                     if new_scol._jc.equals(scol._jc):
                         new_scol = F.when(cond, value).otherwise(scol).alias(spark_column_name)
+                        new_dtype = spark_type_to_pandas_dtype(
+                            self._internal.spark_frame.select(new_scol).schema[0].dataType,
+                            use_extension_dtypes=isinstance(new_dtype, extension_dtypes),
+                        )
                         break
                 new_data_spark_columns.append(new_scol)
+                new_dtypes.append(new_dtype)
 
             column_labels = self._internal.column_labels.copy()
             for label in missing_keys:
@@ -692,8 +712,11 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
                     )
                 column_labels.append(label)
                 new_data_spark_columns.append(F.when(cond, value).alias(name_like_string(label)))
+                new_dtypes.append(None)
 
-            internal = self._internal.with_new_columns(new_data_spark_columns, column_labels)
+            internal = self._internal.with_new_columns(
+                new_data_spark_columns, column_labels=column_labels, data_dtypes=new_dtypes
+            )
             self._kdf_or_kser._update_internal_frame(internal, requires_same_anchor=False)
 
 
@@ -1065,7 +1088,7 @@ class LocIndexer(LocIndexerLike):
 
     def _get_from_multiindex_column(
         self, key, missing_keys, labels=None, recursed=0
-    ) -> Tuple[List[Tuple], Optional[List[spark.Column]], bool, Optional[Tuple]]:
+    ) -> Tuple[List[Tuple], Optional[List[spark.Column]], Any, bool, Optional[Tuple]]:
         """ Select columns from multi-index columns. """
         assert isinstance(key, tuple)
         if labels is None:
@@ -1081,7 +1104,7 @@ class LocIndexer(LocIndexerLike):
                     raise KeyError(k)
                 else:
                     missing_keys.append(key)
-                    return [], [], False, None
+                    return [], [], [], False, None
 
         if all(lbl is not None and len(lbl) > 0 and lbl[0] == "" for _, lbl in labels):
             # If the head is '', drill down recursively.
@@ -1095,6 +1118,7 @@ class LocIndexer(LocIndexerLike):
                 label = list(labels)[0]
                 column_labels = [label]
                 data_spark_columns = [self._internal.spark_column_for(label)]
+                data_dtypes = [self._internal.dtype_for(label)]
                 if label is None:
                     series_name = None
                 else:
@@ -1106,47 +1130,52 @@ class LocIndexer(LocIndexerLike):
                     None if lbl is None or lbl == (None,) else lbl for _, lbl in labels
                 ]
                 data_spark_columns = [self._internal.spark_column_for(label) for label, _ in labels]
+                data_dtypes = [self._internal.dtype_for(label) for label, _ in labels]
                 series_name = None
 
-            return column_labels, data_spark_columns, returns_series, series_name
+            return column_labels, data_spark_columns, data_dtypes, returns_series, series_name
 
     def _select_cols_by_series(
         self, cols_sel: "Series", missing_keys: Optional[List[Tuple]]
-    ) -> Tuple[List[Tuple], Optional[List[spark.Column]], bool, Optional[Tuple]]:
+    ) -> Tuple[List[Tuple], Optional[List[spark.Column]], Any, bool, Optional[Tuple]]:
         column_labels = [cols_sel._column_label]
         data_spark_columns = [cols_sel.spark.column]
-        return column_labels, data_spark_columns, True, None
+        data_dtypes = [cols_sel.dtype]
+        return column_labels, data_spark_columns, data_dtypes, True, None
 
     def _select_cols_by_spark_column(
         self, cols_sel: spark.Column, missing_keys: Optional[List[Tuple]]
-    ) -> Tuple[List[Tuple], Optional[List[spark.Column]], bool, Optional[Tuple]]:
+    ) -> Tuple[List[Tuple], Optional[List[spark.Column]], Any, bool, Optional[Tuple]]:
         column_labels = [
             (self._internal.spark_frame.select(cols_sel).columns[0],)
         ]  # type: List[Tuple]
         data_spark_columns = [cols_sel]
-        return column_labels, data_spark_columns, True, None
+        return column_labels, data_spark_columns, None, True, None
 
     def _select_cols_by_slice(
         self, cols_sel: slice, missing_keys: Optional[List[Tuple]]
-    ) -> Tuple[List[Tuple], Optional[List[spark.Column]], bool, Optional[Tuple]]:
+    ) -> Tuple[List[Tuple], Optional[List[spark.Column]], Any, bool, Optional[Tuple]]:
         start, stop = self._kdf_or_kser.columns.slice_locs(start=cols_sel.start, end=cols_sel.stop)
         column_labels = self._internal.column_labels[start:stop]
         data_spark_columns = self._internal.data_spark_columns[start:stop]
-        return column_labels, data_spark_columns, False, None
+        data_dtypes = self._internal.data_dtypes[start:stop]
+        return column_labels, data_spark_columns, data_dtypes, False, None
 
     def _select_cols_by_iterable(
         self, cols_sel: Iterable, missing_keys: Optional[List[Tuple]]
-    ) -> Tuple[List[Tuple], Optional[List[spark.Column]], bool, Optional[Tuple]]:
+    ) -> Tuple[List[Tuple], Optional[List[spark.Column]], Any, bool, Optional[Tuple]]:
         from databricks.koalas.series import Series
 
         if all(isinstance(key, Series) for key in cols_sel):
             column_labels = [key._column_label for key in cols_sel]
             data_spark_columns = [key.spark.column for key in cols_sel]
+            data_dtypes = [key.dtype for key in cols_sel]
         elif all(isinstance(key, spark.Column) for key in cols_sel):
             column_labels = [
                 (self._internal.spark_frame.select(col).columns[0],) for col in cols_sel
             ]
             data_spark_columns = list(cols_sel)
+            data_dtypes = None
         elif any(isinstance(key, tuple) for key in cols_sel) and any(
             not is_name_like_tuple(key) for key in cols_sel
         ):
@@ -1163,12 +1192,14 @@ class LocIndexer(LocIndexerLike):
 
             column_labels = []
             data_spark_columns = []
+            data_dtypes = []
             for key in cols_sel:
                 found = False
                 for label in self._internal.column_labels:
                     if label == key or label[0] == key:
                         column_labels.append(label)
                         data_spark_columns.append(self._internal.spark_column_for(label))
+                        data_dtypes.append(self._internal.dtype_for(label))
                         found = True
                 if not found:
                     if missing_keys is None:
@@ -1176,11 +1207,11 @@ class LocIndexer(LocIndexerLike):
                     else:
                         missing_keys.append(key)
 
-        return column_labels, data_spark_columns, False, None
+        return column_labels, data_spark_columns, data_dtypes, False, None
 
     def _select_cols_else(
         self, cols_sel: Any, missing_keys: Optional[List[Tuple]]
-    ) -> Tuple[List[Tuple], Optional[List[spark.Column]], bool, Optional[Tuple]]:
+    ) -> Tuple[List[Tuple], Optional[List[spark.Column]], Any, bool, Optional[Tuple]]:
         if not is_name_like_tuple(cols_sel):
             cols_sel = (cols_sel,)
         return self._get_from_multiindex_column(cols_sel, missing_keys)
@@ -1498,7 +1529,7 @@ class iLocIndexer(LocIndexerLike):
 
     def _select_cols_by_series(
         self, cols_sel: "Series", missing_keys: Optional[List[Tuple]]
-    ) -> Tuple[List[Tuple], Optional[List[spark.Column]], bool, Optional[Tuple]]:
+    ) -> Tuple[List[Tuple], Optional[List[spark.Column]], Any, bool, Optional[Tuple]]:
         raise ValueError(
             "Location based indexing can only have [integer, integer slice, "
             "listlike of integers, boolean array] types, got {}".format(cols_sel)
@@ -1506,7 +1537,7 @@ class iLocIndexer(LocIndexerLike):
 
     def _select_cols_by_spark_column(
         self, cols_sel: spark.Column, missing_keys: Optional[List[Tuple]]
-    ) -> Tuple[List[Tuple], Optional[List[spark.Column]], bool, Optional[Tuple]]:
+    ) -> Tuple[List[Tuple], Optional[List[spark.Column]], Any, bool, Optional[Tuple]]:
         raise ValueError(
             "Location based indexing can only have [integer, integer slice, "
             "listlike of integers, boolean array] types, got {}".format(cols_sel)
@@ -1514,12 +1545,14 @@ class iLocIndexer(LocIndexerLike):
 
     def _select_cols_by_slice(
         self, cols_sel: slice, missing_keys: Optional[List[Tuple]]
-    ) -> Tuple[List[Tuple], Optional[List[spark.Column]], bool, Optional[Tuple]]:
+    ) -> Tuple[List[Tuple], Optional[List[spark.Column]], Any, bool, Optional[Tuple]]:
         if all(
             s is None or isinstance(s, int) for s in (cols_sel.start, cols_sel.stop, cols_sel.step)
         ):
             column_labels = self._internal.column_labels[cols_sel]
             data_spark_columns = self._internal.data_spark_columns[cols_sel]
+            data_dtypes = self._internal.data_dtypes[cols_sel]
+            return column_labels, data_spark_columns, data_dtypes, False, None
         else:
             not_none = (
                 cols_sel.start
@@ -1533,29 +1566,30 @@ class iLocIndexer(LocIndexerLike):
                     not_none, type(not_none)
                 )
             )
-        return column_labels, data_spark_columns, False, None
 
     def _select_cols_by_iterable(
         self, cols_sel: Iterable, missing_keys: Optional[List[Tuple]]
-    ) -> Tuple[List[Tuple], Optional[List[spark.Column]], bool, Optional[Tuple]]:
+    ) -> Tuple[List[Tuple], Optional[List[spark.Column]], Any, bool, Optional[Tuple]]:
         if all(isinstance(s, bool) for s in cols_sel):
             cols_sel = [i for i, s in enumerate(cols_sel) if s]
         if all(isinstance(s, int) for s in cols_sel):
             column_labels = [self._internal.column_labels[s] for s in cols_sel]
             data_spark_columns = [self._internal.data_spark_columns[s] for s in cols_sel]
-            return column_labels, data_spark_columns, False, None
+            data_dtypes = [self._internal.data_dtypes[s] for s in cols_sel]
+            return column_labels, data_spark_columns, data_dtypes, False, None
         else:
             raise TypeError("cannot perform reduce with flexible type")
 
     def _select_cols_else(
         self, cols_sel: Any, missing_keys: Optional[List[Tuple]]
-    ) -> Tuple[List[Tuple], Optional[List[spark.Column]], bool, Optional[Tuple]]:
+    ) -> Tuple[List[Tuple], Optional[List[spark.Column]], Any, bool, Optional[Tuple]]:
         if isinstance(cols_sel, int):
             if cols_sel > len(self._internal.column_labels):
                 raise KeyError(cols_sel)
             column_labels = [self._internal.column_labels[cols_sel]]
             data_spark_columns = [self._internal.data_spark_columns[cols_sel]]
-            return column_labels, data_spark_columns, True, None
+            data_dtypes = [self._internal.data_dtypes[cols_sel]]
+            return column_labels, data_spark_columns, data_dtypes, True, None
         else:
             raise ValueError(
                 "Location based indexing can only have [integer, integer slice, "

--- a/databricks/koalas/internal.py
+++ b/databricks/koalas/internal.py
@@ -46,6 +46,7 @@ if TYPE_CHECKING:
     from databricks.koalas.series import Series
 from databricks.koalas.config import get_option
 from databricks.koalas.typedef import (
+    Dtype,
     as_spark_type,
     extension_dtypes,
     infer_pd_series_spark_type,
@@ -389,10 +390,10 @@ class InternalFrame(object):
         spark_frame: spark.DataFrame,
         index_spark_columns: Optional[List[spark.Column]],
         index_names: Optional[List[Optional[Tuple]]] = None,
-        index_dtypes: Optional[List] = None,
+        index_dtypes: Optional[List[Dtype]] = None,
         column_labels: Optional[List[Tuple]] = None,
         data_spark_columns: Optional[List[spark.Column]] = None,
-        data_dtypes: Optional[List] = None,
+        data_dtypes: Optional[List[Dtype]] = None,
         column_label_names: Optional[List[Optional[Tuple]]] = None,
     ) -> None:
         """
@@ -797,7 +798,7 @@ class InternalFrame(object):
         """ Return Spark Column for the given column label. """
         column_labels_to_scol = dict(zip(self.column_labels, self.data_spark_columns))
         if label in column_labels_to_scol:
-            return column_labels_to_scol[label]  # type: ignore
+            return column_labels_to_scol[label]
         else:
             raise KeyError(name_like_string(label))
 
@@ -825,11 +826,11 @@ class InternalFrame(object):
             scol = self.spark_column_for(label_or_scol)
         return self.spark_frame.select(scol).schema[0].nullable
 
-    def dtype_for(self, label: Tuple):
+    def dtype_for(self, label: Tuple) -> Dtype:
         """ Return dtype for the given column label. """
         column_labels_to_dtype = dict(zip(self.column_labels, self.data_dtypes))
         if label in column_labels_to_dtype:
-            return column_labels_to_dtype[label]  # type: ignore
+            return column_labels_to_dtype[label]
         else:
             raise KeyError(name_like_string(label))
 
@@ -899,12 +900,12 @@ class InternalFrame(object):
         return self._column_label_names
 
     @property
-    def index_dtypes(self) -> List:
+    def index_dtypes(self) -> List[Dtype]:
         """ Return dtypes for the managed index columns. """
         return self._index_dtypes
 
     @property
-    def data_dtypes(self) -> List:
+    def data_dtypes(self) -> List[Dtype]:
         """ Return dtypes for the managed columns. """
         return self._data_dtypes
 
@@ -1050,7 +1051,7 @@ class InternalFrame(object):
         scols_or_ksers: List[Union[spark.Column, "Series"]],
         *,
         column_labels: Optional[List[Tuple]] = None,
-        data_dtypes: Optional[List] = None,
+        data_dtypes: Optional[List[Dtype]] = None,
         column_label_names: Optional[Union[List[Optional[Tuple]], _NoValueType]] = _NoValue,
         keep_order: bool = True
     ) -> "InternalFrame":
@@ -1190,10 +1191,10 @@ class InternalFrame(object):
         spark_frame: Union[spark.DataFrame, _NoValueType] = _NoValue,
         index_spark_columns: Union[List[spark.Column], _NoValueType] = _NoValue,
         index_names: Union[List[Optional[Tuple]], _NoValueType] = _NoValue,
-        index_dtypes: Optional[Union[List, _NoValueType]] = _NoValue,
+        index_dtypes: Optional[Union[List[Dtype], _NoValueType]] = _NoValue,
         column_labels: Optional[Union[List[Tuple], _NoValueType]] = _NoValue,
         data_spark_columns: Optional[Union[List[spark.Column], _NoValueType]] = _NoValue,
-        data_dtypes: Optional[Union[List, _NoValueType]] = _NoValue,
+        data_dtypes: Optional[Union[List[Dtype], _NoValueType]] = _NoValue,
         column_label_names: Optional[Union[List[Optional[Tuple]], _NoValueType]] = _NoValue,
         *,
         preserve_dtypes: bool = False  # TODO: remove eventually.

--- a/databricks/koalas/internal.py
+++ b/databricks/koalas/internal.py
@@ -987,7 +987,7 @@ class InternalFrame(object):
         spark_frame: spark.DataFrame,
         data_columns: Optional[List[str]] = None,
         *,
-        preserve_dtypes: bool = False,
+        preserve_dtypes: bool = False
     ) -> "InternalFrame":
         """ Copy the immutable InternalFrame with the updates by the specified Spark DataFrame.
 
@@ -1017,7 +1017,7 @@ class InternalFrame(object):
         column_labels: Optional[List[Tuple]] = None,
         column_label_names: Optional[Union[List[Optional[Tuple]], _NoValueType]] = _NoValue,
         *,
-        keep_order: bool = True,
+        keep_order: bool = True
     ) -> "InternalFrame":
         """
         Copy the immutable InternalFrame with the updates by the specified Spark Columns or Series.
@@ -1149,7 +1149,7 @@ class InternalFrame(object):
         data_dtypes: Optional[Union[List, _NoValueType]] = _NoValue,
         column_label_names: Optional[Union[List[Optional[Tuple]], _NoValueType]] = _NoValue,
         *,
-        preserve_dtypes: bool = False,  # TODO: remove eventually.
+        preserve_dtypes: bool = False  # TODO: remove eventually.
     ) -> "InternalFrame":
         """ Copy the immutable InternalFrame.
 

--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -2016,7 +2016,9 @@ def concat(objs, axis=0, join="outer", ignore_index=False, sort=False) -> Union[
                 concat_kdf = DataFrame(
                     concat_kdf._internal.with_new_columns(
                         concat_kdf._internal.data_spark_columns + kdf._internal.data_spark_columns,
-                        concat_kdf._internal.column_labels + kdf._internal.column_labels,
+                        column_labels=(
+                            concat_kdf._internal.column_labels + kdf._internal.column_labels
+                        ),
                     )
                 )
             else:

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -1058,8 +1058,11 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             index = (index,)
         scol = self.spark.column.alias(name_like_string(index))
 
-        internal = self._kdf._internal.copy(
-            column_labels=[index], data_spark_columns=[scol], column_label_names=None
+        internal = self._internal.copy(
+            column_labels=[index],
+            data_spark_columns=[scol],
+            column_label_names=None,
+            preserve_dtypes=True,
         )
         kdf = DataFrame(internal)  # type: DataFrame
 
@@ -4919,7 +4922,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             product_ksers = [other._kser_for(label) * self_kser for label in column_labels]
 
             dot_product_kser = DataFrame(
-                other._internal.with_new_columns(product_ksers, column_labels)
+                other._internal.with_new_columns(product_ksers, column_labels=column_labels)
             ).sum()
 
             return cast(Series, dot_product_kser).rename(self.name)

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -372,7 +372,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
                 )
             internal = InternalFrame.from_pandas(pd.DataFrame(s))
             if s.name is None:
-                internal = internal.copy(column_labels=[None], keep_dtypes=True)
+                internal = internal.copy(column_labels=[None], preserve_dtypes=True)
             anchor = DataFrame(internal)
 
             self._anchor = anchor

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -372,7 +372,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
                 )
             internal = InternalFrame.from_pandas(pd.DataFrame(s))
             if s.name is None:
-                internal = internal.copy(column_labels=[None])
+                internal = internal.copy(column_labels=[None], keep_dtypes=True)
             anchor = DataFrame(internal)
 
             self._anchor = anchor
@@ -399,7 +399,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         self._anchor = kdf
         object.__setattr__(kdf, "_kseries", {self._column_label: self})
 
-    def _with_new_scol(self, scol: spark.Column) -> "Series":
+    def _with_new_scol(self, scol: spark.Column, *, dtype=None) -> "Series":
         """
         Copy Koalas Series with the new Spark Column.
 
@@ -407,7 +407,8 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         :return: the copied Series
         """
         internal = self._internal.copy(
-            data_spark_columns=[scol.alias(name_like_string(self._column_label))]
+            data_spark_columns=[scol.alias(name_like_string(self._column_label))],
+            data_dtypes=(None if dtype is None else [dtype]),
         )
         return first_series(DataFrame(internal))
 

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -408,7 +408,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         """
         internal = self._internal.copy(
             data_spark_columns=[scol.alias(name_like_string(self._column_label))],
-            data_dtypes=(None if dtype is None else [dtype]),
+            data_dtypes=[dtype],
         )
         return first_series(DataFrame(internal))
 

--- a/databricks/koalas/strings.py
+++ b/databricks/koalas/strings.py
@@ -2000,7 +2000,7 @@ class StringMethods(object):
             spark_columns = [scol[i].alias(str(i)) for i in range(n + 1)]
             column_labels = [(i,) for i in range(n + 1)]
             internal = kdf._internal.with_new_columns(
-                spark_columns, cast(Optional[List], column_labels)
+                spark_columns, column_labels=cast(Optional[List], column_labels)
             )
             return DataFrame(internal)
         else:
@@ -2136,7 +2136,7 @@ class StringMethods(object):
             spark_columns = [scol[i].alias(str(i)) for i in range(n + 1)]
             column_labels = [(i,) for i in range(n + 1)]
             internal = kdf._internal.with_new_columns(
-                spark_columns, cast(Optional[List], column_labels)
+                spark_columns, column_labels=cast(Optional[List], column_labels)
             )
             return DataFrame(internal)
         else:

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -96,10 +96,12 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(kdf[index_cols], pdf[index_cols])
 
     def _check_extension(self, kdf, pdf):
-        # FIXME: check_exact=True; pandas' assert_xxx_equal doesn't support extention dtypes.
-        self.assert_eq(kdf, pdf, check_exact=False)
-        for dtype in kdf.dtypes:
-            self.assertTrue(isinstance(dtype, extension_dtypes))
+        if LooseVersion("1.1") <= LooseVersion(pd.__version__) < LooseVersion("1.2.2"):
+            self.assert_eq(kdf, pdf, check_exact=False)
+            for dtype in kdf.dtypes:
+                self.assertTrue(isinstance(dtype, extension_dtypes))
+        else:
+            self.assert_eq(kdf, pdf)
 
     @unittest.skipIf(not extension_dtypes_available, "pandas extension dtypes are not available")
     def test_extension_dtypes(self):

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -111,6 +111,25 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         for dtype in kdf.dtypes:
             self.assertTrue(isinstance(dtype, extension_dtypes))
 
+    @unittest.skipIf(not extension_dtypes_available, "pandas extension dtypes are not available")
+    def test_astype_extension_dtypes(self):
+        pdf = pd.DataFrame(
+            {
+                "a": [1, 2, None, 4],
+                "b": [1, None, None, 4],
+                "c": [1, 2, None, None],
+                "d": [None, 2, None, 4],
+            }
+        )
+        kdf = ks.from_pandas(pdf)
+
+        astype = {"a": "Int8", "b": "Int16", "c": "Int32", "d": "Int64"}
+
+        # FIXME: check_exact=True; pandas' assert_xxx_equal doesn't support extention dtypes.
+        self.assert_eq(kdf.astype(astype), pdf.astype(astype), check_exact=False)
+        for dtype in kdf.astype(astype).dtypes:
+            self.assertTrue(isinstance(dtype, extension_dtypes))
+
     @unittest.skipIf(
         not extension_object_dtypes_available, "pandas extension object dtypes are not available"
     )
@@ -129,6 +148,20 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             self.assertTrue(isinstance(dtype, extension_dtypes))
 
     @unittest.skipIf(
+        not extension_object_dtypes_available, "pandas extension object dtypes are not available"
+    )
+    def test_astype_extension_object_dtypes(self):
+        pdf = pd.DataFrame({"a": ["a", "b", None, "c"], "b": [True, None, False, True]})
+        kdf = ks.from_pandas(pdf)
+
+        astype = {"a": "string", "b": "boolean"}
+
+        # FIXME: check_exact=True; pandas' assert_xxx_equal doesn't support extention dtypes.
+        self.assert_eq(kdf.astype(astype), pdf.astype(astype), check_exact=False)
+        for dtype in kdf.astype(astype).dtypes:
+            self.assertTrue(isinstance(dtype, extension_dtypes))
+
+    @unittest.skipIf(
         not extension_float_dtypes_available, "pandas extension float dtypes are not available"
     )
     def test_extension_float_dtypes(self):
@@ -143,6 +176,20 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         # FIXME: check_exact=True; pandas' assert_xxx_equal doesn't support extention dtypes.
         self.assert_eq(kdf, pdf, check_exact=False)
         for dtype in kdf.dtypes:
+            self.assertTrue(isinstance(dtype, extension_dtypes))
+
+    @unittest.skipIf(
+        not extension_float_dtypes_available, "pandas extension float dtypes are not available"
+    )
+    def test_astype_extension_float_dtypes(self):
+        pdf = pd.DataFrame({"a": [1.0, 2.0, None, 4.0], "b": [1.0, None, 3.0, 4.0]})
+        kdf = ks.from_pandas(pdf)
+
+        astype = {"a": "Float32", "b": "Float64"}
+
+        # FIXME: check_exact=True; pandas' assert_xxx_equal doesn't support extention dtypes.
+        self.assert_eq(kdf.astype(astype), pdf.astype(astype), check_exact=False)
+        for dtype in kdf.astype(astype).dtypes:
             self.assertTrue(isinstance(dtype, extension_dtypes))
 
     def test_insert(self):

--- a/databricks/koalas/tests/test_ops_on_diff_frames.py
+++ b/databricks/koalas/tests/test_ops_on_diff_frames.py
@@ -15,6 +15,7 @@
 #
 from distutils.version import LooseVersion
 from itertools import product
+import unittest
 
 import pandas as pd
 import numpy as np
@@ -23,7 +24,13 @@ import pyspark
 
 from databricks import koalas as ks
 from databricks.koalas.config import set_option, reset_option
+from databricks.koalas.frame import DataFrame
 from databricks.koalas.testing.utils import ReusedSQLTestCase, SQLTestUtils
+from databricks.koalas.typedef.typehints import (
+    extension_dtypes,
+    extension_dtypes_available,
+    extension_float_dtypes_available,
+)
 
 
 class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
@@ -163,24 +170,53 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
             ).set_index("b")
 
     def test_arithmetic(self):
-        kdf1 = self.kdf1
-        kdf2 = self.kdf2
-        pdf1 = self.pdf1
-        pdf2 = self.pdf2
-        kser1 = self.kser1
-        pser1 = self.pser1
-        kser2 = self.kser2
-        pser2 = self.pser2
+        self._test_arithmetic_frame(self.pdf1, self.pdf2, check_extension=False)
+        self._test_arithmetic_series(self.pser1, self.pser2, check_extension=False)
+
+    @unittest.skipIf(not extension_dtypes_available, "pandas extension dtypes are not available")
+    def test_arithmetic_extension_dtypes(self):
+        self._test_arithmetic_frame(
+            self.pdf1.astype("Int64"), self.pdf2.astype("Int64"), check_extension=True
+        )
+        self._test_arithmetic_series(
+            self.pser1.astype(int).astype("Int64"),
+            self.pser2.astype(int).astype("Int64"),
+            check_extension=True,
+        )
+
+    @unittest.skipIf(
+        not extension_float_dtypes_available, "pandas extension float dtypes are not available"
+    )
+    def test_arithmetic_extension_float_dtypes(self):
+        self._test_arithmetic_frame(
+            self.pdf1.astype("Float64"), self.pdf2.astype("Float64"), check_extension=True
+        )
+        self._test_arithmetic_series(
+            self.pser1.astype("Float64"), self.pser2.astype("Float64"), check_extension=True
+        )
+
+    def _test_arithmetic_frame(self, pdf1, pdf2, *, check_extension):
+        kdf1 = ks.from_pandas(pdf1)
+        kdf2 = ks.from_pandas(pdf2)
+
+        def assert_eq(actual, expected):
+            self.assert_eq(actual, expected, check_exact=not check_extension)
+            if check_extension:
+                if isinstance(actual, DataFrame):
+                    for dtype in actual.dtypes:
+                        self.assertTrue(isinstance(dtype, extension_dtypes))
+                else:
+                    self.assertTrue(isinstance(actual.dtype, extension_dtypes))
 
         # Series
-        self.assert_eq((kdf1.a - kdf2.b).sort_index(), (pdf1.a - pdf2.b).sort_index())
+        assert_eq((kdf1.a - kdf2.b).sort_index(), (pdf1.a - pdf2.b).sort_index())
 
-        self.assert_eq((kdf1.a * kdf2.a).sort_index(), (pdf1.a * pdf2.a).sort_index())
+        assert_eq((kdf1.a * kdf2.a).sort_index(), (pdf1.a * pdf2.a).sort_index())
 
-        self.assert_eq((kdf1["a"] / kdf2["a"]).sort_index(), (pdf1["a"] / pdf2["a"]).sort_index())
+        assert_eq((kdf1["a"] / kdf2["a"]).sort_index(), (pdf1["a"] / pdf2["a"]).sort_index())
 
         # DataFrame
-        self.assert_eq((kdf1 + kdf2).sort_index(), (pdf1 + pdf2).sort_index())
+        assert_eq((kdf1 + kdf2).sort_index(), (pdf1 + pdf2).sort_index())
 
         # Multi-index columns
         columns = pd.MultiIndex.from_tuples([("x", "a"), ("x", "b")])
@@ -190,65 +226,113 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
         pdf2.columns = columns
 
         # Series
-        self.assert_eq(
+        assert_eq(
             (kdf1[("x", "a")] - kdf2[("x", "b")]).sort_index(),
             (pdf1[("x", "a")] - pdf2[("x", "b")]).sort_index(),
         )
 
-        self.assert_eq(
+        assert_eq(
             (kdf1[("x", "a")] - kdf2["x"]["b"]).sort_index(),
             (pdf1[("x", "a")] - pdf2["x"]["b"]).sort_index(),
         )
 
-        self.assert_eq(
+        assert_eq(
             (kdf1["x"]["a"] - kdf2[("x", "b")]).sort_index(),
             (pdf1["x"]["a"] - pdf2[("x", "b")]).sort_index(),
         )
 
         # DataFrame
-        self.assert_eq((kdf1 + kdf2).sort_index(), (pdf1 + pdf2).sort_index())
+        assert_eq((kdf1 + kdf2).sort_index(), (pdf1 + pdf2).sort_index())
+
+    def _test_arithmetic_series(self, pser1, pser2, *, check_extension):
+        kser1 = ks.from_pandas(pser1)
+        kser2 = ks.from_pandas(pser2)
+
+        def assert_eq(actual, expected):
+            self.assert_eq(actual, expected, check_exact=not check_extension)
+            if check_extension:
+                self.assertTrue(isinstance(actual.dtype, extension_dtypes))
 
         # MultiIndex Series
-        self.assert_eq((kser1 + kser2).sort_index(), (pser1 + pser2).sort_index())
+        assert_eq((kser1 + kser2).sort_index(), (pser1 + pser2).sort_index())
 
-        self.assert_eq((kser1 - kser2).sort_index(), (pser1 - pser2).sort_index())
+        assert_eq((kser1 - kser2).sort_index(), (pser1 - pser2).sort_index())
 
-        self.assert_eq((kser1 * kser2).sort_index(), (pser1 * pser2).sort_index())
+        assert_eq((kser1 * kser2).sort_index(), (pser1 * pser2).sort_index())
 
-        self.assert_eq((kser1 / kser2).sort_index(), (pser1 / pser2).sort_index())
+        assert_eq((kser1 / kser2).sort_index(), (pser1 / pser2).sort_index())
 
     def test_arithmetic_chain(self):
-        kdf1 = self.kdf1
-        kdf2 = self.kdf2
-        kdf3 = self.kdf3
-        pdf1 = self.pdf1
-        pdf2 = self.pdf2
-        pdf3 = self.pdf3
-        kser1 = self.kser1
-        pser1 = self.pser1
-        kser2 = self.kser2
-        pser2 = self.pser2
-        kser3 = self.kser3
-        pser3 = self.pser3
-
-        # Series
-        self.assert_eq(
-            (kdf1.a - kdf2.b - kdf3.c).sort_index(), (pdf1.a - pdf2.b - pdf3.c).sort_index()
+        self._test_arithmetic_chain_frame(self.pdf1, self.pdf2, self.pdf3, check_extension=False)
+        self._test_arithmetic_chain_series(
+            self.pser1, self.pser2, self.pser3, check_extension=False
         )
 
-        self.assert_eq(
+    @unittest.skipIf(not extension_dtypes_available, "pandas extension dtypes are not available")
+    def test_arithmetic_chain_extension_dtypes(self):
+        self._test_arithmetic_chain_frame(
+            self.pdf1.astype("Int64"),
+            self.pdf2.astype("Int64"),
+            self.pdf3.astype("Int64"),
+            check_extension=True,
+        )
+        self._test_arithmetic_chain_series(
+            self.pser1.astype(int).astype("Int64"),
+            self.pser2.astype(int).astype("Int64"),
+            self.pser3.astype(int).astype("Int64"),
+            check_extension=True,
+        )
+
+    @unittest.skipIf(
+        not extension_float_dtypes_available, "pandas extension float dtypes are not available"
+    )
+    def test_arithmetic_chain_extension_float_dtypes(self):
+        self._test_arithmetic_chain_frame(
+            self.pdf1.astype("Float64"),
+            self.pdf2.astype("Float64"),
+            self.pdf3.astype("Float64"),
+            check_extension=True,
+        )
+        self._test_arithmetic_chain_series(
+            self.pser1.astype("Float64"),
+            self.pser2.astype("Float64"),
+            self.pser3.astype("Float64"),
+            check_extension=True,
+        )
+
+    def _test_arithmetic_chain_frame(self, pdf1, pdf2, pdf3, *, check_extension):
+        kdf1 = ks.from_pandas(pdf1)
+        kdf2 = ks.from_pandas(pdf2)
+        kdf3 = ks.from_pandas(pdf3)
+
+        common_columns = set(kdf1.columns).intersection(kdf2.columns).intersection(kdf3.columns)
+
+        def assert_eq(actual, expected):
+            self.assert_eq(actual, expected, check_exact=not check_extension)
+            if check_extension:
+                if isinstance(actual, DataFrame):
+                    for column, dtype in zip(actual.columns, actual.dtypes):
+                        if column in common_columns:
+                            self.assertTrue(isinstance(dtype, extension_dtypes))
+                        else:
+                            self.assertFalse(isinstance(dtype, extension_dtypes))
+                else:
+                    self.assertTrue(isinstance(actual.dtype, extension_dtypes))
+
+        # Series
+        assert_eq((kdf1.a - kdf2.b - kdf3.c).sort_index(), (pdf1.a - pdf2.b - pdf3.c).sort_index())
+
+        assert_eq(
             (kdf1.a * (kdf2.a * kdf3.c)).sort_index(), (pdf1.a * (pdf2.a * pdf3.c)).sort_index()
         )
 
-        self.assert_eq(
+        assert_eq(
             (kdf1["a"] / kdf2["a"] / kdf3["c"]).sort_index(),
             (pdf1["a"] / pdf2["a"] / pdf3["c"]).sort_index(),
         )
 
         # DataFrame
-        self.assert_eq(
-            (kdf1 + kdf2 - kdf3).sort_index(), (pdf1 + pdf2 - pdf3).sort_index(), almost=True
-        )
+        assert_eq((kdf1 + kdf2 - kdf3).sort_index(), (pdf1 + pdf2 - pdf3).sort_index())
 
         # Multi-index columns
         columns = pd.MultiIndex.from_tuples([("x", "a"), ("x", "b")])
@@ -260,30 +344,40 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
         kdf3.columns = columns
         pdf3.columns = columns
 
+        common_columns = set(kdf1.columns).intersection(kdf2.columns).intersection(kdf3.columns)
+
         # Series
-        self.assert_eq(
+        assert_eq(
             (kdf1[("x", "a")] - kdf2[("x", "b")] - kdf3[("y", "c")]).sort_index(),
             (pdf1[("x", "a")] - pdf2[("x", "b")] - pdf3[("y", "c")]).sort_index(),
         )
 
-        self.assert_eq(
+        assert_eq(
             (kdf1[("x", "a")] * (kdf2[("x", "b")] * kdf3[("y", "c")])).sort_index(),
             (pdf1[("x", "a")] * (pdf2[("x", "b")] * pdf3[("y", "c")])).sort_index(),
         )
 
         # DataFrame
-        self.assert_eq(
-            (kdf1 + kdf2 - kdf3).sort_index(), (pdf1 + pdf2 - pdf3).sort_index(), almost=True
-        )
+        assert_eq((kdf1 + kdf2 - kdf3).sort_index(), (pdf1 + pdf2 - pdf3).sort_index())
+
+    def _test_arithmetic_chain_series(self, pser1, pser2, pser3, *, check_extension):
+        kser1 = ks.from_pandas(pser1)
+        kser2 = ks.from_pandas(pser2)
+        kser3 = ks.from_pandas(pser3)
+
+        def assert_eq(actual, expected):
+            self.assert_eq(actual, expected, check_exact=not check_extension)
+            if check_extension:
+                self.assertTrue(isinstance(actual.dtype, extension_dtypes))
 
         # MultiIndex Series
-        self.assert_eq((kser1 + kser2 - kser3).sort_index(), (pser1 + pser2 - pser3).sort_index())
+        assert_eq((kser1 + kser2 - kser3).sort_index(), (pser1 + pser2 - pser3).sort_index())
 
-        self.assert_eq((kser1 * kser2 * kser3).sort_index(), (pser1 * pser2 * pser3).sort_index())
+        assert_eq((kser1 * kser2 * kser3).sort_index(), (pser1 * pser2 * pser3).sort_index())
 
-        self.assert_eq((kser1 - kser2 / kser3).sort_index(), (pser1 - pser2 / pser3).sort_index())
+        assert_eq((kser1 - kser2 / kser3).sort_index(), (pser1 - pser2 / pser3).sort_index())
 
-        self.assert_eq((kser1 + kser2 * kser3).sort_index(), (pser1 + pser2 * pser3).sort_index())
+        assert_eq((kser1 + kser2 * kser3).sort_index(), (pser1 + pser2 * pser3).sort_index())
 
     def test_mod(self):
         pser = pd.Series([100, None, -300, None, 500, -700])

--- a/databricks/koalas/tests/test_ops_on_diff_frames.py
+++ b/databricks/koalas/tests/test_ops_on_diff_frames.py
@@ -216,7 +216,9 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
         if extension_float_dtypes_available:
             assert_eq((kdf1["a"] / kdf2["a"]).sort_index(), (pdf1["a"] / pdf2["a"]).sort_index())
         else:
-            self.assert_eq((kdf1["a"] / kdf2["a"]).sort_index(), (pdf1["a"] / pdf2["a"]).sort_index())
+            self.assert_eq(
+                (kdf1["a"] / kdf2["a"]).sort_index(), (pdf1["a"] / pdf2["a"]).sort_index()
+            )
 
         # DataFrame
         assert_eq((kdf1 + kdf2).sort_index(), (pdf1 + pdf2).sort_index())
@@ -390,7 +392,9 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
         if extension_float_dtypes_available:
             assert_eq((kser1 - kser2 / kser3).sort_index(), (pser1 - pser2 / pser3).sort_index())
         else:
-            self.assert_eq((kser1 - kser2 / kser3).sort_index(), (pser1 - pser2 / pser3).sort_index())
+            self.assert_eq(
+                (kser1 - kser2 / kser3).sort_index(), (pser1 - pser2 / pser3).sort_index()
+            )
 
         assert_eq((kser1 + kser2 * kser3).sort_index(), (pser1 + pser2 * pser3).sort_index())
 

--- a/databricks/koalas/tests/test_ops_on_diff_frames.py
+++ b/databricks/koalas/tests/test_ops_on_diff_frames.py
@@ -201,13 +201,16 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
         kdf2 = ks.from_pandas(pdf2)
 
         def assert_eq(actual, expected):
-            self.assert_eq(actual, expected, check_exact=not check_extension)
-            if check_extension:
-                if isinstance(actual, DataFrame):
-                    for dtype in actual.dtypes:
-                        self.assertTrue(isinstance(dtype, extension_dtypes))
-                else:
-                    self.assertTrue(isinstance(actual.dtype, extension_dtypes))
+            if LooseVersion("1.1") <= LooseVersion(pd.__version__) < LooseVersion("1.2.2"):
+                self.assert_eq(actual, expected, check_exact=not check_extension)
+                if check_extension:
+                    if isinstance(actual, DataFrame):
+                        for dtype in actual.dtypes:
+                            self.assertTrue(isinstance(dtype, extension_dtypes))
+                    else:
+                        self.assertTrue(isinstance(actual.dtype, extension_dtypes))
+            else:
+                self.assert_eq(actual, expected)
 
         # Series
         assert_eq((kdf1.a - kdf2.b).sort_index(), (pdf1.a - pdf2.b).sort_index())
@@ -255,9 +258,12 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
         kser2 = ks.from_pandas(pser2)
 
         def assert_eq(actual, expected):
-            self.assert_eq(actual, expected, check_exact=not check_extension)
-            if check_extension:
-                self.assertTrue(isinstance(actual.dtype, extension_dtypes))
+            if LooseVersion("1.1") <= LooseVersion(pd.__version__) < LooseVersion("1.2.2"):
+                self.assert_eq(actual, expected, check_exact=not check_extension)
+                if check_extension:
+                    self.assertTrue(isinstance(actual.dtype, extension_dtypes))
+            else:
+                self.assert_eq(actual, expected)
 
         # MultiIndex Series
         assert_eq((kser1 + kser2).sort_index(), (pser1 + pser2).sort_index())
@@ -317,16 +323,19 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
         common_columns = set(kdf1.columns).intersection(kdf2.columns).intersection(kdf3.columns)
 
         def assert_eq(actual, expected):
-            self.assert_eq(actual, expected, check_exact=not check_extension)
-            if check_extension:
-                if isinstance(actual, DataFrame):
-                    for column, dtype in zip(actual.columns, actual.dtypes):
-                        if column in common_columns:
-                            self.assertTrue(isinstance(dtype, extension_dtypes))
-                        else:
-                            self.assertFalse(isinstance(dtype, extension_dtypes))
-                else:
-                    self.assertTrue(isinstance(actual.dtype, extension_dtypes))
+            if LooseVersion("1.1") <= LooseVersion(pd.__version__) < LooseVersion("1.2.2"):
+                self.assert_eq(actual, expected, check_exact=not check_extension)
+                if check_extension:
+                    if isinstance(actual, DataFrame):
+                        for column, dtype in zip(actual.columns, actual.dtypes):
+                            if column in common_columns:
+                                self.assertTrue(isinstance(dtype, extension_dtypes))
+                            else:
+                                self.assertFalse(isinstance(dtype, extension_dtypes))
+                    else:
+                        self.assertTrue(isinstance(actual.dtype, extension_dtypes))
+            else:
+                self.assert_eq(actual, expected)
 
         # Series
         assert_eq((kdf1.a - kdf2.b - kdf3.c).sort_index(), (pdf1.a - pdf2.b - pdf3.c).sort_index())
@@ -395,9 +404,12 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
         kser3 = ks.from_pandas(pser3)
 
         def assert_eq(actual, expected):
-            self.assert_eq(actual, expected, check_exact=not check_extension)
-            if check_extension:
-                self.assertTrue(isinstance(actual.dtype, extension_dtypes))
+            if LooseVersion("1.1") <= LooseVersion(pd.__version__) < LooseVersion("1.2.2"):
+                self.assert_eq(actual, expected, check_exact=not check_extension)
+                if check_extension:
+                    self.assertTrue(isinstance(actual.dtype, extension_dtypes))
+            else:
+                self.assert_eq(actual, expected)
 
         # MultiIndex Series
         assert_eq((kser1 + kser2 - kser3).sort_index(), (pser1 + pser2 - pser3).sort_index())
@@ -510,8 +522,11 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
     )
     def test_bitwise_extension_dtype(self):
         def assert_eq(actual, expected):
-            self.assert_eq(actual, expected, check_exact=False)
-            self.assertTrue(isinstance(actual.dtype, extension_dtypes))
+            if LooseVersion("1.1") <= LooseVersion(pd.__version__) < LooseVersion("1.2.2"):
+                self.assert_eq(actual, expected, check_exact=False)
+                self.assertTrue(isinstance(actual.dtype, extension_dtypes))
+            else:
+                self.assert_eq(actual, expected)
 
         pser1 = pd.Series(
             [True, False, True, False, np.nan, np.nan, True, False, np.nan], dtype="boolean"

--- a/databricks/koalas/tests/test_ops_on_diff_frames.py
+++ b/databricks/koalas/tests/test_ops_on_diff_frames.py
@@ -213,7 +213,10 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
 
         assert_eq((kdf1.a * kdf2.a).sort_index(), (pdf1.a * pdf2.a).sort_index())
 
-        assert_eq((kdf1["a"] / kdf2["a"]).sort_index(), (pdf1["a"] / pdf2["a"]).sort_index())
+        if extension_float_dtypes_available:
+            assert_eq((kdf1["a"] / kdf2["a"]).sort_index(), (pdf1["a"] / pdf2["a"]).sort_index())
+        else:
+            self.assert_eq((kdf1["a"] / kdf2["a"]).sort_index(), (pdf1["a"] / pdf2["a"]).sort_index())
 
         # DataFrame
         assert_eq((kdf1 + kdf2).sort_index(), (pdf1 + pdf2).sort_index())
@@ -260,7 +263,10 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
 
         assert_eq((kser1 * kser2).sort_index(), (pser1 * pser2).sort_index())
 
-        assert_eq((kser1 / kser2).sort_index(), (pser1 / pser2).sort_index())
+        if extension_float_dtypes_available:
+            assert_eq((kser1 / kser2).sort_index(), (pser1 / pser2).sort_index())
+        else:
+            self.assert_eq((kser1 / kser2).sort_index(), (pser1 / pser2).sort_index())
 
     def test_arithmetic_chain(self):
         self._test_arithmetic_chain_frame(self.pdf1, self.pdf2, self.pdf3, check_extension=False)
@@ -326,10 +332,16 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
             (kdf1.a * (kdf2.a * kdf3.c)).sort_index(), (pdf1.a * (pdf2.a * pdf3.c)).sort_index()
         )
 
-        assert_eq(
-            (kdf1["a"] / kdf2["a"] / kdf3["c"]).sort_index(),
-            (pdf1["a"] / pdf2["a"] / pdf3["c"]).sort_index(),
-        )
+        if extension_float_dtypes_available:
+            assert_eq(
+                (kdf1["a"] / kdf2["a"] / kdf3["c"]).sort_index(),
+                (pdf1["a"] / pdf2["a"] / pdf3["c"]).sort_index(),
+            )
+        else:
+            self.assert_eq(
+                (kdf1["a"] / kdf2["a"] / kdf3["c"]).sort_index(),
+                (pdf1["a"] / pdf2["a"] / pdf3["c"]).sort_index(),
+            )
 
         # DataFrame
         assert_eq((kdf1 + kdf2 - kdf3).sort_index(), (pdf1 + pdf2 - pdf3).sort_index())
@@ -375,7 +387,10 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
 
         assert_eq((kser1 * kser2 * kser3).sort_index(), (pser1 * pser2 * pser3).sort_index())
 
-        assert_eq((kser1 - kser2 / kser3).sort_index(), (pser1 - pser2 / pser3).sort_index())
+        if extension_float_dtypes_available:
+            assert_eq((kser1 - kser2 / kser3).sort_index(), (pser1 - pser2 / pser3).sort_index())
+        else:
+            self.assert_eq((kser1 - kser2 / kser3).sort_index(), (pser1 - pser2 / pser3).sort_index())
 
         assert_eq((kser1 + kser2 * kser3).sort_index(), (pser1 + pser2 * pser3).sort_index())
 

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -350,6 +350,20 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
 
         self.assert_eq(pdf["left"] | pdf["right"], kdf["left"] | kdf["right"])
 
+    @unittest.skipIf(
+        not extension_object_dtypes_available, "pandas extension object dtypes are not available"
+    )
+    def test_or_extenstion_dtypes(self):
+        pdf = pd.DataFrame(
+            {
+                "left": [True, False, True, False, np.nan, np.nan, True, False, np.nan],
+                "right": [True, False, False, True, True, False, np.nan, np.nan, np.nan],
+            }
+        ).astype("boolean")
+        kdf = ks.from_pandas(pdf)
+
+        self._check_extension(kdf["left"] | kdf["right"], pdf["left"] | pdf["right"])
+
     def test_and(self):
         pdf = pd.DataFrame(
             {
@@ -362,6 +376,20 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(
             pdf["left"] & pdf["right"], kdf["left"] & kdf["right"],
         )
+
+    @unittest.skipIf(
+        not extension_object_dtypes_available, "pandas extension object dtypes are not available"
+    )
+    def test_and_extenstion_dtypes(self):
+        pdf = pd.DataFrame(
+            {
+                "left": [True, False, True, False, np.nan, np.nan, True, False, np.nan],
+                "right": [True, False, False, True, True, False, np.nan, np.nan, np.nan],
+            }
+        ).astype("boolean")
+        kdf = ks.from_pandas(pdf)
+
+        self._check_extension(kdf["left"] & kdf["right"], pdf["left"] & pdf["right"])
 
     def test_to_numpy(self):
         pser = pd.Series([1, 2, 3, 4, 5, 6, 7], name="x")

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -91,9 +91,11 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         self.assertEqual(s.__repr__(), s.rename("a").__repr__())
 
     def _check_extension(self, kser, pser):
-        # FIXME: check_exact=True; pandas' assert_xxx_equal doesn't support extention dtypes.
-        self.assert_eq(kser, pser, check_exact=False)
-        self.assertTrue(isinstance(kser.dtype, extension_dtypes))
+        if LooseVersion("1.1") <= LooseVersion(pd.__version__) < LooseVersion("1.2.2"):
+            self.assert_eq(kser, pser, check_exact=False)
+            self.assertTrue(isinstance(kser.dtype, extension_dtypes))
+        else:
+            self.assert_eq(kser, pser)
 
     @unittest.skipIf(not extension_dtypes_available, "pandas extension dtypes are not available")
     def test_extension_dtypes(self):
@@ -1504,7 +1506,6 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         if extension_object_dtypes_available:
             from pandas import StringDtype
 
-            # FIXME: check_exact=True; pandas' assert_xxx_equal doesn't support extention dtypes.
             if LooseVersion(pd.__version__) >= LooseVersion("1.1"):
                 self._check_extension(kser.astype("string"), pser.astype("string"))
                 self._check_extension(kser.astype(StringDtype()), pser.astype(StringDtype()))

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -1430,6 +1430,41 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(kser.astype("str"), pser.astype("str"))
         self.assert_eq(kser.astype("U"), pser.astype("U"))
 
+        if extension_dtypes_available:
+            from pandas import Int8Dtype, Int16Dtype, Int32Dtype, Int64Dtype
+
+            # FIXME: check_exact=True; pandas' assert_xxx_equal doesn't support extention dtypes.
+            self.assert_eq(kser.astype("Int8"), pser.astype("Int8"), check_exact=False)
+            self.assert_eq(kser.astype("Int16"), pser.astype("Int16"), check_exact=False)
+            self.assert_eq(kser.astype("Int32"), pser.astype("Int32"), check_exact=False)
+            self.assert_eq(kser.astype("Int64"), pser.astype("Int64"), check_exact=False)
+            self.assert_eq(kser.astype(Int8Dtype()), pser.astype(Int8Dtype()), check_exact=False)
+            self.assert_eq(kser.astype(Int16Dtype()), pser.astype(Int16Dtype()), check_exact=False)
+            self.assert_eq(kser.astype(Int32Dtype()), pser.astype(Int32Dtype()), check_exact=False)
+            self.assert_eq(kser.astype(Int64Dtype()), pser.astype(Int64Dtype()), check_exact=False)
+
+        if extension_object_dtypes_available:
+            from pandas import StringDtype
+
+            # FIXME: check_exact=True; pandas' assert_xxx_equal doesn't support extention dtypes.
+            self.assert_eq(kser.astype("string"), pser.astype("string"), check_exact=False)
+            self.assert_eq(
+                kser.astype(StringDtype()), pser.astype(StringDtype()), check_exact=False
+            )
+
+        if extension_float_dtypes_available:
+            from pandas import Float32Dtype, Float64Dtype
+
+            # FIXME: check_exact=True; pandas' assert_xxx_equal doesn't support extention dtypes.
+            self.assert_eq(kser.astype("Float32"), pser.astype("Float32"), check_exact=False)
+            self.assert_eq(kser.astype("Float64"), pser.astype("Float64"), check_exact=False)
+            self.assert_eq(
+                kser.astype(Float32Dtype()), pser.astype(Float32Dtype()), check_exact=False
+            )
+            self.assert_eq(
+                kser.astype(Float64Dtype()), pser.astype(Float64Dtype()), check_exact=False
+            )
+
         pser = pd.Series([10, 20, 15, 30, 45, None, np.nan], name="x")
         kser = ks.Series(pser)
 
@@ -1447,11 +1482,33 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
             self.assert_eq(kser.astype(str), pser.astype(str))
         self.assert_eq(kser.str.strip().astype(bool), pser.str.strip().astype(bool))
 
+        if extension_object_dtypes_available:
+            from pandas import StringDtype
+
+            # FIXME: check_exact=True; pandas' assert_xxx_equal doesn't support extention dtypes.
+            self.assert_eq(kser.astype("string"), pser.astype("string"), check_exact=False)
+            self.assert_eq(
+                kser.astype(StringDtype()), pser.astype(StringDtype()), check_exact=False
+            )
+
         pser = pd.Series([True, False, None], name="x")
         kser = ks.Series(pser)
 
         self.assert_eq(kser.astype(bool), pser.astype(bool))
         self.assert_eq(kser.astype(str), pser.astype(str))
+
+        if extension_object_dtypes_available:
+            from pandas import BooleanDtype, StringDtype
+
+            # FIXME: check_exact=True; pandas' assert_xxx_equal doesn't support extention dtypes.
+            self.assert_eq(kser.astype("boolean"), pser.astype("boolean"), check_exact=False)
+            self.assert_eq(kser.astype("string"), pser.astype("string"), check_exact=False)
+            self.assert_eq(
+                kser.astype(BooleanDtype()), pser.astype(BooleanDtype()), check_exact=False
+            )
+            self.assert_eq(
+                kser.astype(StringDtype()), pser.astype(StringDtype()), check_exact=False
+            )
 
         pser = pd.Series(["2020-10-27 00:00:01", None], name="x")
         kser = ks.Series(pser)
@@ -1461,6 +1518,21 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(kser.astype("M"), pser.astype("M"))
         self.assert_eq(kser.astype("M").astype(str), pser.astype("M").astype(str))
         self.assert_eq(kser.astype("M").dt.date.astype(str), pser.astype("M").dt.date.astype(str))
+
+        if extension_object_dtypes_available:
+            from pandas import StringDtype
+
+            # FIXME: check_exact=True; pandas' assert_xxx_equal doesn't support extention dtypes.
+            self.assert_eq(
+                kser.astype("M").astype("string"),
+                pser.astype("M").astype("string"),
+                check_exact=False,
+            )
+            self.assert_eq(
+                kser.astype("M").astype(StringDtype()),
+                pser.astype("M").astype(StringDtype()),
+                check_exact=False,
+            )
 
         with self.assertRaisesRegex(TypeError, "not understood"):
             kser.astype("int63")

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -124,10 +124,8 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         kser = ks.from_pandas(pser)
 
         self._check_extension(kser, pser)
-        # TODO: self._check_extension(kser & kser, pser & pser)
-        # TODO: self._check_extension(kser | kser, pser | pser)
-        # TODO: self._check_extension(kser + kser, pser + pser)
-        # TODO: self._check_extension(kser * kser, pser * pser)
+        self._check_extension(kser & kser, pser & pser)
+        self._check_extension(kser | kser, pser | pser)
 
     @unittest.skipIf(
         not extension_float_dtypes_available, "pandas extension float dtypes are not available"
@@ -348,7 +346,13 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         )
         kdf = ks.from_pandas(pdf)
 
-        self.assert_eq(pdf["left"] | pdf["right"], kdf["left"] | kdf["right"])
+        self.assert_eq(kdf["left"] | kdf["right"], pdf["left"] | pdf["right"])
+        self.assert_eq(kdf["left"] | True, pdf["left"] | True)
+        self.assert_eq(kdf["left"] | False, pdf["left"] | False)
+        self.assert_eq(kdf["left"] | None, pdf["left"] | None)
+        self.assert_eq(True | kdf["right"], True | pdf["right"])
+        self.assert_eq(False | kdf["right"], False | pdf["right"])
+        self.assert_eq(None | kdf["right"], None | pdf["right"])
 
     @unittest.skipIf(
         not extension_object_dtypes_available, "pandas extension object dtypes are not available"
@@ -363,6 +367,12 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         kdf = ks.from_pandas(pdf)
 
         self._check_extension(kdf["left"] | kdf["right"], pdf["left"] | pdf["right"])
+        self._check_extension(kdf["left"] | True, pdf["left"] | True)
+        self._check_extension(kdf["left"] | False, pdf["left"] | False)
+        self._check_extension(kdf["left"] | pd.NA, pdf["left"] | pd.NA)
+        self._check_extension(True | kdf["right"], True | pdf["right"])
+        self._check_extension(False | kdf["right"], False | pdf["right"])
+        self._check_extension(pd.NA | kdf["right"], pd.NA | pdf["right"])
 
     def test_and(self):
         pdf = pd.DataFrame(
@@ -373,9 +383,13 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         )
         kdf = ks.from_pandas(pdf)
 
-        self.assert_eq(
-            pdf["left"] & pdf["right"], kdf["left"] & kdf["right"],
-        )
+        self.assert_eq(kdf["left"] & kdf["right"], pdf["left"] & pdf["right"])
+        self.assert_eq(kdf["left"] & True, pdf["left"] & True)
+        self.assert_eq(kdf["left"] & False, pdf["left"] & False)
+        self.assert_eq(kdf["left"] & None, pdf["left"] & None)
+        self.assert_eq(True & kdf["right"], True & pdf["right"])
+        self.assert_eq(False & kdf["right"], False & pdf["right"])
+        self.assert_eq(None & kdf["right"], None & pdf["right"])
 
     @unittest.skipIf(
         not extension_object_dtypes_available, "pandas extension object dtypes are not available"
@@ -390,6 +404,12 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         kdf = ks.from_pandas(pdf)
 
         self._check_extension(kdf["left"] & kdf["right"], pdf["left"] & pdf["right"])
+        self._check_extension(kdf["left"] & True, pdf["left"] & True)
+        self._check_extension(kdf["left"] & False, pdf["left"] & False)
+        self._check_extension(kdf["left"] & pd.NA, pdf["left"] & pd.NA)
+        self._check_extension(True & kdf["right"], True & pdf["right"])
+        self._check_extension(False & kdf["right"], False & pdf["right"])
+        self._check_extension(pd.NA & kdf["right"], pd.NA & pdf["right"])
 
     def test_to_numpy(self):
         pser = pd.Series([1, 2, 3, 4, 5, 6, 7], name="x")

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -40,6 +40,12 @@ from databricks.koalas.testing.utils import (
 )
 from databricks.koalas.exceptions import PandasNotImplementedError
 from databricks.koalas.missing.series import MissingPandasLikeSeries
+from databricks.koalas.typedef.typehints import (
+    extension_dtypes,
+    extension_dtypes_available,
+    extension_float_dtypes_available,
+    extension_object_dtypes_available,
+)
 
 
 class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
@@ -82,6 +88,48 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         s.__repr__()
         s.rename("a", inplace=True)
         self.assertEqual(s.__repr__(), s.rename("a").__repr__())
+
+    @unittest.skipIf(not extension_dtypes_available, "pandas extension dtypes are not available")
+    def test_extension_dtypes(self):
+        for pser in [
+            pd.Series([1, 2, None, 4], dtype="Int8"),
+            pd.Series([1, 2, None, 4], dtype="Int16"),
+            pd.Series([1, 2, None, 4], dtype="Int32"),
+            pd.Series([1, 2, None, 4], dtype="Int64"),
+        ]:
+            kser = ks.from_pandas(pser)
+
+            # FIXME: check_exact=True; pandas' assert_xxx_equal doesn't support extention dtypes.
+            self.assert_eq(kser, pser, check_exact=False)
+            self.assertTrue(isinstance(kser.dtype, extension_dtypes))
+
+    @unittest.skipIf(
+        not extension_object_dtypes_available, "pandas extension object dtypes are not available"
+    )
+    def test_extension_object_dtypes(self):
+        for pser in [
+            pd.Series(["a", None, "c", "d"], dtype="string"),
+            pd.Series([True, False, True, None], dtype="boolean"),
+        ]:
+            kser = ks.from_pandas(pser)
+
+            # FIXME: check_exact=True; pandas' assert_xxx_equal doesn't support extention dtypes.
+            self.assert_eq(kser, pser, check_exact=False)
+            self.assertTrue(isinstance(kser.dtype, extension_dtypes))
+
+    @unittest.skipIf(
+        not extension_float_dtypes_available, "pandas extension float dtypes are not available"
+    )
+    def test_extension_float_dtypes(self):
+        for pser in [
+            pd.Series([1.0, 2.0, None, 4.0], dtype="Float32"),
+            pd.Series([1.0, 2.0, None, 4.0], dtype="Float64"),
+        ]:
+            kser = ks.from_pandas(pser)
+
+            # FIXME: check_exact=True; pandas' assert_xxx_equal doesn't support extention dtypes.
+            self.assert_eq(kser, pser, check_exact=False)
+            self.assertTrue(isinstance(kser.dtype, extension_dtypes))
 
     def test_empty_series(self):
         pser_a = pd.Series([], dtype="i1")

--- a/databricks/koalas/tests/test_typedef.py
+++ b/databricks/koalas/tests/test_typedef.py
@@ -40,7 +40,13 @@ from pyspark.sql.types import (
     TimestampType,
 )
 
-from databricks.koalas.typedef import infer_return_type, as_spark_type
+from databricks.koalas.typedef import (
+    infer_return_type,
+    as_spark_type,
+    extension_dtypes_available,
+    extension_float_dtypes_available,
+    extension_object_dtypes_available,
+)
 from databricks import koalas as ks
 
 
@@ -277,3 +283,45 @@ class TypeHintTests(unittest.TestCase):
 
         with self.assertRaisesRegex(TypeError, "Type uint64 was not understood."):
             as_spark_type(np.dtype("uint64"))
+
+    @unittest.skipIf(not extension_dtypes_available, "The pandas extension types are not available")
+    def test_as_spark_type_extension_dtypes(self):
+        from pandas import Int8Dtype, Int16Dtype, Int32Dtype, Int64Dtype
+
+        type_mapper = {
+            Int8Dtype(): ByteType(),
+            Int16Dtype(): ShortType(),
+            Int32Dtype(): IntegerType(),
+            Int64Dtype(): LongType(),
+        }
+
+        for extension_dtype, spark_type in type_mapper.items():
+            self.assertEqual(as_spark_type(extension_dtype), spark_type)
+
+    @unittest.skipIf(
+        not extension_object_dtypes_available, "The pandas extension object types are not available"
+    )
+    def test_as_spark_type_extension_object_dtypes(self):
+        from pandas import BooleanDtype, StringDtype
+
+        type_mapper = {
+            BooleanDtype(): BooleanType(),
+            StringDtype(): StringType(),
+        }
+
+        for extension_dtype, spark_type in type_mapper.items():
+            self.assertEqual(as_spark_type(extension_dtype), spark_type)
+
+    @unittest.skipIf(
+        not extension_float_dtypes_available, "The pandas extension float types are not available"
+    )
+    def test_as_spark_type_extension_float_dtypes(self):
+        from pandas import Float32Dtype, Float64Dtype
+
+        type_mapper = {
+            Float32Dtype(): FloatType(),
+            Float64Dtype(): DoubleType(),
+        }
+
+        for extension_dtype, spark_type in type_mapper.items():
+            self.assertEqual(as_spark_type(extension_dtype), spark_type)

--- a/databricks/koalas/typedef/typehints.py
+++ b/databricks/koalas/typedef/typehints.py
@@ -210,7 +210,7 @@ def spark_type_to_pandas_dtype(spark_type: types.DataType, *, use_extension_dtyp
         # IntegralType
         if isinstance(spark_type, types.ByteType):
             return Int8Dtype()
-        elif isinstance(spark_type, types.StructType):
+        elif isinstance(spark_type, types.ShortType):
             return Int16Dtype()
         elif isinstance(spark_type, types.IntegerType):
             return Int32Dtype()

--- a/databricks/koalas/typedef/typehints.py
+++ b/databricks/koalas/typedef/typehints.py
@@ -24,6 +24,35 @@ from inspect import getfullargspec, isclass
 
 import numpy as np
 import pandas as pd
+
+try:
+    from pandas import Int8Dtype, Int16Dtype, Int32Dtype, Int64Dtype
+
+    extension_dtypes_available = True
+    extension_dtypes = (Int8Dtype, Int16Dtype, Int32Dtype, Int64Dtype)  # type: typing.Tuple
+
+    try:
+        from pandas import BooleanDtype, StringDtype
+
+        extension_object_dtypes_available = True
+        extension_dtypes += (BooleanDtype, StringDtype)
+    except ImportError:
+        extension_object_dtypes_available = False
+
+    try:
+        from pandas import Float32Dtype, Float64Dtype
+
+        extension_float_dtypes_available = True
+        extension_dtypes += (Float32Dtype, Float64Dtype)
+    except ImportError:
+        extension_float_dtypes_available = False
+
+except ImportError:
+    extension_dtypes_available = False
+    extension_object_dtypes_available = False
+    extension_float_dtypes_available = False
+    extension_dtypes = ()
+
 import pyarrow as pa
 import pyspark.sql.types as types
 
@@ -90,7 +119,7 @@ class NameTypeHolder(object):
     tpe = None
 
 
-def as_spark_type(tpe) -> types.DataType:
+def as_spark_type(tpe, *, raise_error: bool = True) -> types.DataType:
     """
     Given a Python type, returns the equivalent spark type.
     Accepts:
@@ -137,12 +166,69 @@ def as_spark_type(tpe) -> types.DataType:
     # TimestampType
     elif tpe in (datetime.datetime, np.datetime64, "datetime64[ns]", "M"):
         return types.TimestampType()
-    else:
+
+    # extension types
+    elif extension_dtypes_available:
+        # IntegralType
+        if isinstance(tpe, Int8Dtype) or (isinstance(tpe, str) and tpe == "Int8"):
+            return types.ByteType()
+        elif isinstance(tpe, Int16Dtype) or (isinstance(tpe, str) and tpe == "Int16"):
+            return types.ShortType()
+        elif isinstance(tpe, Int32Dtype) or (isinstance(tpe, str) and tpe == "Int32"):
+            return types.IntegerType()
+        elif isinstance(tpe, Int64Dtype) or (isinstance(tpe, str) and tpe == "Int64"):
+            return types.LongType()
+
+        if extension_object_dtypes_available:
+            # BooleanType
+            if isinstance(tpe, BooleanDtype) or (isinstance(tpe, str) and tpe == "boolean"):
+                return types.BooleanType()
+            # StringType
+            elif isinstance(tpe, StringDtype) or (isinstance(tpe, str) and tpe == "string"):
+                return types.StringType()
+
+        if extension_float_dtypes_available:
+            # FractionalType
+            if isinstance(tpe, Float32Dtype) or (isinstance(tpe, str) and tpe == "Float32"):
+                return types.FloatType()
+            elif isinstance(tpe, Float64Dtype) or (isinstance(tpe, str) and tpe == "Float64"):
+                return types.DoubleType()
+
+    if raise_error:
         raise TypeError("Type %s was not understood." % tpe)
+    else:
+        return None
 
 
-def spark_type_to_pandas_dtype(spark_type):
+def spark_type_to_pandas_dtype(spark_type: types.DataType, *, use_extension_dtypes: bool = False):
     """ Return the given Spark DataType to pandas dtype. """
+
+    if use_extension_dtypes and extension_dtypes_available:
+        # IntegralType
+        if isinstance(spark_type, types.ByteType):
+            return Int8Dtype()
+        elif isinstance(spark_type, types.StructType):
+            return Int16Dtype()
+        elif isinstance(spark_type, types.IntegerType):
+            return Int32Dtype()
+        elif isinstance(spark_type, types.LongType):
+            return Int64Dtype()
+
+        if extension_object_dtypes_available:
+            # BooleanType
+            if isinstance(spark_type, types.BooleanType):
+                return BooleanDtype()
+            # StringType
+            elif isinstance(spark_type, types.StringType):
+                return StringDtype()
+
+        # FractionalType
+        if extension_float_dtypes_available:
+            if isinstance(spark_type, types.FloatType):
+                return Float32Dtype()
+            elif isinstance(spark_type, types.DoubleType):
+                return Float64Dtype()
+
     if isinstance(
         spark_type, (types.DateType, types.NullType, types.StructType, types.UserDefinedType)
     ):

--- a/databricks/koalas/typedef/typehints.py
+++ b/databricks/koalas/typedef/typehints.py
@@ -134,7 +134,10 @@ def as_spark_type(tpe, *, raise_error: bool = True) -> types.DataType:
     if tpe in (np.ndarray,):
         return types.ArrayType(types.StringType())
     elif hasattr(tpe, "__origin__") and issubclass(tpe.__origin__, list):
-        return types.ArrayType(as_spark_type(tpe.__args__[0]))
+        element_type = as_spark_type(tpe.__args__[0], raise_error=raise_error)
+        if element_type is None:
+            return None
+        return types.ArrayType(element_type)
     # BinaryType
     elif tpe in (bytes, np.character, np.bytes_, np.string_):
         return types.BinaryType()

--- a/databricks/koalas/utils.py
+++ b/databricks/koalas/utils.py
@@ -34,7 +34,11 @@ from pandas.api.types import is_list_like
 
 # For running doctests and reference resolution in PyCharm.
 from databricks import koalas as ks  # noqa: F401
-from databricks.koalas.typedef.typehints import as_spark_type
+from databricks.koalas.typedef.typehints import (
+    as_spark_type,
+    extension_dtypes,
+    spark_type_to_pandas_dtype,
+)
 
 if TYPE_CHECKING:
     # This is required in old Python 3.5 to prevent circular reference.
@@ -143,16 +147,25 @@ def combine_frames(this, *args, how="full", preserve_order_column=False):
                 data_spark_columns=[
                     scol_for(sdf, rename(col)) for col in internal.data_spark_column_names
                 ],
+                preserve_dtypes=True,
             )
 
         this_internal = resolve(this._internal, "this")
         that_internal = resolve(that._internal, "that")
 
         this_index_map = list(
-            zip(this_internal.index_spark_column_names, this_internal.index_names)
+            zip(
+                this_internal.index_spark_column_names,
+                this_internal.index_names,
+                this_internal.index_dtypes,
+            )
         )
         that_index_map = list(
-            zip(that_internal.index_spark_column_names, that_internal.index_names)
+            zip(
+                that_internal.index_spark_column_names,
+                that_internal.index_names,
+                that_internal.index_dtypes,
+            )
         )
         assert len(this_index_map) == len(that_index_map)
 
@@ -168,9 +181,11 @@ def combine_frames(this, *args, how="full", preserve_order_column=False):
 
         # If the same named index is found, that's used.
         index_column_names = []
-        for i, ((this_column, this_name), (that_column, that_name)) in enumerate(
-            this_and_that_index_map
-        ):
+        index_use_extension_dtypes = []
+        for (
+            i,
+            ((this_column, this_name, this_dtype), (that_column, that_name, that_dtype)),
+        ) in enumerate(this_and_that_index_map):
             if this_name == that_name:
                 # We should merge the Spark columns into one
                 # to mimic pandas' behavior.
@@ -181,6 +196,9 @@ def combine_frames(this, *args, how="full", preserve_order_column=False):
 
                 column_name = SPARK_INDEX_NAME_FORMAT(i)
                 index_column_names.append(column_name)
+                index_use_extension_dtypes.append(
+                    any(isinstance(dtype, extension_dtypes) for dtype in [this_dtype, that_dtype])
+                )
                 merged_index_scols.append(
                     F.when(this_scol.isNotNull(), this_scol).otherwise(that_scol).alias(column_name)
                 )
@@ -209,12 +227,22 @@ def combine_frames(this, *args, how="full", preserve_order_column=False):
             + order_column
         )
 
+        index_spark_columns = [scol_for(joined_df, col) for col in index_column_names]
+        index_dtypes = [
+            spark_type_to_pandas_dtype(field.dataType, use_extension_dtypes=use_extension_dtypes)
+            for field, use_extension_dtypes in zip(
+                joined_df.select(index_spark_columns).schema, index_use_extension_dtypes
+            )
+        ]
+
         index_columns = set(index_column_names)
         new_data_columns = [
             col
             for col in joined_df.columns
             if col not in index_columns and col != NATURAL_ORDER_COLUMN_NAME
         ]
+        data_dtypes = this_internal.data_dtypes + that_internal.data_dtypes
+
         level = max(this_internal.column_labels_level, that_internal.column_labels_level)
 
         def fill_label(label):
@@ -232,10 +260,12 @@ def combine_frames(this, *args, how="full", preserve_order_column=False):
         return DataFrame(
             InternalFrame(
                 spark_frame=joined_df,
-                index_spark_columns=[scol_for(joined_df, col) for col in index_column_names],
+                index_spark_columns=index_spark_columns,
                 index_names=this_internal.index_names,
+                index_dtypes=index_dtypes,
                 column_labels=column_labels,
                 data_spark_columns=[scol_for(joined_df, col) for col in new_data_columns],
+                data_dtypes=data_dtypes,
                 column_label_names=column_label_names,
             )
         )

--- a/databricks/koalas/utils.py
+++ b/databricks/koalas/utils.py
@@ -28,7 +28,7 @@ import pyarrow
 import pyspark
 from pyspark import sql as spark
 from pyspark.sql import functions as F
-from pyspark.sql.types import FloatType
+from pyspark.sql.types import DoubleType
 import pandas as pd
 from pandas.api.types import is_list_like
 
@@ -335,6 +335,8 @@ def align_diff_frames(
         - inner: Same as 'full' mode; however, internally performs inner join instead.
     :return: Aligned DataFrame
     """
+    from databricks.koalas.frame import DataFrame
+
     assert how == "full" or how == "left" or how == "inner"
 
     this_column_labels = this._internal.column_labels
@@ -371,10 +373,10 @@ def align_diff_frames(
                 # is intentional so that `this_columns` and `that_columns` can be paired.
                 additional_that_columns.append(combined_label)
             elif fillna:
-                columns_to_keep.append(F.lit(None).cast(FloatType()).alias(str(combined_label)))
+                columns_to_keep.append(F.lit(None).cast(DoubleType()).alias(str(combined_label)))
                 column_labels_to_keep.append(combined_label)
             else:
-                columns_to_keep.append(combined._internal.spark_column_for(combined_label))
+                columns_to_keep.append(combined._kser_for(combined_label))
                 column_labels_to_keep.append(combined_label)
 
     that_columns_to_apply += additional_that_columns
@@ -385,16 +387,18 @@ def align_diff_frames(
         kser_set, column_labels_applied = zip(
             *resolve_func(combined, this_columns_to_apply, that_columns_to_apply)
         )
-        columns_applied = [c.spark.column for c in kser_set]
+        columns_applied = list(kser_set)
         column_labels_applied = list(column_labels_applied)
     else:
         columns_applied = []
         column_labels_applied = []
 
-    applied = combined[columns_applied + columns_to_keep]
-    applied.columns = pd.MultiIndex.from_tuples(
-        column_labels_applied + column_labels_to_keep, names=combined.columns.names
-    )
+    applied = DataFrame(
+        combined._internal.with_new_columns(
+            columns_applied + columns_to_keep,
+            column_labels=column_labels_applied + column_labels_to_keep,
+        )
+    )  # type: DataFrame
 
     # 3. Restore the names back and deduplicate columns.
     this_labels = OrderedDict()


### PR DESCRIPTION
Adds basic extension dtypes support.

The following types are supported if the underlying pandas supports them:

- pandas >= 0.24
  - `Int8Dtype`
  - `Int16Dtype`
  - `Int32Dtype`
  - `Int64Dtype`
- pandas >= 1.0
  - `BooleanDtype`
  - `StringDtype`
- pandas >= 1.2
  - `Float32Dtype`
  - `Float64Dtype`

Internally, `index_dtypes` and `data_dtypes` are introduced in `InternalFrame`.

```py
>>> kdf = ks.DataFrame({'a': [1,2,None,3], 'b': [4,5,6,None]}).astype({'a': 'Int32', 'b': 'Int64'})
>>> kdf
      a     b
0     1     4
1     2     5
2  <NA>     6
3     3  <NA>
>>> kdf.dtypes
a    Int32
b    Int64
dtype: object

>>> kdf._internal.index_dtypes
[dtype('int64')]
>>> kdf._internal.data_dtypes
[Int32Dtype(), Int64Dtype()]
```

Currently binary operations and type casting are supported:

```py
>>> kdf.a + kdf.b
0       5
1       7
2    <NA>
3    <NA>
dtype: Int64
>>> kdf + kdf
      a     b
0     2     8
1     4    10
2  <NA>    12
3     6  <NA>
>>> kdf.a.astype('Float64')
0     1.0
1     2.0
2    <NA>
3     3.0
Name: a, dtype: Float64
```

Resolves #2009.