### PR TITLE
Fix groupby-apply and transform to support additional dtypes.

### DIFF
--- a/databricks/koalas/tests/test_categorical.py
+++ b/databricks/koalas/tests/test_categorical.py
@@ -23,15 +23,27 @@ from databricks.koalas.testing.utils import ReusedSQLTestCase, TestUtils
 
 
 class CategoricalTest(ReusedSQLTestCase, TestUtils):
-    def test_categorical_frame(self):
-        pdf = pd.DataFrame(
+    @property
+    def pdf(self):
+        return pd.DataFrame(
             {
                 "a": pd.Categorical([1, 2, 3, 1, 2, 3]),
-                "b": pd.Categorical(["a", "b", "c", "a", "b", "c"], categories=["c", "b", "a"]),
+                "b": pd.Categorical(
+                    ["b", "a", "c", "c", "b", "a"], categories=["c", "b", "d", "a"]
+                ),
             },
-            index=pd.Categorical([10, 20, 30, 20, 30, 10], categories=[30, 10, 20], ordered=True),
         )
-        kdf = ks.from_pandas(pdf)
+
+    @property
+    def kdf(self):
+        return ks.from_pandas(self.pdf)
+
+    @property
+    def df_pair(self):
+        return (self.pdf, self.kdf)
+
+    def test_categorical_frame(self):
+        pdf, kdf = self.df_pair
 
         self.assert_eq(kdf, pdf)
         self.assert_eq(kdf.a, pdf.a)
@@ -95,15 +107,7 @@ class CategoricalTest(ReusedSQLTestCase, TestUtils):
         self.assert_eq(kuniques, puniques)
 
     def test_groupby_apply(self):
-        pdf = pd.DataFrame(
-            {
-                "a": pd.Categorical([1, 2, 3, 1, 2, 3]),
-                "b": pd.Categorical(
-                    ["b", "a", "c", "c", "b", "a"], categories=["c", "b", "d", "a"]
-                ),
-            },
-        )
-        kdf = ks.from_pandas(pdf)
+        pdf, kdf = self.df_pair
 
         self.assert_eq(
             kdf.groupby("a").apply(lambda df: df).sort_index(),
@@ -134,3 +138,52 @@ class CategoricalTest(ReusedSQLTestCase, TestUtils):
     def test_groupby_apply_without_shortcut(self):
         with ks.option_context("compute.shortcut_limit", 0):
             self.test_groupby_apply()
+
+        pdf, kdf = self.df_pair
+
+        def identity(df) -> ks.DataFrame[zip(kdf.columns, kdf.dtypes)]:
+            return df
+
+        self.assert_eq(
+            kdf.groupby("a").apply(identity).sort_values(["a", "b"]).reset_index(drop=True),
+            pdf.groupby("a").apply(identity).sort_values(["a", "b"]).reset_index(drop=True),
+        )
+
+    def test_groupby_transform(self):
+        pdf, kdf = self.df_pair
+
+        self.assert_eq(
+            kdf.groupby("a").transform(lambda x: x).sort_index(),
+            pdf.groupby("a").transform(lambda x: x).sort_index(),
+        )
+
+        dtype = CategoricalDtype(categories=["a", "b", "c", "d"])
+
+        self.assert_eq(
+            kdf.groupby("a").transform(lambda x: x.astype(dtype)).sort_index(),
+            pdf.groupby("a").transform(lambda x: x.astype(dtype)).sort_index(),
+        )
+
+    def test_groupby_transform_without_shortcut(self):
+        with ks.option_context("compute.shortcut_limit", 0):
+            self.test_groupby_transform()
+
+        pdf, kdf = self.df_pair
+
+        def identity(x) -> ks.Series[kdf.b.dtype]:  # type: ignore
+            return x
+
+        self.assert_eq(
+            kdf.groupby("a").transform(identity).sort_values("b").reset_index(drop=True),
+            pdf.groupby("a").transform(identity).sort_values("b").reset_index(drop=True),
+        )
+
+        dtype = CategoricalDtype(categories=["a", "b", "c", "d"])
+
+        def astype(x) -> ks.Series[dtype]:
+            return x.astype(dtype)
+
+        self.assert_eq(
+            kdf.groupby("a").transform(astype).sort_values("b").reset_index(drop=True),
+            pdf.groupby("a").transform(astype).sort_values("b").reset_index(drop=True),
+        )


### PR DESCRIPTION
Fix groupby-apply and transform to support additional dtypes.

After this, additional dtypes can be specified in the return type annotation of the UDFs for groupby-apply and transform.

```py
>>> kdf = ks.DataFrame(
...     {
...         "a": pd.Categorical([1, 2, 3, 1, 2, 3]),
...         "b": pd.Categorical(
...             ["b", "a", "c", "c", "b", "a"], categories=["c", "b", "d", "a"]
...         ),
...     },
... )
>>> def identity(df) -> ks.DataFrame[zip(kdf.columns, kdf.dtypes)]:
...     return df
...
>>> applied = kdf.groupby("a").apply(identity)
>>> applied
   a  b
0  2  a
1  2  b
2  3  c
3  3  a
4  1  b
5  1  c
>>> applied.dtypes
a    category
b    category
dtype: object
```

FYI: without the fix:

```py
>>> applied
   a  b
0  1  3
1  1  1
2  2  0
3  2  3
4  0  1
5  0  0
>>> applied.dtypes
a    int64
b    int64
dtype: object
```