### PR TITLE
Implement DatetimeIndex.ceil()

### DIFF
--- a/databricks/koalas/indexes/datetimes.py
+++ b/databricks/koalas/indexes/datetimes.py
@@ -431,3 +431,49 @@ class DatetimeIndex(Index):
         return Index(self.to_series().dt.days_in_month)
 
     days_in_month.__doc__ = daysinmonth.__doc__
+
+    # Methods
+    def ceil(self, freq, *args, **kwargs) -> Index:
+        """
+        Perform floor operation on the data to the specified freq.
+
+        Parameters
+        ----------
+        freq : str or Offset
+            The frequency level to ceil the index to. Must be a fixed
+            frequency like 'S' (second) not 'ME' (month end).
+
+        nonexistent : 'shift_forward', 'shift_backward, 'NaT', timedelta, default 'raise'
+            A nonexistent time does not exist in a particular timezone
+            where clocks moved forward due to DST.
+
+            - 'shift_forward' will shift the nonexistent time forward to the
+              closest existing time
+            - 'shift_backward' will shift the nonexistent time backward to the
+              closest existing time
+            - 'NaT' will return NaT where there are nonexistent times
+            - timedelta objects will shift nonexistent times by the timedelta
+            - 'raise' will raise an NonExistentTimeError if there are
+              nonexistent times
+
+            .. note:: this option only works with pandas 0.24.0+
+
+        Returns
+        -------
+        Index
+
+        Raises
+        ------
+        ValueError if the `freq` cannot be converted.
+
+        Examples
+        --------
+        >>> rng = ks.from_pandas(pd.date_range('1/1/2018 11:59:00', periods=3, freq='min'))
+        >>> rng.ceil('H')
+        DatetimeIndex(['2018-01-01 12:00:00', '2018-01-01 12:00:00',
+                       '2018-01-01 13:00:00'],
+                      dtype='datetime64[ns]', freq=None)
+        """
+        assert freq not in ["N", "ns"], "nanoseconds is not supported"
+
+        return Index(self.to_series().dt.ceil(freq, *args, **kwargs))

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -408,6 +408,30 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
                 self.assert_eq(kidx.day_of_year, pidx.day_of_year)
                 self.assert_eq(kidx.day_of_week, pidx.day_of_week)
 
+    def test_datetime_index_ceil(self):
+        fixed_freqs = [
+            "D",
+            "H",
+            "T",  # min
+            "S",
+            "L",  # ms
+            "U",  # us
+            # 'N'
+        ]
+        non_fixed_freqs = ["W", "Q"]
+        pidx_list = [
+            pd.DatetimeIndex([0]),
+            pd.DatetimeIndex(["2004-01-01", "2002-12-31", "2000-04-01"]),
+        ] + [
+            pd.date_range("2000-01-01", periods=3, freq=freq)
+            for freq in (fixed_freqs + non_fixed_freqs)
+        ]
+
+        for pidx in pidx_list:
+            kidx = ks.from_pandas(pidx)
+            for freq in fixed_freqs:
+                self.assert_eq(kidx.ceil(freq), pidx.ceil(freq))
+
     def test_multi_index_copy(self):
         arrays = [[1, 1, 2, 2], ["red", "blue", "red", "blue"]]
         idx = pd.MultiIndex.from_arrays(arrays, names=("number", "color"))

--- a/docs/source/reference/indexing.rst
+++ b/docs/source/reference/indexing.rst
@@ -323,3 +323,7 @@ Time/date components
    DatetimeIndex.is_leap_year
    DatetimeIndex.daysinmonth
    DatetimeIndex.days_in_month
+
+Time-specific operations
+~~~~~~~~~~~~~~~~~~~~~~~~
+   DatetimeIndex.ceil


### PR DESCRIPTION
```
>>> rng = ks.from_pandas(pd.date_range('1/1/2018 11:59:00', periods=3, freq='min'))
>>> rng.ceil('H')
DatetimeIndex(['2018-01-01 12:00:00', '2018-01-01 12:00:00',
               '2018-01-01 13:00:00'],
              dtype='datetime64[ns]', freq=None)
```