### PR TITLE
Disable check_freq in testing util.

### DIFF
--- a/databricks/koalas/testing/utils.py
+++ b/databricks/koalas/testing/utils.py
@@ -20,6 +20,7 @@ import tempfile
 import unittest
 import warnings
 from contextlib import contextmanager
+from distutils.version import LooseVersion
 
 import pandas as pd
 from pandas.api.types import is_list_like
@@ -124,13 +125,18 @@ class ReusedSQLTestCase(unittest.TestCase, SQLTestUtils):
     def assertPandasEqual(self, left, right, check_exact=True):
         if isinstance(left, pd.DataFrame) and isinstance(right, pd.DataFrame):
             try:
+                if LooseVersion(pd.__version__) >= LooseVersion("1.1"):
+                    kwargs = dict(check_freq=False)
+                else:
+                    kwargs = dict()
+
                 assert_frame_equal(
                     left,
                     right,
                     check_index_type=("equiv" if len(left.index) > 0 else False),
                     check_column_type=("equiv" if len(left.columns) > 0 else False),
                     check_exact=check_exact,
-                    check_freq=False,
+                    **kwargs
                 )
             except AssertionError as e:
                 msg = (
@@ -141,12 +147,17 @@ class ReusedSQLTestCase(unittest.TestCase, SQLTestUtils):
                 raise AssertionError(msg) from e
         elif isinstance(left, pd.Series) and isinstance(right, pd.Series):
             try:
+                if LooseVersion(pd.__version__) >= LooseVersion("1.1"):
+                    kwargs = dict(check_freq=False)
+                else:
+                    kwargs = dict()
+
                 assert_series_equal(
                     left,
                     right,
                     check_index_type=("equiv" if len(left.index) > 0 else False),
                     check_exact=check_exact,
-                    check_freq=False,
+                    **kwargs
                 )
             except AssertionError as e:
                 msg = (

--- a/databricks/koalas/testing/utils.py
+++ b/databricks/koalas/testing/utils.py
@@ -130,6 +130,7 @@ class ReusedSQLTestCase(unittest.TestCase, SQLTestUtils):
                     check_index_type=("equiv" if len(left.index) > 0 else False),
                     check_column_type=("equiv" if len(left.columns) > 0 else False),
                     check_exact=check_exact,
+                    check_freq=False,
                 )
             except AssertionError as e:
                 msg = (
@@ -145,6 +146,7 @@ class ReusedSQLTestCase(unittest.TestCase, SQLTestUtils):
                     right,
                     check_index_type=("equiv" if len(left.index) > 0 else False),
                     check_exact=check_exact,
+                    check_freq=False,
                 )
             except AssertionError as e:
                 msg = (

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -5428,9 +5428,8 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         pdf = pd.DataFrame({"A": [1, 2, 3, 4]}, index=idx)
         kdf = ks.from_pandas(pdf)
         self.assert_eq(
-            pdf.between_time("0:15", "0:45"),
+            pdf.between_time("0:15", "0:45").sort_index(),
             kdf.between_time("0:15", "0:45").sort_index(),
-            almost=True,
         )
 
         with self.assertRaisesRegex(


### PR DESCRIPTION
We'd disable `check_freq` for checking the `freq` in `DatetimeIndex` because so far we don't provide `freq` in `DatetimeIndex`.