### PR TITLE
Upgrade pandas to 1.2.3 for CI

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -107,7 +107,7 @@ jobs:
             pyarrow-version: 1.0.1
           - python-version: 3.8
             spark-version: 3.0.2
-            pandas-version: 1.2.2
+            pandas-version: 1.2.3
             pyarrow-version: 3.0.0
             default-index-type: 'distributed-sequence'
     env:


### PR DESCRIPTION
pandas 1.2.3 is released yesterday, so we should test this in CI.

[What's new in 1.2.3](https://pandas.pydata.org/pandas-docs/dev/whatsnew/v1.2.3.html)