### PR TITLE
Fix bug on pow and rpow

### DIFF
--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -581,13 +581,13 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
 
     def __pow__(self, other) -> Union["Series", "Index"]:
         def pow_func(left, right):
-            return F.when(F.lit(right is np.nan) & (left == 1), left).otherwise(pow(left, right))
+            return F.when(left == 1, left).otherwise(Column.__pow__(left, right))
 
         return column_op(pow_func)(self, other)
 
     def __rpow__(self, other) -> Union["Series", "Index"]:
         def rpow_func(left, right):
-            return F.when(left.isNull() & F.lit(right == 1), right).otherwise(pow(right, left))
+            return F.when(F.lit(right == 1), right).otherwise(Column.__rpow__(left, right))
 
         return column_op(rpow_func)(self, other)
 

--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -579,8 +579,18 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
 
         return column_op(rmod)(self, other)
 
-    __pow__ = column_op(Column.__pow__)
-    __rpow__ = column_op(Column.__rpow__)
+    def __pow__(self, other) -> Union["Series", "Index"]:
+        def pow_func(left, right):
+            return F.when(F.lit(right is np.nan) & (left == 1), left).otherwise(pow(left, right))
+
+        return column_op(pow_func)(self, other)
+
+    def __rpow__(self, other) -> Union["Series", "Index"]:
+        def rpow_func(left, right):
+            return F.when(left.isNull() & F.lit(right == 1), right).otherwise(pow(right, left))
+
+        return column_op(rpow_func)(self, other)
+
     __abs__ = column_op(F.abs)
 
     # comparison operators

--- a/databricks/koalas/tests/test_ops_on_diff_frames.py
+++ b/databricks/koalas/tests/test_ops_on_diff_frames.py
@@ -1518,6 +1518,16 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
         self.assertRaises(ValueError, lambda: kdf1.align(kdf3, axis=None))
         self.assertRaises(ValueError, lambda: kdf1.align(kdf3, axis=1))
 
+    def test_pow_and_rpow(self):
+        pser = pd.Series([1, 2, np.nan])
+        kser = ks.from_pandas(pser)
+        pser_other = pd.Series([np.nan, 2, 3])
+        kser_other = ks.from_pandas(pser_other)
+
+        self.assert_eq(pser.pow(pser_other), kser.pow(kser_other))
+        self.assert_eq(pser ** pser_other, kser ** kser_other)
+        self.assert_eq(pser.rpow(pser_other), kser.rpow(kser_other))
+
 
 class OpsOnDiffFramesDisabledTest(ReusedSQLTestCase, SQLTestUtils):
     @classmethod
@@ -1671,3 +1681,16 @@ class OpsOnDiffFramesDisabledTest(ReusedSQLTestCase, SQLTestUtils):
 
         with self.assertRaisesRegex(ValueError, "Cannot combine the series or dataframe"):
             kdf1.align(kdf2, axis=0)
+
+    def test_pow_and_rpow(self):
+        pser = pd.Series([1, 2, np.nan])
+        kser = ks.from_pandas(pser)
+        pser_other = pd.Series([np.nan, 2, 3])
+        kser_other = ks.from_pandas(pser_other)
+
+        with self.assertRaisesRegex(ValueError, "Cannot combine the series or dataframe"):
+            kser.pow(kser_other)
+        with self.assertRaisesRegex(ValueError, "Cannot combine the series or dataframe"):
+            kser ** kser_other
+        with self.assertRaisesRegex(ValueError, "Cannot combine the series or dataframe"):
+            kser.rpow(kser_other)

--- a/databricks/koalas/tests/test_ops_on_diff_frames.py
+++ b/databricks/koalas/tests/test_ops_on_diff_frames.py
@@ -1524,9 +1524,9 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
         pser_other = pd.Series([np.nan, 2, 3])
         kser_other = ks.from_pandas(pser_other)
 
-        self.assert_eq(pser.pow(pser_other), kser.pow(kser_other))
-        self.assert_eq(pser ** pser_other, kser ** kser_other)
-        self.assert_eq(pser.rpow(pser_other), kser.rpow(kser_other))
+        self.assert_eq(pser.pow(pser_other), kser.pow(kser_other).sort_index())
+        self.assert_eq(pser ** pser_other, (kser ** kser_other).sort_index())
+        self.assert_eq(pser.rpow(pser_other), kser.rpow(kser_other).sort_index())
 
 
 class OpsOnDiffFramesDisabledTest(ReusedSQLTestCase, SQLTestUtils):

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -2673,3 +2673,12 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
                 self.assert_eq(kdf_r, pdf_r)
 
         self.assertRaises(ValueError, lambda: kdf.a.align(kdf.b, axis=1))
+
+    def test_pow_and_rpow(self):
+        pser = pd.Series([1, 2, np.nan])
+        kser = ks.from_pandas(pser)
+
+        self.assert_eq(pser.pow(np.nan), kser.pow(np.nan))
+        self.assert_eq(pser ** np.nan, kser ** np.nan)
+        self.assert_eq(pser.rpow(np.nan), kser.rpow(np.nan))
+        self.assert_eq(1 ** pser, 1 ** kser)


### PR DESCRIPTION
Fixed incompatible behavior for `pow` and `rpow`.

In pandas:

```python
>>> pd.Series([1, 2, 3]) ** np.nan
0    1.0
1    NaN
2    NaN
dtype: float64

>>> 1 ** pd.Series([np.nan, 2, 3])
0    1.0
1    1.0
2    1.0
dtype: float64
```

In Koalas:

```python
>>> ks.Series([1, 2, 3]) ** np.nan
0    NaN  # doesn't match
1    NaN
2    NaN
dtype: float64

>>> 1 ** ks.Series([np.nan, 2, 3])
0    NaN  # doesn't match
1    1.0
2    1.0
dtype: float64
```