### PR TITLE
Upgrade pandas in CI

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -107,7 +107,7 @@ jobs:
             pyarrow-version: 1.0.1
           - python-version: 3.8
             spark-version: 3.0.1
-            pandas-version: 1.2.1
+            pandas-version: 1.2.2
             pyarrow-version: 3.0.0
             default-index-type: 'distributed-sequence'
     env:


### PR DESCRIPTION
Upgrade pandas version in CI since [pandas 1.2.2 was released](https://pandas.pydata.org/pandas-docs/stable/whatsnew/v1.2.2.html)