### PR TITLE
Avoid deprecated testing APIs.

### DIFF
--- a/databricks/koalas/testing/utils.py
+++ b/databricks/koalas/testing/utils.py
@@ -24,6 +24,7 @@ from distutils.version import LooseVersion
 
 import pandas as pd
 from pandas.api.types import is_list_like
+from pandas.testing import assert_frame_equal, assert_index_equal, assert_series_equal
 import pyspark
 
 from databricks import koalas as ks
@@ -143,7 +144,7 @@ class ReusedSQLTestCase(unittest.TestCase, SQLTestUtils):
     def assertPandasEqual(self, left, right, check_exact=True):
         if isinstance(left, pd.DataFrame) and isinstance(right, pd.DataFrame):
             try:
-                pd.util.testing.assert_frame_equal(
+                assert_frame_equal(
                     left,
                     right,
                     check_index_type=("equiv" if len(left.index) > 0 else False),
@@ -159,7 +160,7 @@ class ReusedSQLTestCase(unittest.TestCase, SQLTestUtils):
                 raise AssertionError(msg) from e
         elif isinstance(left, pd.Series) and isinstance(right, pd.Series):
             try:
-                pd.util.testing.assert_series_equal(
+                assert_series_equal(
                     left,
                     right,
                     check_index_type=("equiv" if len(left.index) > 0 else False),
@@ -174,7 +175,7 @@ class ReusedSQLTestCase(unittest.TestCase, SQLTestUtils):
                 raise AssertionError(msg) from e
         elif isinstance(left, pd.Index) and isinstance(right, pd.Index):
             try:
-                pd.util.testing.assert_index_equal(left, right, check_exact=check_exact)
+                assert_index_equal(left, right, check_exact=check_exact)
             except AssertionError as e:
                 msg = (
                     str(e)

--- a/databricks/koalas/tests/test_stats.py
+++ b/databricks/koalas/tests/test_stats.py
@@ -224,7 +224,7 @@ class StatsTest(ReusedSQLTestCase, SQLTestUtils):
         with self.sql_conf({SPARK_CONF_ARROW_ENABLED: False}):
             # DataFrame
             # we do not handle NaNs for now
-            pdf = pd.util.testing.makeMissingDataframe(0.3, 42).fillna(0)
+            pdf = pd.util.testing.makeMissingDataframe(0.3, 42).fillna(0)  # TODO: deprecated.
             kdf = ks.from_pandas(pdf)
 
             self.assert_eq(kdf.corr(), pdf.corr(), check_exact=False)

--- a/databricks/koalas/tests/test_stats.py
+++ b/databricks/koalas/tests/test_stats.py
@@ -18,6 +18,11 @@ from distutils.version import LooseVersion
 import numpy as np
 import pandas as pd
 
+try:
+    from pandas._testing import makeMissingDataframe
+except ImportError:
+    from pandas.util.testing import makeMissingDataframe
+
 from databricks import koalas as ks
 from databricks.koalas.config import option_context
 from databricks.koalas.testing.utils import (
@@ -224,7 +229,7 @@ class StatsTest(ReusedSQLTestCase, SQLTestUtils):
         with self.sql_conf({SPARK_CONF_ARROW_ENABLED: False}):
             # DataFrame
             # we do not handle NaNs for now
-            pdf = pd.util.testing.makeMissingDataframe(0.3, 42).fillna(0)  # TODO: deprecated.
+            pdf = makeMissingDataframe(0.3, 42).fillna(0)
             kdf = ks.from_pandas(pdf)
 
             self.assert_eq(kdf.corr(), pdf.corr(), check_exact=False)


### PR DESCRIPTION
The package `pd.util.testing` is deprecated. We should use `pd.testing` instead.