### PR TITLE
Fix (DataFrame|Series).isin to pass numpy array

### DIFF
--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -1161,7 +1161,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
 
         Parameters
         ----------
-        values : list or set
+        values : set or list-like
             The sequence of values to test.
 
         Returns
@@ -1202,7 +1202,8 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
                 " to isin(), you passed a [{values_type}]".format(values_type=type(values).__name__)
             )
 
-        return self._with_new_scol(self.spark.column.isin(list(values)))
+        values = values.tolist() if isinstance(values, np.ndarray) else list(values)
+        return self._with_new_scol(self.spark.column.isin(values))
 
     def isnull(self) -> Union["Series", "Index"]:
         """

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -7090,9 +7090,11 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         if isinstance(values, dict):
             for i, col in enumerate(self.columns):
                 if col in values:
+                    item = values[col]
+                    item = item.tolist() if isinstance(item, np.ndarray) else list(item)
                     data_spark_columns.append(
                         self._internal.spark_column_for(self._internal.column_labels[i])
-                        .isin(values[col])
+                        .isin(item)
                         .alias(self._internal.data_spark_column_names[i])
                     )
                 else:
@@ -7100,9 +7102,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                         F.lit(False).alias(self._internal.data_spark_column_names[i])
                     )
         elif is_list_like(values):
+            values = values.tolist() if isinstance(values, np.ndarray) else list(values)
             data_spark_columns += [
                 self._internal.spark_column_for(label)
-                .isin(list(values))
+                .isin(values)
                 .alias(self._internal.spark_column_name_for(label))
                 for label in self._internal.column_labels
             ]

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -1848,9 +1848,15 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         kdf = ks.from_pandas(pdf)
 
         self.assert_eq(kdf.isin([4, "six"]), pdf.isin([4, "six"]))
+        # Seems like pandas has a bug when passing `np.array` as parameter
+        self.assert_eq(kdf.isin(np.array([4, "six"])), pdf.isin([4, "six"]))
         self.assert_eq(
             kdf.isin({"a": [2, 8], "c": ["three", "one"]}),
             pdf.isin({"a": [2, 8], "c": ["three", "one"]}),
+        )
+        self.assert_eq(
+            kdf.isin({"a": np.array([2, 8]), "c": ["three", "one"]}),
+            pdf.isin({"a": np.array([2, 8]), "c": ["three", "one"]}),
         )
 
         msg = "'DataFrame' object has no attribute {'e'}"

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -419,6 +419,7 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         kser = ks.from_pandas(pser)
 
         self.assert_eq(kser.isin(["cow", "lama"]), pser.isin(["cow", "lama"]))
+        self.assert_eq(kser.isin(np.array(["cow", "lama"])), pser.isin(np.array(["cow", "lama"])))
         self.assert_eq(kser.isin({"cow"}), pser.isin({"cow"}))
 
         msg = "only list-like objects are allowed to be passed to isin()"


### PR DESCRIPTION
`(Series|DataFrame).isin` don't work properly when passing numpy array as a parameter.

```python
>>> df = pd.DataFrame({'a': [1, 2, 3], 'b': [2, 3, 4]})
>>> numpy_arr = np.array([3, 4, 5])
>>> df['a'].isin(numpy_arr)
0    False
1    False
2     True
Name: a, dtype: bool

>>> kdf = ks.from_pandas(df)
>>> kdf[kdf['a'].isin(numpy_arr)]
Traceback (most recent call last):
...
AttributeError: 'numpy.int64' object has no attribute '_get_object_id'
```

This should resolve #2098 