### PR TITLE
Pin docutils to 0.16.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,6 +19,7 @@ numpydoc>=1.1.0
 pypandoc
 ipython
 pydata-sphinx-theme
+docutils==0.16
 
 # Linter
 mypy


### PR DESCRIPTION
The `docutils==0.17` released on Apr 3 has a bug which cause the sphinx build failure.

- https://sourceforge.net/p/docutils/bugs/416/