### PR TITLE
Improve documentations of transform/apply functions

### DIFF
--- a/databricks/koalas/accessors.py
+++ b/databricks/koalas/accessors.py
@@ -236,6 +236,11 @@ class KoalasFrameMethods(object):
             >>> def plus_one(x) -> ks.DataFrame[zip(pdf.dtypes, pdf.columns)]:
             ...     return x + 1
 
+            When the given function has the return type annotated, the original index of the
+            DataFrame will be lost and a default index will be attached to the result DataFrame.
+            Please be careful about configuring the default index. See also `Default Index Type
+            <https://koalas.readthedocs.io/en/latest/user_guide/options.html#default-index-type>`_.
+
 
         Parameters
         ----------
@@ -441,6 +446,11 @@ class KoalasFrameMethods(object):
             >>> def plus_one(x) -> ks.DataFrame[zip(pdf.dtypes, pdf.columns)]:
             ...     return x + 1
 
+            When the given function returns DataFrame and has the return type annotated, the
+            original index of the DataFrame will be lost and then a default index will be attached
+            to the result. Please be careful about configuring the default index. See also
+            `Default Index Type
+            <https://koalas.readthedocs.io/en/latest/user_guide/options.html#default-index-type>`_.
 
         Parameters
         ----------

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -2373,6 +2373,11 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             because the type hint cannot express the index type at this moment. Use
             `reset_index()` to keep index as a workaround.
 
+            When the given function has the return type annotated, the original index of the
+            DataFrame will be lost and then a default index will be attached to the result.
+            Please be careful about configuring the default index. See also `Default Index Type
+            <https://koalas.readthedocs.io/en/latest/user_guide/options.html#default-index-type>`_.
+
         Parameters
         ----------
         func : function

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -2045,6 +2045,11 @@ class GroupBy(object, metaclass=ABCMeta):
              >>> def convert_to_string(x) -> ks.Series[str]:
              ...     return x.apply("a string {}".format)
 
+            When the given function has the return type annotated, the original index of the
+            GroupBy object will be lost and a default index will be attached to the result.
+            Please be careful about configuring the default index. See also `Default Index Type
+            <https://koalas.readthedocs.io/en/latest/user_guide/options.html#default-index-type>`_.
+
         .. note:: the series within ``func`` is actually a pandas series. Therefore,
             any pandas APIs within this function is allowed.
 

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -998,6 +998,11 @@ class GroupBy(object, metaclass=ABCMeta):
             >>> def plus_one(x) -> ks.DataFrame[zip(pdf.columns, pdf.dtypes)]:
             ...     return x[['B', 'C']] / x[['B', 'C']]
 
+            When the given function has the return type annotated, the original index of the
+            GroupBy object will be lost and a default index will be attached to the result.
+            Please be careful about configuring the default index. See also `Default Index Type
+            <https://koalas.readthedocs.io/en/latest/user_guide/options.html#default-index-type>`_.
+
         .. note:: the dataframe within ``func`` is actually a pandas dataframe. Therefore,
             any pandas APIs within this function is allowed.
 

--- a/docs/source/user_guide/transform_apply.rst
+++ b/docs/source/user_guide/transform_apply.rst
@@ -90,7 +90,7 @@ Koalas combines the pandas DataFrames as a Koalas DataFrame.
 
 Note that :func:`DataFrame.koalas.transform_batch` has the length restriction - the length of input and output should be
 the same whereas :func:`DataFrame.koalas.apply_batch` does not.  However, it is important to know that
-the output belongs to the same DataFrame when :func:`DataFrame.koalas.transform_batch` can a Series, and
+the output belongs to the same DataFrame when :func:`DataFrame.koalas.transform_batch` returns a Series, and
 you can avoid a shuffle by the operations between different DataFrames. In case of :func:`DataFrame.koalas.apply_batch`, its output is always
 treated that it belongs to a new different DataFrame. See also
 `Operations on different DataFrames <options.rst#operations-on-different-dataframes>`_ for more details.


### PR DESCRIPTION
Improve documentations of transform/apply functions.

Some transform/apply functions will add a default index when the given UDF has return type annotated. This PR raises users' attention on that.