### PR TITLE
Make Index constructors follow pandas.

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -3254,7 +3254,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         """
         from databricks.koalas.indexes.base import Index
 
-        return Index(self)
+        return Index._new_instance(self)
 
     @property
     def empty(self) -> bool:

--- a/databricks/koalas/indexes/base.py
+++ b/databricks/koalas/indexes/base.py
@@ -15,7 +15,7 @@
 #
 
 from functools import partial
-from typing import Any, List, Optional, Tuple, Union
+from typing import Any, List, Optional, Tuple, Union, cast
 import warnings
 
 import pandas as pd
@@ -70,22 +70,26 @@ class Index(IndexOpsMixin):
     Koalas Index that corresponds to pandas Index logically. This might hold Spark Column
     internally.
 
-    :ivar _kdf: The parent dataframe
-    :type _kdf: DataFrame
-    :ivar _scol: Spark Column instance
-    :type _scol: pyspark.Column
-
     Parameters
     ----------
-    data : DataFrame or list
-        Index can be created by DataFrame or list
+    data : array-like (1-dimensional)
     dtype : dtype, default None
-        Data type to force. Only a single dtype is allowed. If None, infer
-    name : name of index, hashable
+        If dtype is None, we find the dtype that best fits the data.
+        If an actual dtype is provided, we coerce to that dtype if it's safe.
+        Otherwise, an error will be raised.
+    copy : bool
+        Make a copy of input ndarray.
+    name : object
+        Name to be stored in the index.
+    tupleize_cols : bool (default: True)
+        When True, attempt to create a MultiIndex if possible.
 
     See Also
     --------
     MultiIndex : A multi-level, or hierarchical, Index.
+    DatetimeIndex : Index of datetime64 data.
+    Int64Index : A special case of :class:`Index` with purely integer labels.
+    Float64Index : A special case of :class:`Index` with purely float labels.
 
     Examples
     --------
@@ -95,51 +99,57 @@ class Index(IndexOpsMixin):
     >>> ks.DataFrame({'a': [1, 2, 3]}, index=list('abc')).index
     Index(['a', 'b', 'c'], dtype='object')
 
-    >>> Index([1, 2, 3])
+    >>> ks.Index([1, 2, 3])
     Int64Index([1, 2, 3], dtype='int64')
 
-    >>> Index(list('abc'))
+    >>> ks.Index(list('abc'))
     Index(['a', 'b', 'c'], dtype='object')
     """
 
-    def __new__(cls, data: Union[DataFrame, list], dtype=None, name=None, names=None):
+    def __new__(
+        cls, data=None, dtype=None, copy=False, name=None, tupleize_cols=True, **kwargs
+    ) -> "Index":
+        if not is_hashable(name):
+            raise TypeError("Index.name must be a hashable type")
+
+        return cast(
+            Index,
+            ks.from_pandas(
+                pd.Index(
+                    data=data,
+                    dtype=dtype,
+                    copy=copy,
+                    name=name,
+                    tupleize_cols=tupleize_cols,
+                    **kwargs
+                )
+            ),
+        )
+
+    @staticmethod
+    def _new_instance(anchor: DataFrame) -> "Index":
         from databricks.koalas.indexes.datetimes import DatetimeIndex
         from databricks.koalas.indexes.multi import MultiIndex
         from databricks.koalas.indexes.numeric import Float64Index, Int64Index
 
-        assert data is not None
-
-        if not isinstance(data, DataFrame):
-            if isinstance(data, list) and all([isinstance(item, tuple) for item in data]):
-                return MultiIndex.from_tuples(data, names=names)
-
-            if not is_hashable(name):
-                raise TypeError("Index.name must be a hashable type")
-
-            index = pd.Index(data=data, dtype=dtype, name=name)
-            return DataFrame(index=index).index
-
-        assert dtype is None
-        assert name is None
-
-        if data._internal.index_level > 1:
+        if anchor._internal.index_level > 1:
             instance = object.__new__(MultiIndex)
         elif isinstance(
-            data._internal.spark_type_for(data._internal.index_spark_columns[0]), IntegralType
+            anchor._internal.spark_type_for(anchor._internal.index_spark_columns[0]), IntegralType
         ):
             instance = object.__new__(Int64Index)
         elif isinstance(
-            data._internal.spark_type_for(data._internal.index_spark_columns[0]), FractionalType
+            anchor._internal.spark_type_for(anchor._internal.index_spark_columns[0]), FractionalType
         ):
             instance = object.__new__(Float64Index)
         elif isinstance(
-            data._internal.spark_type_for(data._internal.index_spark_columns[0]), TimestampType
+            anchor._internal.spark_type_for(anchor._internal.index_spark_columns[0]), TimestampType
         ):
             instance = object.__new__(DatetimeIndex)
         else:
             instance = object.__new__(Index)
 
-        instance._anchor = data
+        instance._anchor = anchor
         return instance
 
     @property
@@ -1122,19 +1132,16 @@ class Index(IndexOpsMixin):
         """
         internal = self._internal.resolved_copy
         sdf = internal.spark_frame[~internal.index_spark_columns[0].isin(labels)]
-        return Index(
-            DataFrame(
-                InternalFrame(
-                    spark_frame=sdf,
-                    index_spark_columns=[
-                        scol_for(sdf, col) for col in self._internal.index_spark_column_names
-                    ],
-                    index_names=self._internal.index_names,
-                    column_labels=[],
-                    data_spark_columns=[],
-                )
-            )
+        internal = InternalFrame(
+            spark_frame=sdf,
+            index_spark_columns=[
+                scol_for(sdf, col) for col in self._internal.index_spark_column_names
+            ],
+            index_names=self._internal.index_names,
+            column_labels=[],
+            data_spark_columns=[],
         )
+        return DataFrame(internal).index
 
     def _validate_index_level(self, level):
         """
@@ -1362,7 +1369,7 @@ class Index(IndexOpsMixin):
             ],
             index_names=self._internal.index_names,
         )
-        result = Index(DataFrame(internal))
+        result = DataFrame(internal).index
 
         if result_name:
             result.name = result_name

--- a/databricks/koalas/indexes/base.py
+++ b/databricks/koalas/indexes/base.py
@@ -15,7 +15,7 @@
 #
 
 from functools import partial
-from typing import Any, List, Optional, Tuple, Union, cast
+from typing import Any, List, Optional, Tuple, Union
 import warnings
 
 import pandas as pd
@@ -106,24 +106,14 @@ class Index(IndexOpsMixin):
     Index(['a', 'b', 'c'], dtype='object')
     """
 
-    def __new__(
-        cls, data=None, dtype=None, copy=False, name=None, tupleize_cols=True, **kwargs
-    ) -> "Index":
+    def __new__(cls, data=None, dtype=None, copy=False, name=None, tupleize_cols=True, **kwargs):
         if not is_hashable(name):
             raise TypeError("Index.name must be a hashable type")
 
-        return cast(
-            Index,
-            ks.from_pandas(
-                pd.Index(
-                    data=data,
-                    dtype=dtype,
-                    copy=copy,
-                    name=name,
-                    tupleize_cols=tupleize_cols,
-                    **kwargs
-                )
-            ),
+        return ks.from_pandas(
+            pd.Index(
+                data=data, dtype=dtype, copy=copy, name=name, tupleize_cols=tupleize_cols, **kwargs
+            )
         )
 
     @staticmethod

--- a/databricks/koalas/indexes/datetimes.py
+++ b/databricks/koalas/indexes/datetimes.py
@@ -20,7 +20,7 @@ import pandas as pd
 from pandas.api.types import is_hashable
 from pyspark._globals import _NoValue
 
-import databricks.koalas as ks
+from databricks import koalas as ks
 from databricks.koalas.indexes.base import Index
 from databricks.koalas.missing.indexes import MissingPandasLikeDatetimeIndex
 

--- a/databricks/koalas/indexes/multi.py
+++ b/databricks/koalas/indexes/multi.py
@@ -56,13 +56,29 @@ class MultiIndex(Index):
     Koalas MultiIndex that corresponds to pandas MultiIndex logically. This might hold Spark Column
     internally.
 
-    :ivar _kdf: The parent dataframe
-    :type _kdf: DataFrame
-    :ivar _scol: Spark Column instance
-    :type _scol: pyspark.Column
+    Parameters
+    ----------
+    levels : sequence of arrays
+        The unique labels for each level.
+    codes : sequence of arrays
+        Integers for each level designating which label at each location.
+    sortorder : optional int
+        Level of sortedness (must be lexicographically sorted by that
+        level).
+    names : optional sequence of objects
+        Names for each of the index levels. (name is accepted for compat).
+    copy : bool, default False
+        Copy the meta-data.
+    verify_integrity : bool, default True
+        Check that the levels/codes are consistent and valid.
 
     See Also
     --------
+    MultiIndex.from_arrays  : Convert list of arrays to MultiIndex.
+    MultiIndex.from_product : Create a MultiIndex from the cartesian product
+                              of iterables.
+    MultiIndex.from_tuples  : Convert list of tuples to a MultiIndex.
+    MultiIndex.from_frame   : Make a MultiIndex from a DataFrame.
     Index : A single-level Index.
 
     Examples
@@ -80,10 +96,43 @@ class MultiIndex(Index):
                )
     """
 
-    def __new__(cls, kdf: DataFrame):
-        assert kdf._internal.index_level > 1
+    def __new__(
+        cls,
+        levels=None,
+        codes=None,
+        sortorder=None,
+        names=None,
+        dtype=None,
+        copy=False,
+        name=None,
+        verify_integrity: bool = True,
+    ):
+        if LooseVersion(pd.__version__) < LooseVersion("0.24"):
+            if levels is None or codes is None:
+                raise TypeError("Must pass both levels and codes")
 
-        return super().__new__(cls, data=kdf)
+            pidx = pd.MultiIndex(
+                levels=levels,
+                labels=codes,
+                sortorder=sortorder,
+                names=names,
+                dtype=dtype,
+                copy=copy,
+                name=name,
+                verify_integrity=verify_integrity,
+            )
+        else:
+            pidx = pd.MultiIndex(
+                levels=levels,
+                codes=codes,
+                sortorder=sortorder,
+                names=names,
+                dtype=dtype,
+                copy=copy,
+                name=name,
+                verify_integrity=verify_integrity,
+            )
+        return ks.from_pandas(pidx)
 
     @property
     def _internal(self):
@@ -144,9 +193,9 @@ class MultiIndex(Index):
         """
         return cast(
             MultiIndex,
-            DataFrame(
-                index=pd.MultiIndex.from_tuples(tuples=tuples, sortorder=sortorder, names=names)
-            ).index,
+            ks.from_pandas(
+                pd.MultiIndex.from_tuples(tuples=tuples, sortorder=sortorder, names=names)
+            ),
         )
 
     @staticmethod
@@ -181,9 +230,9 @@ class MultiIndex(Index):
         """
         return cast(
             MultiIndex,
-            DataFrame(
-                index=pd.MultiIndex.from_arrays(arrays=arrays, sortorder=sortorder, names=names)
-            ).index,
+            ks.from_pandas(
+                pd.MultiIndex.from_arrays(arrays=arrays, sortorder=sortorder, names=names)
+            ),
         )
 
     @staticmethod
@@ -226,11 +275,9 @@ class MultiIndex(Index):
         """
         return cast(
             MultiIndex,
-            DataFrame(
-                index=pd.MultiIndex.from_product(
-                    iterables=iterables, sortorder=sortorder, names=names
-                )
-            ).index,
+            ks.from_pandas(
+                pd.MultiIndex.from_product(iterables=iterables, sortorder=sortorder, names=names)
+            ),
         )
 
     @staticmethod
@@ -731,7 +778,7 @@ class MultiIndex(Index):
             ],
             index_names=self._internal.index_names,
         )
-        result = MultiIndex(DataFrame(internal))
+        result = cast(MultiIndex, DataFrame(internal).index)
 
         if result_name:
             result.names = result_name
@@ -797,19 +844,14 @@ class MultiIndex(Index):
                 raise KeyError("Level {} not found".format(name_like_string(level)))
         sdf = sdf[~scol.isin(codes)]
 
-        return MultiIndex(
-            DataFrame(
-                InternalFrame(
-                    spark_frame=sdf,
-                    index_spark_columns=[
-                        scol_for(sdf, col) for col in internal.index_spark_column_names
-                    ],
-                    index_names=internal.index_names,
-                    column_labels=[],
-                    data_spark_columns=[],
-                )
-            )
+        internal = InternalFrame(
+            spark_frame=sdf,
+            index_spark_columns=[scol_for(sdf, col) for col in internal.index_spark_column_names],
+            index_names=internal.index_names,
+            column_labels=[],
+            data_spark_columns=[],
         )
+        return cast(MultiIndex, DataFrame(internal).index)
 
     def value_counts(
         self, normalize=False, sort=True, ascending=False, bins=None, dropna=True

--- a/databricks/koalas/indexes/numeric.py
+++ b/databricks/koalas/indexes/numeric.py
@@ -13,7 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import pandas as pd
+from pandas.api.types import is_hashable
 
+import databricks.koalas as ks
 from databricks.koalas.indexes.base import Index
 
 
@@ -26,6 +29,30 @@ class NumericIndex(Index):
     pass
 
 
+_class_descr = """
+    Immutable ndarray implementing an ordered, sliceable set. The basic object
+    storing axis labels for all pandas objects. {klass}s is a special case
+    of `Index` with purely {ltype}s labels.
+
+    Parameters
+    ----------
+    data : array-like (1-dimensional)
+    dtype : NumPy dtype (default: {dtype}s)
+    copy : bool
+        Make a copy of input ndarray.
+    name : object
+        Name to be stored in the index.
+
+    See Also
+    --------
+    Index : The base pandas Index type.
+
+    Notes
+    -----
+    An Index instance can **only** contain hashable objects.
+"""
+
+
 class IntegerIndex(NumericIndex):
     """
     This is an abstract class for Int64Index.
@@ -35,36 +62,38 @@ class IntegerIndex(NumericIndex):
 
 
 class Int64Index(IntegerIndex):
-    """
-    Immutable sequence used for indexing and alignment. The basic object
-    storing axis labels for all pandas objects. Int64Index is a special case
-    of `Index` with purely integer labels.
+    __doc__ = (
+        _class_descr.format(klass="Int64Index", ltype="integer", dtype="int64")
+        + """
 
-    See Also
+    Examples
     --------
-    Index : The base pandas Index type.
-
-    Notes
-    -----
-    An Index instance can **only** contain hashable objects.
+    >>> ks.Int64Index([1, 2, 3])
+    Int64Index([1, 2, 3], dtype='int64')
     """
+    )
 
-    pass
+    def __new__(cls, data=None, dtype=None, copy=False, name=None):
+        if not is_hashable(name):
+            raise TypeError("Index.name must be a hashable type")
+
+        return ks.from_pandas(pd.Int64Index(data=data, dtype=dtype, copy=copy, name=name))
 
 
 class Float64Index(NumericIndex):
-    """
-    Immutable sequence used for indexing and alignment. The basic object
-    storing axis labels for all pandas objects. Float64Index is a special case
-    of `Index` with purely float labels.
+    __doc__ = (
+        _class_descr.format(klass="Float64Index", ltype="float", dtype="float64")
+        + """
 
-    See Also
+    Examples
     --------
-    Index : The base pandas Index type.
-
-    Notes
-    -----
-    An Index instance can **only** contain hashable objects.
+    >>> ks.Float64Index([1.0, 2.0, 3.0])
+    Float64Index([1.0, 2.0, 3.0], dtype='float64')
     """
+    )
 
-    pass
+    def __new__(cls, data=None, dtype=None, copy=False, name=None):
+        if not is_hashable(name):
+            raise TypeError("Index.name must be a hashable type")
+
+        return ks.from_pandas(pd.Float64Index(data=data, dtype=dtype, copy=copy, name=name))

--- a/databricks/koalas/indexes/numeric.py
+++ b/databricks/koalas/indexes/numeric.py
@@ -16,7 +16,7 @@
 import pandas as pd
 from pandas.api.types import is_hashable
 
-import databricks.koalas as ks
+from databricks import koalas as ks
 from databricks.koalas.indexes.base import Index
 
 

--- a/databricks/koalas/indexes/numeric.py
+++ b/databricks/koalas/indexes/numeric.py
@@ -29,30 +29,6 @@ class NumericIndex(Index):
     pass
 
 
-_class_descr = """
-    Immutable ndarray implementing an ordered, sliceable set. The basic object
-    storing axis labels for all pandas objects. {klass}s is a special case
-    of `Index` with purely {ltype}s labels.
-
-    Parameters
-    ----------
-    data : array-like (1-dimensional)
-    dtype : NumPy dtype (default: {dtype}s)
-    copy : bool
-        Make a copy of input ndarray.
-    name : object
-        Name to be stored in the index.
-
-    See Also
-    --------
-    Index : The base pandas Index type.
-
-    Notes
-    -----
-    An Index instance can **only** contain hashable objects.
-"""
-
-
 class IntegerIndex(NumericIndex):
     """
     This is an abstract class for Int64Index.
@@ -62,16 +38,34 @@ class IntegerIndex(NumericIndex):
 
 
 class Int64Index(IntegerIndex):
-    __doc__ = (
-        _class_descr.format(klass="Int64Index", ltype="integer", dtype="int64")
-        + """
+    """
+    Immutable sequence used for indexing and alignment. The basic object
+    storing axis labels for all pandas objects. Int64Index is a special case
+    of `Index` with purely integer labels.
+
+    Parameters
+    ----------
+    data : array-like (1-dimensional)
+    dtype : NumPy dtype (default: int64)
+    copy : bool
+        Make a copy of input ndarray.
+    name : object
+        Name to be stored in the index.
+
+    See Also
+    --------
+    Index : The base Koalas Index type.
+    Float64Index : A special case of :class:`Index` with purely float labels.
+
+    Notes
+    -----
+    An Index instance can **only** contain hashable objects.
 
     Examples
     --------
     >>> ks.Int64Index([1, 2, 3])
     Int64Index([1, 2, 3], dtype='int64')
     """
-    )
 
     def __new__(cls, data=None, dtype=None, copy=False, name=None):
         if not is_hashable(name):
@@ -81,16 +75,34 @@ class Int64Index(IntegerIndex):
 
 
 class Float64Index(NumericIndex):
-    __doc__ = (
-        _class_descr.format(klass="Float64Index", ltype="float", dtype="float64")
-        + """
+    """
+    Immutable sequence used for indexing and alignment. The basic object
+    storing axis labels for all pandas objects. Float64Index is a special case
+    of `Index` with purely float labels.
+
+    Parameters
+    ----------
+    data : array-like (1-dimensional)
+    dtype : NumPy dtype (default: float64)
+    copy : bool
+        Make a copy of input ndarray.
+    name : object
+        Name to be stored in the index.
+
+    See Also
+    --------
+    Index : The base Koalas Index type.
+    Int64Index : A special case of :class:`Index` with purely integer labels.
+
+    Notes
+    -----
+    An Index instance can **only** contain hashable objects.
 
     Examples
     --------
     >>> ks.Float64Index([1.0, 2.0, 3.0])
     Float64Index([1.0, 2.0, 3.0], dtype='float64')
     """
-    )
 
     def __new__(cls, data=None, dtype=None, copy=False, name=None):
         if not is_hashable(name):


### PR DESCRIPTION
Makes `Index` constructors follow pandas to create `Index` with the same signature as pandas'.

```py
>>> ks.Index([1, 2, 3])
Int64Index([1, 2, 3], dtype='int64')
>>> ks.Int64Index([1, 2, 3])
Int64Index([1, 2, 3], dtype='int64')
>>> ks.Float64Index([1.0, 2.0, 3.0])
Float64Index([1.0, 2.0, 3.0], dtype='float64')
>>> ks.DatetimeIndex(['1970-01-01', '1970-01-01', '1970-01-01'])
DatetimeIndex(['1970-01-01', '1970-01-01', '1970-01-01'], dtype='datetime64[ns]', freq=None)
```