### PR TITLE
Fix DataFrame.koalas.transform_batch to support additional dtypes.

### DIFF
--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -1372,7 +1372,7 @@ class GroupBy(object, metaclass=ABCMeta):
         arguments_for_restore_index = kdf._internal.arguments_for_restore_index
 
         def rename_output(pdf):
-            pdf = InternalFrame.restore_index(pdf, **arguments_for_restore_index)
+            pdf = InternalFrame.restore_index(pdf.copy(), **arguments_for_restore_index)
 
             pdf = func(pdf)
 

--- a/databricks/koalas/tests/test_categorical.py
+++ b/databricks/koalas/tests/test_categorical.py
@@ -338,6 +338,77 @@ class CategoricalTest(ReusedSQLTestCase, TestUtils):
             kdf.koalas.apply_batch(to_category).sort_index(), to_category(pdf).sort_index()
         )
 
+    def test_frame_transform_batch(self):
+        pdf, kdf = self.df_pair
+
+        self.assert_eq(
+            kdf.koalas.transform_batch(lambda pdf: pdf.astype(str)).sort_index(),
+            pdf.astype(str).sort_index(),
+        )
+        self.assert_eq(
+            kdf.koalas.transform_batch(lambda pdf: pdf.b.cat.codes).sort_index(),
+            pdf.b.cat.codes.sort_index(),
+        )
+
+        pdf = pd.DataFrame(
+            {"a": ["a", "b", "c", "a", "b", "c"], "b": ["b", "a", "c", "c", "b", "a"]}
+        )
+        kdf = ks.from_pandas(pdf)
+
+        dtype = CategoricalDtype(categories=["a", "b", "c", "d"])
+
+        self.assert_eq(
+            kdf.koalas.transform_batch(lambda pdf: pdf.astype(dtype)).sort_index(),
+            pdf.astype(dtype).sort_index(),
+        )
+        self.assert_eq(
+            kdf.koalas.transform_batch(lambda pdf: pdf.b.astype(dtype)).sort_index(),
+            pdf.b.astype(dtype).sort_index(),
+        )
+
+    def test_frame_transform_batch_without_shortcut(self):
+        with ks.option_context("compute.shortcut_limit", 0):
+            self.test_frame_transform_batch()
+
+        pdf, kdf = self.df_pair
+
+        def to_str(pdf) -> 'ks.DataFrame["a":str, "b":str]':  # noqa: F821
+            return pdf.astype(str)
+
+        self.assert_eq(
+            kdf.koalas.transform_batch(to_str).sort_index(), to_str(pdf).sort_index(),
+        )
+
+        def to_codes(pdf) -> ks.Series[np.int8]:
+            return pdf.b.cat.codes
+
+        self.assert_eq(
+            kdf.koalas.transform_batch(to_codes).sort_index(), to_codes(pdf).sort_index(),
+        )
+
+        pdf = pd.DataFrame(
+            {"a": ["a", "b", "c", "a", "b", "c"], "b": ["b", "a", "c", "c", "b", "a"]}
+        )
+        kdf = ks.from_pandas(pdf)
+
+        dtype = CategoricalDtype(categories=["a", "b", "c", "d"])
+        ret = ks.DataFrame["a":dtype, "b":dtype]
+
+        def to_category(pdf) -> ret:
+            return pdf.astype(dtype)
+
+        self.assert_eq(
+            kdf.koalas.transform_batch(to_category).sort_index(), to_category(pdf).sort_index(),
+        )
+
+        def to_category(pdf) -> ks.Series[dtype]:
+            return pdf.b.astype(dtype)
+
+        self.assert_eq(
+            kdf.koalas.transform_batch(to_category).sort_index(),
+            to_category(pdf).rename().sort_index(),
+        )
+
     def test_series_transform_batch(self):
         pdf, kdf = self.df_pair
 


### PR DESCRIPTION
Fix `DataFrame.koalas.transform_batch` to support additional dtypes.

After this, additional dtypes can be specified in the return type annotation of the UDFs for `DataFrame.koalas.transform_batch`.

```py
>>> kdf = ks.DataFrame(
...     {"a": ["a", "b", "c", "a", "b", "c"], "b": ["b", "a", "c", "c", "b", "a"]}
... )
>>> dtype = pd.CategoricalDtype(categories=["a", "b", "c", "d"])
>>> def to_category(pdf) -> ks.DataFrame["a":dtype, "b":dtype]:
...   return pdf.astype(dtype)
...
>>> applied = kdf.koalas.transform_batch(to_category)
>>> applied
   a  b
0  a  b
1  b  a
2  c  c
3  a  c
4  b  b
5  c  a
>>> applied.dtypes
a    category
b    category
dtype: object
```