### PR TITLE
Fix backward compatibility for Python version 3.5.*

### DIFF
--- a/databricks/koalas/internal.py
+++ b/databricks/koalas/internal.py
@@ -47,8 +47,8 @@ if TYPE_CHECKING:
 from databricks.koalas.config import get_option
 from databricks.koalas.typedef import (
     Dtype,
+    DtypeDataTypes,
     as_spark_type,
-    dtype_data_types,
     extension_dtypes,
     infer_pd_series_spark_type,
     spark_type_to_pandas_dtype,
@@ -541,7 +541,7 @@ class InternalFrame(object):
         ]
 
         assert all(
-            isinstance(dtype, dtype_data_types)
+            isinstance(dtype, DtypeDataTypes)
             and (dtype == np.dtype("object") or as_spark_type(dtype, raise_error=False) is not None)
             for dtype in index_dtypes
         ), index_dtypes
@@ -602,7 +602,7 @@ class InternalFrame(object):
         ]
 
         assert all(
-            isinstance(dtype, dtype_data_types)
+            isinstance(dtype, DtypeDataTypes)
             and (dtype == np.dtype("object") or as_spark_type(dtype, raise_error=False) is not None)
             for dtype in data_dtypes
         ), data_dtypes

--- a/databricks/koalas/internal.py
+++ b/databricks/koalas/internal.py
@@ -25,7 +25,6 @@ import py4j
 
 import numpy as np
 import pandas as pd
-from pandas.api.extensions import ExtensionDtype
 from pandas.api.types import CategoricalDtype, is_datetime64_dtype, is_datetime64tz_dtype
 import pyspark
 from pyspark import sql as spark
@@ -49,6 +48,7 @@ from databricks.koalas.config import get_option
 from databricks.koalas.typedef import (
     Dtype,
     as_spark_type,
+    dtype_data_types,
     extension_dtypes,
     infer_pd_series_spark_type,
     spark_type_to_pandas_dtype,
@@ -77,8 +77,6 @@ HIDDEN_COLUMNS = {NATURAL_ORDER_COLUMN_NAME}
 
 DEFAULT_SERIES_NAME = 0
 SPARK_DEFAULT_SERIES_NAME = str(DEFAULT_SERIES_NAME)
-
-dtype_data_types = (np.dtype, ExtensionDtype)
 
 
 class InternalFrame(object):

--- a/databricks/koalas/internal.py
+++ b/databricks/koalas/internal.py
@@ -25,6 +25,7 @@ import py4j
 
 import numpy as np
 import pandas as pd
+from pandas.api.extensions import ExtensionDtype
 from pandas.api.types import CategoricalDtype, is_datetime64_dtype, is_datetime64tz_dtype
 import pyspark
 from pyspark import sql as spark
@@ -76,6 +77,8 @@ HIDDEN_COLUMNS = {NATURAL_ORDER_COLUMN_NAME}
 
 DEFAULT_SERIES_NAME = 0
 SPARK_DEFAULT_SERIES_NAME = str(DEFAULT_SERIES_NAME)
+
+dtype_data_types = (np.dtype, ExtensionDtype)
 
 
 class InternalFrame(object):
@@ -540,7 +543,7 @@ class InternalFrame(object):
         ]
 
         assert all(
-            isinstance(dtype, Dtype.__args__)  # type: ignore
+            isinstance(dtype, dtype_data_types)  # type: ignore
             and (dtype == np.dtype("object") or as_spark_type(dtype, raise_error=False) is not None)
             for dtype in index_dtypes
         ), index_dtypes
@@ -601,7 +604,7 @@ class InternalFrame(object):
         ]
 
         assert all(
-            isinstance(dtype, Dtype.__args__)  # type: ignore
+            isinstance(dtype, dtype_data_types)  # type: ignore
             and (dtype == np.dtype("object") or as_spark_type(dtype, raise_error=False) is not None)
             for dtype in data_dtypes
         ), data_dtypes

--- a/databricks/koalas/internal.py
+++ b/databricks/koalas/internal.py
@@ -543,7 +543,7 @@ class InternalFrame(object):
         ]
 
         assert all(
-            isinstance(dtype, dtype_data_types)  # type: ignore
+            isinstance(dtype, dtype_data_types)
             and (dtype == np.dtype("object") or as_spark_type(dtype, raise_error=False) is not None)
             for dtype in index_dtypes
         ), index_dtypes
@@ -604,7 +604,7 @@ class InternalFrame(object):
         ]
 
         assert all(
-            isinstance(dtype, dtype_data_types)  # type: ignore
+            isinstance(dtype, dtype_data_types)
             and (dtype == np.dtype("object") or as_spark_type(dtype, raise_error=False) is not None)
             for dtype in data_dtypes
         ), data_dtypes

--- a/databricks/koalas/typedef/typehints.py
+++ b/databricks/koalas/typedef/typehints.py
@@ -74,6 +74,13 @@ Scalar = Union[
 
 Dtype = Union[np.dtype, ExtensionDtype]
 
+if hasattr(Dtype, "__union_params__"):
+    # Python 3.5.0 to 3.5.2 has '__union_params__' instead.
+    # See https://github.com/python/cpython/blob/v3.5.2/Lib/typing.py
+    dtype_data_types = getattr(Dtype, "__union_params__")
+else:
+    dtype_data_types = getattr(Dtype, "__args__")
+
 
 # A column of data, with the data type.
 class SeriesType(Generic[T]):

--- a/databricks/koalas/typedef/typehints.py
+++ b/databricks/koalas/typedef/typehints.py
@@ -77,9 +77,9 @@ Dtype = Union[np.dtype, ExtensionDtype]
 if hasattr(Dtype, "__union_params__"):
     # Python 3.5.0 to 3.5.2 has '__union_params__' instead.
     # See https://github.com/python/cpython/blob/v3.5.2/Lib/typing.py
-    dtype_data_types = getattr(Dtype, "__union_params__")
+    DtypeDataTypes = getattr(Dtype, "__union_params__")
 else:
-    dtype_data_types = getattr(Dtype, "__args__")
+    DtypeDataTypes = getattr(Dtype, "__args__")
 
 
 # A column of data, with the data type.


### PR DESCRIPTION
In Python 3.5.2, errors as below are raised for `Dtype.__args__`. 

```py
databricks/koalas/internal.py
    543             isinstance(dtype, Dtype.__args__)  # type: ignore
    544             and (dtype == np.dtype("object") or as_spark_type(dtype, raise_error=False) is not None)
--> 545             for dtype in index_dtypes
    546         ), index_dtypes
    547 

AttributeError: type object 'Union' has no attribute '__args__'
```

We fix backward compatibility for Python version 3.5.* by introducing `DtypeDataTypes` with `__union_params__` for 3.5.0~3.5.2.