### PR TITLE
Remove the upperbound for numpy.

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -160,7 +160,7 @@ jobs:
           conda install -c conda-forge --yes pyspark==$SPARK_VERSION
         fi
         conda install -c conda-forge --yes pandas==$PANDAS_VERSION pyarrow==$PYARROW_VERSION numpy==$NUMPY_VERSION
-        sed -i -e "/pandas/d" -e "/pyarrow/d" -e "/numpy/d" requirements-dev.txt
+        sed -i -e "/pandas/d" -e "/pyarrow/d" -e "/numpy>=/d" requirements-dev.txt
         # Disable mypy check for PySpark 3.1
         if [[ "$SPARK_VERSION" > "3.1" ]]; then sed -i '/mypy/d' requirements-dev.txt; fi
         # sphinx-plotly-directive is not available on Conda.

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -89,11 +89,13 @@ jobs:
             spark-version: 2.4.7
             pandas-version: 0.24.2
             pyarrow-version: 0.14.1
+            numpy-version: 1.19.5
             logger: databricks.koalas.usage_logging.usage_logger
           - python-version: 3.7
             spark-version: 2.4.7
             pandas-version: 0.25.3
             pyarrow-version: 0.15.1
+            numpy-version: 1.19.5
             default-index-type: 'distributed-sequence'
           - python-version: 3.7
             spark-version: 3.0.2
@@ -103,21 +105,25 @@ jobs:
             spark-version: 3.1.1
             pandas-version: 1.1.5
             pyarrow-version: 2.0.0
+            numpy-version: 1.19.5
             default-index-type: 'distributed-sequence'
           - python-version: 3.8
             spark-version: 3.0.2
             pandas-version: 1.1.5
             pyarrow-version: 2.0.0
+            numpy-version: 1.20.3
           - python-version: 3.8
             spark-version: 3.1.1
             pandas-version: 1.2.4
             pyarrow-version: 3.0.0
+            numpy-version: 1.20.3
             default-index-type: 'distributed-sequence'
     env:
       PYTHON_VERSION: ${{ matrix.python-version }}
       SPARK_VERSION: ${{ matrix.spark-version }}
       PANDAS_VERSION: ${{ matrix.pandas-version }}
       PYARROW_VERSION: ${{ matrix.pyarrow-version }}
+      NUMPY_VERSION: ${{ matrix.numpy-version }}
       DEFAULT_INDEX_TYPE: ${{ matrix.default-index-type }}
       KOALAS_TESTING: 1
       SPARK_LOCAL_IP: 127.0.0.1
@@ -145,6 +151,7 @@ jobs:
         conda config --env --add pinned_packages python=$PYTHON_VERSION
         conda config --env --add pinned_packages pandas==$PANDAS_VERSION
         conda config --env --add pinned_packages pyarrow==$PYARROW_VERSION
+        conda config --env --add pinned_packages numpy==$NUMPY_VERSION
         conda config --env --add pinned_packages pyspark==$SPARK_VERSION
         if [[ "$SPARK_VERSION" < "3.0" ]]; then
           pip install pyspark==$SPARK_VERSION
@@ -152,7 +159,7 @@ jobs:
           conda install -c conda-forge --yes pyspark==$SPARK_VERSION
         fi
         conda install -c conda-forge --yes pandas==$PANDAS_VERSION pyarrow==$PYARROW_VERSION
-        sed -i -e "/pandas/d" -e "/pyarrow/d" requirements-dev.txt
+        sed -i -e "/pandas/d" -e "/pyarrow/d" -e "/numpy/d" requirements-dev.txt
         # Disable mypy check for PySpark 3.1
         if [[ "$SPARK_VERSION" > "3.1" ]]; then sed -i '/mypy/d' requirements-dev.txt; fi
         # sphinx-plotly-directive is not available on Conda.

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -159,7 +159,7 @@ jobs:
         else
           conda install -c conda-forge --yes pyspark==$SPARK_VERSION
         fi
-        conda install -c conda-forge --yes pandas==$PANDAS_VERSION pyarrow==$PYARROW_VERSION
+        conda install -c conda-forge --yes pandas==$PANDAS_VERSION pyarrow==$PYARROW_VERSION numpy==$NUMPY_VERSION
         sed -i -e "/pandas/d" -e "/pyarrow/d" -e "/numpy/d" requirements-dev.txt
         # Disable mypy check for PySpark 3.1
         if [[ "$SPARK_VERSION" > "3.1" ]]; then sed -i '/mypy/d' requirements-dev.txt; fi

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -112,7 +112,7 @@ jobs:
             spark-version: 3.0.2
             pandas-version: 1.1.5
             pyarrow-version: 2.0.0
-            numpy-version: 1.20.3
+            numpy-version: 1.19.5
           - python-version: 3.8
             spark-version: 3.1.1
             pandas-version: 1.2.4
@@ -162,7 +162,7 @@ jobs:
         conda install -c conda-forge --yes pandas==$PANDAS_VERSION pyarrow==$PYARROW_VERSION numpy==$NUMPY_VERSION
         sed -i -e "/pandas/d" -e "/pyarrow/d" -e "/numpy>=/d" requirements-dev.txt
         # Disable mypy check for PySpark 3.1
-        if [[ "$SPARK_VERSION" > "3.1" ]] || [[ "$NUMPY_VERSION" > "1.20" ]]; then sed -i '/mypy/d' requirements-dev.txt; fi
+        if [[ "$SPARK_VERSION" > "3.1" ]]; then sed -i '/mypy/d' requirements-dev.txt; fi
         # sphinx-plotly-directive is not available on Conda.
         sed -i '/sphinx-plotly-directive/d' requirements-dev.txt
         conda install -c conda-forge --yes --file requirements-dev.txt

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -162,7 +162,7 @@ jobs:
         conda install -c conda-forge --yes pandas==$PANDAS_VERSION pyarrow==$PYARROW_VERSION numpy==$NUMPY_VERSION
         sed -i -e "/pandas/d" -e "/pyarrow/d" -e "/numpy>=/d" requirements-dev.txt
         # Disable mypy check for PySpark 3.1
-        if [[ "$SPARK_VERSION" > "3.1" ]]; then sed -i '/mypy/d' requirements-dev.txt; fi
+        if [[ "$SPARK_VERSION" > "3.1" ]] || [[ "$NUMPY_VERSION" > "1.20" ]]; then sed -i '/mypy/d' requirements-dev.txt; fi
         # sphinx-plotly-directive is not available on Conda.
         sed -i '/sphinx-plotly-directive/d' requirements-dev.txt
         conda install -c conda-forge --yes --file requirements-dev.txt

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -101,6 +101,7 @@ jobs:
             spark-version: 3.0.2
             pandas-version: 1.0.5
             pyarrow-version: 1.0.1
+            numpy-version: 1.19.5
           - python-version: 3.7
             spark-version: 3.1.1
             pandas-version: 1.1.5

--- a/databricks/koalas/__init__.py
+++ b/databricks/koalas/__init__.py
@@ -72,6 +72,24 @@ assert_python_version()
 assert_pyspark_version()
 
 import pyspark
+import numpy
+
+if LooseVersion(pyspark.__version__) < LooseVersion("3.1") and LooseVersion(
+    numpy.__version__
+) >= LooseVersion("1.20"):
+    import logging
+
+    logging.warning(
+        'Found numpy version "{numpy_version}" installed with pyspark version "{pyspark_version}". '
+        "Some functions will not work well with this combination of "
+        'numpy version "{numpy_version}" and pyspark version "{pyspark_version}". '
+        "Please try to upgrade pyspark version to 3.1 or above, "
+        "or downgrade numpy version to below 1.20.".format(
+            numpy_version=numpy.__version__, pyspark_version=pyspark.__version__
+        )
+    )
+
+
 import pyarrow
 
 if LooseVersion(pyspark.__version__) < LooseVersion("3.0"):

--- a/databricks/koalas/tests/test_stats.py
+++ b/databricks/koalas/tests/test_stats.py
@@ -367,8 +367,16 @@ class StatsTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(len(kdf.kurtosis(numeric_only=True)), len(pdf.kurtosis(numeric_only=True)))
         self.assert_eq(len(kdf.skew(numeric_only=True)), len(pdf.skew(numeric_only=True)))
 
+        # Boolean was excluded because of a behavior change in NumPy
+        # https://github.com/numpy/numpy/pull/16273#discussion_r641264085 which pandas inherits
+        # but this behavior is inconsistent in pandas context.
+        # Boolean column in quantile tests are excluded for now.
+        # TODO(SPARK-35555): track and match the behavior of quantile to pandas'
+        pdf = pd.DataFrame({"i": [0, 1, 2], "s": ["x", "y", "z"]})
+        kdf = ks.from_pandas(pdf)
         self.assert_eq(
-            len(kdf.quantile(q=0.5, numeric_only=True)), len(pdf.quantile(q=0.5, numeric_only=True))
+            len(kdf.quantile(q=0.5, numeric_only=True)),
+            len(pdf.quantile(q=0.5, numeric_only=True)),
         )
         self.assert_eq(
             len(kdf.quantile(q=[0.25, 0.5, 0.75], numeric_only=True)),

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 # Dependencies in Koalas. When you update don't forget to update setup.py and install.rst in docs.
 pandas>=0.23.2
 pyarrow>=0.10
-numpy>=1.14,<1.20.0
+numpy>=1.14,<1.20.0  # Keep the upperbound for the local tests; otherwise, mypy check will fail.
 
 # Optional dependencies in Koalas.
 mlflow>=1.0

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
     install_requires=[
         'pandas>=0.23.2',
         'pyarrow>=0.10',
-        'numpy>=1.14,<1.20.0',
+        'numpy>=1.14',
     ],
     author="Databricks",
     author_email="koalas@databricks.com",


### PR DESCRIPTION
Removed the upperbound for `numpy`.
`numpy>=1.20` only works with `pyspark>=3.1`, so show a warning when `numpy>=1.20` with `pyspark<3.1` together.