### PR TITLE
Add note about the porting to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**NOTE**: Koalas will be ported into [Apache Spark](https://github.com/apache/spark) after Apache Spark 3.2 release. Koalas is in maintenance mode and we only accept critical and uegent issues. See the [SPIP Voting](http://apache-spark-developers-list.1001551.n3.nabble.com/VOTE-SPIP-Support-pandas-API-layer-on-PySpark-td30996.html) for more details.
+**NOTE**: Koalas supports Apache Spark 3.1 and below as it will be [officially included to PySpark in the upcoming Apache Spark 3.2](http://apache-spark-developers-list.1001551.n3.nabble.com/VOTE-SPIP-Support-pandas-API-layer-on-PySpark-td30996.html). This repository is now in maintenance mode. For Apache Spark 3.2 and above, please use PySpark directly.
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,8 @@
 **NOTE**: Koalas supports Apache Spark 3.1 and below as it will be [officially included to PySpark in the upcoming Apache Spark 3.2](http://apache-spark-developers-list.1001551.n3.nabble.com/VOTE-SPIP-Support-pandas-API-layer-on-PySpark-td30996.html). This repository is now in maintenance mode. For Apache Spark 3.2 and above, please use PySpark directly.
 
-
-
 <p align="center">
   <img src="https://raw.githubusercontent.com/databricks/koalas/master/icons/koalas-logo.png" width="140"/>
 </p>
-
 
 <p align="center">
   pandas API on Apache Spark

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
+**NOTE**: Koalas will be ported into [Apache Spark](https://github.com/apache/spark) after Apache Spark 3.2 release. Koalas is in maintenance mode and we only accept critical and uegent issues. See the [SPIP Voting](http://apache-spark-developers-list.1001551.n3.nabble.com/VOTE-SPIP-Support-pandas-API-layer-on-PySpark-td30996.html) for more details.
+
+
+
 <p align="center">
   <img src="https://raw.githubusercontent.com/databricks/koalas/master/icons/koalas-logo.png" width="140"/>
 </p>
+
 
 <p align="center">
   pandas API on Apache Spark


### PR DESCRIPTION
Since Koalas will be ported into Apache Spark, added note on `README.md` to notify this.