### PR TITLE
Exclude docs/build from pycodestyle check.

### DIFF
--- a/databricks/koalas/plot/core.py
+++ b/databricks/koalas/plot/core.py
@@ -637,9 +637,9 @@ class KoalasPlotAccessor(PandasObject):
             >>> df = ks.DataFrame({'speed': speed,
             ...                    'lifespan': lifespan}, index=index)
             >>> fig = (make_subplots(rows=2, cols=1)
-            ...     .add_trace(df.plot.bar(y='speed').data[0], row=1, col=1)
-            ...     .add_trace(df.plot.bar(y='speed').data[0], row=1, col=1)
-            ...     .add_trace(df.plot.bar(y='lifespan').data[0], row=2, col=1))
+            ...        .add_trace(df.plot.bar(y='speed').data[0], row=1, col=1)
+            ...        .add_trace(df.plot.bar(y='speed').data[0], row=1, col=1)
+            ...        .add_trace(df.plot.bar(y='lifespan').data[0], row=2, col=1))
             >>> fig  # doctest: +SKIP
 
         Plot a single column.

--- a/dev/tox.ini
+++ b/dev/tox.ini
@@ -16,4 +16,4 @@
 [pycodestyle]
 ignore=E203,E226,E231,E241,E305,E402,E722,E731,E741,W503,W504
 max-line-length=100
-exclude=.git/*
+exclude=.git/*,docs/build/*


### PR DESCRIPTION
Excludes docs/build from pycodestyle check; otherwise it fails with the following errors if there are documents built:

```
pycodestyle checks failed:
./docs/build/html/reference/api/databricks-koalas-DataFrame-plot-bar-4.py:9:5: E128 continuation line under-indented for visual indent
./docs/build/html/reference/api/databricks-koalas-DataFrame-plot-bar-4.py:10:5: E128 continuation line under-indented for visual indent
./docs/build/html/reference/api/databricks-koalas-DataFrame-plot-bar-4.py:11:5: E128 continuation line under-indented for visual indent
./docs/build/html/reference/api/databricks-koalas-Series-plot-bar-4.py:9:5: E128 continuation line under-indented for visual indent
./docs/build/html/reference/api/databricks-koalas-Series-plot-bar-4.py:10:5: E128 continuation line under-indented for visual indent
./docs/build/html/reference/api/databricks-koalas-Series-plot-bar-4.py:11:5: E128 continuation line under-indented for visual indent
```