### PR TITLE
Add a note for GroupBy and compute.max_rows

### DIFF
--- a/databricks/koalas/config.py
+++ b/databricks/koalas/config.py
@@ -134,9 +134,9 @@ _options = [
     Option(
         key="compute.max_rows",
         doc=(
-            "'compute.max_rows' sets the limit of the current DataFrame. Set `None` to unlimit "
-            "the input length. When the limit is set, it is executed by the shortcut by "
-            "collecting the data into driver side, and then using pandas API. If the limit is "
+            "'compute.max_rows' sets the limit of the current Koalas DataFrame. Set `None` to "
+            "unlimit the input length. When the limit is set, it is executed by the shortcut by "
+            "collecting the data into the driver, and then using the pandas API. If the limit is "
             "unset, the operation is executed by PySpark. Default is 1000."
         ),
         default=1000,

--- a/dev/gendoc.py
+++ b/dev/gendoc.py
@@ -94,7 +94,7 @@ def gen_release_notes(path):
     shutil.rmtree(whatsnew_dir, ignore_errors=True)
     os.mkdir(whatsnew_dir)
 
-    with open("%s/index.rst" % whatsnew_dir, "a") as index_file:
+    with open("%s/index.rst" % whatsnew_dir, "a", encoding="utf-8") as index_file:
         title = "Release Notes"
 
         index_file.write("=" * len(title))
@@ -126,7 +126,8 @@ def gen_release_notes(path):
             index_file.write("\n")
             index_file.write("\n")
 
-            with open("%s/%s.rst" % (whatsnew_dir, tag_name), "a") as release_file:
+            with open("%s/%s.rst" % (whatsnew_dir, tag_name), "a", encoding="utf-8") \
+                    as release_file:
                 release_file.write("=" * len(name))
                 release_file.write("\n")
                 release_file.write(name)

--- a/docs/source/user_guide/options.rst
+++ b/docs/source/user_guide/options.rst
@@ -236,10 +236,10 @@ display.max_rows                1000           This sets the maximum number of r
                                                at the repr() in a dataframe. Set `None` to unlimit
                                                the input length. Default is 1000.
 compute.max_rows                1000           'compute.max_rows' sets the limit of the current
-                                               DataFrame. Set `None` to unlimit the input length.
-                                               When the limit is set, it is executed by the shortcut
-                                               by collecting the data into driver side, and then
-                                               using pandas API. If the limit is unset, the
+                                               Koalas DataFrame. Set `None` to unlimit the input
+                                               length. When the limit is set, it is executed by the
+                                               shortcut by collecting the data into the driver, and
+                                               then using the pandas API. If the limit is unset, the
                                                operation is executed by PySpark. Default is 1000.
 compute.shortcut_limit          1000           'compute.shortcut_limit' sets the limit for a
                                                shortcut. It computes specified number of rows and
@@ -270,6 +270,7 @@ plotting.sample_ratio           None           'plotting.sample_ratio' sets the 
                                                'plotting.max_rows' option.
 plotting.backend                'plotly'       Backend to use for plotting. Default is plotly.
                                                Supports any package that has a top-level `.plot`
-                                               method. Some options are: [matplotlib, plotly,
-                                               pandas_bokeh, pandas_altair].
+                                               method. Known options are: [matplotlib, plotly].
 =============================== ============== =====================================================
+
+

--- a/docs/source/user_guide/options.rst
+++ b/docs/source/user_guide/options.rst
@@ -272,5 +272,3 @@ plotting.backend                'plotly'       Backend to use for plotting. Defa
                                                Supports any package that has a top-level `.plot`
                                                method. Known options are: [matplotlib, plotly].
 =============================== ============== =====================================================
-
-


### PR DESCRIPTION
This clarifies a question raised in #2072 regarding the impact of max_rows on the size of dataframes/series received by function when using, e.g., `groupby` and `apply`, where the groups can exceed `compute.max_rows` rows.