### PR TITLE
Upgrade PySpark to 3.0.2 in CI.

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -102,11 +102,11 @@ jobs:
             pyarrow-version: 0.15.1
             default-index-type: 'distributed-sequence'
           - python-version: 3.7
-            spark-version: 3.0.1
+            spark-version: 3.0.2
             pandas-version: 0.25.3
             pyarrow-version: 1.0.1
           - python-version: 3.8
-            spark-version: 3.0.1
+            spark-version: 3.0.2
             pandas-version: 1.2.2
             pyarrow-version: 3.0.0
             default-index-type: 'distributed-sequence'


### PR DESCRIPTION
As PySpark 3.0.2 has been released, we should upgrade it in CI.
- http://spark.apache.org/news/spark-3-0-2-released.html