### PR TITLE
[docs] Fix plot was showing twice the same data.

### DIFF
--- a/databricks/koalas/plot/core.py
+++ b/databricks/koalas/plot/core.py
@@ -638,7 +638,7 @@ class KoalasPlotAccessor(PandasObject):
             ...                    'lifespan': lifespan}, index=index)
             >>> fig = (make_subplots(rows=2, cols=1)
             ...        .add_trace(df.plot.bar(y='speed').data[0], row=1, col=1)
-            ...        .add_trace(df.plot.bar(y='speed').data[0], row=1, col=1)
+            ...        .add_trace(df.plot.bar(y='lifespan').data[0], row=1, col=1)
             ...        .add_trace(df.plot.bar(y='lifespan').data[0], row=2, col=1))
             >>> fig  # doctest: +SKIP
 


### PR DESCRIPTION
On API docs, `databricks.koalas.DataFrame.plot.bar`, an example plot was showing on its first row two bars per element, both of them showing the same data. Changed it to show different data, so it is visually clearer.