### PR TITLE
Fix to delegate dtypes.

### DIFF
--- a/databricks/koalas/accessors.py
+++ b/databricks/koalas/accessors.py
@@ -175,11 +175,13 @@ class KoalasFrameMethods(object):
                     scol_for(sdf, SPARK_INDEX_NAME_FORMAT(i)) for i in range(internal.index_level)
                 ],
                 index_names=internal.index_names,
+                index_dtypes=internal.index_dtypes,
                 column_labels=internal.column_labels + [column],
                 data_spark_columns=(
                     [scol_for(sdf, name_like_string(label)) for label in internal.column_labels]
                     + [scol_for(sdf, name_like_string(column))]
                 ),
+                data_dtypes=(internal.data_dtypes + [None]),
                 column_label_names=internal.column_label_names,
             ).resolved_copy
         )
@@ -589,6 +591,7 @@ class KoalasFrameMethods(object):
                             kser._internal.data_spark_column_names[0]
                         )
                     ],
+                    data_dtypes=kser._internal.data_dtypes,
                     column_label_names=kser._internal.column_label_names,
                 )
                 return first_series(DataFrame(internal))
@@ -656,6 +659,7 @@ class KoalasFrameMethods(object):
                             SPARK_DEFAULT_SERIES_NAME
                         )
                     ],
+                    data_dtypes=[None],
                     column_label_names=None,
                 )
                 return first_series(DataFrame(internal))
@@ -847,4 +851,4 @@ class KoalasSeriesMethods(object):
             spark_return_type = return_schema
 
         pudf = pandas_udf(func, returnType=spark_return_type, functionType=PandasUDFType.SCALAR)
-        return self._kser._with_new_scol(scol=pudf(self._kser.spark.column))
+        return self._kser._with_new_scol(scol=pudf(self._kser.spark.column))  # TODO: dtype?

--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -468,7 +468,9 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
 
         if isinstance(self.spark.data_type, StringType):
             if isinstance(other, str):
-                return self._with_new_scol(F.concat(F.lit(other), self.spark.column))
+                return self._with_new_scol(
+                    F.concat(F.lit(other), self.spark.column)
+                )  # TODO: dtype?
             else:
                 raise TypeError("string addition can only be applied to string series or literals.")
         else:
@@ -1422,7 +1424,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
         )
         lag_col = F.lag(col, periods).over(window)
         col = F.when(lag_col.isNull() | F.isnan(lag_col), fill_value).otherwise(lag_col)
-        return self._with_new_scol(col)
+        return self._with_new_scol(col)  # TODO: dtype?
 
     # TODO: Update Documentation for Bins Parameter when its supported
     def value_counts(

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -7312,7 +7312,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             rename = lambda col: "__{}_{}".format(side, col)
             internal = internal.resolved_copy
             sdf = internal.spark_frame
-            sdf = internal.spark_frame.select(
+            sdf = sdf.select(
                 [
                     scol_for(sdf, col).alias(rename(col))
                     for col in sdf.columns
@@ -7328,7 +7328,6 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 data_spark_columns=[
                     scol_for(sdf, rename(col)) for col in internal.data_spark_column_names
                 ],
-                preserve_dtypes=True,
             )
 
         left_internal = self._internal.resolved_copy

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -705,6 +705,7 @@ class DataFrame(Frame, Generic[T]):
                     scol_for(sdf, col) for col in self._internal.index_spark_column_names
                 ],
                 index_names=self._internal.index_names,
+                index_dtypes=self._internal.index_dtypes,
             )
             return first_series(DataFrame(internal)).rename(pser.name)
 
@@ -2750,7 +2751,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 kser = self._kser_for(input_label)
                 applied.append(kser._with_new_scol(scol=pudf(kser.spark.column)))
 
-            internal = self._internal.with_new_columns(applied)
+            internal = self._internal.with_new_columns(
+                applied, data_dtypes=kdf._internal.data_dtypes
+            )
             return DataFrame(internal)
         else:
             return self._apply_series_op(
@@ -2965,9 +2968,12 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 + internal.index_spark_columns[level + len(key) :]
             )
             index_names = internal.index_names[:level] + internal.index_names[level + len(key) :]
+            index_dtypes = internal.index_dtypes[:level] + internal.index_dtypes[level + len(key) :]
 
             internal = internal.copy(
-                index_spark_columns=index_spark_columns, index_names=index_names
+                index_spark_columns=index_spark_columns,
+                index_names=index_names,
+                index_dtypes=index_dtypes,
             ).resolved_copy
             return DataFrame(internal)
 
@@ -3158,7 +3164,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         return DataFrame(
             kdf._internal.with_new_columns(
-                data_spark_columns, column_labels=self._internal.column_labels
+                data_spark_columns, column_labels=self._internal.column_labels  # TODO: dtypes?
             )
         )
 
@@ -3381,15 +3387,21 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 self._internal.spark_column_for(label) for label in keys
             ]
             index_names = self._internal.index_names + keys
+            index_dtypes = self._internal.index_dtypes + [
+                self._internal.dtype_for(label) for label in keys
+            ]
         else:
             index_spark_columns = [self._internal.spark_column_for(label) for label in keys]
             index_names = keys
+            index_dtypes = [self._internal.dtype_for(label) for label in keys]
 
         internal = self._internal.copy(
             index_spark_columns=index_spark_columns,
             index_names=index_names,
+            index_dtypes=index_dtypes,
             column_labels=column_labels,
             data_spark_columns=[self._internal.spark_column_for(label) for label in column_labels],
+            data_dtypes=[self._internal.dtype_for(label) for label in column_labels],
         )
 
         if inplace:
@@ -3564,9 +3576,11 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 scol.alias(name_like_string(label))
                 for scol, label in zip(self._internal.index_spark_columns, new_column_labels)
             ]
+            new_data_dtypes = self._internal.index_dtypes
 
             index_spark_columns = []
             index_names = []
+            index_dtypes = []
         else:
             if is_list_like(level):
                 level = list(level)
@@ -3610,9 +3624,11 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
             new_column_labels = []
             new_data_spark_columns = []
+            new_data_dtypes = []
 
             index_spark_columns = self._internal.index_spark_columns.copy()
             index_names = self._internal.index_names.copy()
+            index_dtypes = self._internal.index_dtypes.copy()
 
             for i in idx[::-1]:
                 name = index_names.pop(i)
@@ -3621,9 +3637,12 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 scol = index_spark_columns.pop(i)
                 new_data_spark_columns.insert(0, scol.alias(name_like_string(name)))
 
+                new_data_dtypes.insert(0, index_dtypes.pop(i))
+
         if drop:
             new_data_spark_columns = []
             new_column_labels = []
+            new_data_dtypes = []
 
         for label in new_column_labels:
             if label in self._internal.column_labels:
@@ -3651,8 +3670,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         internal = self._internal.copy(
             index_spark_columns=index_spark_columns,
             index_names=index_names,
+            index_dtypes=index_dtypes,
             column_labels=new_column_labels + self._internal.column_labels,
             data_spark_columns=new_data_spark_columns + self._internal.data_spark_columns,
+            data_dtypes=new_data_dtypes + self._internal.data_dtypes,
         )
 
         if inplace:
@@ -4001,9 +4022,11 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 spark_frame=sdf,
                 index_spark_columns=[scol_for(sdf, SPARK_DEFAULT_INDEX_NAME)],
                 index_names=[None],
+                index_dtypes=[None],
                 data_spark_columns=[
                     scol_for(sdf, col) for col in self._internal.data_spark_column_names
                 ],
+                data_dtypes=None,
             )
             return first_series(DataFrame(internal).transpose())
 
@@ -4198,6 +4221,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                         scol_for(sdf, col) for col in self._internal.index_spark_column_names
                     ],
                     index_names=self._internal.index_names,
+                    index_dtypes=self._internal.index_dtypes,
                     column_labels=[None],  # type: ignore
                     data_spark_columns=[scol_for(sdf, SPARK_DEFAULT_SERIES_NAME)],
                 )
@@ -4748,38 +4772,44 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         pairs = {
             (k if is_name_like_tuple(k) else (k,)): (
-                v.spark.column
+                (v.spark.column, v.dtype)
                 if isinstance(v, IndexOpsMixin) and not isinstance(v, MultiIndex)
-                else v
+                else (v, None)
                 if isinstance(v, spark.Column)
-                else F.lit(v)
+                else (F.lit(v), None)
             )
             for k, v in kwargs.items()
         }
 
         scols = []
+        data_dtypes = []
         for label in self._internal.column_labels:
             for i in range(len(label)):
                 if label[: len(label) - i] in pairs:
-                    name = self._internal.spark_column_name_for(label)
-                    scol = pairs[label[: len(label) - i]].alias(name)
+                    scol, dtype = pairs[label[: len(label) - i]]
+                    scol = scol.alias(self._internal.spark_column_name_for(label))
                     break
             else:
                 scol = self._internal.spark_column_for(label)
+                dtype = self._internal.dtype_for(label)
             scols.append(scol)
+            data_dtypes.append(dtype)
 
         column_labels = self._internal.column_labels.copy()
-        for label, scol in pairs.items():
+        for label, (scol, dtype) in pairs.items():
             if label not in set(i[: len(label)] for i in self._internal.column_labels):
                 scols.append(scol.alias(name_like_string(label)))
                 column_labels.append(label)
+                data_dtypes.append(dtype)
 
         level = self._internal.column_labels_level
         column_labels = [
             tuple(list(label) + ([""] * (level - len(label)))) for label in column_labels
         ]
 
-        internal = self._internal.with_new_columns(scols, column_labels=column_labels)
+        internal = self._internal.with_new_columns(
+            scols, column_labels=column_labels, data_dtypes=data_dtypes
+        )
         return DataFrame(internal)
 
     @staticmethod
@@ -5504,7 +5534,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             sdf = self._internal.resolved_copy.spark_frame
             if get_option("compute.ordered_head"):
                 sdf = sdf.orderBy(NATURAL_ORDER_COLUMN_NAME)
-            return DataFrame(self._internal.with_new_sdf(sdf.limit(n), preserve_dtypes=True))
+            return DataFrame(self._internal.with_new_sdf(sdf.limit(n)))
 
     def pivot_table(
         self, values=None, index=None, columns=None, aggfunc="mean", fill_value=None
@@ -5702,8 +5732,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             sdf = sdf.fillna(fill_value)
 
         if index is not None:
+            index_columns = [self._internal.spark_column_name_for(label) for label in index]
+            index_dtypes = [self._internal.dtype_for(label) for label in index]
+
             if isinstance(values, list):
-                index_columns = [self._internal.spark_column_name_for(label) for label in index]
                 data_columns = [column for column in sdf.columns if column not in index_columns]
 
                 if len(values) > 1:
@@ -5730,6 +5762,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                         spark_frame=sdf,
                         index_spark_columns=[scol_for(sdf, col) for col in index_columns],
                         index_names=index,
+                        index_dtypes=index_dtypes,
                         column_labels=column_labels,
                         data_spark_columns=[scol_for(sdf, col) for col in data_columns],
                         column_label_names=column_label_names,  # type: ignore
@@ -5742,17 +5775,18 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                         spark_frame=sdf,
                         index_spark_columns=[scol_for(sdf, col) for col in index_columns],
                         index_names=index,
+                        index_dtypes=index_dtypes,
                         column_labels=column_labels,
                         data_spark_columns=[scol_for(sdf, col) for col in data_columns],
                         column_label_names=column_label_names,  # type: ignore
                     )
                     kdf = DataFrame(internal)
             else:
-                index_columns = [self._internal.spark_column_name_for(label) for label in index]
                 internal = InternalFrame(
                     spark_frame=sdf,
                     index_spark_columns=[scol_for(sdf, col) for col in index_columns],
                     index_names=index,
+                    index_dtypes=index_dtypes,
                     column_label_names=[columns],
                 )
                 kdf = DataFrame(internal)
@@ -6185,9 +6219,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             if should_include:
                 column_labels.append(label)
 
-        data_spark_columns = [self._internal.spark_column_for(label) for label in column_labels]
         return DataFrame(
-            self._internal.with_new_columns(data_spark_columns, column_labels=column_labels)
+            self._internal.with_new_columns([self._kser_for(label) for label in column_labels])
         )
 
     def droplevel(self, level, axis=0) -> "DataFrame":
@@ -6276,18 +6309,24 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                     "at least one level must be left.".format(len(level), nlevels)
                 )
 
-            index_spark_columns, index_names = zip(
+            index_spark_columns, index_names, index_dtypes = zip(
                 *[
                     item
                     for i, item in enumerate(
-                        zip(self._internal.index_spark_columns, self._internal.index_names)
+                        zip(
+                            self._internal.index_spark_columns,
+                            self._internal.index_names,
+                            self._internal.index_dtypes,
+                        )
                     )
                     if i not in int_level
                 ]
             )
 
             internal = self._internal.copy(
-                index_spark_columns=list(index_spark_columns), index_names=list(index_names)
+                index_spark_columns=list(index_spark_columns),
+                index_names=list(index_names),
+                index_dtypes=list(index_dtypes),
             )
             return DataFrame(internal)
         else:
@@ -6399,10 +6438,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                     if label not in drop_column_labels
                 )
             )
-            data_spark_columns = [self._internal.spark_column_for(label) for label in labels]
-            internal = self._internal.with_new_columns(
-                data_spark_columns, column_labels=list(labels)
-            )
+            internal = self._internal.with_new_columns([self._kser_for(label) for label in labels])
             return DataFrame(internal)
         else:
             raise ValueError("Need to specify at least one of 'labels' or 'columns'")
@@ -6429,9 +6465,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         }
         by = [mapper[(asc, na_position)](scol) for scol, asc in zip(by, ascending)]
         sdf = self._internal.resolved_copy.spark_frame.sort(*(by + [NATURAL_ORDER_COLUMN_NAME]))
-        kdf = DataFrame(
-            self._internal.with_new_sdf(sdf, preserve_dtypes=True)
-        )  # type: ks.DataFrame
+        kdf = DataFrame(self._internal.with_new_sdf(sdf))  # type: DataFrame
         if inplace:
             self._update_internal_frame(kdf._internal)
             return None
@@ -6841,11 +6875,19 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                     "%s is not a valid level number" % (self._internal.index_level, index)
                 )
 
-        index_map = list(zip(self._internal.index_spark_columns, self._internal.index_names))
+        index_map = list(
+            zip(
+                self._internal.index_spark_columns,
+                self._internal.index_names,
+                self._internal.index_dtypes,
+            )
+        )
         index_map[i], index_map[j], = index_map[j], index_map[i]
-        index_spark_columns, index_names = zip(*index_map)
+        index_spark_columns, index_names, index_dtypes = zip(*index_map)
         internal = self._internal.copy(
-            index_spark_columns=list(index_spark_columns), index_names=list(index_names),
+            index_spark_columns=list(index_spark_columns),
+            index_names=list(index_names),
+            index_dtypes=list(index_dtypes),
         )
         return internal
 
@@ -7666,6 +7708,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             other[update_columns], rsuffix="_new"
         )._internal.resolved_copy.spark_frame
 
+        data_dtypes = self._internal.data_dtypes.copy()
         for column_labels in update_columns:
             column_name = self._internal.spark_column_name_for(column_labels)
             old_col = scol_for(update_sdf, column_name)
@@ -7680,11 +7723,12 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 update_sdf = update_sdf.withColumn(
                     column_name, F.when(old_col.isNull(), new_col).otherwise(old_col)
                 )
+            data_dtypes[self._internal.column_labels.index(column_labels)] = None  # TODO: dtype?
         sdf = update_sdf.select(
             [scol_for(update_sdf, col) for col in self._internal.spark_column_names]
             + list(HIDDEN_COLUMNS)
         )
-        internal = self._internal.with_new_sdf(sdf)
+        internal = self._internal.with_new_sdf(sdf, data_dtypes=data_dtypes)
         self._update_internal_frame(internal, requires_same_anchor=False)
 
     def sample(
@@ -8398,7 +8442,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         if isinstance(index, ks.Index):
             if nlevels != index.nlevels:
-                return DataFrame(index._internal.with_new_columns([], column_labels=[])).reindex(
+                return DataFrame(index._internal.with_new_columns([])).reindex(
                     columns=self.columns, fill_value=fill_value
                 )
 
@@ -8464,6 +8508,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 scol_for(sdf, col) for col in self._internal.index_spark_column_names
             ],
             index_names=index_names,
+            index_dtypes=None,  # TODO: dtypes?
             data_spark_columns=[
                 scol_for(sdf, col) for col in self._internal.data_spark_column_names
             ],
@@ -8485,12 +8530,12 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                     "shape (1,{}) doesn't match the shape (1,{})".format(len(col), level)
                 )
         fill_value = np.nan if fill_value is None else fill_value
-        scols, labels = [], []
+        scols_or_ksers, labels = [], []
         for label in label_columns:
             if label in self._internal.column_labels:
-                scols.append(self._internal.spark_column_for(label))
+                scols_or_ksers.append(self._kser_for(label))
             else:
-                scols.append(F.lit(fill_value).alias(name_like_string(label)))
+                scols_or_ksers.append(F.lit(fill_value).alias(name_like_string(label)))
             labels.append(label)
 
         if isinstance(columns, pd.Index):
@@ -8498,10 +8543,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 name if is_name_like_tuple(name) else (name,) for name in columns.names
             ]
             internal = self._internal.with_new_columns(
-                scols, column_labels=labels, column_label_names=column_label_names
+                scols_or_ksers, column_labels=labels, column_label_names=column_label_names
             )
         else:
-            internal = self._internal.with_new_columns(scols, column_labels=labels)
+            internal = self._internal.with_new_columns(scols_or_ksers, column_labels=labels)
 
         return DataFrame(internal)
 
@@ -8958,13 +9003,14 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             + [sdf["pairs"][name].alias(name) for name in data_columns]
         )
 
-        internal = InternalFrame(
+        internal = InternalFrame(  # TODO: dtypes?
             spark_frame=sdf,
             index_spark_columns=[
                 scol_for(sdf, col)
                 for col in (self._internal.index_spark_column_names + [index_column])
             ],
             index_names=self._internal.index_names + [index_name],
+            index_dtypes=self._internal.index_dtypes + [None],
             column_labels=list(column_labels),
             data_spark_columns=[scol_for(sdf, col) for col in data_columns],
             column_label_names=column_label_names,  # type: ignore
@@ -9068,6 +9114,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             )
             internal = df._internal.copy(
                 index_names=self._internal.index_names[:-1],
+                index_dtypes=self._internal.index_dtypes[:-1],
                 column_label_names=(
                     df._internal.column_label_names[:-1]
                     + [
@@ -9123,7 +9170,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         index_spark_column_names, index_names = zip(*new_index_map)
         return first_series(
             DataFrame(
-                InternalFrame(
+                InternalFrame(  # TODO: dtypes?
                     exploded_df,
                     index_spark_columns=[
                         scol_for(exploded_df, col) for col in index_spark_column_names
@@ -9208,7 +9255,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         )
         sdf = sdf.selectExpr("col.*")
 
-        internal = self._internal.copy(
+        internal = InternalFrame(
             spark_frame=sdf,
             index_spark_columns=[
                 scol_for(sdf, SPARK_INDEX_NAME_FORMAT(i))
@@ -9217,7 +9264,6 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             index_names=self._internal.column_label_names,
             column_labels=[None],
             data_spark_columns=[scol_for(sdf, value_column)],
-            column_label_names=None,
         )
 
         return first_series(DataFrame(internal))
@@ -9296,7 +9342,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         )
         sdf = sdf.selectExpr("col.*")
 
-        internal = self._internal.copy(
+        internal = InternalFrame(
             spark_frame=sdf,
             index_spark_columns=[
                 scol_for(sdf, SPARK_INDEX_NAME_FORMAT(i))
@@ -9305,7 +9351,6 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             index_names=self._internal.column_label_names,
             column_labels=[None],
             data_spark_columns=[scol_for(sdf, value_column)],
-            column_label_names=None,
         )
 
         return first_series(DataFrame(internal))
@@ -9691,7 +9736,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             if not index and not columns:
                 raise ValueError("Either `index` or `columns` should be provided.")
 
-        internal = self._internal
+        kdf = self.copy()
         if index_mapper_fn:
             # rename index labels, if `level` is None, rename all index columns, otherwise only
             # rename the corresponding level index.
@@ -9706,7 +9751,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             #           .withColumn("index_1", mapper_fn_udf(col("index_1"))
             #   ```
 
-            index_columns = internal.index_spark_column_names
+            index_columns = kdf._internal.index_spark_column_names
             num_indices = len(index_columns)
             if level:
                 if level < 0 or level >= num_indices:
@@ -9718,21 +9763,24 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 index_mapper_udf = pandas_udf(
                     lambda s: s.map(index_mapper_fn), returnType=index_mapper_ret_stype
                 )
-                return index_mapper_udf(scol_for(internal.spark_frame, index_col_name))
+                return index_mapper_udf(scol_for(kdf._internal.spark_frame, index_col_name))
 
-            sdf = internal.resolved_copy.spark_frame
+            sdf = kdf._internal.resolved_copy.spark_frame
+            index_dtypes = self._internal.index_dtypes.copy()
             if level is None:
                 for i in range(num_indices):
                     sdf = sdf.withColumn(index_columns[i], gen_new_index_column(i))
+                    index_dtypes[i] = None  # TODO: dtype?
             else:
                 sdf = sdf.withColumn(index_columns[level], gen_new_index_column(level))
-            internal = internal.with_new_sdf(sdf)
+                index_dtypes[level] = None  # TODO: dtype?
+            kdf = DataFrame(kdf._internal.with_new_sdf(sdf, index_dtypes=index_dtypes))
         if columns_mapper_fn:
             # rename column name.
             # Will modify the `_internal._column_labels` and transform underlying spark dataframe
             # to the same column name with `_internal._column_labels`.
             if level:
-                if level < 0 or level >= internal.column_labels_level:
+                if level < 0 or level >= kdf._internal.column_labels_level:
                     raise ValueError("level should be an integer between [0, column_labels_level)")
 
             def gen_new_column_labels_entry(column_labels_entry):
@@ -9748,18 +9796,18 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 else:
                     return columns_mapper_fn(column_labels_entry)
 
-            new_column_labels = list(map(gen_new_column_labels_entry, internal.column_labels))
+            new_column_labels = list(map(gen_new_column_labels_entry, kdf._internal.column_labels))
 
             new_data_scols = [
-                scol.alias(name_like_string(new_label))
-                for scol, new_label in zip(internal.data_spark_columns, new_column_labels)
+                kdf._kser_for(old_label).rename(new_label)
+                for old_label, new_label in zip(kdf._internal.column_labels, new_column_labels)
             ]
-            internal = internal.with_new_columns(new_data_scols, column_labels=new_column_labels)
+            kdf = DataFrame(kdf._internal.with_new_columns(new_data_scols))
         if inplace:
-            self._update_internal_frame(internal)
+            self._update_internal_frame(kdf._internal)
             return None
         else:
-            return DataFrame(internal)
+            return kdf
 
     def rename_axis(
         self,
@@ -10803,7 +10851,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             kser._internal.data_spark_column_names[0], F.explode_outer(kser.spark.column)
         )
 
-        internal = kdf._internal.with_new_sdf(sdf)
+        data_dtypes = kdf._internal.data_dtypes.copy()
+        data_dtypes[kdf._internal.column_labels.index(kser._column_label)] = None  # TODO: dtype?
+
+        internal = kdf._internal.with_new_sdf(sdf, data_dtypes=data_dtypes)
         return DataFrame(internal)
 
     def mad(self, axis=0) -> "Series":
@@ -10895,6 +10946,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                         SPARK_DEFAULT_SERIES_NAME
                     )
                 ],
+                data_dtypes=[None],
                 column_label_names=None,
             )
             return first_series(DataFrame(internal))

--- a/databricks/koalas/indexes/base.py
+++ b/databricks/koalas/indexes/base.py
@@ -152,6 +152,7 @@ class Index(IndexOpsMixin):
         return internal.copy(
             column_labels=internal.index_names,
             data_spark_columns=internal.index_spark_columns,
+            data_dtypes=internal.index_dtypes,
             column_label_names=None,
         )
 
@@ -735,7 +736,7 @@ class Index(IndexOpsMixin):
         if not isinstance(value, (float, int, str, bool)):
             raise TypeError("Unsupported type %s" % type(value).__name__)
         sdf = self._internal.spark_frame.fillna(value)
-        result = DataFrame(self._kdf._internal.with_new_sdf(sdf)).index
+        result = DataFrame(self._kdf._internal.with_new_sdf(sdf)).index  # TODO: dtype?
         return result
 
     # TODO: ADD keep parameter
@@ -770,6 +771,7 @@ class Index(IndexOpsMixin):
                 scol_for(sdf, col) for col in self._internal.index_spark_column_names
             ],
             index_names=self._internal.index_names,
+            index_dtypes=self._internal.index_dtypes,
         )
         return DataFrame(internal).index
 
@@ -802,16 +804,15 @@ class Index(IndexOpsMixin):
         """
         if not is_hashable(name):
             raise TypeError("Series.name must be a hashable type")
-        kdf = self._kdf
         scol = self.spark.column
         if name is not None:
             scol = scol.alias(name_like_string(name))
-        elif kdf._internal.index_level == 1:
+        elif self._internal.index_level == 1:
             name = self.name
         column_labels = [
             name if is_name_like_tuple(name) else (name,)
         ]  # type: List[Optional[Tuple]]
-        internal = kdf._internal.copy(
+        internal = self._internal.copy(
             column_labels=column_labels, data_spark_columns=[scol], column_label_names=None
         )
         return first_series(DataFrame(internal))
@@ -882,16 +883,20 @@ class Index(IndexOpsMixin):
         if index:
             index_spark_columns = self._internal.index_spark_columns
             index_names = self._internal.index_names
+            index_dtypes = self._internal.index_dtypes
         else:
             index_spark_columns = []
             index_names = []
+            index_dtypes = []
 
         internal = InternalFrame(
             spark_frame=self._internal.spark_frame,
             index_spark_columns=index_spark_columns,
             index_names=index_names,
+            index_dtypes=index_dtypes,
             column_labels=names,
             data_spark_columns=self._internal.index_spark_columns,
+            data_dtypes=self._internal.index_dtypes,
         )
         return DataFrame(internal)
 
@@ -1046,6 +1051,7 @@ class Index(IndexOpsMixin):
                 scol_for(sdf, col) for col in self._internal.index_spark_column_names
             ],
             index_names=self._internal.index_names,
+            index_dtypes=self._internal.index_dtypes,
         )
         return DataFrame(internal).index
 
@@ -1095,6 +1101,7 @@ class Index(IndexOpsMixin):
                     scol_for(sdf, col) for col in self._internal.index_spark_column_names
                 ],
                 index_names=self._internal.index_names,
+                index_dtypes=self._internal.index_dtypes,
             )
         ).index
 
@@ -1130,8 +1137,10 @@ class Index(IndexOpsMixin):
                         scol_for(sdf, col) for col in self._internal.index_spark_column_names
                     ],
                     index_names=self._internal.index_names,
+                    index_dtypes=self._internal.index_dtypes,
                     column_labels=[],
                     data_spark_columns=[],
+                    data_dtypes=[],
                 )
             )
         )
@@ -1277,11 +1286,15 @@ class Index(IndexOpsMixin):
                 "left.".format(len(level), nlevels)
             )
 
-        index_spark_columns, index_names = zip(
+        index_spark_columns, index_names, index_dtypes = zip(
             *[
                 item
                 for i, item in enumerate(
-                    zip(self._internal.index_spark_columns, self._internal.index_names,)
+                    zip(
+                        self._internal.index_spark_columns,
+                        self._internal.index_names,
+                        self._internal.index_dtypes,
+                    )
                 )
                 if i not in int_level
             ]
@@ -1290,8 +1303,10 @@ class Index(IndexOpsMixin):
         internal = self._internal.copy(
             index_spark_columns=list(index_spark_columns),
             index_names=list(index_names),
+            index_dtypes=list(index_dtypes),
             column_labels=[],
             data_spark_columns=[],
+            data_dtypes=[],
         )
         return DataFrame(internal).index
 
@@ -1361,6 +1376,7 @@ class Index(IndexOpsMixin):
                 scol_for(sdf_symdiff, col) for col in self._internal.index_spark_column_names
             ],
             index_names=self._internal.index_names,
+            index_dtypes=self._internal.index_dtypes,
         )
         result = Index(DataFrame(internal))
 
@@ -1441,6 +1457,7 @@ class Index(IndexOpsMixin):
                 scol_for(sdf, col) for col in self._internal.index_spark_column_names
             ],
             index_names=self._internal.index_names,
+            index_dtypes=self._internal.index_dtypes,
         )
         return DataFrame(internal).index
 
@@ -1633,6 +1650,7 @@ class Index(IndexOpsMixin):
                 scol_for(sdf, col) for col in self._internal.index_spark_column_names
             ],
             index_names=self._internal.index_names,
+            index_dtypes=self._internal.index_dtypes,
         )
 
         return DataFrame(internal).index
@@ -1690,7 +1708,7 @@ class Index(IndexOpsMixin):
         else:
             index_names = None
 
-        internal = InternalFrame(
+        internal = InternalFrame(  # TODO: dtypes?
             spark_frame=sdf_appended,
             index_spark_columns=[
                 scol_for(sdf_appended, col) for col in self._internal.index_spark_column_names
@@ -1910,6 +1928,7 @@ class Index(IndexOpsMixin):
                 scol_for(sdf_diff, col) for col in self._internal.index_spark_column_names
             ],
             index_names=self._internal.index_names,
+            index_dtypes=self._internal.index_dtypes,
         )
         result = DataFrame(internal).index
         # Name(s) will be kept when only name(s) of (Multi)Index are the same.
@@ -2138,7 +2157,7 @@ class Index(IndexOpsMixin):
             sdf = sdf.drop_duplicates()
         if sort:
             sdf = sdf.sort(self._internal.index_spark_column_names)
-        internal = InternalFrame(
+        internal = InternalFrame(  # TODO: dtypes?
             spark_frame=sdf,
             index_spark_columns=[
                 scol_for(sdf, col) for col in self._internal.index_spark_column_names
@@ -2230,7 +2249,7 @@ class Index(IndexOpsMixin):
             index_names = self._internal.index_names
         else:
             index_names = None
-        internal = InternalFrame(
+        internal = InternalFrame(  # TODO: dtypes?
             spark_frame=spark_frame_intersected,
             index_spark_columns=[scol_for(spark_frame_intersected, SPARK_DEFAULT_INDEX_NAME)],
             index_names=index_names,
@@ -2298,7 +2317,7 @@ class Index(IndexOpsMixin):
         sdf_after = self.to_frame(name=index_name)[loc:].to_spark()
         sdf = sdf_before.union(sdf_middle).union(sdf_after)
 
-        internal = self._internal.with_new_sdf(sdf)
+        internal = self._internal.with_new_sdf(sdf)  # TODO: dtype?
         return DataFrame(internal).index
 
     def view(self) -> "Index":

--- a/databricks/koalas/indexes/multi.py
+++ b/databricks/koalas/indexes/multi.py
@@ -90,7 +90,10 @@ class MultiIndex(Index):
         internal = self._kdf._internal
         scol = F.struct(internal.index_spark_columns)
         return internal.copy(
-            column_labels=[None], data_spark_columns=[scol], column_label_names=None
+            column_labels=[None],
+            data_spark_columns=[scol],
+            data_dtypes=[None],
+            column_label_names=None,
         )
 
     @property
@@ -378,14 +381,22 @@ class MultiIndex(Index):
                     "%s is not a valid level number" % (len(self.names), index)
                 )
 
-        index_map = list(zip(self._internal.index_spark_columns, self._internal.index_names))
+        index_map = list(
+            zip(
+                self._internal.index_spark_columns,
+                self._internal.index_names,
+                self._internal.index_dtypes,
+            )
+        )
         index_map[i], index_map[j], = index_map[j], index_map[i]
-        index_spark_columns, index_names = zip(*index_map)
+        index_spark_columns, index_names, index_dtypes = zip(*index_map)
         internal = self._internal.copy(
             index_spark_columns=list(index_spark_columns),
             index_names=list(index_names),
+            index_dtypes=list(index_dtypes),
             column_labels=[],
             data_spark_columns=[],
+            data_dtypes=[],
         )
         return cast(MultiIndex, DataFrame(internal).index)
 
@@ -456,6 +467,7 @@ class MultiIndex(Index):
                 scol_for(sdf, col) for col in self._internal.index_spark_column_names
             ],
             index_names=self._internal.index_names,
+            index_dtypes=self._internal.index_dtypes,
         )
 
         return first_series(DataFrame(internal))
@@ -499,6 +511,7 @@ class MultiIndex(Index):
                 scol_for(sdf, col) for col in self._internal.index_spark_column_names
             ],
             index_names=self._internal.index_names,
+            index_dtypes=self._internal.index_dtypes,
         )
 
         return first_series(DataFrame(internal))
@@ -724,7 +737,7 @@ class MultiIndex(Index):
         if sort:
             sdf_symdiff = sdf_symdiff.sort(self._internal.index_spark_columns)
 
-        internal = InternalFrame(
+        internal = InternalFrame(  # TODO: dtypes?
             spark_frame=sdf_symdiff,
             index_spark_columns=[
                 scol_for(sdf_symdiff, col) for col in self._internal.index_spark_column_names
@@ -805,6 +818,7 @@ class MultiIndex(Index):
                         scol_for(sdf, col) for col in internal.index_spark_column_names
                     ],
                     index_names=internal.index_names,
+                    index_dtypes=internal.index_dtypes,
                     column_labels=[],
                     data_spark_columns=[],
                 )
@@ -937,11 +951,14 @@ class MultiIndex(Index):
         level = self._get_level_number(level)
         index_scol = self._internal.index_spark_columns[level]
         index_name = self._internal.index_names[level]
+        index_dtype = self._internal.index_dtypes[level]
         internal = self._internal.copy(
             index_spark_columns=[index_scol],
             index_names=[index_name],
+            index_dtypes=[index_dtype],
             column_labels=[],
             data_spark_columns=[],
+            data_dtypes=[],
         )
         return DataFrame(internal).index
 
@@ -1000,7 +1017,7 @@ class MultiIndex(Index):
         sdf_after = self.to_frame(name=index_name)[loc:].to_spark()
         sdf = sdf_before.union(sdf_middle).union(sdf_after)
 
-        internal = InternalFrame(
+        internal = InternalFrame(  # TODO: dtypes?
             spark_frame=sdf,
             index_spark_columns=[
                 scol_for(sdf, col) for col in self._internal.index_spark_column_names
@@ -1077,7 +1094,7 @@ class MultiIndex(Index):
             index_names = self._internal.index_names
         else:
             index_names = None
-        internal = InternalFrame(
+        internal = InternalFrame(  # TODO: dtypes?
             spark_frame=spark_frame_intersected,
             index_spark_columns=[scol_for(spark_frame_intersected, col) for col in default_name],
             index_names=index_names,

--- a/databricks/koalas/indexing.py
+++ b/databricks/koalas/indexing.py
@@ -621,7 +621,9 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
                 .alias(name_like_string(self._kdf_or_kser.name or SPARK_DEFAULT_SERIES_NAME))
             )
 
-            internal = self._internal.with_new_spark_column(self._kdf_or_kser._column_label, scol)
+            internal = self._internal.with_new_spark_column(
+                self._kdf_or_kser._column_label, scol  # TODO: dtype?
+            )
             self._kdf_or_kser._kdf._update_internal_frame(internal, requires_same_anchor=False)
         else:
             assert self._is_df

--- a/databricks/koalas/mlflow.py
+++ b/databricks/koalas/mlflow.py
@@ -95,7 +95,7 @@ class PythonModelWrapper(object):
                 (col,) for col in data._internal.spark_frame.select(return_col).columns
             ]
             internal = data._internal.copy(
-                column_labels=column_labels, data_spark_columns=[return_col]
+                column_labels=column_labels, data_spark_columns=[return_col], data_dtypes=None
             )
             return first_series(DataFrame(internal))
 

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -372,7 +372,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
                 )
             internal = InternalFrame.from_pandas(pd.DataFrame(s))
             if s.name is None:
-                internal = internal.copy(column_labels=[None], preserve_dtypes=True)
+                internal = internal.copy(column_labels=[None])
             anchor = DataFrame(internal)
 
             self._anchor = anchor
@@ -1059,10 +1059,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         scol = self.spark.column.alias(name_like_string(index))
 
         internal = self._internal.copy(
-            column_labels=[index],
-            data_spark_columns=[scol],
-            column_label_names=None,
-            preserve_dtypes=True,
+            column_labels=[index], data_spark_columns=[scol], column_label_names=None
         )
         kdf = DataFrame(internal)  # type: DataFrame
 
@@ -1850,7 +1847,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             self._kdf._update_internal_frame(kser._kdf._internal, requires_same_anchor=False)
             return None
         else:
-            return kser._with_new_scol(kser.spark.column)
+            return kser._with_new_scol(kser.spark.column)  # TODO: dtype?
 
     def _fillna(self, value=None, method=None, axis=None, limit=None, part_cols=()):
         axis = validate_axis(axis)
@@ -1901,7 +1898,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         return DataFrame(
             self._kdf._internal.with_new_spark_column(
-                self._column_label, scol.alias(name_like_string(self.name))
+                self._column_label, scol.alias(name_like_string(self.name))  # TODO: dtype?
             )
         )._kser_for(self._column_label)
 
@@ -2135,7 +2132,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
                 scol = F.when(scol < lower, lower).otherwise(scol)
             if upper is not None:
                 scol = F.when(scol > upper, upper).otherwise(scol)
-            return self._with_new_scol(scol)
+            return self._with_new_scol(scol, dtype=self.dtype)
         else:
             return self
 
@@ -2373,6 +2370,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             index_spark_columns=None,
             column_labels=[self._column_label],
             data_spark_columns=[scol_for(sdf, self._internal.data_spark_column_names[0])],
+            data_dtypes=[self.dtype],
             column_label_names=self._internal.column_label_names,
         )
         return first_series(DataFrame(internal))
@@ -2715,7 +2713,9 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             ]
             + internal.data_spark_columns
         )
-        return first_series(DataFrame(internal.with_new_sdf(sdf)))
+        return first_series(
+            DataFrame(internal.with_new_sdf(sdf, index_dtypes=([None] * internal.index_level)))
+        )
 
     def add_suffix(self, suffix) -> "Series":
         """
@@ -2768,7 +2768,9 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             ]
             + internal.data_spark_columns
         )
-        return first_series(DataFrame(internal.with_new_sdf(sdf)))
+        return first_series(
+            DataFrame(internal.with_new_sdf(sdf, index_dtypes=([None] * internal.index_level)))
+        )
 
     def corr(self, other, method="pearson") -> float:
         """
@@ -3660,7 +3662,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             .rowsBetween(-periods, -periods)
         )
         scol = self.spark.column - F.lag(self.spark.column, periods).over(window)
-        return self._with_new_scol(scol)
+        return self._with_new_scol(scol, dtype=self.dtype)
 
     def idxmax(self, skipna=True) -> Union[Tuple, Any]:
         """
@@ -4029,6 +4031,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
                 spark_frame=sdf,
                 index_spark_columns=[scol_for(sdf, SPARK_DEFAULT_INDEX_NAME)],
                 column_labels=[self._column_label],
+                data_dtypes=[self.dtype],
             )
             return first_series(DataFrame(internal))
         else:
@@ -4037,6 +4040,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
                 index_spark_columns=[
                     scol_for(sdf, col) for col in internal.index_spark_column_names[len(item) :]
                 ],
+                index_dtypes=internal.index_dtypes[len(item) :],
                 index_names=self._internal.index_names[len(item) :],
                 data_spark_columns=[scol_for(sdf, internal.data_spark_column_names[0])],
             )
@@ -4375,7 +4379,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
                 cond = cond | F.isnan(self.spark.column) | self.spark.column.isNull()
             current = F.when(cond, value).otherwise(self.spark.column)
 
-        return self._with_new_scol(current)
+        return self._with_new_scol(current)  # TODO: dtype?
 
     def update(self, other) -> None:
         """
@@ -4461,7 +4465,9 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             .alias(self._kdf._internal.spark_column_name_for(self._column_label))
         )
 
-        internal = combined["this"]._internal.with_new_spark_column(self._column_label, scol)
+        internal = combined["this"]._internal.with_new_spark_column(
+            self._column_label, scol  # TODO: dtype?
+        )
 
         self._kdf._update_internal_frame(internal.resolved_copy, requires_same_anchor=False)
 
@@ -4723,11 +4729,13 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             + internal.index_spark_column_names[level + len(key) :]
         )
         index_names = internal.index_names[:level] + internal.index_names[level + len(key) :]
+        index_dtypes = internal.index_dtypes[:level] + internal.index_dtypes[level + len(key) :]
 
         internal = internal.copy(
             spark_frame=sdf,
             index_spark_columns=[scol_for(sdf, col) for col in index_spark_column_names],
             index_names=index_names,
+            index_dtypes=index_dtypes,
             data_spark_columns=[scol_for(sdf, internal.data_spark_column_names[0])],
         )
         return first_series(DataFrame(internal))
@@ -4832,12 +4840,12 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         cond = F.when(this.isNull(), that).otherwise(this)
         # If `self` and `other` come from same frame, the anchor should be kept
         if same_anchor(self, other):
-            return self._with_new_scol(cond)
+            return self._with_new_scol(cond)  # TODO: dtype?
         index_scols = combined._internal.index_spark_columns
         sdf = combined._internal.spark_frame.select(
             *index_scols, cond.alias(self._internal.data_spark_column_names[0])
         ).distinct()
-        internal = self._internal.with_new_sdf(sdf)
+        internal = self._internal.with_new_sdf(sdf, data_dtypes=[None])  # TODO: dtype?
         return first_series(DataFrame(internal))
 
     def dot(self, other: Union["Series", DataFrame]) -> Union[Scalar, "Series"]:
@@ -5201,7 +5209,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         sdf = internal.spark_frame
         sdf = sdf.groupby(list(index_scol_names)).pivot(pivot_col).agg(F.first(scol_for(sdf, col)))
-        internal = InternalFrame(
+        internal = InternalFrame(  # TODO: dtypes?
             spark_frame=sdf,
             index_spark_columns=[scol_for(sdf, col) for col in index_scol_names],
             index_names=list(index_names),
@@ -5417,11 +5425,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         scol = F.explode_outer(self.spark.column).alias(name_like_string(self._column_label))
 
-        internal = self._kdf._internal.copy(
-            column_labels=[self._column_label], data_spark_columns=[scol], column_label_names=None
-        ).resolved_copy
-        # For resetting `__natural_order__` to remove duplication order.
-        internal = internal.copy(spark_frame=internal.spark_frame.drop(NATURAL_ORDER_COLUMN_NAME))
+        internal = self._internal.with_new_columns([scol], keep_order=False)
         return first_series(DataFrame(internal))
 
     def argsort(self) -> "Series":
@@ -5522,7 +5526,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         sdf = sdf_for_index.join(sdf_for_data, on=tmp_join_key).drop(tmp_join_key)
 
         internal = self._internal.with_new_sdf(
-            spark_frame=sdf, data_columns=[SPARK_DEFAULT_SERIES_NAME]
+            spark_frame=sdf, data_columns=[SPARK_DEFAULT_SERIES_NAME], data_dtypes=[None]
         )
         kser = first_series(DataFrame(internal))
 
@@ -5691,8 +5695,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             other_column_label = verify_temp_column_name(self.to_frame(), "__other_column__")
             combined = DataFrame(
                 self._internal.with_new_columns(
-                    [self._internal.data_spark_columns[0], other._internal.data_spark_columns[0]],
-                    column_labels=[self_column_label, other_column_label],
+                    [self.rename(self_column_label), other.rename(other_column_label)]
                 )
             )  # type: DataFrame
         else:
@@ -5734,6 +5737,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
                 scol_for(sdf, col) for col in self._internal.index_spark_column_names
             ],
             index_names=self._internal.index_names,
+            index_dtypes=self._internal.index_dtypes,
             column_labels=[(this_column_label,), (that_column_label,)],
             data_spark_columns=[scol_for(sdf, this_column_label), scol_for(sdf, that_column_label)],
             column_label_names=[None],

--- a/databricks/koalas/strings.py
+++ b/databricks/koalas/strings.py
@@ -1992,7 +1992,7 @@ class StringMethods(object):
             returnType=ArrayType(StringType(), containsNull=True),
             functionType=PandasUDFType.SCALAR,
         )
-        kser = self._data._with_new_scol(scol=pudf(self._data.spark.column))
+        kser = self._data._with_new_scol(pudf(self._data.spark.column), dtype=self._data.dtype)
 
         if expand:
             kdf = kser.to_frame()
@@ -2000,7 +2000,9 @@ class StringMethods(object):
             spark_columns = [scol[i].alias(str(i)) for i in range(n + 1)]
             column_labels = [(i,) for i in range(n + 1)]
             internal = kdf._internal.with_new_columns(
-                spark_columns, column_labels=cast(Optional[List], column_labels)
+                spark_columns,
+                column_labels=cast(Optional[List], column_labels),
+                data_dtypes=([self._data.dtype] * len(column_labels)),
             )
             return DataFrame(internal)
         else:
@@ -2128,7 +2130,7 @@ class StringMethods(object):
             returnType=ArrayType(StringType(), containsNull=True),
             functionType=PandasUDFType.SCALAR,
         )
-        kser = self._data._with_new_scol(scol=pudf(self._data.spark.column))
+        kser = self._data._with_new_scol(pudf(self._data.spark.column), dtype=self._data.dtype)
 
         if expand:
             kdf = kser.to_frame()
@@ -2136,7 +2138,9 @@ class StringMethods(object):
             spark_columns = [scol[i].alias(str(i)) for i in range(n + 1)]
             column_labels = [(i,) for i in range(n + 1)]
             internal = kdf._internal.with_new_columns(
-                spark_columns, column_labels=cast(Optional[List], column_labels)
+                spark_columns,
+                column_labels=cast(Optional[List], column_labels),
+                data_dtypes=([self._data.dtype] * len(column_labels)),
             )
             return DataFrame(internal)
         else:

--- a/databricks/koalas/utils.py
+++ b/databricks/koalas/utils.py
@@ -147,7 +147,6 @@ def combine_frames(this, *args, how="full", preserve_order_column=False):
                 data_spark_columns=[
                     scol_for(sdf, rename(col)) for col in internal.data_spark_column_names
                 ],
-                preserve_dtypes=True,
             )
 
         this_internal = resolve(this._internal, "this")


### PR DESCRIPTION
Fixes to delegate dtypes properly.
The parameter `preserve_dtypes` for the workaround was removed.
Also maked as `TODO` where the dtypes are unknown.