### PR TITLE
Fix Index.difference to avoid collect 'other' to driver side

### DIFF
--- a/databricks/koalas/indexes/base.py
+++ b/databricks/koalas/indexes/base.py
@@ -1950,7 +1950,21 @@ class Index(IndexOpsMixin):
         """
         from databricks.koalas.indexes.multi import MultiIndex
 
-        if not is_list_like(other):
+        # Check if the `self` and `other` have different index types.
+        # 1. `self` is Index, `other` is MultiIndex
+        # 2. `self` is MultiIndex, `other` is Index
+        is_index_types_different = isinstance(other, Index) and not isinstance(self, type(other))
+        if is_index_types_different:
+            if isinstance(self, MultiIndex):
+                # In case `self` is MultiIndex and `other` is Index,
+                # return MultiIndex without its names.
+                return self.rename([None] * len(self))
+            elif isinstance(self, Index):
+                # In case `self` is Index and `other` is MultiIndex,
+                # return Index without its name.
+                return self.rename(None)
+
+        if not isinstance(other, (Index, Series, tuple, list, set, dict)):
             raise TypeError("Input must be Index or array-like")
         if not isinstance(sort, (type(None), type(True))):
             raise ValueError(
@@ -1958,11 +1972,17 @@ class Index(IndexOpsMixin):
                     sort
                 )
             )
-        # Handling MultiIndex
+        # Handling MultiIndex when `other` is MultiIndex.
         if isinstance(self, MultiIndex) and not isinstance(other, MultiIndex):
-            if not all([isinstance(item, tuple) for item in other]):
+            is_other_list_of_tuples = isinstance(other, (list, set, dict)) and all(
+                [isinstance(item, tuple) for item in other]
+            )
+            if is_other_list_of_tuples:
+                other = MultiIndex.from_tuples(other)
+            elif isinstance(other, Series):
+                other = Index(other)
+            else:
                 raise TypeError("other must be a MultiIndex or a list of tuples")
-            other = MultiIndex.from_tuples(other)
 
         if not isinstance(other, Index):
             other = Index(other)

--- a/databricks/koalas/tests/indexes/test_base.py
+++ b/databricks/koalas/tests/indexes/test_base.py
@@ -1289,8 +1289,12 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         pidx2 = pd.Index([3, 4, 5, 6], name="koalas")
         kidx1 = ks.from_pandas(pidx1)
         kidx2 = ks.from_pandas(pidx2)
+        # Series
+        pser = pd.Series([3, 4, 5, 6], name="koalas")
+        kser = ks.from_pandas(pser)
 
         self.assert_eq(kidx1.difference(kidx2).sort_values(), pidx1.difference(pidx2).sort_values())
+        self.assert_eq(kidx1.difference(kser).sort_values(), pidx1.difference(pser).sort_values())
         self.assert_eq(
             kidx1.difference([3, 4, 5, 6]).sort_values(),
             pidx1.difference([3, 4, 5, 6]).sort_values(),
@@ -1325,28 +1329,36 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
             kidx1.difference(kidx2, sort=1)
 
         # MultiIndex
-        pidx1 = pd.MultiIndex.from_tuples(
+        pmidx1 = pd.MultiIndex.from_tuples(
             [("a", "x", 1), ("b", "y", 2), ("c", "z", 3)], names=["hello", "koalas", "world"]
         )
-        pidx2 = pd.MultiIndex.from_tuples(
+        pmidx2 = pd.MultiIndex.from_tuples(
             [("a", "x", 1), ("b", "z", 2), ("k", "z", 3)], names=["hello", "koalas", "world"]
         )
-        kidx1 = ks.from_pandas(pidx1)
-        kidx2 = ks.from_pandas(pidx2)
+        kmidx1 = ks.from_pandas(pmidx1)
+        kmidx2 = ks.from_pandas(pmidx2)
 
-        self.assert_eq(kidx1.difference(kidx2).sort_values(), pidx1.difference(pidx2).sort_values())
         self.assert_eq(
-            kidx1.difference({("a", "x", 1)}).sort_values(),
-            pidx1.difference({("a", "x", 1)}).sort_values(),
+            kmidx1.difference(kmidx2).sort_values(), pmidx1.difference(pmidx2).sort_values()
         )
         self.assert_eq(
-            kidx1.difference({("a", "x", 1): [1, 2, 3]}).sort_values(),
-            pidx1.difference({("a", "x", 1): [1, 2, 3]}).sort_values(),
+            kmidx1.difference(kidx1).sort_values(), pmidx1.difference(pidx1).sort_values()
+        )
+        self.assert_eq(
+            kidx1.difference(kmidx1).sort_values(), pidx1.difference(pmidx1).sort_values()
+        )
+        self.assert_eq(
+            kmidx1.difference({("a", "x", 1)}).sort_values(),
+            pmidx1.difference({("a", "x", 1)}).sort_values(),
+        )
+        self.assert_eq(
+            kmidx1.difference({("a", "x", 1): [1, 2, 3]}).sort_values(),
+            pmidx1.difference({("a", "x", 1): [1, 2, 3]}).sort_values(),
         )
 
         # Exceptions for MultiIndex
         with self.assertRaisesRegex(TypeError, "other must be a MultiIndex or a list of tuples"):
-            kidx1.difference(["b", "z", "2"])
+            kmidx1.difference(["b", "z", "2"])
 
     def test_repeat(self):
         pidx = pd.Index(["a", "b", "c"])


### PR DESCRIPTION
This PR basically came from [SPARK-35683](https://issues.apache.org/jira/browse/SPARK-35683).

This PR fix the wrong behavior of `Index.difference` in Koalas, based on the comment https://github.com/databricks/koalas/pull/1325#discussion_r647889901 and https://github.com/databricks/koalas/pull/1325#discussion_r647890007
- it couldn't handle the case properly when `self` is `Index` or `MultiIndex` and `other` is `MultiIndex` or `Index`.
```python
>>> midx1 = ks.MultiIndex.from_tuples([('a', 'x', 1), ('b', 'z', 2), ('k', 'z', 3)])
>>> idx1 = ks.Index([1, 2, 3])
>>> midx1 = ks.MultiIndex.from_tuples([('a', 'x', 1), ('b', 'z', 2), ('k', 'z', 3)])
>>> midx1.difference(idx1)
databricks.koalas.exceptions.PandasNotImplementedError: The method `pd.Index.__iter__()` is not implemented. If you want to collect your data as an NumPy array, use 'to_numpy()' instead.
```
- it's collecting the all data into the driver side when the other is list-like objects, especially when the `other` is distributed object such as Series which is very dangerous.

And added the related test cases.