### PR TITLE
Fix DataFrame.merge to work properly

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -7334,8 +7334,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 ):
                     right_scol = right_scol_for(label)
                     if how == "right":
-                        col = right_prefix + col
-                        scol = right_scol
+                        scol = right_scol.alias(col)
                     elif how == "full":
                         scol = F.when(scol.isNotNull(), scol).otherwise(right_scol).alias(col)
                     else:
@@ -7348,8 +7347,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             data_columns.append(col)
             column_labels.append(label)
         for label in right_internal.column_labels:
-            col = right_internal.spark_column_name_for(label)
-            scol = right_scol_for(label)
+            # recover `right_prefix` here.
+            col = right_internal.spark_column_name_for(label)[len(right_prefix) :]
+            scol = right_scol_for(label).alias(col)
             if label in duplicate_columns:
                 spark_column_name = left_internal.spark_column_name_for(label)
                 if (
@@ -7358,8 +7358,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 ):
                     continue
                 else:
-                    # remove `right_prefix` here.
-                    col = (col + right_suffix)[len(right_prefix) :]
+                    col = col + right_suffix
                     scol = scol.alias(col)
                     label = tuple([str(label[0]) + right_suffix] + list(label[1:]))
             exprs.append(scol)

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -7358,7 +7358,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 ):
                     continue
                 else:
-                    col = col + right_suffix
+                    # remove `right_prefix` here.
+                    col = (col + right_suffix)[len(right_prefix) :]
                     scol = scol.alias(col)
                     label = tuple([str(label[0]) + right_suffix] + list(label[1:]))
             exprs.append(scol)


### PR DESCRIPTION
This should resolve #2055 

Before:
```python
>>> kdf = ks.DataFrame(
...     {
...         "lkey": ["foo", "bar", "baz", "foo", "bar", "l"],
...         "rkey": ["baz", "foo", "bar", "baz", "foo", "r"],
...         "value": [1, 1, 3, 5, 6, 7],
...         "x": list("abcdef"),
...         "y": list("efghij"),
...     },
...     columns=["lkey", "rkey", "value", "x", "y"],
... )

>>> left_kdf = kdf[["lkey", "value", "x"]]
>>> right_kdf = kdf[["rkey", "value", "y"]]

>>> ks.merge(left_kdf, right_kdf, on="value")
Traceback (most recent call last):
...
pyspark.sql.utils.AnalysisException: Resolved attribute(s) y#801,rkey#798 missing from lkey#797,y#842,rkey#839,value#799L,__index_level_0__#837L,__natural_order__#808L,__natural_order__#836L,x#800,__index_level_0__#796L,value#840L in operator !Project [lkey#797, value#799L, x#800, rkey#798, y#801]. Attribute(s) with the same name appear in the operation: y,rkey. Please check if the right attribute(s) are used.;;
...
```

After:
```python
>>> kdf = ks.DataFrame(
...     {
...         "lkey": ["foo", "bar", "baz", "foo", "bar", "l"],
...         "rkey": ["baz", "foo", "bar", "baz", "foo", "r"],
...         "value": [1, 1, 3, 5, 6, 7],
...         "x": list("abcdef"),
...         "y": list("efghij"),
...     },
...     columns=["lkey", "rkey", "value", "x", "y"],
... )

>>> left_kdf = kdf[["lkey", "value", "x"]]
>>> right_kdf = kdf[["rkey", "value", "y"]]

>>> ks.merge(left_kdf, right_kdf, on="value")
  lkey  value  x rkey  y
0    l      7  f    r  j
1  bar      6  e  foo  i
2  foo      5  d  baz  h
3  foo      1  a  baz  e
4  foo      1  a  foo  f
5  bar      1  b  baz  e
6  bar      1  b  foo  f
7  baz      3  c  bar  g
```