### PR TITLE
Support y properly in DataFrame with non-numeric columns with plots

### DIFF
--- a/databricks/koalas/plot/plotly.py
+++ b/databricks/koalas/plot/plotly.py
@@ -72,8 +72,14 @@ def plot_pie(data: Union["ks.DataFrame", "ks.Series"], **kwargs):
 
 def plot_histogram(data: Union["ks.DataFrame", "ks.Series"], **kwargs):
     import plotly.graph_objs as go
+    import databricks.koalas as ks
 
     bins = kwargs.get("bins", 10)
+    y = kwargs.get("y")
+    if y and isinstance(data, ks.DataFrame):
+        # Note that the results here are matched with matplotlib. x and y
+        # handling is different from pandas' plotly output.
+        data = data[y]
     kdf, bins = HistogramPlotBase.prepare_hist_data(data, bins)
     assert len(bins) > 2, "the number of buckets must be higher than 2."
     output_series = HistogramPlotBase.compute_hist(kdf, bins)

--- a/databricks/koalas/tests/plot/test_frame_plot_matplotlib.py
+++ b/databricks/koalas/tests/plot/test_frame_plot_matplotlib.py
@@ -402,6 +402,19 @@ class DataFramePlotMatplotlibTest(ReusedSQLTestCase, TestUtils):
             bin2 = self.plot_to_base64(ax2)
             self.assertEqual(bin1, bin2)
 
+            non_numeric_pdf = self.pdf1.copy()
+            non_numeric_pdf.c = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"]
+            non_numeric_kdf = ks.from_pandas(non_numeric_pdf)
+            ax1 = non_numeric_pdf.plot.hist(
+                x=non_numeric_pdf.columns[0], y=non_numeric_pdf.columns[1], bins=3
+            )
+            bin1 = self.plot_to_base64(ax1)
+            ax2 = non_numeric_kdf.plot.hist(
+                x=non_numeric_pdf.columns[0], y=non_numeric_pdf.columns[1], bins=3
+            )
+            bin2 = self.plot_to_base64(ax2)
+            self.assertEqual(bin1, bin2)
+
         pdf1 = self.pdf1
         kdf1 = self.kdf1
         check_hist_plot(pdf1, kdf1)


### PR DESCRIPTION
```python
ks.DataFrame({'a': [1, 2, 3], 'b':["a", "b", "c"], 'c': [4, 5, 6]}).plot(kind="hist", x="a", y="c", bins=200)
```

**Before:**

```
pyspark.sql.utils.AnalysisException: cannot resolve 'least(min(a), min(b), min(c))' due to data type mismatch: The expressions should all have the same type, got LEAST(bigint, string, bigint).;
'Aggregate [unresolvedalias(least(min(a#1L), min(b#2), min(c#3L)), Some(org.apache.spark.sql.Column$$Lambda$1556/0x0000000800d94840@42fb0cc1)), unresolvedalias(greatest(max(a#1L), max(b#2), max(c#3L)), Some(org.apache.spark.sql.Column$$Lambda$1556/0x0000000800d94840@42fb0cc1))]
+- Project [a#1L, b#2, c#3L]
   +- Project [__index_level_0__#0L, a#1L, b#2, c#3L, monotonically_increasing_id() AS __natural_order__#8L]
      +- LogicalRDD [__index_level_0__#0L, a#1L, b#2, c#3L], false
```

**After:**

```python
Figure({
    'data': [{'hovertemplate': 'variable=a<br>value=%{text}<br>count=%{y}',
              'name': 'a',
...
```

**Notebook tests:**

![Screen Shot 2021-06-11 at 9 11 25 PM](https://user-images.githubusercontent.com/6477701/121686038-a47a1b80-cafb-11eb-8f8e-8d968db7ebef.png)

![Screen Shot 2021-06-11 at 9 48 58 PM](https://user-images.githubusercontent.com/6477701/121688858-e22c7380-cafe-11eb-9d0a-adcbe560030f.png)


Can be tested here: https://mybinder.org/v2/gh/HyukjinKwon/koalas/fix-hist-plot?filepath=docs%2Fsource%2Fgetting_started%2F10min.ipynb