### PR TITLE
Save pandas shortcut of DataFrame.between_time()

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -3066,7 +3066,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         kdf.index.name = verify_temp_column_name(kdf, "__index_name__")
         return_types = [kdf.index.dtype] + list(kdf.dtypes)
 
-        def pandas_between_time(pdf,) -> ks.DataFrame[return_types]:  # type: ignore
+        def pandas_between_time(pdf) -> ks.DataFrame[return_types]:  # type: ignore
             return pdf.between_time(start_time, end_time, include_start, include_end).reset_index()
 
         # apply_batch will remove the index of the Koalas DataFrame and attach a default index,

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -3073,12 +3073,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         # which will never be used. So use "distributed" index as a dummy to avoid overhead.
         with option_context("compute.default_index_type", "distributed"):
             # Get the new column name from pandas reset_index()
-            if self.index.name is None:
-                index_name = "index"
-            elif self.index.name == "index":
-                index_name = "level_0"
-            else:
-                index_name = self.index.name
+            index_name = self.reset_index().columns[0]
             kdf = self.koalas.apply_batch(pandas_between_time).set_index(index_name)
 
         kdf.index.rename(self.index.name, inplace=True)

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -3069,7 +3069,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         ]:
             return pdf.between_time(start_time, end_time, include_start, include_end).reset_index()
 
-        kdf = self.koalas.apply_batch(pandas_between_time).set_index("index")
+        # apply_batch will remove the index of the Koalas DataFrame and attach a default index,
+        # which will never be used. So use "distributed" index as a dummy to avoid overhead.
+        with option_context("compute.default_index_type", "distributed"):
+            kdf = self.koalas.apply_batch(pandas_between_time).set_index("index")
         kdf.index.rename(self.index.name, inplace=True)
         return kdf
 

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -3062,10 +3062,14 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         if not isinstance(self.index, DatetimeIndex):
             raise TypeError("Index must be DatetimeIndex")
 
-        def pandas_between_time(pdf):
-            return pdf.between_time(start_time, end_time, include_start, include_end)
+        def pandas_between_time(
+            pdf,
+        ) -> ks.DataFrame[zip(self.reset_index().columns, self.reset_index().dtypes)]:
+            return pdf.between_time(start_time, end_time, include_start, include_end).reset_index()
 
-        return self.koalas.apply_batch(pandas_between_time)
+        kdf = self.koalas.apply_batch(pandas_between_time).set_index("index")
+        kdf.index.rename(self.index.name, inplace=True)
+        return kdf
 
     def where(self, cond, other=np.nan) -> "DataFrame":
         """

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -3069,10 +3069,14 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         ]:
             return pdf.between_time(start_time, end_time, include_start, include_end).reset_index()
 
+        # In pandas reset_index(), the new column is assigned the name 'index'
+        # if the original index has no name
+        index_name = "index" if self.index.name is None else self.index.name
+
         # apply_batch will remove the index of the Koalas DataFrame and attach a default index,
         # which will never be used. So use "distributed" index as a dummy to avoid overhead.
         with option_context("compute.default_index_type", "distributed"):
-            kdf = self.koalas.apply_batch(pandas_between_time).set_index("index")
+            kdf = self.koalas.apply_batch(pandas_between_time).set_index(index_name)
         kdf.index.rename(self.index.name, inplace=True)
         return kdf
 

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -3066,7 +3066,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         kdf.index.name = verify_temp_column_name(kdf, "__index_name__")
         return_types = [kdf.index.dtype] + list(kdf.dtypes)
 
-        def pandas_between_time(pdf,) -> ks.DataFrame[return_types]:
+        def pandas_between_time(pdf,) -> ks.DataFrame[return_types]:  # type: ignore
             return pdf.between_time(start_time, end_time, include_start, include_end).reset_index()
 
         # apply_batch will remove the index of the Koalas DataFrame and attach a default index,

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -3069,14 +3069,14 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         ]:
             return pdf.between_time(start_time, end_time, include_start, include_end).reset_index()
 
-        # In pandas reset_index(), the new column is assigned the name 'index'
-        # if the original index has no name
-        index_name = "index" if self.index.name is None else self.index.name
-
         # apply_batch will remove the index of the Koalas DataFrame and attach a default index,
         # which will never be used. So use "distributed" index as a dummy to avoid overhead.
         with option_context("compute.default_index_type", "distributed"):
+            # In pandas reset_index(), the new column is assigned the name 'index'
+            # if the original index has no name
+            index_name = "index" if self.index.name is None else self.index.name
             kdf = self.koalas.apply_batch(pandas_between_time).set_index(index_name)
+
         kdf.index.rename(self.index.name, inplace=True)
         return kdf
 

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -3062,22 +3062,25 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         if not isinstance(self.index, DatetimeIndex):
             raise TypeError("Index must be DatetimeIndex")
 
-        def pandas_between_time(
-            pdf,
-        ) -> ks.DataFrame[  # type: ignore
-            zip(self.reset_index().columns, self.reset_index().dtypes)
-        ]:
+        kdf = self.copy()
+        kdf.index.name = verify_temp_column_name(kdf, "__index_name__")
+        return_types = [kdf.index.dtype] + list(kdf.dtypes)
+
+        def pandas_between_time(pdf,) -> ks.DataFrame[return_types]:
             return pdf.between_time(start_time, end_time, include_start, include_end).reset_index()
 
         # apply_batch will remove the index of the Koalas DataFrame and attach a default index,
         # which will never be used. So use "distributed" index as a dummy to avoid overhead.
         with option_context("compute.default_index_type", "distributed"):
-            # Get the new column name from pandas reset_index()
-            index_name = self.reset_index().columns[0]
-            kdf = self.koalas.apply_batch(pandas_between_time).set_index(index_name)
+            kdf = kdf.koalas.apply_batch(pandas_between_time)
 
-        kdf.index.rename(self.index.name, inplace=True)
-        return kdf
+        return DataFrame(
+            self._internal.copy(
+                spark_frame=kdf._internal.spark_frame,
+                index_spark_columns=kdf._internal.data_spark_columns[:1],
+                data_spark_columns=kdf._internal.data_spark_columns[1:],
+            )
+        )
 
     def where(self, cond, other=np.nan) -> "DataFrame":
         """

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -3064,7 +3064,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         def pandas_between_time(
             pdf,
-        ) -> ks.DataFrame[zip(self.reset_index().columns, self.reset_index().dtypes)]:
+        ) -> ks.DataFrame[  # type: ignore
+            zip(self.reset_index().columns, self.reset_index().dtypes)
+        ]:
             return pdf.between_time(start_time, end_time, include_start, include_end).reset_index()
 
         kdf = self.koalas.apply_batch(pandas_between_time).set_index("index")

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -3072,9 +3072,13 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         # apply_batch will remove the index of the Koalas DataFrame and attach a default index,
         # which will never be used. So use "distributed" index as a dummy to avoid overhead.
         with option_context("compute.default_index_type", "distributed"):
-            # In pandas reset_index(), the new column is assigned the name 'index'
-            # if the original index has no name
-            index_name = "index" if self.index.name is None else self.index.name
+            # Get the new column name from pandas reset_index()
+            if self.index.name is None:
+                index_name = "index"
+            elif self.index.name == "index":
+                index_name = "level_0"
+            else:
+                index_name = self.index.name
             kdf = self.koalas.apply_batch(pandas_between_time).set_index(index_name)
 
         kdf.index.rename(self.index.name, inplace=True)

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -5439,7 +5439,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             kdf.between_time("0:15", "0:45").sort_index(),
         )
 
-        pdf.index.name = "index"
+        pdf.columns = pd.Index(["index"])
         kdf = ks.from_pandas(pdf)
         self.assert_eq(
             pdf.between_time("0:15", "0:45").sort_index(),

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -5439,6 +5439,13 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             kdf.between_time("0:15", "0:45").sort_index(),
         )
 
+        pdf.index.name = "index"
+        kdf = ks.from_pandas(pdf)
+        self.assert_eq(
+            pdf.between_time("0:15", "0:45").sort_index(),
+            kdf.between_time("0:15", "0:45").sort_index(),
+        )
+
         with self.assertRaisesRegex(
             NotImplementedError, "between_time currently only works for axis=0"
         ):

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -5432,6 +5432,13 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             kdf.between_time("0:15", "0:45").sort_index(),
         )
 
+        pdf.index.name = "ts"
+        kdf = ks.from_pandas(pdf)
+        self.assert_eq(
+            pdf.between_time("0:15", "0:45").sort_index(),
+            kdf.between_time("0:15", "0:45").sort_index(),
+        )
+
         with self.assertRaisesRegex(
             NotImplementedError, "between_time currently only works for axis=0"
         ):

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -5471,7 +5471,3 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         kdf = ks.DataFrame({"A": [1, 2, 3, 4]})
         with self.assertRaisesRegex(TypeError, "Index must be DatetimeIndex"):
             kdf.between_time("0:15", "0:45")
-
-    def test_between_time_no_shortcut(self):
-        with ks.option_context("compute.shortcut_limit", 0):
-            self.test_between_time()

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -5439,7 +5439,24 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             kdf.between_time("0:15", "0:45").sort_index(),
         )
 
+        # Column label is 'index'
         pdf.columns = pd.Index(["index"])
+        kdf = ks.from_pandas(pdf)
+        self.assert_eq(
+            pdf.between_time("0:15", "0:45").sort_index(),
+            kdf.between_time("0:15", "0:45").sort_index(),
+        )
+
+        # Both index name and column label are 'index'
+        pdf.index.name = "index"
+        kdf = ks.from_pandas(pdf)
+        self.assert_eq(
+            pdf.between_time("0:15", "0:45").sort_index(),
+            kdf.between_time("0:15", "0:45").sort_index(),
+        )
+
+        # Index name is 'index', column label is ('X', 'A')
+        pdf.columns = pd.MultiIndex.from_arrays([["X"], ["A"]])
         kdf = ks.from_pandas(pdf)
         self.assert_eq(
             pdf.between_time("0:15", "0:45").sort_index(),


### PR DESCRIPTION
The UDF in DataFrame.between_time() was without return type hint, so the pandas shortcut was required to infer the return type. The PR is proposed to add type hint to the UDF in DataFrame.between_time().