### PR TITLE
Restructure the hierarchy of Index unit tests

### DIFF
--- a/databricks/koalas/tests/indexes/__init__.py
+++ b/databricks/koalas/tests/indexes/__init__.py
@@ -1,0 +1,15 @@
+#
+# Copyright (C) 2019 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/databricks/koalas/tests/indexes/test_base.py
+++ b/databricks/koalas/tests/indexes/test_base.py
@@ -370,44 +370,6 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         with self.assertRaisesRegex(KeyError, "Requested level (hi)*"):
             kidx.unique(level="hi")
 
-    def test_datetime_index_properties(self):
-        pidx_list = [
-            pd.DatetimeIndex([0]),
-            pd.DatetimeIndex(["2004-01-01", "2002-12-31", "2000-04-01"]),
-        ] + [
-            pd.date_range("2000-01-01", periods=3, freq=unit)
-            for unit in ["ns", "us", "ms", "s", "m", "h", "D"]
-        ]
-
-        for pidx in pidx_list:
-            kidx = ks.from_pandas(pidx)
-            self.assert_eq(kidx.year, pidx.year)
-            self.assert_eq(kidx.month, pidx.month)
-            self.assert_eq(kidx.day, pidx.day)
-            self.assert_eq(kidx.hour, pidx.hour)
-            self.assert_eq(kidx.minute, pidx.minute)
-            self.assert_eq(kidx.second, pidx.second)
-            self.assert_eq(kidx.microsecond, pidx.microsecond)
-            self.assert_eq(kidx.week, pidx.week)
-            self.assert_eq(kidx.weekofyear, pidx.weekofyear)
-            self.assert_eq(kidx.dayofweek, pidx.dayofweek)
-            self.assert_eq(kidx.weekday, pidx.weekday)
-            self.assert_eq(kidx.dayofyear, pidx.dayofyear)
-            self.assert_eq(kidx.quarter, pidx.quarter)
-            self.assert_eq(kidx.daysinmonth, pidx.daysinmonth)
-            self.assert_eq(kidx.days_in_month, pidx.days_in_month)
-            self.assert_eq(kidx.is_month_start, pd.Index(pidx.is_month_start))
-            self.assert_eq(kidx.is_month_end, pd.Index(pidx.is_month_end))
-            self.assert_eq(kidx.is_quarter_start, pd.Index(pidx.is_quarter_start))
-            self.assert_eq(kidx.is_quarter_end, pd.Index(pidx.is_quarter_end))
-            self.assert_eq(kidx.is_year_start, pd.Index(pidx.is_year_start))
-            self.assert_eq(kidx.is_year_end, pd.Index(pidx.is_year_end))
-            self.assert_eq(kidx.is_leap_year, pd.Index(pidx.is_leap_year))
-
-            if LooseVersion(pd.__version__) >= LooseVersion("1.2.0"):
-                self.assert_eq(kidx.day_of_year, pidx.day_of_year)
-                self.assert_eq(kidx.day_of_week, pidx.day_of_week)
-
     def test_multi_index_copy(self):
         arrays = [[1, 1, 2, 2], ["red", "blue", "red", "blue"]]
         idx = pd.MultiIndex.from_arrays(arrays, names=("number", "color"))

--- a/databricks/koalas/tests/indexes/test_datetime.py
+++ b/databricks/koalas/tests/indexes/test_datetime.py
@@ -17,7 +17,6 @@
 from distutils.version import LooseVersion
 
 import pandas as pd
-
 import databricks.koalas as ks
 
 from databricks.koalas.testing.utils import ReusedSQLTestCase, TestUtils

--- a/databricks/koalas/tests/indexes/test_datetime.py
+++ b/databricks/koalas/tests/indexes/test_datetime.py
@@ -1,0 +1,88 @@
+#
+# Copyright (C) 2019 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from distutils.version import LooseVersion
+
+import pandas as pd
+
+import databricks.koalas as ks
+
+from databricks.koalas.testing.utils import ReusedSQLTestCase, TestUtils
+
+
+class DatetimeIndexTest(ReusedSQLTestCase, TestUtils):
+    @property
+    def fixed_freqs(self):
+        return [
+            "D",
+            "H",
+            "T",  # min
+            "S",
+            "L",  # ms
+            "U",  # us
+            # 'N' not supported
+        ]
+
+    @property
+    def non_fixed_freqs(self):
+        return ["W", "Q"]
+
+    @property
+    def pidxs(self):
+        return [
+            pd.DatetimeIndex([0]),
+            pd.DatetimeIndex(["2004-01-01", "2002-12-31", "2000-04-01"]),
+        ] + [
+            pd.date_range("2000-01-01", periods=3, freq=freq)
+            for freq in (self.fixed_freqs + self.non_fixed_freqs)
+        ]
+
+    @property
+    def kidxs(self):
+        return [ks.from_pandas(pidx) for pidx in self.pidxs]
+
+    @property
+    def idx_pairs(self):
+        return list(zip(self.kidxs, self.pidxs))
+
+    def test_properties(self):
+        for kidx, pidx in self.idx_pairs:
+            self.assert_eq(kidx.year, pidx.year)
+            self.assert_eq(kidx.month, pidx.month)
+            self.assert_eq(kidx.day, pidx.day)
+            self.assert_eq(kidx.hour, pidx.hour)
+            self.assert_eq(kidx.minute, pidx.minute)
+            self.assert_eq(kidx.second, pidx.second)
+            self.assert_eq(kidx.microsecond, pidx.microsecond)
+            self.assert_eq(kidx.week, pidx.week)
+            self.assert_eq(kidx.weekofyear, pidx.weekofyear)
+            self.assert_eq(kidx.dayofweek, pidx.dayofweek)
+            self.assert_eq(kidx.weekday, pidx.weekday)
+            self.assert_eq(kidx.dayofyear, pidx.dayofyear)
+            self.assert_eq(kidx.quarter, pidx.quarter)
+            self.assert_eq(kidx.daysinmonth, pidx.daysinmonth)
+            self.assert_eq(kidx.days_in_month, pidx.days_in_month)
+            self.assert_eq(kidx.is_month_start, pd.Index(pidx.is_month_start))
+            self.assert_eq(kidx.is_month_end, pd.Index(pidx.is_month_end))
+            self.assert_eq(kidx.is_quarter_start, pd.Index(pidx.is_quarter_start))
+            self.assert_eq(kidx.is_quarter_end, pd.Index(pidx.is_quarter_end))
+            self.assert_eq(kidx.is_year_start, pd.Index(pidx.is_year_start))
+            self.assert_eq(kidx.is_year_end, pd.Index(pidx.is_year_end))
+            self.assert_eq(kidx.is_leap_year, pd.Index(pidx.is_leap_year))
+
+            if LooseVersion(pd.__version__) >= LooseVersion("1.2.0"):
+                self.assert_eq(kidx.day_of_year, pidx.day_of_year)
+                self.assert_eq(kidx.day_of_week, pidx.day_of_week)


### PR DESCRIPTION
Proposal: 
`databricks/koalas/tests/test_indexes.py` -> `databricks/koalas/tests/indexes/test_base.py`
Create `databricks/koalas/tests/indexes/test_datetime.py`