### PR TITLE
Minor fix to docs for read_csv

### DIFF
--- a/databricks/koalas/namespace.py
+++ b/databricks/koalas/namespace.py
@@ -249,7 +249,7 @@ def read_csv(
         The character used to denote the start and end of a quoted item. Quoted items can include
         the delimiter and it will be ignored.
     escapechar : str (length 1), default None
-        One-character string used to escape delimiter
+        One-character string used for escaping quotes inside an already quoted value.
     comment: str, optional
         Indicates the line should not be parsed.
     options : dict


### PR DESCRIPTION
Fixed documentation of the escapechar parameter of read_csv function
(docs incorrectly say this is for escaping the delimiter - it is for escaping a quotechar)