### PR TITLE
Upgrade pandas in CI to 1.2.4.

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -110,7 +110,7 @@ jobs:
             pyarrow-version: 2.0.0
           - python-version: 3.8
             spark-version: 3.1.1
-            pandas-version: 1.2.3
+            pandas-version: 1.2.4
             pyarrow-version: 3.0.0
             default-index-type: 'distributed-sequence'
     env:


### PR DESCRIPTION
pandas 1.2.4 has been released, so we should test this in CI.

- https://pandas.pydata.org/pandas-docs/dev/whatsnew/v1.2.4.html