### PR TITLE
Implement DatetimeIndex.indexer_between_time()

### DIFF
--- a/databricks/koalas/indexes/datetimes.py
+++ b/databricks/koalas/indexes/datetimes.py
@@ -681,18 +681,13 @@ class DatetimeIndex(Index):
         dtype: int64
         """
 
-        def pandas_indexer_between_time(pdf):
-            return pd.DataFrame(
-                pdf.index.indexer_between_time(
-                    start_time=start_time,
-                    end_time=end_time,
-                    include_start=include_start,
-                    include_end=include_end,
-                )
-            )
+        def pandas_between_time(pdf):
+            return pd.DataFrame(pdf.between_time(start_time, end_time, include_start, include_end))
 
-        kdf = self.to_frame().koalas.apply_batch(pandas_indexer_between_time)
-        return first_series(kdf).rename(self.name)
+        kdf = self.to_frame().reset_index(drop=True).reset_index().set_index(0)
+        kdf_2 = kdf.apply_batch(pandas_between_time)
+
+        return first_series(kdf_2).reset_index(drop=True).rename(self.name)
 
 
 def disallow_nanoseconds(freq):

--- a/databricks/koalas/indexes/datetimes.py
+++ b/databricks/koalas/indexes/datetimes.py
@@ -664,7 +664,7 @@ class DatetimeIndex(Index):
         Examples
         --------
         >>> kidx = ks.date_range("2000-01-01", periods=3, freq="T")
-        >>> kidx
+        >>> kidx  # doctest: +NORMALIZE_WHITESPACE
         DatetimeIndex(['2000-01-01 00:00:00', '2000-01-01 00:01:00',
                        '2000-01-01 00:02:00'],
                       dtype='datetime64[ns]', freq=None)

--- a/databricks/koalas/indexes/datetimes.py
+++ b/databricks/koalas/indexes/datetimes.py
@@ -23,7 +23,6 @@ from pyspark._globals import _NoValue
 
 from databricks import koalas as ks
 from databricks.koalas.indexes.base import Index
-from databricks.koalas.internal import DEFAULT_SERIES_NAME
 from databricks.koalas.missing.indexes import MissingPandasLikeDatetimeIndex
 from databricks.koalas.series import Series, first_series
 from databricks.koalas.utils import verify_temp_column_name

--- a/databricks/koalas/indexes/datetimes.py
+++ b/databricks/koalas/indexes/datetimes.py
@@ -685,7 +685,7 @@ class DatetimeIndex(Index):
         id_column_name = verify_temp_column_name(kdf, "__id_column__")
         kdf = kdf.koalas.attach_id_column("distributed-sequence", id_column_name)
         with ks.option_context("compute.default_index_type", "distributed"):
-            # The attached index in the statement will be dropped soon,
+            # The attached index in the statement below will be dropped soon,
             # so we enforce “distributed” default index type
             kdf = kdf.koalas.apply_batch(pandas_between_time)
         return ks.Index(first_series(kdf).rename(self.name))

--- a/databricks/koalas/indexes/datetimes.py
+++ b/databricks/koalas/indexes/datetimes.py
@@ -671,10 +671,10 @@ class DatetimeIndex(Index):
         >>> kidx.indexer_between_time("00:01", "00:02").sort_values()
         Int64Index([1, 2], dtype='int64')
 
-        >>> kidx.indexer_between_time("00:01", "00:02", include_end=False).sort_values()
+        >>> kidx.indexer_between_time("00:01", "00:02", include_end=False)
         Int64Index([1], dtype='int64')
 
-        >>> kidx.indexer_between_time("00:01", "00:02", include_start=False).sort_values()
+        >>> kidx.indexer_between_time("00:01", "00:02", include_start=False)
         Int64Index([2], dtype='int64')
         """
 

--- a/databricks/koalas/missing/indexes.py
+++ b/databricks/koalas/missing/indexes.py
@@ -110,7 +110,6 @@ class MissingPandasLikeDatetimeIndex(MissingPandasLikeIndex):
 
     # Functions
     indexer_at_time = _unsupported_function("indexer_at_time", cls="DatetimeIndex")
-    indexer_between_time = _unsupported_function("indexer_between_time", cls="DatetimeIndex")
     snap = _unsupported_function("snap", cls="DatetimeIndex")
     tz_convert = _unsupported_function("tz_convert", cls="DatetimeIndex")
     tz_localize = _unsupported_function("tz_localize", cls="DatetimeIndex")

--- a/databricks/koalas/tests/indexes/test_datetime.py
+++ b/databricks/koalas/tests/indexes/test_datetime.py
@@ -131,38 +131,37 @@ class DatetimeIndexTest(ReusedSQLTestCase, TestUtils):
             )
 
     def test_indexer_between_time(self):
-        with ks.option_context("compute.shortcut_limit", 0):
-            for kidx, pidx in self.idx_pairs[1:]:
-                self.assert_eq(
-                    kidx.indexer_between_time("00:00:00", "00:01:00").sort_values(),
-                    pd.Index(pidx.indexer_between_time("00:00:00", "00:01:00")),
-                )
+        for kidx, pidx in self.idx_pairs[1:]:
+            self.assert_eq(
+                kidx.indexer_between_time("00:00:00", "00:01:00").sort_values(),
+                pd.Index(pidx.indexer_between_time("00:00:00", "00:01:00")),
+            )
 
-                self.assert_eq(
-                    kidx.indexer_between_time(
-                        datetime.time(0, 0, 0), datetime.time(0, 1, 0)
-                    ).sort_values(),
-                    pd.Index(
-                        pidx.indexer_between_time(datetime.time(0, 0, 0), datetime.time(0, 1, 0))
-                    ),
-                )
+            self.assert_eq(
+                kidx.indexer_between_time(
+                    datetime.time(0, 0, 0), datetime.time(0, 1, 0)
+                ).sort_values(),
+                pd.Index(
+                    pidx.indexer_between_time(datetime.time(0, 0, 0), datetime.time(0, 1, 0))
+                ),
+            )
 
-                self.assert_eq(
-                    kidx.indexer_between_time("00:00:00", "00:01:00", True, False).sort_values(),
-                    pd.Index(pidx.indexer_between_time("00:00:00", "00:01:00", True, False)),
-                )
+            self.assert_eq(
+                kidx.indexer_between_time("00:00:00", "00:01:00", True, False).sort_values(),
+                pd.Index(pidx.indexer_between_time("00:00:00", "00:01:00", True, False)),
+            )
 
-                self.assert_eq(
-                    kidx.indexer_between_time("00:00:00", "00:01:00", False, True).sort_values(),
-                    pd.Index(pidx.indexer_between_time("00:00:00", "00:01:00", False, True)),
-                )
+            self.assert_eq(
+                kidx.indexer_between_time("00:00:00", "00:01:00", False, True).sort_values(),
+                pd.Index(pidx.indexer_between_time("00:00:00", "00:01:00", False, True)),
+            )
 
-                self.assert_eq(
-                    kidx.indexer_between_time("00:00:00", "00:01:00", False, False).sort_values(),
-                    pd.Index(pidx.indexer_between_time("00:00:00", "00:01:00", False, False)),
-                )
+            self.assert_eq(
+                kidx.indexer_between_time("00:00:00", "00:01:00", False, False).sort_values(),
+                pd.Index(pidx.indexer_between_time("00:00:00", "00:01:00", False, False)),
+            )
 
-                self.assert_eq(
-                    kidx.indexer_between_time("00:00:00", "00:01:00", False, False).sort_values(),
-                    pd.Index(pidx.indexer_between_time("00:00:00", "00:01:00", False, False)),
-                )
+            self.assert_eq(
+                kidx.indexer_between_time("00:00:00", "00:01:00", False, False).sort_values(),
+                pd.Index(pidx.indexer_between_time("00:00:00", "00:01:00", False, False)),
+            )

--- a/databricks/koalas/tests/indexes/test_datetime.py
+++ b/databricks/koalas/tests/indexes/test_datetime.py
@@ -141,9 +141,7 @@ class DatetimeIndexTest(ReusedSQLTestCase, TestUtils):
                 kidx.indexer_between_time(
                     datetime.time(0, 0, 0), datetime.time(0, 1, 0)
                 ).sort_values(),
-                pd.Index(
-                    pidx.indexer_between_time(datetime.time(0, 0, 0), datetime.time(0, 1, 0))
-                ),
+                pd.Index(pidx.indexer_between_time(datetime.time(0, 0, 0), datetime.time(0, 1, 0))),
             )
 
             self.assert_eq(

--- a/databricks/koalas/tests/indexes/test_datetime.py
+++ b/databricks/koalas/tests/indexes/test_datetime.py
@@ -131,7 +131,7 @@ class DatetimeIndexTest(ReusedSQLTestCase, TestUtils):
             )
 
     def test_indexer_between_time(self):
-        for kidx, pidx in self.idx_pairs[1:]:
+        for kidx, pidx in self.idx_pairs:
             self.assert_eq(
                 kidx.indexer_between_time("00:00:00", "00:01:00").sort_values(),
                 pd.Index(pidx.indexer_between_time("00:00:00", "00:01:00")),

--- a/databricks/koalas/tests/indexes/test_datetime.py
+++ b/databricks/koalas/tests/indexes/test_datetime.py
@@ -135,32 +135,32 @@ class DatetimeIndexTest(ReusedSQLTestCase, TestUtils):
             for kidx, pidx in self.idx_pairs:
                 self.assert_eq(
                     kidx.indexer_between_time("00:00:00", "00:01:00"),
-                    pd.Series(pidx.indexer_between_time("00:00:00", "00:01:00")),
+                    pd.Index(pidx.indexer_between_time("00:00:00", "00:01:00")),
                 )
 
                 self.assert_eq(
                     kidx.indexer_between_time(datetime.time(0, 0, 0), datetime.time(0, 1, 0)),
-                    pd.Series(
+                    pd.Index(
                         pidx.indexer_between_time(datetime.time(0, 0, 0), datetime.time(0, 1, 0))
                     ),
                 )
 
                 self.assert_eq(
                     kidx.indexer_between_time("00:00:00", "00:01:00", True, False),
-                    pd.Series(pidx.indexer_between_time("00:00:00", "00:01:00", True, False)),
+                    pd.Index(pidx.indexer_between_time("00:00:00", "00:01:00", True, False)),
                 )
 
                 self.assert_eq(
                     kidx.indexer_between_time("00:00:00", "00:01:00", False, True),
-                    pd.Series(pidx.indexer_between_time("00:00:00", "00:01:00", False, True)),
+                    pd.Index(pidx.indexer_between_time("00:00:00", "00:01:00", False, True)),
                 )
 
                 self.assert_eq(
                     kidx.indexer_between_time("00:00:00", "00:01:00", False, False),
-                    pd.Series(pidx.indexer_between_time("00:00:00", "00:01:00", False, False)),
+                    pd.Index(pidx.indexer_between_time("00:00:00", "00:01:00", False, False)),
                 )
 
                 self.assert_eq(
                     kidx.indexer_between_time("00:00:00", "00:01:00", False, False),
-                    pd.Series(pidx.indexer_between_time("00:00:00", "00:01:00", False, False)),
+                    pd.Index(pidx.indexer_between_time("00:00:00", "00:01:00", False, False)),
                 )

--- a/databricks/koalas/tests/indexes/test_datetime.py
+++ b/databricks/koalas/tests/indexes/test_datetime.py
@@ -132,35 +132,37 @@ class DatetimeIndexTest(ReusedSQLTestCase, TestUtils):
 
     def test_indexer_between_time(self):
         with ks.option_context("compute.shortcut_limit", 0):
-            for kidx, pidx in self.idx_pairs:
+            for kidx, pidx in self.idx_pairs[1:]:
                 self.assert_eq(
-                    kidx.indexer_between_time("00:00:00", "00:01:00"),
+                    kidx.indexer_between_time("00:00:00", "00:01:00").sort_values(),
                     pd.Index(pidx.indexer_between_time("00:00:00", "00:01:00")),
                 )
 
                 self.assert_eq(
-                    kidx.indexer_between_time(datetime.time(0, 0, 0), datetime.time(0, 1, 0)),
+                    kidx.indexer_between_time(
+                        datetime.time(0, 0, 0), datetime.time(0, 1, 0)
+                    ).sort_values(),
                     pd.Index(
                         pidx.indexer_between_time(datetime.time(0, 0, 0), datetime.time(0, 1, 0))
                     ),
                 )
 
                 self.assert_eq(
-                    kidx.indexer_between_time("00:00:00", "00:01:00", True, False),
+                    kidx.indexer_between_time("00:00:00", "00:01:00", True, False).sort_values(),
                     pd.Index(pidx.indexer_between_time("00:00:00", "00:01:00", True, False)),
                 )
 
                 self.assert_eq(
-                    kidx.indexer_between_time("00:00:00", "00:01:00", False, True),
+                    kidx.indexer_between_time("00:00:00", "00:01:00", False, True).sort_values(),
                     pd.Index(pidx.indexer_between_time("00:00:00", "00:01:00", False, True)),
                 )
 
                 self.assert_eq(
-                    kidx.indexer_between_time("00:00:00", "00:01:00", False, False),
+                    kidx.indexer_between_time("00:00:00", "00:01:00", False, False).sort_values(),
                     pd.Index(pidx.indexer_between_time("00:00:00", "00:01:00", False, False)),
                 )
 
                 self.assert_eq(
-                    kidx.indexer_between_time("00:00:00", "00:01:00", False, False),
+                    kidx.indexer_between_time("00:00:00", "00:01:00", False, False).sort_values(),
                     pd.Index(pidx.indexer_between_time("00:00:00", "00:01:00", False, False)),
                 )

--- a/databricks/koalas/tests/indexes/test_datetime.py
+++ b/databricks/koalas/tests/indexes/test_datetime.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import datetime
 
 from distutils.version import LooseVersion
 
@@ -127,4 +128,38 @@ class DatetimeIndexTest(ReusedSQLTestCase, TestUtils):
         for kidx, pidx in self.idx_pairs:
             self.assert_eq(
                 kidx.strftime(date_format="%B %d, %Y"), pidx.strftime(date_format="%B %d, %Y")
+            )
+
+    def test_indexer_between_time(self):
+        for kidx, pidx in self.idx_pairs:
+            self.assert_eq(
+                kidx.indexer_between_time("00:00:00", "00:01:00"),
+                pd.Series(pidx.indexer_between_time("00:00:00", "00:01:00")),
+            )
+
+            self.assert_eq(
+                kidx.indexer_between_time(datetime.time(0, 0, 0), datetime.time(0, 1, 0)),
+                pd.Series(
+                    pidx.indexer_between_time(datetime.time(0, 0, 0), datetime.time(0, 1, 0))
+                ),
+            )
+
+            self.assert_eq(
+                kidx.indexer_between_time("00:00:00", "00:01:00", True, False),
+                pd.Series(pidx.indexer_between_time("00:00:00", "00:01:00", True, False)),
+            )
+
+            self.assert_eq(
+                kidx.indexer_between_time("00:00:00", "00:01:00", False, True),
+                pd.Series(pidx.indexer_between_time("00:00:00", "00:01:00", False, True)),
+            )
+
+            self.assert_eq(
+                kidx.indexer_between_time("00:00:00", "00:01:00", False, False),
+                pd.Series(pidx.indexer_between_time("00:00:00", "00:01:00", False, False)),
+            )
+
+            self.assert_eq(
+                kidx.indexer_between_time("00:00:00", "00:01:00", False, False),
+                pd.Series(pidx.indexer_between_time("00:00:00", "00:01:00", False, False)),
             )

--- a/databricks/koalas/tests/indexes/test_datetime.py
+++ b/databricks/koalas/tests/indexes/test_datetime.py
@@ -131,35 +131,36 @@ class DatetimeIndexTest(ReusedSQLTestCase, TestUtils):
             )
 
     def test_indexer_between_time(self):
-        for kidx, pidx in self.idx_pairs:
-            self.assert_eq(
-                kidx.indexer_between_time("00:00:00", "00:01:00"),
-                pd.Series(pidx.indexer_between_time("00:00:00", "00:01:00")),
-            )
+        with ks.option_context("compute.shortcut_limit", 0):
+            for kidx, pidx in self.idx_pairs:
+                self.assert_eq(
+                    kidx.indexer_between_time("00:00:00", "00:01:00"),
+                    pd.Series(pidx.indexer_between_time("00:00:00", "00:01:00")),
+                )
 
-            self.assert_eq(
-                kidx.indexer_between_time(datetime.time(0, 0, 0), datetime.time(0, 1, 0)),
-                pd.Series(
-                    pidx.indexer_between_time(datetime.time(0, 0, 0), datetime.time(0, 1, 0))
-                ),
-            )
+                self.assert_eq(
+                    kidx.indexer_between_time(datetime.time(0, 0, 0), datetime.time(0, 1, 0)),
+                    pd.Series(
+                        pidx.indexer_between_time(datetime.time(0, 0, 0), datetime.time(0, 1, 0))
+                    ),
+                )
 
-            self.assert_eq(
-                kidx.indexer_between_time("00:00:00", "00:01:00", True, False),
-                pd.Series(pidx.indexer_between_time("00:00:00", "00:01:00", True, False)),
-            )
+                self.assert_eq(
+                    kidx.indexer_between_time("00:00:00", "00:01:00", True, False),
+                    pd.Series(pidx.indexer_between_time("00:00:00", "00:01:00", True, False)),
+                )
 
-            self.assert_eq(
-                kidx.indexer_between_time("00:00:00", "00:01:00", False, True),
-                pd.Series(pidx.indexer_between_time("00:00:00", "00:01:00", False, True)),
-            )
+                self.assert_eq(
+                    kidx.indexer_between_time("00:00:00", "00:01:00", False, True),
+                    pd.Series(pidx.indexer_between_time("00:00:00", "00:01:00", False, True)),
+                )
 
-            self.assert_eq(
-                kidx.indexer_between_time("00:00:00", "00:01:00", False, False),
-                pd.Series(pidx.indexer_between_time("00:00:00", "00:01:00", False, False)),
-            )
+                self.assert_eq(
+                    kidx.indexer_between_time("00:00:00", "00:01:00", False, False),
+                    pd.Series(pidx.indexer_between_time("00:00:00", "00:01:00", False, False)),
+                )
 
-            self.assert_eq(
-                kidx.indexer_between_time("00:00:00", "00:01:00", False, False),
-                pd.Series(pidx.indexer_between_time("00:00:00", "00:01:00", False, False)),
-            )
+                self.assert_eq(
+                    kidx.indexer_between_time("00:00:00", "00:01:00", False, False),
+                    pd.Series(pidx.indexer_between_time("00:00:00", "00:01:00", False, False)),
+                )

--- a/docs/source/reference/indexing.rst
+++ b/docs/source/reference/indexing.rst
@@ -343,6 +343,13 @@ Time/date components
    DatetimeIndex.daysinmonth
    DatetimeIndex.days_in_month
 
+Selecting
+~~~~~~~~~~~~~~~~~~~~~~~~
+.. autosummary::
+   :toctree: api/
+
+   DatetimeIndex.indexer_between_time
+
 Time-specific operations
 ~~~~~~~~~~~~~~~~~~~~~~~~
 .. autosummary::


### PR DESCRIPTION
Implement DatetimeIndex.indexer_between_time()
```py
>>> kidx = ks.date_range("2000-01-01", periods=3, freq="T")
>>> kidx 
DatetimeIndex(['2000-01-01 00:00:00', '2000-01-01 00:01:00',
               '2000-01-01 00:02:00'],
              dtype='datetime64[ns]', freq=None)
>>> kidx.indexer_between_time("00:01", "00:02").sort_values()
Int64Index([1, 2], dtype='int64')
>>> kidx.indexer_between_time("00:01", "00:02", include_end=False).sort_values()
Int64Index([1], dtype='int64')
>>> kidx.indexer_between_time("00:01", "00:02", include_start=False).sort_values()
Int64Index([2], dtype='int64')
```