### PR TITLE
Implement DatetimeIndex.month_name() and DatetimeIndex.day_name()

### DIFF
--- a/databricks/koalas/indexes/datetimes.py
+++ b/databricks/koalas/indexes/datetimes.py
@@ -523,6 +523,52 @@ class DatetimeIndex(Index):
 
         return DatetimeIndex(self.to_series().dt.round(freq, *args, **kwargs))
 
+    def month_name(self, locale=None) -> Index:
+        """
+        Return the month names of the DateTimeIndex with specified locale.
+
+        Parameters
+        ----------
+        locale : str, optional
+            Locale determining the language in which to return the month name.
+            Default is English locale.
+
+        Returns
+        -------
+        Index
+            Series of month names.
+
+        Examples
+        --------
+        >>> idx = ks.date_range(start='2018-01', freq='M', periods=3)
+        >>> idx.month_name()
+        Index(['January', 'February', 'March'], dtype='object')
+        """
+        return Index(self.to_series().dt.month_name(locale))
+
+    def day_name(self, locale=None) -> Index:
+        """
+        Return the day names of the series with specified locale.
+
+        Parameters
+        ----------
+        locale : str, optional
+            Locale determining the language in which to return the day name.
+            Default is English locale.
+
+        Returns
+        -------
+        Index
+            Index of day names.
+
+        Examples
+        --------
+        >>> idx = ks.date_range(start='2018-01-01', freq='D', periods=3)
+        >>> idx.day_name()
+        Index(['Monday', 'Tuesday', 'Wednesday'], dtype='object')
+        """
+        return Index(self.to_series().dt.day_name(locale))
+
     def normalize(self) -> "DatetimeIndex":
         """
         Convert times to midnight.

--- a/databricks/koalas/indexes/datetimes.py
+++ b/databricks/koalas/indexes/datetimes.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 from functools import partial
-from typing import Any
+from typing import Any, Optional
 
 import pandas as pd
 from pandas.api.types import is_hashable
@@ -523,7 +523,7 @@ class DatetimeIndex(Index):
 
         return DatetimeIndex(self.to_series().dt.round(freq, *args, **kwargs))
 
-    def month_name(self, locale=None) -> Index:
+    def month_name(self, locale: Optional[str] = None) -> Index:
         """
         Return the month names of the DateTimeIndex with specified locale.
 
@@ -546,7 +546,7 @@ class DatetimeIndex(Index):
         """
         return Index(self.to_series().dt.month_name(locale))
 
-    def day_name(self, locale=None) -> Index:
+    def day_name(self, locale: Optional[str] = None) -> Index:
         """
         Return the day names of the series with specified locale.
 

--- a/databricks/koalas/indexes/datetimes.py
+++ b/databricks/koalas/indexes/datetimes.py
@@ -525,7 +525,7 @@ class DatetimeIndex(Index):
 
     def month_name(self, locale: Optional[str] = None) -> Index:
         """
-        Return the month names of the DateTimeIndex with specified locale.
+        Return the month names of the DatetimeIndex with specified locale.
 
         Parameters
         ----------

--- a/databricks/koalas/missing/indexes.py
+++ b/databricks/koalas/missing/indexes.py
@@ -118,8 +118,6 @@ class MissingPandasLikeDatetimeIndex(MissingPandasLikeIndex):
     to_period = _unsupported_function("to_period", cls="DatetimeIndex")
     to_perioddelta = _unsupported_function("to_perioddelta", cls="DatetimeIndex")
     to_pydatetime = _unsupported_function("to_pydatetime", cls="DatetimeIndex")
-    month_name = _unsupported_function("month_name", cls="DatetimeIndex")
-    day_name = _unsupported_function("day_name", cls="DatetimeIndex")
     mean = _unsupported_function("mean", cls="DatetimeIndex")
     std = _unsupported_function("std", cls="DatetimeIndex")
 

--- a/databricks/koalas/tests/indexes/test_datetime.py
+++ b/databricks/koalas/tests/indexes/test_datetime.py
@@ -111,6 +111,18 @@ class DatetimeIndexTest(ReusedSQLTestCase, TestUtils):
 
         self._disallow_nanoseconds(self.kidxs[0].round)
 
+    def test_day_name(self):
+        for kidx, pidx in self.idx_pairs:
+            self.assert_eq(kidx.day_name(), pidx.day_name())
+            self.assert_eq(kidx.day_name(locale="zh_CN.UTF-8"), pidx.day_name(locale="zh_CN.UTF-8"))
+
+    def test_month_name(self):
+        for kidx, pidx in self.idx_pairs:
+            self.assert_eq(kidx.day_name(), pidx.day_name())
+            self.assert_eq(
+                kidx.month_name(locale="zh_CN.UTF-8"), pidx.month_name(locale="zh_CN.UTF-8")
+            )
+
     def test_normalize(self):
         for kidx, pidx in self.idx_pairs:
             self.assert_eq(kidx.normalize(), pidx.normalize())

--- a/databricks/koalas/tests/indexes/test_datetime.py
+++ b/databricks/koalas/tests/indexes/test_datetime.py
@@ -114,14 +114,11 @@ class DatetimeIndexTest(ReusedSQLTestCase, TestUtils):
     def test_day_name(self):
         for kidx, pidx in self.idx_pairs:
             self.assert_eq(kidx.day_name(), pidx.day_name())
-            self.assert_eq(kidx.day_name(locale="zh_CN.UTF-8"), pidx.day_name(locale="zh_CN.UTF-8"))
+
 
     def test_month_name(self):
         for kidx, pidx in self.idx_pairs:
             self.assert_eq(kidx.day_name(), pidx.day_name())
-            self.assert_eq(
-                kidx.month_name(locale="zh_CN.UTF-8"), pidx.month_name(locale="zh_CN.UTF-8")
-            )
 
     def test_normalize(self):
         for kidx, pidx in self.idx_pairs:

--- a/databricks/koalas/tests/indexes/test_datetime.py
+++ b/databricks/koalas/tests/indexes/test_datetime.py
@@ -115,7 +115,6 @@ class DatetimeIndexTest(ReusedSQLTestCase, TestUtils):
         for kidx, pidx in self.idx_pairs:
             self.assert_eq(kidx.day_name(), pidx.day_name())
 
-
     def test_month_name(self):
         for kidx, pidx in self.idx_pairs:
             self.assert_eq(kidx.day_name(), pidx.day_name())

--- a/docs/source/reference/indexing.rst
+++ b/docs/source/reference/indexing.rst
@@ -334,3 +334,5 @@ Time-specific operations
    DatetimeIndex.round
    DatetimeIndex.floor
    DatetimeIndex.ceil
+   DatetimeIndex.month_name
+   DatetimeIndex.day_name


### PR DESCRIPTION
```py
>>> idx = ks.date_range(start='2018-01', freq='M', periods=3)
>>> idx.month_name()
Index(['January', 'February', 'March'], dtype='object')

>>> idx = ks.date_range(start='2018-01-01', freq='D', periods=3)
>>> idx.day_name()
Index(['Monday', 'Tuesday', 'Wednesday'], dtype='object')
```