### PR TITLE
Resolve copy before broadcast

### DIFF
--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -2597,7 +2597,7 @@ def broadcast(obj) -> DataFrame:
     """
     if not isinstance(obj, DataFrame):
         raise ValueError("Invalid type : expected DataFrame got {}".format(type(obj).__name__))
-    return DataFrame(obj._internal.with_new_sdf(F.broadcast(obj._internal.spark_frame)))
+    return DataFrame(obj._internal.with_new_sdf(F.broadcast(obj._internal.resolved_copy.spark_frame)))
 
 
 def read_orc(

--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -2597,7 +2597,9 @@ def broadcast(obj) -> DataFrame:
     """
     if not isinstance(obj, DataFrame):
         raise ValueError("Invalid type : expected DataFrame got {}".format(type(obj).__name__))
-    return DataFrame(obj._internal.with_new_sdf(F.broadcast(obj._internal.resolved_copy.spark_frame)))
+    return DataFrame(
+        obj._internal.with_new_sdf(F.broadcast(obj._internal.resolved_copy.spark_frame))
+    )
 
 
 def read_orc(

--- a/databricks/koalas/tests/test_namespace.py
+++ b/databricks/koalas/tests/test_namespace.py
@@ -239,10 +239,10 @@ class NamespaceTest(ReusedSQLTestCase, SQLTestUtils):
         )
         self.assert_eq(kdf, ks.broadcast(kdf))
 
-        kdf.columns = ['x', 'y']
+        kdf.columns = ["x", "y"]
         self.assert_eq(kdf, ks.broadcast(kdf))
 
-        kdf.columns = [('a', 'c'), ('b', 'd')]
+        kdf.columns = [("a", "c"), ("b", "d")]
         self.assert_eq(kdf, ks.broadcast(kdf))
 
         kser = ks.Series([1, 2, 3])

--- a/databricks/koalas/tests/test_namespace.py
+++ b/databricks/koalas/tests/test_namespace.py
@@ -239,6 +239,12 @@ class NamespaceTest(ReusedSQLTestCase, SQLTestUtils):
         )
         self.assert_eq(kdf, ks.broadcast(kdf))
 
+        kdf.columns = ['x', 'y']
+        self.assert_eq(kdf, ks.broadcast(kdf))
+
+        kdf.columns = [('a', 'c'), ('b', 'd')]
+        self.assert_eq(kdf, ks.broadcast(kdf))
+
         kser = ks.Series([1, 2, 3])
         expected_error_message = "Invalid type : expected DataFrame got {}".format(
             type(kser).__name__


### PR DESCRIPTION
Fix ks.broadcast by resolving copy before braodcast.

Before
```py
>>> kdf = ks.DataFrame({'a': [1], 'b':[2]})
>>> kdf
   a  b
0  1  2
>>> kdf.columns = ['c', 'd']
>>> ks.broadcast(kdf)
Traceback (most recent call last):
...
pyspark.sql.utils.AnalysisException: Cannot resolve column name "`c`" among (__index_level_0__, a, b);
```

After
```py
>>> kdf = ks.DataFrame({'a': [1], 'b':[2]})
>>> kdf
   a  b
0  1  2
>>> kdf.columns = ['c', 'd']
>>> ks.broadcast(kdf)
   c  d
0  1  2
```