### PR TITLE
Implement `DataFrame.last` and `Series.last` functionality

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -5660,6 +5660,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         >>> index = pd.date_range('2018-04-09', periods=4, freq='2D')
         >>> pdf = pd.DataFrame({'A': [1, 2, 3, 4]}, index=index)
         >>> kdf = ks.from_pandas(pdf)
+        >>> kdf
                     A
         2018-04-09  1
         2018-04-11  2

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -5683,7 +5683,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         if not isinstance(self.index, DatetimeIndex):
             raise TypeError("'last' only supports a DatetimeIndex")
 
-        offset = pd._libs.tslibs.offsets.to_offset(offset)
+        offset = pd.tseries.frequencies.to_offset(offset)
         index_max = self.index.max()
         from_date = index_max - offset
 

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -5683,9 +5683,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         if not isinstance(self.index, DatetimeIndex):
             raise TypeError("'last' only supports a DatetimeIndex")
 
-        from pandas._libs.tslibs.offsets import to_offset
-
-        offset = to_offset(offset)
+        offset = pd._libs.tslibs.offsets.to_offset(offset)
         index_max = self.index.max()
         from_date = index_max - offset
 

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -5678,10 +5678,12 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         """
         # Check index type should be format DateTime
         from databricks.koalas.indexes import DatetimeIndex
+
         if not isinstance(self.index, DatetimeIndex):
             raise TypeError("'last' only supports a DatetimeIndex")
 
         from pandas._libs.tslibs.offsets import to_offset
+
         offset = to_offset(offset)
         index_max = self.index.max()
         from_date = index_max - offset
@@ -5698,12 +5700,12 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             kdf = kdf.koalas.apply_batch(pandas_loc)
 
         return DataFrame(
-                self._internal.copy(
-                    spark_frame=kdf._internal.spark_frame,
-                    index_spark_columns=kdf._internal.data_spark_columns[:1],
-                    data_spark_columns=kdf._internal.data_spark_columns[1:],
-                )
+            self._internal.copy(
+                spark_frame=kdf._internal.spark_frame,
+                index_spark_columns=kdf._internal.data_spark_columns[:1],
+                data_spark_columns=kdf._internal.data_spark_columns[1:],
             )
+        )
 
     def pivot_table(
         self, values=None, index=None, columns=None, aggfunc="mean", fill_value=None

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -5682,6 +5682,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         # Leverage pandas offsets to set a range
         from pandas._libs.tslibs.offsets import to_offset
+
         offset = to_offset(offset)
         index_max = self.index.max()
         from_date = index_max - offset

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -5652,12 +5652,13 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         Raises
         ------
         TypeError
-            If the index is not  a :type:`np.datetime64`
+            If the index is not  a :class:`DatetimeIndex`
 
         Examples
         --------
+
         >>> index = pd.date_range('2018-04-09', periods=4, freq='2D')
-        >>> pdf = pd.DataFrame({'A': [1, 2, 3, 4]}, index=i)
+        >>> pdf = pd.DataFrame({'A': [1, 2, 3, 4]}, index=index)
         >>> kdf = ks.from_pandas(pdf)
                     A
         2018-04-09  1

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -5688,8 +5688,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         offset = pd.tseries.frequencies.to_offset(offset)
         from_date = self.index.max() - offset
 
-        kdf = self.copy()
-        kdf.index.name = verify_temp_column_name(kdf, "__index_name__")
+        self.index.name = verify_temp_column_name(self, "__index_name__")
 
         return self[from_date:]
 

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -49,7 +49,7 @@ import numpy as np
 import pandas as pd
 from pandas.api.types import is_list_like, is_dict_like, is_scalar
 from pandas.api.extensions import ExtensionDtype
-from pandas.tseries.frequencies import DateOffset
+from pandas.tseries.frequencies import DateOffset, to_offset
 
 if TYPE_CHECKING:
     from pandas.io.formats.style import Styler
@@ -5689,8 +5689,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         --------
 
         >>> index = pd.date_range('2018-04-09', periods=4, freq='2D')
-        >>> pdf = pd.DataFrame({'A': [1, 2, 3, 4]}, index=index)
-        >>> kdf = ks.from_pandas(pdf)
+        >>> kdf = ks.DataFrame({'A': [1, 2, 3, 4]}, index=index)
         >>> kdf
                     A
         2018-04-09  1
@@ -5715,10 +5714,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         if not isinstance(self.index, DatetimeIndex):
             raise TypeError("'last' only supports a DatetimeIndex")
 
-        offset = pd.tseries.frequencies.to_offset(offset)
+        offset = to_offset(offset)
         from_date = self.index.max() - offset
-
-        self.index.name = verify_temp_column_name(self, "__index_name__")
 
         return self[from_date:]
 

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -5640,7 +5640,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Parameters
         ----------
-        offset : str, DateOffset
+        offset : str or DateOffset
             The offset length of the data that will be selected. For instance,
             '3D' will display all the rows having their index within the last 3 days.
 

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -48,6 +48,7 @@ import datetime
 import numpy as np
 import pandas as pd
 from pandas.api.types import is_list_like, is_dict_like, is_scalar
+from pandas.tseries.frequencies import DateOffset
 
 if TYPE_CHECKING:
     from pandas.io.formats.style import Styler
@@ -5631,7 +5632,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 sdf = sdf.orderBy(NATURAL_ORDER_COLUMN_NAME)
             return DataFrame(self._internal.with_new_sdf(sdf.limit(n)))
 
-    def last(self, offset) -> "DataFrame":
+    def last(self, offset: Union[str, DateOffset]) -> "DataFrame":
         """
         Select final periods of time series data based on a date offset.
 
@@ -5652,7 +5653,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         Raises
         ------
         TypeError
-            If the index is not  a :class:`DatetimeIndex`
+            If the index is not a :class:`DatetimeIndex`
 
         Examples
         --------

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -5717,7 +5717,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         offset = to_offset(offset)
         from_date = self.index.max() - offset
 
-        return self[from_date:]
+        return cast(DataFrame, self.loc[from_date:])
 
     def pivot_table(
         self, values=None, index=None, columns=None, aggfunc="mean", fill_value=None

--- a/databricks/koalas/missing/frame.py
+++ b/databricks/koalas/missing/frame.py
@@ -49,7 +49,6 @@ class _MissingPandasLikeDataFrame(object):
     first = _unsupported_function("first")
     infer_objects = _unsupported_function("infer_objects")
     interpolate = _unsupported_function("interpolate")
-    last = _unsupported_function("last")
     lookup = _unsupported_function("lookup")
     mode = _unsupported_function("mode")
     reorder_levels = _unsupported_function("reorder_levels")

--- a/databricks/koalas/missing/series.py
+++ b/databricks/koalas/missing/series.py
@@ -46,7 +46,6 @@ class MissingPandasLikeSeries(object):
     first = _unsupported_function("first")
     infer_objects = _unsupported_function("infer_objects")
     interpolate = _unsupported_function("interpolate")
-    last = _unsupported_function("last")
     reorder_levels = _unsupported_function("reorder_levels")
     resample = _unsupported_function("resample")
     searchsorted = _unsupported_function("searchsorted")

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -2191,6 +2191,52 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         """
         return first_series(self.to_frame().head(n)).rename(self.name)
 
+    def last(self, offset) -> "Series":
+        """
+        Select final periods of time series data based on a date offset.
+
+        When having a Series with dates as index, this function can
+        select the last few elements based on a date offset.
+
+        Parameters
+        ----------
+        offset : str, DateOffset
+            The offset length of the data that will be selected. For instance,
+            '3D' will display all the rows having their index within the last 3 days.
+
+        Returns
+        -------
+        Series
+            A subset of the caller.
+
+        Raises
+        ------
+        TypeError
+            If the index is not  a :type:`np.datetime64`
+
+        Examples
+        --------
+        >>> index = pd.date_range('2018-04-09', periods=4, freq='2D')
+        >>> ks_series = ks.Series([1, 2, 3, 4], index=index)
+        2018-04-09  1
+        2018-04-11  2
+        2018-04-13  3
+        2018-04-15  4
+        dtype: int64
+
+        Get the rows for the last 3 days:
+
+        >>> ks_series.last('3D')
+        2018-04-13  3
+        2018-04-15  4
+        dtype: int64
+
+        Notice the data for 3 last calendar days were returned, not the last
+        3 observed days in the dataset, and therefore data for 2018-04-11 was
+        not returned.
+        """
+        return first_series(self.to_frame().last(offset=offset)).rename(self.name)
+
     # TODO: Categorical type isn't supported (due to PySpark's limitation) and
     # some doctests related with timestamps were not added.
     def unique(self) -> "Series":

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -2219,17 +2219,17 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         >>> index = pd.date_range('2018-04-09', periods=4, freq='2D')
         >>> ks_series = ks.Series([1, 2, 3, 4], index=index)
         >>> ks_series
-        2018-04-09  1
-        2018-04-11  2
-        2018-04-13  3
-        2018-04-15  4
+        2018-04-09    1
+        2018-04-11    2
+        2018-04-13    3
+        2018-04-15    4
         dtype: int64
 
         Get the rows for the last 3 days:
 
         >>> ks_series.last('3D')
-        2018-04-13  3
-        2018-04-15  4
+        2018-04-13    3
+        2018-04-15    4
         dtype: int64
 
         Notice the data for 3 last calendar days were returned, not the last

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -2212,7 +2212,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         Raises
         ------
         TypeError
-            If the index is not  a :type:`np.datetime64`
+            If the index is not  a a :class:`DatetimeIndex`
 
         Examples
         --------

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -31,6 +31,7 @@ import pandas as pd
 from pandas.core.accessor import CachedAccessor
 from pandas.io.formats.printing import pprint_thing
 from pandas.api.types import is_list_like, is_hashable
+from pandas.tseries.frequencies import DateOffset
 import pyspark
 from pyspark import sql as spark
 from pyspark.sql import functions as F, Column
@@ -2191,7 +2192,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         """
         return first_series(self.to_frame().head(n)).rename(self.name)
 
-    def last(self, offset) -> "Series":
+    def last(self, offset: Union[str, DateOffset]) -> "Series":
         """
         Select final periods of time series data based on a date offset.
 
@@ -2212,7 +2213,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         Raises
         ------
         TypeError
-            If the index is not  a a :class:`DatetimeIndex`
+            If the index is not a :class:`DatetimeIndex`
 
         Examples
         --------

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -2218,6 +2218,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         --------
         >>> index = pd.date_range('2018-04-09', periods=4, freq='2D')
         >>> ks_series = ks.Series([1, 2, 3, 4], index=index)
+        >>> ks_series
         2018-04-09  1
         2018-04-11  2
         2018-04-13  3

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -2235,7 +2235,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         3 observed days in the dataset, and therefore data for 2018-04-11 was
         not returned.
         """
-        return first_series(self.to_frame().last(offset=offset)).rename(self.name)
+        return first_series(self.to_frame().last(offset)).rename(self.name)
 
     # TODO: Categorical type isn't supported (due to PySpark's limitation) and
     # some doctests related with timestamps were not added.

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -2200,7 +2200,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         Parameters
         ----------
-        offset : str, DateOffset
+        offset : str or DateOffset
             The offset length of the data that will be selected. For instance,
             '3D' will display all the rows having their index within the last 3 days.
 

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -5203,10 +5203,12 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(pdf.last_valid_index(), kdf.last_valid_index())
 
     def test_last(self):
+        from pandas.tseries.offsets import DateOffset
         index = pd.date_range("2018-04-09", periods=4, freq="2D")
         pdf = pd.DataFrame([1, 2, 3, 4], index=index)
         kdf = ks.from_pandas(pdf)
         self.assert_eq(pdf.last("1D"), kdf.last("1D"))
+        self.assert_eq(pdf.last(DateOffset(days=1)), kdf.last(DateOffset(days=1)))
 
     def test_first_valid_index(self):
         pdf = pd.DataFrame(

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -22,6 +22,7 @@ from io import StringIO
 
 import numpy as np
 import pandas as pd
+from pandas.tseries.offsets import DateOffset
 import pyspark
 from pyspark import StorageLevel
 from pyspark.ml.linalg import SparseVector
@@ -5203,13 +5204,13 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(pdf.last_valid_index(), kdf.last_valid_index())
 
     def test_last(self):
-        from pandas.tseries.offsets import DateOffset
-
         index = pd.date_range("2018-04-09", periods=4, freq="2D")
         pdf = pd.DataFrame([1, 2, 3, 4], index=index)
         kdf = ks.from_pandas(pdf)
         self.assert_eq(pdf.last("1D"), kdf.last("1D"))
         self.assert_eq(pdf.last(DateOffset(days=1)), kdf.last(DateOffset(days=1)))
+        with self.assertRaisesRegex(TypeError, "'last' only supports a DatetimeIndex"):
+            ks.DataFrame([1, 2, 3, 4]).last("1D")
 
     def test_first_valid_index(self):
         pdf = pd.DataFrame(

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -5204,6 +5204,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
     def test_last(self):
         from pandas.tseries.offsets import DateOffset
+
         index = pd.date_range("2018-04-09", periods=4, freq="2D")
         pdf = pd.DataFrame([1, 2, 3, 4], index=index)
         kdf = ks.from_pandas(pdf)

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -5202,6 +5202,12 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         kdf = ks.Series([]).to_frame()
         self.assert_eq(pdf.last_valid_index(), kdf.last_valid_index())
 
+    def test_last(self):
+        index = pd.date_range('2018-04-09', periods=4, freq='2D')
+        pdf = pd.DataFrame([1, 2, 3, 4], index=index)
+        kdf = ks.from_pandas(pdf)
+        self.assert_eq(pdf.last('1D'), kdf.last('1D'))
+
     def test_first_valid_index(self):
         pdf = pd.DataFrame(
             {"a": [None, 2, 3, 2], "b": [None, 2.0, 3.0, 1.0], "c": [None, 200, 400, 200]},

--- a/databricks/koalas/tests/test_dataframe.py
+++ b/databricks/koalas/tests/test_dataframe.py
@@ -5203,10 +5203,10 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(pdf.last_valid_index(), kdf.last_valid_index())
 
     def test_last(self):
-        index = pd.date_range('2018-04-09', periods=4, freq='2D')
+        index = pd.date_range("2018-04-09", periods=4, freq="2D")
         pdf = pd.DataFrame([1, 2, 3, 4], index=index)
         kdf = ks.from_pandas(pdf)
-        self.assert_eq(pdf.last('1D'), kdf.last('1D'))
+        self.assert_eq(pdf.last("1D"), kdf.last("1D"))
 
     def test_first_valid_index(self):
         pdf = pd.DataFrame(

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -180,6 +180,14 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(kser.head(-3), pser.head(-3))
         self.assert_eq(kser.head(-10), pser.head(-10))
 
+    def test_last(self):
+        index = pd.date_range('2018-04-09', periods=4, freq='2D')
+        pd_input = pd.Series([1, 2, 3, 4], index=index)
+        ks_input = ks.Series([1, 2, 3, 4], index=index)
+        with self.assertRaises(TypeError):
+             self.kser.last('1D')
+        self.assert_eq(ks_input.last('1D'), pd_input.last('1D'))
+
     def test_rename(self):
         pser = pd.Series([1, 2, 3, 4, 5, 6, 7], name="x")
         kser = ks.from_pandas(pser)

--- a/databricks/koalas/tests/test_series.py
+++ b/databricks/koalas/tests/test_series.py
@@ -181,12 +181,12 @@ class SeriesTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(kser.head(-10), pser.head(-10))
 
     def test_last(self):
-        index = pd.date_range('2018-04-09', periods=4, freq='2D')
+        index = pd.date_range("2018-04-09", periods=4, freq="2D")
         pd_input = pd.Series([1, 2, 3, 4], index=index)
         ks_input = ks.Series([1, 2, 3, 4], index=index)
         with self.assertRaises(TypeError):
-             self.kser.last('1D')
-        self.assert_eq(ks_input.last('1D'), pd_input.last('1D'))
+            self.kser.last("1D")
+        self.assert_eq(ks_input.last("1D"), pd_input.last("1D"))
 
     def test_rename(self):
         pser = pd.Series([1, 2, 3, 4, 5, 6, 7], name="x")

--- a/docs/source/reference/frame.rst
+++ b/docs/source/reference/frame.rst
@@ -172,6 +172,7 @@ Reindexing / Selection / Label manipulation
    DataFrame.equals
    DataFrame.filter
    DataFrame.head
+   DataFrame.last
    DataFrame.rename
    DataFrame.rename_axis
    DataFrame.reset_index

--- a/docs/source/reference/series.rst
+++ b/docs/source/reference/series.rst
@@ -171,6 +171,7 @@ Reindexing / Selection / Label manipulation
    Series.idxmax
    Series.idxmin
    Series.isin
+   Series.last
    Series.rename
    Series.rename_axis
    Series.reindex


### PR DESCRIPTION
Please see change to implement `DataFrame.last` and `Series.last` functionality similar to that available in pandas. Requirement raised in issue: https://github.com/databricks/koalas/issues/1929

```python
>>> index = pd.date_range('2018-04-09', periods=4, freq='2D')
>>> ks_series = ks.Series([1, 2, 3, 4], index=index)
2018-04-09  1
2018-04-11  2
2018-04-13  3
2018-04-15  4
dtype: int64

>>> ks_series.last('3D')
2018-04-13  3
2018-04-15  4
dtype: int64
```

```python
>>> index = pd.date_range('2018-04-09', periods=4, freq='2D')
>>> pdf = pd.DataFrame({'A': [1, 2, 3, 4]}, index=i)
>>> kdf = fs.from_pandas(pdf)
            A
2018-04-09  1
2018-04-11  2
2018-04-13  3
2018-04-15  4

 >>> kdf.last('3D')
            A
2018-04-13  3
2018-04-15  4      
```

