### PR TITLE
Make Index constructor take Series or Index objects.

### DIFF
--- a/databricks/koalas/indexes/base.py
+++ b/databricks/koalas/indexes/base.py
@@ -110,6 +110,31 @@ class Index(IndexOpsMixin):
         if not is_hashable(name):
             raise TypeError("Index.name must be a hashable type")
 
+        if isinstance(data, Series):
+            if dtype is not None:
+                data = data.astype(dtype)
+            if name is not None:
+                data = data.rename(name)
+
+            internal = InternalFrame(
+                spark_frame=data._internal.spark_frame,
+                index_spark_columns=data._internal.data_spark_columns,
+                index_names=data._internal.column_labels,
+                index_dtypes=data._internal.data_dtypes,
+                column_labels=[],
+                data_spark_columns=[],
+                data_dtypes=[],
+            )
+            return DataFrame(internal).index
+        elif isinstance(data, Index):
+            if copy:
+                data = data.copy()
+            if dtype is not None:
+                data = data.astype(dtype)
+            if name is not None:
+                data = data.rename(name)
+            return data
+
         return ks.from_pandas(
             pd.Index(
                 data=data, dtype=dtype, copy=copy, name=name, tupleize_cols=tupleize_cols, **kwargs

--- a/databricks/koalas/indexes/base.py
+++ b/databricks/koalas/indexes/base.py
@@ -105,20 +105,17 @@ class Index(IndexOpsMixin):
     >>> ks.Index(list('abc'))
     Index(['a', 'b', 'c'], dtype='object')
 
-    From a Seires:
+    From a Series:
 
-    >>> s = ks.Series([1, 2, 3], name="a", index=[10, 20, 30])
+    >>> s = ks.Series([1, 2, 3], index=[10, 20, 30])
     >>> ks.Index(s)
-    Int64Index([1, 2, 3], dtype='int64', name='a')
+    Int64Index([1, 2, 3], dtype='int64')
 
-    >>> s = ks.Series([1.0, 2.0, 3.0], name="a", index=[10, 20, 30])
-    >>> ks.Index(s)
-    Float64Index([1.0, 2.0, 3.0], dtype='float64', name='a')
+    From an Index:
 
-    >>> from datetime import datetime
-    >>> s = ks.Series([datetime(2021, 3, 1), datetime(2021, 3, 2)], index=[10, 20])
-    >>> ks.Index(s)
-    DatetimeIndex(['2021-03-01', '2021-03-02'], dtype='datetime64[ns]', freq=None)
+    >>> idx = ks.Index([1, 2, 3])
+    >>> ks.Index(idx)
+    Int64Index([1, 2, 3], dtype='int64')
     """
 
     def __new__(cls, data=None, dtype=None, copy=False, name=None, tupleize_cols=True, **kwargs):

--- a/databricks/koalas/indexes/base.py
+++ b/databricks/koalas/indexes/base.py
@@ -104,6 +104,21 @@ class Index(IndexOpsMixin):
 
     >>> ks.Index(list('abc'))
     Index(['a', 'b', 'c'], dtype='object')
+
+    From a Seires:
+
+    >>> s = ks.Series([1, 2, 3], name="a", index=[10, 20, 30])
+    >>> ks.Index(s)
+    Int64Index([1, 2, 3], dtype='int64', name='a')
+
+    >>> s = ks.Series([1.0, 2.0, 3.0], name="a", index=[10, 20, 30])
+    >>> ks.Index(s)
+    Float64Index([1.0, 2.0, 3.0], dtype='float64', name='a')
+
+    >>> from datetime import datetime
+    >>> s = ks.Series([datetime(2021, 3, 1), datetime(2021, 3, 2)], index=[10, 20])
+    >>> ks.Index(s)
+    DatetimeIndex(['2021-03-01', '2021-03-02'], dtype='datetime64[ns]', freq=None)
     """
 
     def __new__(cls, data=None, dtype=None, copy=False, name=None, tupleize_cols=True, **kwargs):

--- a/databricks/koalas/indexes/datetimes.py
+++ b/databricks/koalas/indexes/datetimes.py
@@ -81,12 +81,18 @@ class DatetimeIndex(Index):
     >>> ks.DatetimeIndex(['1970-01-01', '1970-01-01', '1970-01-01'])
     DatetimeIndex(['1970-01-01', '1970-01-01', '1970-01-01'], dtype='datetime64[ns]', freq=None)
 
-    From a Seires:
+    From a Series:
 
     >>> from datetime import datetime
     >>> s = ks.Series([datetime(2021, 3, 1), datetime(2021, 3, 2)], index=[10, 20])
     >>> ks.DatetimeIndex(s)
     DatetimeIndex(['2021-03-01', '2021-03-02'], dtype='datetime64[ns]', freq=None)
+
+    From an Index:
+
+    >>> idx = ks.DatetimeIndex(['1970-01-01', '1970-01-01', '1970-01-01'])
+    >>> ks.DatetimeIndex(idx)
+    DatetimeIndex(['1970-01-01', '1970-01-01', '1970-01-01'], dtype='datetime64[ns]', freq=None)
     """
 
     def __new__(

--- a/databricks/koalas/indexes/datetimes.py
+++ b/databricks/koalas/indexes/datetimes.py
@@ -80,6 +80,13 @@ class DatetimeIndex(Index):
     --------
     >>> ks.DatetimeIndex(['1970-01-01', '1970-01-01', '1970-01-01'])
     DatetimeIndex(['1970-01-01', '1970-01-01', '1970-01-01'], dtype='datetime64[ns]', freq=None)
+
+    From a Seires:
+
+    >>> from datetime import datetime
+    >>> s = ks.Series([datetime(2021, 3, 1), datetime(2021, 3, 2)], index=[10, 20])
+    >>> ks.DatetimeIndex(s)
+    DatetimeIndex(['2021-03-01', '2021-03-02'], dtype='datetime64[ns]', freq=None)
     """
 
     def __new__(

--- a/databricks/koalas/indexes/datetimes.py
+++ b/databricks/koalas/indexes/datetimes.py
@@ -23,6 +23,7 @@ from pyspark._globals import _NoValue
 from databricks import koalas as ks
 from databricks.koalas.indexes.base import Index
 from databricks.koalas.missing.indexes import MissingPandasLikeDatetimeIndex
+from databricks.koalas.series import Series
 
 
 class DatetimeIndex(Index):
@@ -96,6 +97,11 @@ class DatetimeIndex(Index):
     ):
         if not is_hashable(name):
             raise TypeError("Index.name must be a hashable type")
+
+        if isinstance(data, (Series, Index)):
+            if dtype is None:
+                dtype = "datetime64[ns]"
+            return Index(data, dtype=dtype, copy=copy, name=name)
 
         kwargs = dict(
             data=data,

--- a/databricks/koalas/indexes/datetimes.py
+++ b/databricks/koalas/indexes/datetimes.py
@@ -30,9 +30,6 @@ class DatetimeIndex(Index):
     """
     Immutable ndarray-like of datetime64 data.
 
-    Represented internally as int64, and which can be boxed to Timestamp objects
-    that are subclasses of datetime and carry metadata.
-
     Parameters
     ----------
     data : array-like (1-dimensional), optional
@@ -64,7 +61,7 @@ class DatetimeIndex(Index):
         If True, parse dates in `data` with the day first order.
     yearfirst : bool, default False
         If True parse dates in `data` with the year first order.
-    dtype : numpy.dtype or DatetimeTZDtype or str, default None
+    dtype : numpy.dtype or str, default None
         Note that the only NumPy dtype allowed is ‘datetime64[ns]’.
     copy : bool, default False
         Make a copy of input ndarray.

--- a/databricks/koalas/indexes/numeric.py
+++ b/databricks/koalas/indexes/numeric.py
@@ -66,6 +66,12 @@ class Int64Index(IntegerIndex):
     --------
     >>> ks.Int64Index([1, 2, 3])
     Int64Index([1, 2, 3], dtype='int64')
+
+    From a Seires:
+
+    >>> s = ks.Series([1, 2, 3], name="a", index=[10, 20, 30])
+    >>> ks.Int64Index(s)
+    Int64Index([1, 2, 3], dtype='int64', name='a')
     """
 
     def __new__(cls, data=None, dtype=None, copy=False, name=None):
@@ -108,6 +114,12 @@ class Float64Index(NumericIndex):
     --------
     >>> ks.Float64Index([1.0, 2.0, 3.0])
     Float64Index([1.0, 2.0, 3.0], dtype='float64')
+
+    From a Seires:
+
+    >>> s = ks.Series([1, 2, 3], name="a", index=[10, 20, 30])
+    >>> ks.Float64Index(s)
+    Float64Index([1.0, 2.0, 3.0], dtype='float64', name='a')
     """
 
     def __new__(cls, data=None, dtype=None, copy=False, name=None):

--- a/databricks/koalas/indexes/numeric.py
+++ b/databricks/koalas/indexes/numeric.py
@@ -18,6 +18,7 @@ from pandas.api.types import is_hashable
 
 from databricks import koalas as ks
 from databricks.koalas.indexes.base import Index
+from databricks.koalas.series import Series
 
 
 class NumericIndex(Index):
@@ -71,6 +72,11 @@ class Int64Index(IntegerIndex):
         if not is_hashable(name):
             raise TypeError("Index.name must be a hashable type")
 
+        if isinstance(data, (Series, Index)):
+            if dtype is None:
+                dtype = "int64"
+            return Index(data, dtype=dtype, copy=copy, name=name)
+
         return ks.from_pandas(pd.Int64Index(data=data, dtype=dtype, copy=copy, name=name))
 
 
@@ -107,5 +113,10 @@ class Float64Index(NumericIndex):
     def __new__(cls, data=None, dtype=None, copy=False, name=None):
         if not is_hashable(name):
             raise TypeError("Index.name must be a hashable type")
+
+        if isinstance(data, (Series, Index)):
+            if dtype is None:
+                dtype = "float64"
+            return Index(data, dtype=dtype, copy=copy, name=name)
 
         return ks.from_pandas(pd.Float64Index(data=data, dtype=dtype, copy=copy, name=name))

--- a/databricks/koalas/indexes/numeric.py
+++ b/databricks/koalas/indexes/numeric.py
@@ -67,11 +67,17 @@ class Int64Index(IntegerIndex):
     >>> ks.Int64Index([1, 2, 3])
     Int64Index([1, 2, 3], dtype='int64')
 
-    From a Seires:
+    From a Series:
 
-    >>> s = ks.Series([1, 2, 3], name="a", index=[10, 20, 30])
+    >>> s = ks.Series([1, 2, 3], index=[10, 20, 30])
     >>> ks.Int64Index(s)
-    Int64Index([1, 2, 3], dtype='int64', name='a')
+    Int64Index([1, 2, 3], dtype='int64')
+
+    From an Index:
+
+    >>> idx = ks.Index([1, 2, 3])
+    >>> ks.Int64Index(idx)
+    Int64Index([1, 2, 3], dtype='int64')
     """
 
     def __new__(cls, data=None, dtype=None, copy=False, name=None):
@@ -115,11 +121,17 @@ class Float64Index(NumericIndex):
     >>> ks.Float64Index([1.0, 2.0, 3.0])
     Float64Index([1.0, 2.0, 3.0], dtype='float64')
 
-    From a Seires:
+    From a Series:
 
-    >>> s = ks.Series([1, 2, 3], name="a", index=[10, 20, 30])
+    >>> s = ks.Series([1, 2, 3], index=[10, 20, 30])
     >>> ks.Float64Index(s)
-    Float64Index([1.0, 2.0, 3.0], dtype='float64', name='a')
+    Float64Index([1.0, 2.0, 3.0], dtype='float64')
+
+    From an Index:
+
+    >>> idx = ks.Index([1, 2, 3])
+    >>> ks.Float64Index(idx)
+    Float64Index([1.0, 2.0, 3.0], dtype='float64')
     """
 
     def __new__(cls, data=None, dtype=None, copy=False, name=None):

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -45,7 +45,7 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
     def kdf(self):
         return ks.from_pandas(self.pdf)
 
-    def test_index(self):
+    def test_index_basic(self):
         for pdf in [
             pd.DataFrame(np.random.randn(10, 5), index=np.random.randint(100, size=10)),
             pd.DataFrame(
@@ -62,6 +62,40 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
             kdf = ks.from_pandas(pdf)
             self.assert_eq(kdf.index, pdf.index)
             self.assert_eq(type(kdf.index).__name__, type(pdf.index).__name__)
+
+    def test_index_from_series(self):
+        pser = pd.Series([1, 2, 3], name="a", index=[10, 20, 30])
+        kser = ks.from_pandas(pser)
+
+        self.assert_eq(ks.Index(kser), pd.Index(pser))
+        self.assert_eq(ks.Index(kser, dtype="float"), pd.Index(pser, dtype="float"))
+        self.assert_eq(ks.Index(kser, name="x"), pd.Index(pser, name="x"))
+
+        self.assert_eq(ks.Int64Index(kser), pd.Int64Index(pser))
+        self.assert_eq(ks.Float64Index(kser), pd.Float64Index(pser))
+
+        pser = pd.Series([datetime(2021, 3, 1), datetime(2021, 3, 2)], index=[10, 20])
+        kser = ks.from_pandas(pser)
+
+        self.assert_eq(ks.Index(kser), pd.Index(pser))
+        self.assert_eq(ks.DatetimeIndex(kser), pd.DatetimeIndex(pser))
+
+    def test_index_from_index(self):
+        pidx = pd.Index([1, 2, 3], name="a")
+        kidx = ks.from_pandas(pidx)
+
+        self.assert_eq(ks.Index(kidx), pd.Index(pidx))
+        self.assert_eq(ks.Index(kidx, dtype="float"), pd.Index(pidx, dtype="float"))
+        self.assert_eq(ks.Index(kidx, name="x"), pd.Index(pidx, name="x"))
+
+        self.assert_eq(ks.Int64Index(kidx), pd.Int64Index(pidx))
+        self.assert_eq(ks.Float64Index(kidx), pd.Float64Index(pidx))
+
+        pidx = pd.DatetimeIndex(["2021-03-01", "2021-03-02"])
+        kidx = ks.from_pandas(pidx)
+
+        self.assert_eq(ks.Index(kidx), pd.Index(pidx))
+        self.assert_eq(ks.DatetimeIndex(kidx), pd.DatetimeIndex(pidx))
 
     def test_index_getattr(self):
         kidx = self.kdf.index

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -71,10 +71,14 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         self.assert_eq(ks.Index(kser, dtype="float"), pd.Index(pser, dtype="float"))
         self.assert_eq(ks.Index(kser, name="x"), pd.Index(pser, name="x"))
 
-        self.assert_eq(ks.Int64Index(kser), pd.Int64Index(pser))
-        self.assert_eq(ks.Float64Index(kser), pd.Float64Index(pser))
+        if LooseVersion(pd.__version__) >= LooseVersion("1.1"):
+            self.assert_eq(ks.Int64Index(kser), pd.Int64Index(pser))
+            self.assert_eq(ks.Float64Index(kser), pd.Float64Index(pser))
+        else:
+            self.assert_eq(ks.Int64Index(kser), pd.Int64Index(pser).rename("a"))
+            self.assert_eq(ks.Float64Index(kser), pd.Float64Index(pser).rename("a"))
 
-        pser = pd.Series([datetime(2021, 3, 1), datetime(2021, 3, 2)], index=[10, 20])
+        pser = pd.Series([datetime(2021, 3, 1), datetime(2021, 3, 2)], name="x", index=[10, 20])
         kser = ks.from_pandas(pser)
 
         self.assert_eq(ks.Index(kser), pd.Index(pser))


### PR DESCRIPTION
Makes `Index `constructor take `Series` or `Index` objects.

```py
>>> kser = ks.Series([1, 2, 3], name="a", index=[10, 20, 30])
>>> ks.Index(kser)
Int64Index([1, 2, 3], dtype='int64', name='a')
>>> ks.Int64Index(kser)
Int64Index([1, 2, 3], dtype='int64', name='a')
>>> ks.Float64Index(kser)
Float64Index([1.0, 2.0, 3.0], dtype='float64', name='a')

>>> kser = ks.Series([datetime(2021, 3, 1), datetime(2021, 3, 2)], index=[10, 20])
>>> ks.Index(kser)
DatetimeIndex(['2021-03-01', '2021-03-02'], dtype='datetime64[ns]', freq=None)
>>> ks.DatetimeIndex(kser)
DatetimeIndex(['2021-03-01', '2021-03-02'], dtype='datetime64[ns]', freq=None)
```