### PR TITLE
Remove upperbound pandas 1.2

### DIFF
--- a/databricks/koalas/indexing.py
+++ b/databricks/koalas/indexing.py
@@ -1700,17 +1700,21 @@ class iLocIndexer(LocIndexerLike):
             iloc_item = self[key]
             if not is_list_like(key) or not is_list_like(iloc_item):
                 raise ValueError("setting an array element with a sequence.")
-            elif is_list_like(key) and (len(iloc_item) != len(value)):
-                if self._is_series:
-                    raise ValueError(
-                        "cannot set using a list-like indexer with a different length than "
-                        "the value"
-                    )
-                else:
-                    raise ValueError(
-                        "shape mismatch: value array of shape ({},) could not be broadcast "
-                        "to indexing result of shape {}".format(len(value), iloc_item.shape)
-                    )
+            else:
+                shape_iloc_item = iloc_item.shape
+                len_iloc_item = shape_iloc_item[0]
+                len_value = len(value)
+                if len_iloc_item != len_value:
+                    if self._is_series:
+                        raise ValueError(
+                            "cannot set using a list-like indexer with a different length than "
+                            "the value"
+                        )
+                    else:
+                        raise ValueError(
+                            "shape mismatch: value array of shape ({},) could not be broadcast "
+                            "to indexing result of shape {}".format(len_value, shape_iloc_item)
+                        )
         super().__setitem__(key, value)
         # Update again with resolved_copy to drop extra columns.
         self._kdf._update_internal_frame(

--- a/databricks/koalas/indexing.py
+++ b/databricks/koalas/indexing.py
@@ -1697,8 +1697,10 @@ class iLocIndexer(LocIndexerLike):
 
     def __setitem__(self, key, value):
         if is_list_like(value) and not isinstance(value, spark.Column):
-            kdf_or_kser = self[key]
-            if is_list_like(key) and (len(kdf_or_kser) != len(value)):
+            iloc_item = self[key]
+            if not is_list_like(key) or not is_list_like(iloc_item):
+                raise ValueError("setting an array element with a sequence.")
+            elif is_list_like(key) and (len(iloc_item) != len(value)):
                 if self._is_series:
                     raise ValueError(
                         "cannot set using a list-like indexer with a different length than "
@@ -1707,10 +1709,8 @@ class iLocIndexer(LocIndexerLike):
                 else:
                     raise ValueError(
                         "shape mismatch: value array of shape ({},) could not be broadcast "
-                        "to indexing result of shape {}".format(len(value), kdf_or_kser.shape)
+                        "to indexing result of shape {}".format(len(value), iloc_item.shape)
                     )
-            elif not is_list_like(key):
-                raise ValueError("setting an array element with a sequence.")
         super().__setitem__(key, value)
         # Update again with resolved_copy to drop extra columns.
         self._kdf._update_internal_frame(

--- a/databricks/koalas/indexing.py
+++ b/databricks/koalas/indexing.py
@@ -1701,13 +1701,13 @@ class iLocIndexer(LocIndexerLike):
             if is_list_like(key) and (len(kdf_or_kser) != len(value)):
                 if self._is_series:
                     raise ValueError(
-                        "cannot set using a list-like indexer with a different length than the value"
+                        "cannot set using a list-like indexer with a different length than "
+                        "the value"
                     )
                 else:
                     raise ValueError(
-                        "shape mismatch: value array of shape ({},) could not be broadcast to indexing result of shape {}".format(
-                            len(value), kdf_or_kser.shape
-                        )
+                        "shape mismatch: value array of shape ({},) could not be broadcast "
+                        "to indexing result of shape {}".format(len(value), kdf_or_kser.shape)
                     )
             elif not is_list_like(key):
                 raise ValueError("setting an array element with a sequence.")

--- a/databricks/koalas/tests/test_indexing.py
+++ b/databricks/koalas/tests/test_indexing.py
@@ -1226,14 +1226,13 @@ class IndexingTest(ReusedSQLTestCase):
         self.assert_eq(kser, pser)
         self.assert_eq(kdf, pdf)
 
-        # TODO: matching the behavior with pandas 1.2 and uncomment below test.
-        # with self.assertRaisesRegex(
-        #     ValueError,
-        #     "cannot set using a list-like indexer with a different length than the value",
-        # ):
-        #     kser.iloc[[1]] = -kdf.b
+        with self.assertRaisesRegex(
+            ValueError,
+            "cannot set using a list-like indexer with a different length than the value",
+        ):
+            kser.iloc[[1]] = -kdf.b
 
-        with self.assertRaisesRegex(ValueError, "Incompatible indexer with DataFrame"):
+        with self.assertRaisesRegex(ValueError, "setting an array element with a sequence."):
             kser.iloc[1] = kdf[["b"]]
 
     def test_iloc_raises(self):

--- a/databricks/koalas/tests/test_indexing.py
+++ b/databricks/koalas/tests/test_indexing.py
@@ -1088,7 +1088,7 @@ class IndexingTest(ReusedSQLTestCase):
         kdf.iloc[0, 1] = 50
         self.assert_eq(kdf, pdf)
 
-        with self.assertRaisesRegex(ValueError, "Incompatible indexer with Series"):
+        with self.assertRaisesRegex(ValueError, "setting an array element with a sequence."):
             kdf.iloc[0, 0] = -kdf.max_speed
         with self.assertRaisesRegex(ValueError, "shape mismatch"):
             kdf.iloc[:, [1, 0]] = -kdf.max_speed

--- a/databricks/koalas/tests/test_ops_on_diff_frames.py
+++ b/databricks/koalas/tests/test_ops_on_diff_frames.py
@@ -1149,25 +1149,23 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
         pdf.iloc[[0, 1, 2], 1] = -pdf.max_speed
         self.assert_eq(kdf, pdf)
 
-        # TODO: matching the behavior with pandas 1.2 and uncomment below test
-        # with self.assertRaisesRegex(
-        #     ValueError,
-        #     "shape mismatch: value array of shape (3,) could not be broadcast to indexing "
-        #     "result of shape (2,1)",
-        # ):
-        #     kdf.iloc[[1, 2], [1]] = -another_kdf.max_speed
+        with self.assertRaisesRegex(
+            ValueError,
+            "shape mismatch: value array of shape \(3,\) could not be broadcast to indexing "
+            "result of shape \(2, 1\)",
+        ):
+            kdf.iloc[[1, 2], [1]] = -another_kdf.max_speed
 
         kdf.iloc[[0, 1, 2], 1] = 10 * another_kdf.max_speed
         pdf.iloc[[0, 1, 2], 1] = 10 * pdf.max_speed
         self.assert_eq(kdf, pdf)
 
-        # TODO: matching the behavior with pandas 1.2 and uncomment below test
-        # with self.assertRaisesRegex(
-        #     ValueError,
-        #     "shape mismatch: value array of shape (3,) could not be broadcast to indexing "
-        #     "result of shape (1,)",
-        # ):
-        #     kdf.iloc[[0], 1] = 10 * another_kdf.max_speed
+        with self.assertRaisesRegex(
+            ValueError,
+            "shape mismatch: value array of shape \(3,\) could not be broadcast to indexing "
+            "result of shape \(1,\)",
+        ):
+            kdf.iloc[[0], 1] = 10 * another_kdf.max_speed
 
     def test_series_loc_setitem(self):
         pdf = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]}, index=["cobra", "viper", "sidewinder"])
@@ -1267,12 +1265,11 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(kdf, pdf)
         self.assert_eq(ksery, psery)
 
-        # TODO: matching the behavior with pandas 1.2 and uncomment below test.
-        # with self.assertRaisesRegex(
-        #     ValueError,
-        #     "cannot set using a list-like indexer with a different length than the value",
-        # ):
-        #     kser.iloc[[1, 2]] = -kser_another
+        with self.assertRaisesRegex(
+            ValueError,
+            "cannot set using a list-like indexer with a different length than the value",
+        ):
+            kser.iloc[[1, 2]] = -kser_another
 
         kser.iloc[[0, 1, 2]] = 10 * kser_another
         pser.iloc[[0, 1, 2]] = 10 * pser_another
@@ -1280,11 +1277,11 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(kdf, pdf)
         self.assert_eq(ksery, psery)
 
-        # with self.assertRaisesRegex(
-        #     ValueError,
-        #     "cannot set using a list-like indexer with a different length than the value",
-        # ):
-        #     kser.iloc[[0]] = 10 * kser_another
+        with self.assertRaisesRegex(
+            ValueError,
+            "cannot set using a list-like indexer with a different length than the value",
+        ):
+            kser.iloc[[0]] = 10 * kser_another
 
         kser1.iloc[[0, 1, 2]] = -kser_another
         pser1.iloc[[0, 1, 2]] = -pser_another
@@ -1292,11 +1289,11 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(kdf, pdf)
         self.assert_eq(ksery, psery)
 
-        # with self.assertRaisesRegex(
-        #     ValueError,
-        #     "cannot set using a list-like indexer with a different length than the value",
-        # ):
-        #     kser1.iloc[[1, 2]] = -kser_another
+        with self.assertRaisesRegex(
+            ValueError,
+            "cannot set using a list-like indexer with a different length than the value",
+        ):
+            kser1.iloc[[1, 2]] = -kser_another
 
         pdf = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]}, index=["cobra", "viper", "sidewinder"])
         kdf = ks.from_pandas(pdf)
@@ -1315,12 +1312,11 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(kdf, pdf)
         self.assert_eq(ksery, psery)
 
-        # TODO: matching the behavior with pandas 1.2 and uncomment below test.
-        # with self.assertRaisesRegex(
-        #     ValueError,
-        #     "cannot set using a list-like indexer with a different length than the value",
-        # ):
-        #     kiloc[[1, 2]] = -kser_another
+        with self.assertRaisesRegex(
+            ValueError,
+            "cannot set using a list-like indexer with a different length than the value",
+        ):
+            kiloc[[1, 2]] = -kser_another
 
         kiloc[[0, 1, 2]] = 10 * kser_another
         piloc[[0, 1, 2]] = 10 * pser_another
@@ -1328,11 +1324,11 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(kdf, pdf)
         self.assert_eq(ksery, psery)
 
-        # with self.assertRaisesRegex(
-        #     ValueError,
-        #     "cannot set using a list-like indexer with a different length than the value",
-        # ):
-        #     kiloc[[0]] = 10 * kser_another
+        with self.assertRaisesRegex(
+            ValueError,
+            "cannot set using a list-like indexer with a different length than the value",
+        ):
+            kiloc[[0]] = 10 * kser_another
 
     def test_update(self):
         pdf = pd.DataFrame({"x": [1, 2, 3], "y": [10, 20, 30]})

--- a/databricks/koalas/tests/test_ops_on_diff_frames.py
+++ b/databricks/koalas/tests/test_ops_on_diff_frames.py
@@ -1150,9 +1150,7 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(kdf, pdf)
 
         with self.assertRaisesRegex(
-            ValueError,
-            "shape mismatch: value array of shape \(3,\) could not be broadcast to indexing "
-            "result of shape \(2, 1\)",
+            ValueError, "shape mismatch",
         ):
             kdf.iloc[[1, 2], [1]] = -another_kdf.max_speed
 
@@ -1160,11 +1158,7 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
         pdf.iloc[[0, 1, 2], 1] = 10 * pdf.max_speed
         self.assert_eq(kdf, pdf)
 
-        with self.assertRaisesRegex(
-            ValueError,
-            "shape mismatch: value array of shape \(3,\) could not be broadcast to indexing "
-            "result of shape \(1,\)",
-        ):
+        with self.assertRaisesRegex(ValueError, "shape mismatch"):
             kdf.iloc[[0], 1] = 10 * another_kdf.max_speed
 
     def test_series_loc_setitem(self):

--- a/databricks/koalas/tests/test_ops_on_diff_frames.py
+++ b/databricks/koalas/tests/test_ops_on_diff_frames.py
@@ -1851,7 +1851,7 @@ class OpsOnDiffFramesDisabledTest(ReusedSQLTestCase, SQLTestUtils):
         another_kdf = ks.DataFrame(pdf)
 
         with self.assertRaisesRegex(ValueError, "Cannot combine the series or dataframe"):
-            kdf.iloc[[1, 2], [1]] = another_kdf.max_speed
+            kdf.iloc[[1, 2], [1]] = another_kdf.max_speed.iloc[[1, 2]]
 
     def test_series_loc_setitem(self):
         pser = pd.Series([1, 2, 3], index=["cobra", "viper", "sidewinder"])
@@ -1877,7 +1877,7 @@ class OpsOnDiffFramesDisabledTest(ReusedSQLTestCase, SQLTestUtils):
         kser_another = ks.from_pandas(pser_another)
 
         with self.assertRaisesRegex(ValueError, "Cannot combine the series or dataframe"):
-            kser.iloc[[1]] = -kser_another
+            kser.iloc[[1]] = -kser_another.iloc[[1]]
 
     def test_where(self):
         pdf1 = pd.DataFrame({"A": [0, 1, 2, 3, 4], "B": [100, 200, 300, 400, 500]})

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 # Dependencies in Koalas. When you update don't forget to update setup.py and install.rst in docs.
-pandas>=0.23.2,<1.2.0
+pandas>=0.23.2
 pyarrow>=0.10
 numpy>=1.14,<1.20.0
 

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
     },
     python_requires='>=3.5,<3.9',
     install_requires=[
-        'pandas>=0.23.2,<1.2.0',
+        'pandas>=0.23.2',
         'pyarrow>=0.10',
         'numpy>=1.14,<1.20.0',
     ],


### PR DESCRIPTION
Fix several incompatible behavior with pandas in `iLocIndexer` to remove upperbound pandas 1.2.