### PR TITLE
Support bool list-like column selection for loc indexer

### DIFF
--- a/databricks/koalas/indexing.py
+++ b/databricks/koalas/indexing.py
@@ -1239,16 +1239,18 @@ class LocIndexer(LocIndexerLike):
                         "(index of the boolean Series and of the indexed object do not match)"
                     )
                 else:
-                    cols_sel = [
-                        self._internal.spark_column_for((label,))
-                        for label, col in cols_sel.iteritems()
-                        if col
-                    ]
                     column_labels = [
-                        (self._internal.spark_frame.select(col).columns[0],) for col in cols_sel
+                        column_label
+                        for column_label in self._internal.column_labels
+                        if cols_sel[column_label if len(column_label) > 1 else column_label[0]]
                     ]
-                    data_spark_columns = list(cols_sel)
-                    data_dtypes = None
+                    data_spark_columns = [
+                        self._internal.spark_column_for(column_label)
+                        for column_label in column_labels
+                    ]
+                    data_dtypes = [
+                        self._internal.dtype_for(column_label) for column_label in column_labels
+                    ]
             else:
                 column_labels = [
                     self._internal.column_labels[i] for i, col in enumerate(cols_sel) if col

--- a/databricks/koalas/indexing.py
+++ b/databricks/koalas/indexing.py
@@ -757,9 +757,14 @@ class LocIndexer(LocIndexerLike):
 
     - A conditional boolean Series derived from the DataFrame or Series
 
+    - A boolean array of the same length as the column axis being sliced, e.g. [True, False, True].
+
+    - An alignable boolean pandas Series to the column axis being sliced.
+      The index of the key will be aligned before masking.
+
     Not allowed inputs which pandas allows are:
 
-    - A boolean array of the same length as the axis being sliced (when axis=0),
+    - A boolean array of the same length as the row axis being sliced,
       e.g. ``[True, False, True]``.
     - A ``callable`` function with one argument (the calling Series, DataFrame
       or Panel) and that returns valid output for indexing (one of the above)
@@ -851,6 +856,22 @@ class LocIndexer(LocIndexerLike):
     >>> df.loc[df['shield'] > 6, ['max_speed']]
                 max_speed
     sidewinder          7
+
+    A boolean array of the same length as the column axis being sliced.
+
+    >>> df.loc[:, [False, True]]
+                shield
+    cobra            2
+    viper            5
+    sidewinder       8
+
+    An alignable boolean Series to the column axis being sliced.
+
+    >>> df.loc[:, pd.Series([False, True], index=['max_speed', 'shield'])]
+                shield
+    cobra            2
+    viper            5
+    sidewinder       8
 
     **Setting values**
 

--- a/databricks/koalas/tests/test_indexing.py
+++ b/databricks/koalas/tests/test_indexing.py
@@ -593,6 +593,18 @@ class IndexingTest(ReusedSQLTestCase):
         self.assert_eq(kdf.loc[:, "a":"d"], pdf.loc[:, "a":"d"])
         self.assert_eq(kdf.loc[:, "c":"d"], pdf.loc[:, "c":"d"])
 
+        # bool list-like column select
+        bool_list = [True, False]
+        self.assert_eq(kdf.loc[:, bool_list], pdf.loc[:, bool_list])
+        self.assert_eq(kdf.loc[:, np.array(bool_list)], pdf.loc[:, np.array(bool_list)])
+
+        pser = pd.Series(bool_list, index=pdf.columns)
+        self.assert_eq(kdf.loc[:, pser], pdf.loc[:, pser])
+
+        self.assertRaises(IndexError, lambda: kdf.loc[:, bool_list[:-1]])
+        self.assertRaises(IndexError, lambda: kdf.loc[:, np.array(bool_list + [True])])
+        self.assertRaises(SparkPandasIndexingError, lambda: kdf.loc[:, pd.Series(bool_list)])
+
         # non-string column names
         kdf = self.kdf2
         pdf = self.pdf2
@@ -696,21 +708,6 @@ class IndexingTest(ReusedSQLTestCase):
 
         self.assert_eq(kdf.loc[kdf.B > 0, "B"], pdf.loc[pdf.B > 0, "B"])
         # TODO?: self.assert_eq(kdf.loc[kdf.B > 0, ['A', 'C']], pdf.loc[pdf.B > 0, ['A', 'C']])
-
-    def test_loc_bool_list_like_col_select(self):
-        pdf = pd.DataFrame({"a": [1, 2], "b": [3, 4], "c": [5, 6]}, index=["x", "y"])
-        kdf = ks.from_pandas(pdf)
-
-        bool_list = [True, False, True]
-        self.assert_eq(kdf.loc[:, bool_list], pdf.loc[:, bool_list])
-        self.assert_eq(kdf.loc[:, np.array(bool_list)], pdf.loc[:, np.array(bool_list)])
-
-        pser = pd.Series(bool_list, index=pdf.columns)
-        self.assert_eq(kdf.loc[:, pser], pdf.loc[:, pser])
-
-        self.assertRaises(IndexError, lambda: kdf.loc[:, bool_list[:-1]])
-        self.assertRaises(IndexError, lambda: kdf.loc[:, np.array(bool_list + [True])])
-        self.assertRaises(SparkPandasIndexingError, lambda: kdf.loc[:, pd.Series(bool_list)])
 
     def test_getitem(self):
         pdf = pd.DataFrame(

--- a/databricks/koalas/tests/test_indexing.py
+++ b/databricks/koalas/tests/test_indexing.py
@@ -600,6 +600,8 @@ class IndexingTest(ReusedSQLTestCase):
 
         pser = pd.Series(bool_list, index=pdf.columns)
         self.assert_eq(kdf.loc[:, pser], pdf.loc[:, pser])
+        pser = pd.Series(reversed(bool_list), index=reversed(pdf.columns))
+        self.assert_eq(kdf.loc[:, pser], pdf.loc[:, pser])
 
         self.assertRaises(IndexError, lambda: kdf.loc[:, bool_list[:-1]])
         self.assertRaises(IndexError, lambda: kdf.loc[:, np.array(bool_list + [True])])

--- a/databricks/koalas/tests/test_indexing.py
+++ b/databricks/koalas/tests/test_indexing.py
@@ -656,6 +656,17 @@ class IndexingTest(ReusedSQLTestCase):
         self.assertRaises(KeyError, lambda: kdf.loc[:, "bar":("baz", "one")])
         self.assertRaises(KeyError, lambda: kdf.loc[:, ("bar", "two"):"bar"])
 
+        # bool list-like column select
+        bool_list = [True, False, True, False]
+        self.assert_eq(kdf.loc[:, bool_list], pdf.loc[:, bool_list])
+        self.assert_eq(kdf.loc[:, np.array(bool_list)], pdf.loc[:, np.array(bool_list)])
+
+        pser = pd.Series(bool_list, index=pdf.columns)
+        self.assert_eq(kdf.loc[:, pser], pdf.loc[:, pser])
+
+        pser = pd.Series(reversed(bool_list), index=reversed(pdf.columns))
+        self.assert_eq(kdf.loc[:, pser], pdf.loc[:, pser])
+
         # non-string column names
         arrays = [np.array([0, 0, 1, 1]), np.array([1, 2, 1, 2])]
 

--- a/databricks/koalas/tests/test_indexing.py
+++ b/databricks/koalas/tests/test_indexing.py
@@ -600,7 +600,7 @@ class IndexingTest(ReusedSQLTestCase):
 
         pser = pd.Series(bool_list, index=pdf.columns)
         self.assert_eq(kdf.loc[:, pser], pdf.loc[:, pser])
-        pser = pd.Series(reversed(bool_list), index=reversed(pdf.columns))
+        pser = pd.Series(list(reversed(bool_list)), index=list(reversed(pdf.columns)))
         self.assert_eq(kdf.loc[:, pser], pdf.loc[:, pser])
 
         self.assertRaises(IndexError, lambda: kdf.loc[:, bool_list[:-1]])
@@ -664,7 +664,7 @@ class IndexingTest(ReusedSQLTestCase):
         pser = pd.Series(bool_list, index=pdf.columns)
         self.assert_eq(kdf.loc[:, pser], pdf.loc[:, pser])
 
-        pser = pd.Series(reversed(bool_list), index=reversed(pdf.columns))
+        pser = pd.Series(list(reversed(bool_list)), index=list(reversed(pdf.columns)))
         self.assert_eq(kdf.loc[:, pser], pdf.loc[:, pser])
 
         # non-string column names

--- a/databricks/koalas/tests/test_indexing.py
+++ b/databricks/koalas/tests/test_indexing.py
@@ -697,6 +697,21 @@ class IndexingTest(ReusedSQLTestCase):
         self.assert_eq(kdf.loc[kdf.B > 0, "B"], pdf.loc[pdf.B > 0, "B"])
         # TODO?: self.assert_eq(kdf.loc[kdf.B > 0, ['A', 'C']], pdf.loc[pdf.B > 0, ['A', 'C']])
 
+    def test_loc_bool_list_like_col_select(self):
+        pdf = pd.DataFrame({"a": [1, 2], "b": [3, 4], "c": [5, 6]}, index=["x", "y"])
+        kdf = ks.from_pandas(pdf)
+
+        bool_list = [True, False, True]
+        self.assert_eq(kdf.loc[:, bool_list], pdf.loc[:, bool_list])
+        self.assert_eq(kdf.loc[:, np.array(bool_list)], pdf.loc[:, np.array(bool_list)])
+
+        pser = pd.Series(bool_list, index=pdf.columns)
+        self.assert_eq(kdf.loc[:, pser], pdf.loc[:, pser])
+
+        self.assertRaises(IndexError, lambda: kdf.loc[:, bool_list[:-1]])
+        self.assertRaises(IndexError, lambda: kdf.loc[:, np.array(bool_list + [True])])
+        self.assertRaises(SparkPandasIndexingError, lambda: kdf.loc[:, pd.Series(bool_list)])
+
     def test_getitem(self):
         pdf = pd.DataFrame(
             {


### PR DESCRIPTION
Here bool list-like column indicates  Python array, numpy array, and pandas Series.

Before:
```py
>>> kdf = ks.DataFrame({"a": [1, 2], "b": [3, 4], "c": [5, 6]}, index=["x", "y"])
>>> kdf
   a  b  c
x  1  3  5
y  2  4  6
>>> kdf.loc[:, [True, False, True]]
Traceback (most recent call last):
...
KeyError: "['True'] not in index"
>>> kdf.loc[:, np.array([True, False, True])]
Traceback (most recent call last):
...
KeyError: "['True'] not in index"
>>> kdf.loc[:, pd.Series([True, False, True], index=['a', 'b', 'c'])]
Traceback (most recent call last):
...
KeyError: "['True'] not in index"
```

After:
```py
>>> kdf = ks.DataFrame({"a": [1, 2], "b": [3, 4], "c": [5, 6]}, index=["x", "y"])
>>> kdf
   a  b  c
x  1  3  5
y  2  4  6
>>> kdf.loc[:, [True, False, True]]
   a  c
x  1  5
y  2  6
>>> kdf.loc[:, np.array([True, False, True])]
   a  c
x  1  5
y  2  6
>>> kdf.loc[:, pd.Series([True, False, True], index=['a', 'b', 'c'])]
   a  c
x  1  5
y  2  6
```

Resolves #2048.