### PR TITLE
Fix DataFrame.koalas.apply_batch to support additional dtypes.

### DIFF
--- a/databricks/koalas/accessors.py
+++ b/databricks/koalas/accessors.py
@@ -393,7 +393,11 @@ class KoalasFrameMethods(object):
                 )
 
             # Otherwise, it loses index.
-            internal = InternalFrame(spark_frame=sdf, index_spark_columns=None)
+            internal = InternalFrame(
+                spark_frame=sdf,
+                index_spark_columns=None,
+                data_dtypes=cast(DataFrameType, return_type).dtypes,
+            )
 
         return DataFrame(internal)
 

--- a/databricks/koalas/tests/test_categorical.py
+++ b/databricks/koalas/tests/test_categorical.py
@@ -23,15 +23,27 @@ from databricks.koalas.testing.utils import ReusedSQLTestCase, TestUtils
 
 
 class CategoricalTest(ReusedSQLTestCase, TestUtils):
-    def test_categorical_frame(self):
-        pdf = pd.DataFrame(
+    @property
+    def pdf(self):
+        return pd.DataFrame(
             {
                 "a": pd.Categorical([1, 2, 3, 1, 2, 3]),
-                "b": pd.Categorical(["a", "b", "c", "a", "b", "c"], categories=["c", "b", "a"]),
+                "b": pd.Categorical(
+                    ["b", "a", "c", "c", "b", "a"], categories=["c", "b", "d", "a"]
+                ),
             },
-            index=pd.Categorical([10, 20, 30, 20, 30, 10], categories=[30, 10, 20], ordered=True),
         )
-        kdf = ks.from_pandas(pdf)
+
+    @property
+    def kdf(self):
+        return ks.from_pandas(self.pdf)
+
+    @property
+    def df_pair(self):
+        return (self.pdf, self.kdf)
+
+    def test_categorical_frame(self):
+        pdf, kdf = self.df_pair
 
         self.assert_eq(kdf, pdf)
         self.assert_eq(kdf.a, pdf.a)
@@ -95,15 +107,7 @@ class CategoricalTest(ReusedSQLTestCase, TestUtils):
         self.assert_eq(kuniques, puniques)
 
     def test_groupby_apply(self):
-        pdf = pd.DataFrame(
-            {
-                "a": pd.Categorical([1, 2, 3, 1, 2, 3]),
-                "b": pd.Categorical(
-                    ["b", "a", "c", "c", "b", "a"], categories=["c", "b", "d", "a"]
-                ),
-            },
-        )
-        kdf = ks.from_pandas(pdf)
+        pdf, kdf = self.df_pair
 
         self.assert_eq(
             kdf.groupby("a").apply(lambda df: df).sort_index(),
@@ -134,3 +138,49 @@ class CategoricalTest(ReusedSQLTestCase, TestUtils):
     def test_groupby_apply_without_shortcut(self):
         with ks.option_context("compute.shortcut_limit", 0):
             self.test_groupby_apply()
+
+    def test_frame_apply_batch(self):
+        pdf, kdf = self.df_pair
+
+        self.assert_eq(
+            kdf.koalas.apply_batch(lambda pdf: pdf.astype(str)).sort_index(),
+            pdf.astype(str).sort_index(),
+        )
+
+        pdf = pd.DataFrame(
+            {"a": ["a", "b", "c", "a", "b", "c"], "b": ["b", "a", "c", "c", "b", "a"]}
+        )
+        kdf = ks.from_pandas(pdf)
+
+        dtype = CategoricalDtype(categories=["a", "b", "c", "d"])
+
+        self.assert_eq(
+            kdf.koalas.apply_batch(lambda pdf: pdf.astype(dtype)).sort_index(),
+            pdf.astype(dtype).sort_index(),
+        )
+
+    def test_frame_apply_batch_without_shortcut(self):
+        with ks.option_context("compute.shortcut_limit", 0):
+            self.test_frame_apply_batch()
+
+        pdf, kdf = self.df_pair
+
+        def to_str(pdf) -> 'ks.DataFrame["a":str, "b":str]':  # noqa: F821
+            return pdf.astype(str)
+
+        self.assert_eq(kdf.koalas.apply_batch(to_str).sort_index(), to_str(pdf).sort_index())
+
+        pdf = pd.DataFrame(
+            {"a": ["a", "b", "c", "a", "b", "c"], "b": ["b", "a", "c", "c", "b", "a"]}
+        )
+        kdf = ks.from_pandas(pdf)
+
+        dtype = CategoricalDtype(categories=["a", "b", "c", "d"])
+        ret = 'ks.DataFrame["a":{dtype}, "b":{dtype}]'.format(dtype=repr(dtype))
+
+        def to_category(pdf) -> ret:
+            return pdf.astype(dtype)
+
+        self.assert_eq(
+            kdf.koalas.apply_batch(to_category).sort_index(), to_category(pdf).sort_index()
+        )

--- a/databricks/koalas/tests/test_categorical.py
+++ b/databricks/koalas/tests/test_categorical.py
@@ -233,7 +233,7 @@ class CategoricalTest(ReusedSQLTestCase, TestUtils):
         kdf = ks.from_pandas(pdf)
 
         dtype = CategoricalDtype(categories=["a", "b", "c", "d"])
-        ret = 'ks.DataFrame["a":{dtype}, "b":{dtype}]'.format(dtype=repr(dtype))
+        ret = ks.DataFrame["a":dtype, "b":dtype]
 
         def to_category(pdf) -> ret:
             return pdf.astype(dtype)


### PR DESCRIPTION
Fix `DataFrame.koalas.apply_batch` to support additional dtypes.

After this, additional dtypes can be specified in the return type annotation of the UDFs for `DataFrame.koalas.apply_batch`.

```py
>>> kdf = ks.DataFrame(
...     {"a": ["a", "b", "c", "a", "b", "c"], "b": ["b", "a", "c", "c", "b", "a"]}
... )
>>> dtype = pd.CategoricalDtype(categories=["a", "b", "c", "d"])
>>> def to_category(pdf) -> ks.DataFrame["a": dtype, "b": dtype]:
...     return pdf.astype(dtype)
...
>>> applied = kdf.koalas.apply_batch(to_category)
>>> applied
   a  b
0  a  b
1  b  a
2  c  c
3  a  c
4  b  b
5  c  a
>>> applied.dtypes
a    category
b    category
dtype: object
```

FYI: without the fix:

```py
>>> applied
   a  b
0  0  1
1  1  0
2  2  2
3  0  2
4  1  1
5  2  0
>>> applied.dtypes
a    int64
b    int64
dtype: object
```
