### PR TITLE
Fix Series.koalas.transform_batch to support additional dtypes and reuse it.

### DIFF
--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -2773,12 +2773,14 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 self._internal.column_labels, kdf._internal.column_labels
             ):
                 kser = self._kser_for(input_label)
+                dtype = kdf._internal.dtype_for(output_label)
                 return_schema = force_decimal_precision_scale(
                     as_nullable_spark_type(kdf._internal.spark_type_for(output_label))
                 )
                 applied.append(
                     kser.koalas._transform_batch(
-                        func=lambda c: func(c, *args, **kwargs), return_schema=return_schema
+                        func=lambda c: func(c, *args, **kwargs),
+                        return_type=SeriesType(dtype, return_schema),
                     )
                 )
 

--- a/databricks/koalas/series.py
+++ b/databricks/koalas/series.py
@@ -3081,15 +3081,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         apply_each = wraps(func)(lambda s: s.apply(func, args=args, **kwds))
 
         if should_infer_schema:
-            # TODO: In this case, it avoids the shortcut for now (but only infers schema)
-            #  because it returns a series from a different DataFrame and it has a different
-            #  anchor. We should fix this to allow the shortcut or only allow to infer
-            #  schema.
-            limit = get_option("compute.shortcut_limit")
-            pser = self.head(limit)._to_internal_pandas()
-            transformed = pser.apply(func, *args, **kwds)
-            kser = Series(transformed)  # type: "Series"
-            return self.koalas._transform_batch(apply_each, kser.spark.data_type)
+            return self.koalas._transform_batch(apply_each, None)
         else:
             sig_return = infer_return_type(func)
             if not isinstance(sig_return, ScalarType):
@@ -3097,8 +3089,8 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
                     "Expected the return type of this function to be of scalar type, "
                     "but found type {}".format(sig_return)
                 )
-            return_schema = cast(ScalarType, sig_return).spark_type
-            return self.koalas._transform_batch(apply_each, return_schema)
+            return_type = cast(ScalarType, sig_return)
+            return self.koalas._transform_batch(apply_each, return_type)
 
     # TODO: not all arguments are implemented comparing to pandas' for now.
     def aggregate(self, func: Union[str, List[str]]) -> Union[Scalar, "Series"]:


### PR DESCRIPTION
Fix `Series.koalas.transform_batch` to support additional dtypes and reuse it in `Series.transform` and `DataFrame.transform`.

After this, additional dtypes can be specified in the return type annotation of the UDFs for `Series.koalas.transform_batch`, `Series.transform`, and `DataFrame.transform`.

```py
>>> kdf = ks.DataFrame(
...     {"a": ["a", "b", "c", "a", "b", "c"], "b": ["b", "a", "c", "c", "b", "a"]}
... )
>>> dtype = pd.CategoricalDtype(categories=["a", "b", "c", "d"])
>>> def to_category(pser) -> ks.Series[dtype]:
...   return pser.astype(dtype)
...
>>> applied = kdf.a.koalas.transform_batch(to_category)
>>> applied
0    a
1    b
2    c
3    a
4    b
5    c
Name: a, dtype: category
Categories (4, object): ['a', 'b', 'c', 'd']
>>> applied.dtype
CategoricalDtype(categories=['a', 'b', 'c', 'd'], ordered=False)
```

