### PR TITLE
Fix window functions to resolve.

### DIFF
--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -1403,9 +1403,9 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
         >>> df.index.shift(periods=3, fill_value=0)
         Int64Index([0, 0, 0, 0, 1], dtype='int64')
         """
-        return self._shift(periods, fill_value)
+        return self._shift(periods, fill_value).spark.analyzed
 
-    def _shift(self, periods, fill_value, part_cols=()):
+    def _shift(self, periods, fill_value, *, part_cols=()):
         if not isinstance(periods, int):
             raise ValueError("periods should be an int; however, got [%s]" % type(periods).__name__)
 
@@ -1417,7 +1417,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
         )
         lag_col = F.lag(col, periods).over(window)
         col = F.when(lag_col.isNull() | F.isnan(lag_col), fill_value).otherwise(lag_col)
-        return self._with_new_scol(col)  # TODO: dtype?
+        return self._with_new_scol(col, dtype=self.dtype)
 
     # TODO: Update Documentation for Bins Parameter when its supported
     def value_counts(

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -3873,7 +3873,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         4    20    23    27
 
         """
-        return self._apply_series_op(lambda kser: kser.shift(periods, fill_value))
+        return self._apply_series_op(
+            lambda kser: kser._shift(periods, fill_value), should_resolve=True
+        )
 
     # TODO: axis should support 1 or 'columns' either at this moment
     def diff(self, periods: int = 1, axis: Union[int, str] = 0) -> "DataFrame":
@@ -3948,7 +3950,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         if axis != 0:
             raise NotImplementedError('axis should be either 0 or "index" currently.')
 
-        return self._apply_series_op(lambda kser: kser.diff(periods))
+        return self._apply_series_op(lambda kser: kser._diff(periods), should_resolve=True)
 
     # TODO: axis should support 1 or 'columns' either at this moment
     def nunique(
@@ -9458,7 +9460,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         2  2.0  2.0
         3  3.0  1.0
         """
-        return self._apply_series_op(lambda kser: kser.rank(method=method, ascending=ascending))
+        return self._apply_series_op(
+            lambda kser: kser._rank(method=method, ascending=ascending), should_resolve=True
+        )
 
     def filter(self, items=None, like=None, regex=None, axis=None) -> "DataFrame":
         """
@@ -10086,7 +10090,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 kser._internal.data_spark_column_names[0]
             )
 
-        return self._apply_series_op(op)
+        return self._apply_series_op(op, should_resolve=True)
 
     # TODO: axis = 1
     def idxmax(self, axis=0) -> "Series":

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -701,7 +701,7 @@ class GroupBy(object, metaclass=ABCMeta):
         Name: a, dtype: float64
         """
         return self._apply_series_op(
-            lambda sg: sg._kser._diff(periods, part_cols=sg._groupkeys_scols)
+            lambda sg: sg._kser._diff(periods, part_cols=sg._groupkeys_scols), should_resolve=True
         )
 
     def cumcount(self, ascending=True) -> Series:
@@ -1486,7 +1486,8 @@ class GroupBy(object, metaclass=ABCMeta):
 
         """
         return self._apply_series_op(
-            lambda sg: sg._kser._rank(method, ascending, part_cols=sg._groupkeys_scols)
+            lambda sg: sg._kser._rank(method, ascending, part_cols=sg._groupkeys_scols),
+            should_resolve=True,
         )
 
     # TODO: add axis parameter
@@ -2017,7 +2018,8 @@ class GroupBy(object, metaclass=ABCMeta):
         8  0
         """
         return self._apply_series_op(
-            lambda sg: sg._kser._shift(periods, fill_value, part_cols=sg._groupkeys_scols)
+            lambda sg: sg._kser._shift(periods, fill_value, part_cols=sg._groupkeys_scols),
+            should_resolve=True,
         )
 
     def transform(self, func, *args, **kwargs) -> Union[DataFrame, Series]:

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -3520,9 +3520,9 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         3    3.0
         Name: A, dtype: float64
         """
-        return self._rank(method, ascending)
+        return self._rank(method, ascending).spark.analyzed
 
-    def _rank(self, method="average", ascending=True, part_cols=()):
+    def _rank(self, method="average", ascending=True, *, part_cols=()):
         if method not in ["average", "min", "max", "first", "dense"]:
             msg = "method must be one of 'average', 'min', 'max', 'first', 'dense'"
             raise ValueError(msg)
@@ -3651,9 +3651,9 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         5     NaN
         Name: c, dtype: float64
         """
-        return self._diff(periods)
+        return self._diff(periods).spark.analyzed
 
-    def _diff(self, periods, part_cols=()):
+    def _diff(self, periods, *, part_cols=()):
         if not isinstance(periods, int):
             raise ValueError("periods should be an int; however, got [%s]" % type(periods).__name__)
         window = (
@@ -4791,7 +4791,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         window = Window.orderBy(NATURAL_ORDER_COLUMN_NAME).rowsBetween(-periods, -periods)
         prev_row = F.lag(scol, periods).over(window)
 
-        return self._with_new_scol((scol - prev_row) / prev_row)
+        return self._with_new_scol((scol - prev_row) / prev_row).spark.analyzed
 
     def combine_first(self, other) -> "Series":
         """

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -3808,6 +3808,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         kdf = ks.from_pandas(pdf)
 
         self.assert_eq(pdf.rank().sort_index(), kdf.rank().sort_index())
+        self.assert_eq(pdf.rank().sum(), kdf.rank().sum())
         self.assert_eq(
             pdf.rank(ascending=False).sort_index(), kdf.rank(ascending=False).sort_index()
         )
@@ -3886,6 +3887,8 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         kdf = ks.from_pandas(pdf)
 
         self.assert_eq(pdf.shift(3), kdf.shift(3))
+        self.assert_eq(pdf.shift().shift(-1), kdf.shift().shift(-1))
+        self.assert_eq(pdf.shift().sum().astype(int), kdf.shift().sum())
 
         # Need the expected result since pandas 0.23 does not support `fill_value` argument.
         pdf1 = pd.DataFrame(
@@ -3902,6 +3905,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         pdf.columns = columns
         kdf.columns = columns
         self.assert_eq(pdf.shift(3), kdf.shift(3))
+        self.assert_eq(pdf.shift().shift(-1), kdf.shift().shift(-1))
 
     def test_diff(self):
         pdf = pd.DataFrame(
@@ -3911,6 +3915,8 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         kdf = ks.from_pandas(pdf)
 
         self.assert_eq(pdf.diff(), kdf.diff())
+        self.assert_eq(pdf.diff().diff(-1), kdf.diff().diff(-1))
+        self.assert_eq(pdf.diff().sum().astype(int), kdf.diff().sum())
 
         msg = "should be an int"
         with self.assertRaisesRegex(ValueError, msg):
@@ -4533,6 +4539,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         kdf = ks.from_pandas(pdf)
 
         self.assert_eq(kdf.pct_change(2), pdf.pct_change(2), check_exact=False)
+        self.assert_eq(kdf.pct_change().sum(), pdf.pct_change().sum(), check_exact=False)
 
     def test_where(self):
         kdf = ks.from_pandas(self.pdf)

--- a/databricks/koalas/tests/test_groupby.py
+++ b/databricks/koalas/tests/test_groupby.py
@@ -1083,6 +1083,9 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             pdf.groupby(pdf.b // 5)["a"].diff().sort_index(),
         )
 
+        self.assert_eq(kdf.groupby("b").diff().sum(), pdf.groupby("b").diff().sum().astype(int))
+        self.assert_eq(kdf.groupby(["b"])["a"].diff().sum(), pdf.groupby(["b"])["a"].diff().sum())
+
         # multi-index columns
         columns = pd.MultiIndex.from_tuples([("x", "a"), ("x", "b"), ("y", "c")])
         pdf.columns = columns
@@ -1125,6 +1128,9 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
             kdf.groupby(kdf.b // 5)["a"].rank().sort_index(),
             pdf.groupby(pdf.b // 5)["a"].rank().sort_index(),
         )
+
+        self.assert_eq(kdf.groupby("b").rank().sum(), pdf.groupby("b").rank().sum())
+        self.assert_eq(kdf.groupby(["b"])["a"].rank().sum(), pdf.groupby(["b"])["a"].rank().sum())
 
         # multi-index columns
         columns = pd.MultiIndex.from_tuples([("x", "a"), ("x", "b"), ("y", "c")])
@@ -1831,6 +1837,12 @@ class GroupByTest(ReusedSQLTestCase, TestUtils):
         self.assert_eq(
             kdf.a.rename().groupby(kdf.b.rename()).shift().sort_index(),
             pdf.a.rename().groupby(pdf.b.rename()).shift().sort_index(),
+        )
+
+        self.assert_eq(kdf.groupby("a").shift().sum(), pdf.groupby("a").shift().sum().astype(int))
+        self.assert_eq(
+            kdf.a.rename().groupby(kdf.b).shift().sum(),
+            pdf.a.rename().groupby(pdf.b).shift().sum(),
         )
 
         # multi-index columns

--- a/databricks/koalas/tests/test_ops_on_diff_frames.py
+++ b/databricks/koalas/tests/test_ops_on_diff_frames.py
@@ -1727,6 +1727,60 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(pser ** pser_other, (kser ** kser_other).sort_index())
         self.assert_eq(pser.rpow(pser_other), kser.rpow(kser_other).sort_index())
 
+    def test_shift(self):
+        pdf = pd.DataFrame(
+            {
+                "Col1": [10, 20, 15, 30, 45],
+                "Col2": [13, 23, 18, 33, 48],
+                "Col3": [17, 27, 22, 37, 52],
+            },
+            index=np.random.rand(5),
+        )
+        kdf = ks.from_pandas(pdf)
+
+        self.assert_eq(
+            pdf.shift().loc[pdf["Col1"] == 20].astype(int), kdf.shift().loc[kdf["Col1"] == 20]
+        )
+        self.assert_eq(
+            pdf["Col2"].shift().loc[pdf["Col1"] == 20].astype(int),
+            kdf["Col2"].shift().loc[kdf["Col1"] == 20],
+        )
+
+    def test_diff(self):
+        pdf = pd.DataFrame(
+            {
+                "Col1": [10, 20, 15, 30, 45],
+                "Col2": [13, 23, 18, 33, 48],
+                "Col3": [17, 27, 22, 37, 52],
+            },
+            index=np.random.rand(5),
+        )
+        kdf = ks.from_pandas(pdf)
+
+        self.assert_eq(
+            pdf.diff().loc[pdf["Col1"] == 20].astype(int), kdf.diff().loc[kdf["Col1"] == 20]
+        )
+        self.assert_eq(
+            pdf["Col2"].diff().loc[pdf["Col1"] == 20].astype(int),
+            kdf["Col2"].diff().loc[kdf["Col1"] == 20],
+        )
+
+    def test_rank(self):
+        pdf = pd.DataFrame(
+            {
+                "Col1": [10, 20, 15, 30, 45],
+                "Col2": [13, 23, 18, 33, 48],
+                "Col3": [17, 27, 22, 37, 52],
+            },
+            index=np.random.rand(5),
+        )
+        kdf = ks.from_pandas(pdf)
+
+        self.assert_eq(pdf.rank().loc[pdf["Col1"] == 20], kdf.rank().loc[kdf["Col1"] == 20])
+        self.assert_eq(
+            pdf["Col2"].rank().loc[pdf["Col1"] == 20], kdf["Col2"].rank().loc[kdf["Col1"] == 20]
+        )
+
 
 class OpsOnDiffFramesDisabledTest(ReusedSQLTestCase, SQLTestUtils):
     @classmethod

--- a/databricks/koalas/tests/test_ops_on_diff_frames_groupby.py
+++ b/databricks/koalas/tests/test_ops_on_diff_frames_groupby.py
@@ -496,6 +496,9 @@ class OpsOnDiffFramesGroupByTest(ReusedSQLTestCase, SQLTestUtils):
             pdf.groupby(pkey)[["a"]].diff().sort_index(),
         )
 
+        self.assert_eq(kdf.groupby(kkey).diff().sum(), pdf.groupby(pkey).diff().sum().astype(int))
+        self.assert_eq(kdf.groupby(kkey)["a"].diff().sum(), pdf.groupby(pkey)["a"].diff().sum())
+
     def test_rank(self):
         pdf = pd.DataFrame(
             {
@@ -516,6 +519,9 @@ class OpsOnDiffFramesGroupByTest(ReusedSQLTestCase, SQLTestUtils):
             kdf.groupby(kkey)[["a"]].rank().sort_index(),
             pdf.groupby(pkey)[["a"]].rank().sort_index(),
         )
+
+        self.assert_eq(kdf.groupby(kkey).rank().sum(), pdf.groupby(pkey).rank().sum())
+        self.assert_eq(kdf.groupby(kkey)["a"].rank().sum(), pdf.groupby(pkey)["a"].rank().sum())
 
     @unittest.skipIf(pd.__version__ < "0.24.0", "not supported before pandas 0.24.0")
     def test_shift(self):
@@ -540,6 +546,9 @@ class OpsOnDiffFramesGroupByTest(ReusedSQLTestCase, SQLTestUtils):
             kdf.groupby(kkey)[["a"]].shift().sort_index(),
             pdf.groupby(pkey)[["a"]].shift().sort_index(),
         )
+
+        self.assert_eq(kdf.groupby(kkey).shift().sum(), pdf.groupby(pkey).shift().sum().astype(int))
+        self.assert_eq(kdf.groupby(kkey)["a"].shift().sum(), pdf.groupby(pkey)["a"].shift().sum())
 
     def test_fillna(self):
         pdf = pd.DataFrame(

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -1329,6 +1329,7 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         pser = pd.Series([1, 2, 3, 1], name="x")
         kser = ks.from_pandas(pser)
         self.assert_eq(pser.rank(), kser.rank().sort_index())
+        self.assert_eq(pser.rank().sum(), kser.rank().sum())
         self.assert_eq(pser.rank(ascending=False), kser.rank(ascending=False).sort_index())
         self.assert_eq(pser.rank(method="min"), kser.rank(method="min").sort_index())
         self.assert_eq(pser.rank(method="max"), kser.rank(method="max").sort_index())
@@ -1421,12 +1422,25 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
     def test_shift(self):
         pser = pd.Series([10, 20, 15, 30, 45], name="x")
         kser = ks.Series(pser)
+
+        self.assert_eq(kser.shift(2), pser.shift(2))
+        self.assert_eq(kser.shift().shift(-1), pser.shift().shift(-1))
+        self.assert_eq(kser.shift().sum(), pser.shift().sum())
+
         if LooseVersion(pd.__version__) < LooseVersion("0.24.2"):
             self.assert_eq(kser.shift(periods=2), pser.shift(periods=2))
         else:
             self.assert_eq(kser.shift(periods=2, fill_value=0), pser.shift(periods=2, fill_value=0))
         with self.assertRaisesRegex(ValueError, "periods should be an int; however"):
             kser.shift(periods=1.5)
+
+    def test_diff(self):
+        pser = pd.Series([10, 20, 15, 30, 45], name="x")
+        kser = ks.Series(pser)
+
+        self.assert_eq(kser.diff(2), pser.diff(2))
+        self.assert_eq(kser.diff().diff(-1), pser.diff().diff(-1))
+        self.assert_eq(kser.diff().sum(), pser.diff().sum())
 
     def _test_numeric_astype(self, pser):
         kser = ks.Series(pser)
@@ -1811,6 +1825,7 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         kser = ks.from_pandas(pser)
 
         self.assert_eq(kser.pct_change(), pser.pct_change(), check_exact=False)
+        self.assert_eq(kser.pct_change().sum(), pser.pct_change().sum(), almost=True)
         self.assert_eq(kser.pct_change(periods=2), pser.pct_change(periods=2), check_exact=False)
         self.assert_eq(kser.pct_change(periods=-1), pser.pct_change(periods=-1), check_exact=False)
         self.assert_eq(kser.pct_change(periods=-100000000), pser.pct_change(periods=-100000000))
@@ -1825,6 +1840,7 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         kser = ks.from_pandas(pser)
 
         self.assert_eq(kser.pct_change(), pser.pct_change(), check_exact=False)
+        self.assert_eq(kser.pct_change().sum(), pser.pct_change().sum(), almost=True)
         self.assert_eq(kser.pct_change(periods=2), pser.pct_change(periods=2), check_exact=False)
         self.assert_eq(kser.pct_change(periods=-1), pser.pct_change(periods=-1), check_exact=False)
         self.assert_eq(kser.pct_change(periods=-100000000), pser.pct_change(periods=-100000000))


### PR DESCRIPTION
After the window functions, we should always resolve the `InternalFrame`; otherwise the window will be applied later, causing a weird behavior:

```py
>>> kdf = ks.DataFrame({"Col1": [10, 20, 15, 30, 45], "Col2": [13, 23, 18, 33, 48], "Col3": [17, 27, 22, 37, 52]})
>>> kdf
   Col1  Col2  Col3
0    10    13    17
1    20    23    27
2    15    18    22
3    30    33    37
4    45    48    52
>>> kdf['Col1'].shift().loc[kdf['Col1'] == 20]
1   NaN
Name: Col1, dtype: float64
```

This should be:

```py
>>> pdf = kdf.to_pandas()
>>> pdf['Col1'].shift().loc[pdf['Col1'] == 20]
1    10.0
Name: Col1, dtype: float64
```

Resolves #2078.