### PR TITLE
Remove the duplicated section title in the indexing document

### DIFF
--- a/docs/source/reference/indexing.rst
+++ b/docs/source/reference/indexing.rst
@@ -78,12 +78,6 @@ Compatibility with MultiIndex
    :toctree: api/
 
    Index.set_names
-
-Compatibility with MultiIndex
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.. autosummary::
-   :toctree: api/
-
    Index.droplevel
 
 Missing Values


### PR DESCRIPTION
Remove the duplicated section title "Compatibility with MultiIndex" in the indexing document.