### PR TITLE
Fix astype(str) for some data types.

### DIFF
--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -1386,27 +1386,33 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         kser = ks.Series(pser)
 
         self.assert_eq(kser.astype(bool), pser.astype(bool))
+        self.assert_eq(kser.astype(str), pser.astype(str))
 
         pser = pd.Series(["hi", "hi ", " ", " \t", "", None], name="x")
         kser = ks.Series(pser)
 
         self.assert_eq(kser.astype(bool), pser.astype(bool))
-        # TODO: restore after pandas 1.1.4 is released.
-        # self.assert_eq(kser.astype(str).tolist(), pser.astype(str).tolist())
-        self.assert_eq(kser.astype(str).tolist(), ["hi", "hi ", " ", " \t", "", "None"])
+        if LooseVersion("1.1.1") <= LooseVersion(pd.__version__) < LooseVersion("1.1.4"):
+            # a pandas bug: https://github.com/databricks/koalas/pull/1818#issuecomment-703961980
+            self.assert_eq(kser.astype(str).tolist(), ["hi", "hi ", " ", " \t", "", "None"])
+        else:
+            self.assert_eq(kser.astype(str), pser.astype(str))
         self.assert_eq(kser.str.strip().astype(bool), pser.str.strip().astype(bool))
 
         pser = pd.Series([True, False, None], name="x")
         kser = ks.Series(pser)
 
         self.assert_eq(kser.astype(bool), pser.astype(bool))
+        self.assert_eq(kser.astype(str), pser.astype(str))
 
-        pser = pd.Series(["2020-10-27"], name="x")
+        pser = pd.Series(["2020-10-27 00:00:01", None], name="x")
         kser = ks.Series(pser)
 
         self.assert_eq(kser.astype(np.datetime64), pser.astype(np.datetime64))
         self.assert_eq(kser.astype("datetime64[ns]"), pser.astype("datetime64[ns]"))
         self.assert_eq(kser.astype("M"), pser.astype("M"))
+        self.assert_eq(kser.astype("M").astype(str), pser.astype("M").astype(str))
+        self.assert_eq(kser.astype("M").dt.date.astype(str), pser.astype("M").dt.date.astype(str))
 
         with self.assertRaisesRegex(TypeError, "not understood"):
             kser.astype("int63")


### PR DESCRIPTION
Fixes `Series.astype(str)` for some data types.

```py
>>> ks.Series([1,2,None,4]).astype(str)
0     1.0
1     2.0
2    None
3     4.0
dtype: object
>>> ks.Series([True, False, None], name="x").astype(str)
0     true
1    false
2     None
Name: x, dtype: object
>>> ks.Series(["2020-10-27 00:00:01", None], name="x").astype("M").astype(str)
0    2020-10-27 00:00:01
1                   None
Name: x, dtype: object
```

whereas with pandas:

```py
>>> pd.Series([1,2,None,4]).astype(str)
0    1.0
1    2.0
2    nan
3    4.0
dtype: object
>>> pd.Series([True, False, None], name="x").astype(str)
0     True
1    False
2     None
Name: x, dtype: object
>>> pd.Series(["2020-10-27 00:00:01", None], name="x").astype("M").astype(str)
0    2020-10-27 00:00:01
1                    NaT
Name: x, dtype: object
```

Note that for timestamp type, Koalas won't drop the times even if there are no time values:

```py
>>> ks.Series(["2020-10-27", None], name="x").astype("M").astype(str)
0    2020-10-27 00:00:00
1                    NaT
Name: x, dtype: object
>>> pd.Series(["2020-10-27", None], name="x").astype("M").astype(str)
0    2020-10-27
1           NaT
Name: x, dtype: object
```