### PR TITLE
Upgrade pandas in CI to 1.2.5.

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -29,7 +29,7 @@ jobs:
             default-index-type: 'distributed-sequence'
           - python-version: 3.9
             spark-version: 3.1.1
-            pandas-version: 1.2.4
+            pandas-version: 1.2.5
             pyarrow-version: 3.0.0
             numpy-version: 1.20.3
             default-index-type: 'distributed-sequence'
@@ -126,7 +126,7 @@ jobs:
             numpy-version: 1.19.5
           - python-version: 3.8
             spark-version: 3.1.1
-            pandas-version: 1.2.4
+            pandas-version: 1.2.5
             pyarrow-version: 3.0.0
             numpy-version: 1.20.3
             default-index-type: 'distributed-sequence'


### PR DESCRIPTION
pandas 1.2.5 has been released, so we should test this in CI.

- https://pandas.pydata.org/pandas-docs/dev/whatsnew/v1.2.5.html