### PR TITLE
Support ExtensionDtypes as type arguments.

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -334,6 +334,12 @@ T = TypeVar("T")
 
 
 def _create_tuple_for_frame_type(params):
+    """
+    This is a workaround to support variadic generic in DataFrame.
+
+    See https://github.com/python/typing/issues/193
+    we always wraps the given type hints by a tuple to mimic the variadic generic.
+    """
     from databricks.koalas.typedef import NameTypeHolder
 
     if isinstance(params, zip):

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -47,6 +47,7 @@ from typing import (
 import numpy as np
 import pandas as pd
 from pandas.api.types import is_list_like, is_dict_like, is_scalar
+from pandas.api.extensions import ExtensionDtype
 
 if TYPE_CHECKING:
     from pandas.io.formats.style import Styler
@@ -364,8 +365,16 @@ def _create_tuple_for_frame_type(params):
 
     if not isinstance(params, Iterable):
         params = [params]
-    params = [param.type if isinstance(param, np.dtype) else param for param in params]
-    return Tuple[tuple(params)]
+
+    new_params = []
+    for param in params:
+        if isinstance(param, ExtensionDtype):
+            new_class = type("NameType", (NameTypeHolder,), {})
+            new_class.tpe = param
+            new_params.append(new_class)
+        else:
+            new_params.append(param.type if isinstance(param, np.dtype) else param)
+    return Tuple[tuple(new_params)]
 
 
 if (3, 5) <= sys.version_info < (3, 7):

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -5996,7 +5996,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         return MissingPandasLikeSeries.__iter__(self)
 
     if sys.version_info >= (3, 7):
-
+        # In order to support the type hints such as Series[...]. See DataFrame.__class_getitem__.
         def __class_getitem__(cls, params):
             return _create_type_for_series_type(params)
 

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -24,7 +24,7 @@ import warnings
 from collections.abc import Mapping
 from distutils.version import LooseVersion
 from functools import partial, wraps, reduce
-from typing import Any, Generic, Iterable, List, Optional, Tuple, Type, TypeVar, Union, cast
+from typing import Any, Generic, Iterable, List, Optional, Tuple, TypeVar, Union, cast
 
 import numpy as np
 import pandas as pd
@@ -87,6 +87,7 @@ from databricks.koalas.typedef import (
     spark_type_to_pandas_dtype,
     ScalarType,
     Scalar,
+    SeriesType,
 )
 
 
@@ -327,7 +328,7 @@ def _create_type_for_series_type(param):
     else:
         new_class = param.type if isinstance(param, np.dtype) else param
 
-    return Type[new_class]
+    return SeriesType[new_class]
 
 
 if (3, 5) <= sys.version_info < (3, 7):

--- a/databricks/koalas/tests/test_typedef.py
+++ b/databricks/koalas/tests/test_typedef.py
@@ -179,7 +179,7 @@ class TypeHintTests(unittest.TestCase):
         self.assertRaisesRegex(TypeError, "object.*not understood", try_infer_return_type)
 
         def try_infer_return_type():
-            def f() -> pd.Series[pdf.a.dtypes]:  # type: ignore
+            def f() -> pd.Series[pdf.a.dtype]:  # type: ignore
                 pass
 
             infer_return_type(f)

--- a/databricks/koalas/tests/test_typedef.py
+++ b/databricks/koalas/tests/test_typedef.py
@@ -178,6 +178,14 @@ class TypeHintTests(unittest.TestCase):
 
         self.assertRaisesRegex(TypeError, "object.*not understood", try_infer_return_type)
 
+        def try_infer_return_type():
+            def f() -> pd.Series[pdf.a.dtypes]:  # type: ignore
+                pass
+
+            infer_return_type(f)
+
+        self.assertRaisesRegex(TypeError, "object.*not understood", try_infer_return_type)
+
     def test_infer_schema_with_names_negative(self):
         def try_infer_return_type():
             def f() -> 'ks.DataFrame["a" : np.float : 1, "b":str:2]':  # noqa: F821
@@ -211,6 +219,14 @@ class TypeHintTests(unittest.TestCase):
 
         def try_infer_return_type():
             def f() -> ks.DataFrame[pdf.dtypes]:  # type: ignore
+                pass
+
+            infer_return_type(f)
+
+        self.assertRaisesRegex(TypeError, "object.*not understood", try_infer_return_type)
+
+        def try_infer_return_type():
+            def f() -> ks.Series[pdf.a.dtype]:  # type: ignore
                 pass
 
             infer_return_type(f)

--- a/databricks/koalas/typedef/typehints.py
+++ b/databricks/koalas/typedef/typehints.py
@@ -365,7 +365,7 @@ def infer_return_type(f) -> typing.Union[SeriesType, DataFrameType, ScalarType, 
     if hasattr(tpe, "__origin__") and (
         tpe.__origin__ == ks.DataFrame or tpe.__origin__ == ks.Series
     ):
-        # When Python version is lower then 3.7. Unwrap it to a DataFrameType/SeriesType type hints.
+        # When Python version is lower then 3.7. Unwrap it to a Tuple/SeriesType type hints.
         tpe = tpe.__args__[0]
 
     if hasattr(tpe, "__origin__") and issubclass(tpe.__origin__, SeriesType):

--- a/databricks/koalas/typedef/typehints.py
+++ b/databricks/koalas/typedef/typehints.py
@@ -375,7 +375,7 @@ def infer_return_type(f) -> typing.Union[SeriesType, DataFrameType, ScalarType, 
         inner = as_spark_type(tpe)
         return SeriesType(inner)
 
-    # Note that, DataFrame/Series type hints will create a Tuple/Type.
+    # Note that, DataFrame type hints will create a Tuple.
     # Python 3.6 has `__name__`. Python 3.7 and 3.8 have `_name`.
     # Check if the name is Tuple.
     name = getattr(tpe, "_name", getattr(tpe, "__name__", None))

--- a/databricks/koalas/typedef/typehints.py
+++ b/databricks/koalas/typedef/typehints.py
@@ -20,7 +20,7 @@ Utilities to deal with types. This is mostly focused on python3.
 import typing
 import datetime
 import decimal
-from inspect import getfullargspec, isclass
+from inspect import getfullargspec
 
 import numpy as np
 import pandas as pd
@@ -76,7 +76,7 @@ Dtype = typing.Union[np.dtype, ExtensionDtype]
 
 
 # A column of data, with the data type.
-class SeriesType(typing.Generic[T]):
+class SeriesType(object):
     def __init__(self, tpe):
         self.tpe = tpe  # type: types.DataType
 
@@ -93,7 +93,10 @@ class DataFrameType(object):
             )  # type: types.StructType
         else:
             self.tpe = types.StructType(
-                [types.StructField(n, t) for n, t in zip(names, tpe)]
+                [
+                    types.StructField(n if n is not None else ("c%s" % i), t)
+                    for i, (n, t) in enumerate(zip(names, tpe))
+                ]
             )  # type: types.StructType
 
     def __repr__(self):
@@ -337,6 +340,22 @@ def infer_return_type(f) -> typing.Union[SeriesType, DataFrameType, ScalarType, 
     ...     pass
     >>> infer_return_type(func).tpe
     StructType(List(StructField(a,LongType,true),StructField(b,LongType,true)))
+
+    >>> pdf = pd.DataFrame({"a": [1, 2, 3], "b": pd.Categorical([3, 4, 5])})
+    >>> def func() -> ks.DataFrame[pdf.dtypes]:
+    ...     pass
+    >>> infer_return_type(func).tpe
+    StructType(List(StructField(c0,LongType,true),StructField(c1,LongType,true)))
+
+    >>> def func() -> ks.DataFrame[zip(pdf.columns, pdf.dtypes)]:
+    ...     pass
+    >>> infer_return_type(func).tpe
+    StructType(List(StructField(a,LongType,true),StructField(b,LongType,true)))
+
+    >>> def func() -> ks.Series[pdf.b.dtype]:
+    ...     pass
+    >>> infer_return_type(func).tpe
+    LongType
     """
     # We should re-import to make sure the class 'SeriesType' is not treated as a class
     # within this module locally. See Series.__class_getitem__ which imports this class
@@ -348,23 +367,23 @@ def infer_return_type(f) -> typing.Union[SeriesType, DataFrameType, ScalarType, 
     if isinstance(tpe, str):
         # This type hint can happen when given hints are string to avoid forward reference.
         tpe = resolve_string_type_hint(tpe)
-    if hasattr(tpe, "__origin__") and (
-        issubclass(tpe.__origin__, SeriesType) or tpe.__origin__ == ks.Series
-    ):
-        # TODO: remove "tpe.__origin__ == ks.Series" when we drop Python 3.5 and 3.6.
-        inner = as_spark_type(tpe.__args__[0])
-        return SeriesType(inner)
 
     if hasattr(tpe, "__origin__") and tpe.__origin__ == ks.DataFrame:
         # When Python version is lower then 3.7. Unwrap it to a Tuple type
         # hints.
         tpe = tpe.__args__[0]
 
-    # Note that, DataFrame type hints will create a Tuple.
+    # Note that, DataFrame/Series type hints will create a Tuple/Type.
     # Python 3.6 has `__name__`. Python 3.7 and 3.8 have `_name`.
     # Check if the name is Tuple.
     name = getattr(tpe, "_name", getattr(tpe, "__name__", None))
-    if name == "Tuple":
+    if name == "Type":
+        tpe = tpe.__args__[0]
+        if issubclass(tpe, NameTypeHolder):
+            return SeriesType(as_spark_type(tpe.tpe))
+        else:
+            return SeriesType(as_spark_type(tpe))
+    elif name == "Tuple":
         tuple_type = tpe
         if hasattr(tuple_type, "__tuple_params__"):
             # Python 3.5.0 to 3.5.2 has '__tuple_params__' instead.
@@ -372,13 +391,9 @@ def infer_return_type(f) -> typing.Union[SeriesType, DataFrameType, ScalarType, 
             parameters = getattr(tuple_type, "__tuple_params__")
         else:
             parameters = getattr(tuple_type, "__args__")
-        if len(parameters) > 0 and all(
-            isclass(p) and issubclass(p, NameTypeHolder) for p in parameters
-        ):
-            names = [p.name for p in parameters if issubclass(p, NameTypeHolder)]
-            types = [p.tpe for p in parameters if issubclass(p, NameTypeHolder)]
-            return DataFrameType([as_spark_type(t) for t in types], names)
-        return DataFrameType([as_spark_type(t) for t in parameters])
+        names = [p.name if issubclass(p, NameTypeHolder) else None for p in parameters]
+        types = [p.tpe if issubclass(p, NameTypeHolder) else p for p in parameters]
+        return DataFrameType([as_spark_type(t) for t in types], names)
     inner = as_spark_type(tpe)
     if inner is None:
         return UnknownType(tpe)


### PR DESCRIPTION
Support `ExtensionDtype`s as type arguments by reusing `NameTypeHolder` for DataFrame's type annotation.
Also support to infer Spark DataType from the return type annotation with `ExtensionDtype`s.

Before:

```py
>>> ks.Series[pd.Int32Dtype()]
Traceback (most recent call last):
...
TypeError: Parameters to generic types must be types. Got Int32Dtype().
```

After:

```py
>>> ks.Series[pd.Int32Dtype()]
databricks.koalas.typedef.typehints.SeriesType[databricks.koalas.series.NameType]
>>> def a() -> ks.Series[pd.Int32Dtype()]:
...   pass
...
>>> infer_return_type(a)
SeriesType[IntegerType]
```
