### PR TITLE
Implement DatetimeIndex.indexer_at_time()

### DIFF
--- a/databricks/koalas/indexes/datetimes.py
+++ b/databricks/koalas/indexes/datetimes.py
@@ -709,7 +709,7 @@ class DatetimeIndex(Index):
         Examples
         --------
         >>> kidx = ks.date_range("2000-01-01", periods=3, freq="T")
-        >>> kidx # doctest: +NORMALIZE_WHITESPACE
+        >>> kidx  # doctest: +NORMALIZE_WHITESPACE
         DatetimeIndex(['2000-01-01 00:00:00', '2000-01-01 00:01:00',
                        '2000-01-01 00:02:00'],
                       dtype='datetime64[ns]', freq=None)
@@ -720,6 +720,8 @@ class DatetimeIndex(Index):
         >>> kidx.indexer_at_time("00:01")
         Int64Index([1], dtype='int64')
         """
+        if asof:
+            raise NotImplementedError("'asof' argument is not supported")
 
         def pandas_at_time(pdf) -> ks.DataFrame[int]:
             return pdf.at_time(time, asof)

--- a/databricks/koalas/missing/indexes.py
+++ b/databricks/koalas/missing/indexes.py
@@ -109,7 +109,6 @@ class MissingPandasLikeDatetimeIndex(MissingPandasLikeIndex):
     inferred_freq = _unsupported_property("inferred_freq", cls="DatetimeIndex")
 
     # Functions
-    indexer_at_time = _unsupported_function("indexer_at_time", cls="DatetimeIndex")
     snap = _unsupported_function("snap", cls="DatetimeIndex")
     tz_convert = _unsupported_function("tz_convert", cls="DatetimeIndex")
     tz_localize = _unsupported_function("tz_localize", cls="DatetimeIndex")

--- a/databricks/koalas/tests/indexes/test_datetime.py
+++ b/databricks/koalas/tests/indexes/test_datetime.py
@@ -180,6 +180,7 @@ class DatetimeIndexTest(ReusedSQLTestCase, TestUtils):
                 kidx.indexer_at_time("00:00:01").sort_values(),
                 pd.Index(pidx.indexer_at_time("00:00:01")),
             )
+
         self.assertRaises(
             NotImplementedError,
             lambda: ks.DatetimeIndex([0]).indexer_at_time("00:00:00", asof=True),

--- a/databricks/koalas/tests/indexes/test_datetime.py
+++ b/databricks/koalas/tests/indexes/test_datetime.py
@@ -163,3 +163,20 @@ class DatetimeIndexTest(ReusedSQLTestCase, TestUtils):
                 kidx.indexer_between_time("00:00:00", "00:01:00", False, False).sort_values(),
                 pd.Index(pidx.indexer_between_time("00:00:00", "00:01:00", False, False)),
             )
+
+    def test_indexer_at_time(self):
+        for kidx, pidx in self.idx_pairs:
+            self.assert_eq(
+                kidx.indexer_at_time("00:00:00").sort_values(),
+                pd.Index(pidx.indexer_at_time("00:00:00")),
+            )
+
+            self.assert_eq(
+                kidx.indexer_at_time(datetime.time(0, 1, 0)).sort_values(),
+                pd.Index(pidx.indexer_at_time(datetime.time(0, 1, 0))),
+            )
+
+            self.assert_eq(
+                kidx.indexer_at_time("00:00:01").sort_values(),
+                pd.Index(pidx.indexer_at_time("00:00:01")),
+            )

--- a/databricks/koalas/tests/indexes/test_datetime.py
+++ b/databricks/koalas/tests/indexes/test_datetime.py
@@ -180,3 +180,7 @@ class DatetimeIndexTest(ReusedSQLTestCase, TestUtils):
                 kidx.indexer_at_time("00:00:01").sort_values(),
                 pd.Index(pidx.indexer_at_time("00:00:01")),
             )
+        self.assertRaises(
+            NotImplementedError,
+            lambda: ks.DatetimeIndex([0]).indexer_at_time("00:00:00", asof=True),
+        )

--- a/docs/source/reference/indexing.rst
+++ b/docs/source/reference/indexing.rst
@@ -349,6 +349,7 @@ Selecting
    :toctree: api/
 
    DatetimeIndex.indexer_between_time
+   DatetimeIndex.indexer_at_time
 
 Time-specific operations
 ~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
```py
>>> kidx = ks.date_range("2000-01-01", periods=3, freq="T")
>>> kidx
DatetimeIndex(['2000-01-01 00:00:00', '2000-01-01 00:01:00',
               '2000-01-01 00:02:00'],
              dtype='datetime64[ns]', freq=None)

>>> kidx.indexer_at_time("00:00")
Int64Index([0], dtype='int64')

>>> kidx.indexer_at_time("00:01")
Int64Index([1], dtype='int64')
```