### PR TITLE
Fix type in docstring for DatatimeIndex.month_names

### DIFF
--- a/databricks/koalas/indexes/datetimes.py
+++ b/databricks/koalas/indexes/datetimes.py
@@ -536,7 +536,7 @@ class DatetimeIndex(Index):
         Returns
         -------
         Index
-            Series of month names.
+            Index of month names.
 
         Examples
         --------


### PR DESCRIPTION
Correction the type in docstring for `DatetimeIndex.month_names` from `Series` to `Index`.