### PR TITLE
Make SeriesType, DataFrameType, and ScalarType hold the dtypes as well.

### DIFF
--- a/databricks/koalas/accessors.py
+++ b/databricks/koalas/accessors.py
@@ -372,7 +372,7 @@ class KoalasFrameMethods(object):
             internal = kdf._internal.with_new_sdf(sdf)
         else:
             return_type = infer_return_type(original_func)
-            return_schema = return_type.tpe
+            return_schema = return_type.spark_type
             is_return_dataframe = isinstance(return_type, DataFrameType)
             if not is_return_dataframe:
                 raise TypeError(
@@ -647,7 +647,7 @@ class KoalasFrameMethods(object):
                 return DataFrame(kdf._internal.with_new_sdf(sdf))
         else:
             return_type = infer_return_type(original_func)
-            return_schema = return_type.tpe
+            return_schema = return_type.spark_type
             is_return_series = isinstance(return_type, SeriesType)
             is_return_dataframe = isinstance(return_type, DataFrameType)
             if not is_return_dataframe and not is_return_series:
@@ -831,7 +831,7 @@ class KoalasSeriesMethods(object):
                     "Expected the return type of this function to be of type column,"
                     " but found type {}".format(sig_return)
                 )
-            return_schema = sig_return.tpe
+            return_schema = sig_return.spark_type
 
         ff = func
         func = lambda o: ff(o, *args, **kwargs)

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -117,6 +117,7 @@ from databricks.koalas.typedef import (
     DataFrameType,
     SeriesType,
     Scalar,
+    ScalarType,
 )
 from databricks.koalas.plot import KoalasPlotAccessor
 
@@ -2572,7 +2573,6 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             internal = kdf._internal.with_new_sdf(sdf)
         else:
             return_type = infer_return_type(func)
-            return_schema = return_type.spark_type
             require_index_axis = isinstance(return_type, SeriesType)
             require_column_axis = isinstance(return_type, DataFrameType)
 
@@ -2583,6 +2583,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                         "hints when axis is 0 or 'index'; however, the return type "
                         "was %s" % return_sig
                     )
+                return_schema = cast(SeriesType, return_type).spark_type
                 fields_types = zip(
                     self_applied.columns, [return_schema] * len(self_applied.columns)
                 )
@@ -2594,9 +2595,11 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                         "hints when axis is 1 or 'column'; however, the return type "
                         "was %s" % return_sig
                     )
+                return_schema = cast(DataFrameType, return_type).spark_type
             else:
                 # any axis is fine.
                 should_return_series = True
+                return_schema = cast(ScalarType, return_type).spark_type
                 return_schema = StructType([StructField(SPARK_DEFAULT_SERIES_NAME, return_schema)])
                 column_labels = [None]
 
@@ -9862,7 +9865,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                         return x
 
             elif callable(mapper):
-                spark_return_type = infer_return_type(mapper).spark_type
+                spark_return_type = cast(ScalarType, infer_return_type(mapper)).spark_type
 
                 def mapper_fn(x):
                     return mapper(x)

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -2572,7 +2572,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             internal = kdf._internal.with_new_sdf(sdf)
         else:
             return_type = infer_return_type(func)
-            return_schema = return_type.tpe
+            return_schema = return_type.spark_type
             require_index_axis = isinstance(return_type, SeriesType)
             require_column_axis = isinstance(return_type, DataFrameType)
 
@@ -9862,7 +9862,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                         return x
 
             elif callable(mapper):
-                spark_return_type = infer_return_type(mapper).tpe
+                spark_return_type = infer_return_type(mapper).spark_type
 
                 def mapper_fn(x):
                     return mapper(x)

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -1180,7 +1180,7 @@ class GroupBy(object, metaclass=ABCMeta):
                     "currently; however got [%s]. Use DataFrame type hint instead." % return_sig
                 )
 
-            return_schema = return_type.tpe
+            return_schema = return_type.spark_type
             if not isinstance(return_schema, StructType):
                 should_return_series = True
                 if is_series_groupby:
@@ -2139,7 +2139,7 @@ class GroupBy(object, metaclass=ABCMeta):
             # If schema is inferred, we can restore indexes too.
             internal = kdf_from_pandas._internal.with_new_sdf(sdf)
         else:
-            return_type = infer_return_type(func).tpe
+            return_type = infer_return_type(func).spark_type
             data_columns = kdf._internal.data_spark_column_names
             return_schema = StructType(
                 [StructField(c, return_type) for c in data_columns if c not in groupkey_names]

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -43,7 +43,7 @@ from pyspark.sql.types import (
 from pyspark.sql.functions import PandasUDFType, pandas_udf, Column
 
 from databricks import koalas as ks  # For running doctests and reference resolution in PyCharm.
-from databricks.koalas.typedef import infer_return_type, SeriesType
+from databricks.koalas.typedef import infer_return_type, DataFrameType, ScalarType, SeriesType
 from databricks.koalas.frame import DataFrame
 from databricks.koalas.internal import (
     InternalFrame,
@@ -1180,9 +1180,11 @@ class GroupBy(object, metaclass=ABCMeta):
                     "currently; however got [%s]. Use DataFrame type hint instead." % return_sig
                 )
 
-            return_schema = return_type.spark_type
-            if not isinstance(return_schema, StructType):
+            if isinstance(return_type, DataFrameType):
+                return_schema = cast(DataFrameType, return_type).spark_type
+            else:
                 should_return_series = True
+                return_schema = cast(Union[SeriesType, ScalarType], return_type).spark_type
                 if is_series_groupby:
                     return_schema = StructType([StructField(name, return_schema)])
                 else:
@@ -2139,10 +2141,17 @@ class GroupBy(object, metaclass=ABCMeta):
             # If schema is inferred, we can restore indexes too.
             internal = kdf_from_pandas._internal.with_new_sdf(sdf)
         else:
-            return_type = infer_return_type(func).spark_type
+            return_type = infer_return_type(func)
+            if not isinstance(return_type, SeriesType):
+                raise TypeError(
+                    "Expected the return type of this function to be of Series type, "
+                    "but found type {}".format(return_type)
+                )
+
+            return_schema = cast(SeriesType, return_type).spark_type
             data_columns = kdf._internal.data_spark_column_names
             return_schema = StructType(
-                [StructField(c, return_type) for c in data_columns if c not in groupkey_names]
+                [StructField(c, return_schema) for c in data_columns if c not in groupkey_names]
             )
 
             sdf = GroupBy._spark_group_map_apply(

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -3049,7 +3049,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
                     "Expected the return type of this function to be of scalar type, "
                     "but found type {}".format(sig_return)
                 )
-            return_schema = sig_return.tpe
+            return_schema = sig_return.spark_type
             return self.koalas._transform_batch(apply_each, return_schema)
 
     # TODO: not all arguments are implemented comparing to pandas' for now.

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -3049,7 +3049,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
                     "Expected the return type of this function to be of scalar type, "
                     "but found type {}".format(sig_return)
                 )
-            return_schema = sig_return.spark_type
+            return_schema = cast(ScalarType, sig_return).spark_type
             return self.koalas._transform_batch(apply_each, return_schema)
 
     # TODO: not all arguments are implemented comparing to pandas' for now.

--- a/databricks/koalas/typedef/typehints.py
+++ b/databricks/koalas/typedef/typehints.py
@@ -327,6 +327,11 @@ def infer_pd_series_spark_type(pser: pd.Series, dtype: Dtype) -> types.DataType:
 
 def infer_return_type(f) -> Union[SeriesType, DataFrameType, ScalarType, UnknownType]:
     """
+    Infer the return type from the return type annotation of the given function.
+
+    The returned type class indicates both dtypes (a pandas only dtype object
+    or a numpy dtype object) and its corresponding Spark DataType.
+
     >>> def func() -> int:
     ...    pass
     >>> inferred = infer_return_type(func)

--- a/databricks/koalas/typedef/typehints.py
+++ b/databricks/koalas/typedef/typehints.py
@@ -19,7 +19,7 @@ Utilities to deal with types. This is mostly focused on python3.
 """
 import datetime
 import decimal
-from inspect import getfullargspec
+from inspect import getfullargspec, isclass
 from typing import Generic, List, Optional, Tuple, TypeVar, Union  # noqa: F401
 
 import numpy as np
@@ -497,11 +497,15 @@ def infer_return_type(f) -> Union[SeriesType, DataFrameType, ScalarType, Unknown
             parameters = getattr(tuple_type, "__args__")
         dtypes, spark_types = zip(
             *(
-                koalas_dtype(p.tpe) if issubclass(p, NameTypeHolder) else koalas_dtype(p)
+                koalas_dtype(p.tpe)
+                if isclass(p) and issubclass(p, NameTypeHolder)
+                else koalas_dtype(p)
                 for p in parameters
             )
         )
-        names = [p.name if issubclass(p, NameTypeHolder) else None for p in parameters]
+        names = [
+            p.name if isclass(p) and issubclass(p, NameTypeHolder) else None for p in parameters
+        ]
         return DataFrameType(list(dtypes), list(spark_types), names)
 
     types = koalas_dtype(tpe)


### PR DESCRIPTION
After the return type inference, `SeriesType`, `DataFrameType`, and `ScalarType` hold the dtypes as well as Spark DataTypes.