### PR TITLE
Show a warning message to encourage to use pyspark.pandas.

### DIFF
--- a/databricks/koalas/__init__.py
+++ b/databricks/koalas/__init__.py
@@ -63,7 +63,7 @@ def assert_pyspark_version():
         elif LooseVersion(pyspark_ver) >= LooseVersion("3.2"):
             logging.warning(
                 'Found pyspark version "{}" installed. The pyspark version 3.2 and above has '
-                'a builtin "pandas APIs on Spark" module ported from Koalas. '
+                'a built-in "pandas APIs on Spark" module ported from Koalas. '
                 "Try `import pyspark.pandas as ps` instead. ".format(pyspark_ver)
             )
 

--- a/databricks/koalas/__init__.py
+++ b/databricks/koalas/__init__.py
@@ -60,6 +60,12 @@ def assert_pyspark_version():
                     pyspark_ver if pyspark_ver is not None else "<unknown version>"
                 )
             )
+        elif LooseVersion(pyspark_ver) >= LooseVersion("3.2"):
+            logging.warning(
+                'Found pyspark version "{}" installed. The pyspark version 3.2 and above has '
+                'a builtin "pandas APIs on Spark" module ported from Koalas. '
+                "Try `import pyspark.pandas as ps` instead. ".format(pyspark_ver)
+            )
 
 
 assert_python_version()


### PR DESCRIPTION
Show a warning message to encourage to use `pyspark.pandas` when the underlying PySpark is 3.2 or above.