### PR TITLE
Support tuple to (DataFrame|Series).replace()

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -5322,11 +5322,12 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Parameters
         ----------
-        to_replace : int, float, string, list or dict
+        to_replace : int, float, string, list, tuple or dict
             Value to be replaced.
-        value : int, float, string, or list
+        value : int, float, string, list or tuple
             Value to use to replace holes. The replacement value must be an int, float,
-            or string. If value is a list, value should be of the same length with to_replace.
+            or string.
+            If value is a list or tuple, value should be of the same length with to_replace.
         inplace : boolean, default False
             Fill in place (do not create a new object)
 

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -5404,12 +5404,14 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             raise NotImplementedError("replace currently doesn't supports regex")
         inplace = validate_bool_kwarg(inplace, "inplace")
 
-        if value is not None and not isinstance(value, (int, float, str, list, dict)):
+        if value is not None and not isinstance(value, (int, float, str, list, tuple, dict)):
             raise TypeError("Unsupported type {}".format(type(value).__name__))
-        if to_replace is not None and not isinstance(to_replace, (int, float, str, list, dict)):
+        if to_replace is not None and not isinstance(
+            to_replace, (int, float, str, list, tuple, dict)
+        ):
             raise TypeError("Unsupported type {}".format(type(to_replace).__name__))
 
-        if isinstance(value, list) and isinstance(to_replace, list):
+        if isinstance(value, (list, tuple)) and isinstance(to_replace, (list, tuple)):
             if len(value) != len(to_replace):
                 raise ValueError("Length of to_replace and value must be same")
 

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -4343,10 +4343,12 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         """
         if to_replace is None:
             return self.fillna(method="ffill")
-        if not isinstance(to_replace, (str, list, dict, int, float)):
-            raise ValueError("'to_replace' should be one of str, list, dict, int, float")
+        if not isinstance(to_replace, (str, list, tuple, dict, int, float)):
+            raise ValueError("'to_replace' should be one of str, list, tuple, dict, int, float")
         if regex:
             raise NotImplementedError("replace currently not support for regex")
+        to_replace = list(to_replace) if isinstance(to_replace, tuple) else to_replace
+        value = list(value) if isinstance(value, tuple) else value
         if isinstance(to_replace, list) and isinstance(value, list):
             if not len(to_replace) == len(value):
                 raise ValueError(

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -4196,7 +4196,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         Parameters
         ----------
-        to_replace : str, list, dict, Series, int, float, or None
+        to_replace : str, list, tuple, dict, Series, int, float, or None
             How to find the values that will be replaced.
             * numeric, str:
 
@@ -4205,7 +4205,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
             * list of str or numeric:
 
-                - if to_replace and value are both lists, they must be the same length.
+                - if to_replace and value are both lists or tuples, they must be the same length.
                 - str and numeric rules apply as above.
 
             * dict:
@@ -4224,7 +4224,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
             See the examples section for examples of each of these.
 
-        value : scalar, dict, list, str default None
+        value : scalar, dict, list, tuple, str default None
             Value to replace any values matching to_replace with.
             For a DataFrame a dict of values can be used to specify which value to use
             for each column (columns not in the dict will not be filled).

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -2598,11 +2598,6 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         ):
             kdf.replace(regex="")
 
-        with self.assertRaisesRegex(TypeError, "Unsupported type tuple"):
-            kdf.replace(value=(1, 2, 3))
-        with self.assertRaisesRegex(TypeError, "Unsupported type tuple"):
-            kdf.replace(to_replace=(1, 2, 3))
-
         with self.assertRaisesRegex(ValueError, "Length of to_replace and value must be same"):
             kdf.replace(to_replace=["Ironman"], value=["Spiderman", "Doctor Strange"])
 
@@ -2610,6 +2605,10 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(
             kdf.replace(["Ironman", "Captain America"], ["Rescue", "Hawkeye"]),
             pdf.replace(["Ironman", "Captain America"], ["Rescue", "Hawkeye"]),
+        )
+        self.assert_eq(
+            kdf.replace(("Ironman", "Captain America"), ("Rescue", "Hawkeye")),
+            pdf.replace(("Ironman", "Captain America"), ("Rescue", "Hawkeye")),
         )
 
         # inplace

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -1682,8 +1682,12 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(kser.replace({}), pser.replace({}))
 
         self.assert_eq(kser.replace(np.nan, 45), pser.replace(np.nan, 45))
+        self.assert_eq(kser.replace([10, 15], 45), pser.replace([10, 15], 45))
+        self.assert_eq(kser.replace((10, 15), 45), pser.replace((10, 15), 45))
+        self.assert_eq(kser.replace([10, 15], [45, 50]), pser.replace([10, 15], [45, 50]))
+        self.assert_eq(kser.replace((10, 15), (45, 50)), pser.replace((10, 15), (45, 50)))
 
-        msg = "'to_replace' should be one of str, list, dict, int, float"
+        msg = "'to_replace' should be one of str, list, tuple, dict, int, float"
         with self.assertRaisesRegex(ValueError, msg):
             kser.replace(ks.range(5))
         msg = "Replacement lists must match in length. Expecting 3 got 2"


### PR DESCRIPTION
pandas support `tuple` to `(DataFrame|Series).replace()` for parameter `to_replace` and `value` whereas Koalas doesn't.

We should follow pandas'

```python
>>> df_ks = ks.DataFrame([
...   [1,2,3],
...   [4,5,6],
...   [np.inf, 0, -np.inf]
... ])
>>> df_ks.replace((1, 2), np.nan)
     0    1    2
0  NaN  NaN  3.0
1  4.0  5.0  6.0
2  inf  0.0 -inf
```