### PR TITLE
Add note to MultiIndex.is_monotonic*

### DIFF
--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -767,6 +767,9 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
             which is potentially expensive. In case of multi-index, all data are
             transferred to single node which can easily cause out-of-memory error currently.
 
+        .. note:: Disable the `spark.sql.optimizer.nestedSchemaPruning.enabled`
+            for multi-index if you're using Koalas < 1.7.0 with PySpark 3.1.1.
+
         Returns
         -------
         is_monotonic : bool
@@ -841,6 +844,9 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
             and aggregate multiple times to check the order locally and globally,
             which is potentially expensive. In case of multi-index, all data are transferred
             to single node which can easily cause out-of-memory error currently.
+
+        .. note:: Disable the `spark.sql.optimizer.nestedSchemaPruning.enabled`
+            for multi-index if you're using Koalas < 1.7.0 with PySpark 3.1.1.
 
         Returns
         -------

--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -767,7 +767,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
             which is potentially expensive. In case of multi-index, all data are
             transferred to single node which can easily cause out-of-memory error currently.
 
-        .. note:: Disable the `spark.sql.optimizer.nestedSchemaPruning.enabled`
+        .. note:: Disable the Spark config `spark.sql.optimizer.nestedSchemaPruning.enabled`
             for multi-index if you're using Koalas < 1.7.0 with PySpark 3.1.1.
 
         Returns
@@ -845,7 +845,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
             which is potentially expensive. In case of multi-index, all data are transferred
             to single node which can easily cause out-of-memory error currently.
 
-        .. note:: Disable the `spark.sql.optimizer.nestedSchemaPruning.enabled`
+        .. note:: Disable the Spark config `spark.sql.optimizer.nestedSchemaPruning.enabled`
             for multi-index if you're using Koalas < 1.7.0 with PySpark 3.1.1.
 
         Returns


### PR DESCRIPTION
`MultiIndex.is_monotonic_increasing` and `MultiIndex.is_monotonic_decreasing` won't work in Koalas < 1.7.0 with PySpark 3.1.1 without disabling the `spark.sql.optimizer.nestedSchemaPruning.enabled`.

We should mention this to the docs.